### PR TITLE
Support of connecting via Unix-socket for MySQL checks

### DIFF
--- a/database/mysql/mysqlcmd.pm
+++ b/database/mysql/mysqlcmd.pm
@@ -64,6 +64,7 @@ sub new {
                       "port:s@"                  => { name => 'port' },
                       "username:s@"              => { name => 'username' },
                       "password:s@"              => { name => 'password' },
+                      "socket:s@"                => { name => 'socket' },
                       "sql-errors-exit:s"        => { name => 'sql_errors_exit', default => 'unknown' },
         });
     }
@@ -78,6 +79,7 @@ sub new {
     
     $self->{host} = undef;
     $self->{port} = undef;
+    $self->{socket} = undef;
     $self->{username} = undef;
     $self->{password} = undef;
     
@@ -118,6 +120,7 @@ sub check_options {
     
     $self->{host} = (defined($self->{option_results}->{host})) ? shift(@{$self->{option_results}->{host}}) : undef;
     $self->{port} = (defined($self->{option_results}->{port})) ? shift(@{$self->{option_results}->{port}}) : undef;
+    $self->{socket} = (defined($self->{option_results}->{socket})) ? shift(@{$self->{option_results}->{socket}}) : undef;
     $self->{username} = (defined($self->{option_results}->{username})) ? shift(@{$self->{option_results}->{username}}) : undef;
     $self->{password} = (defined($self->{option_results}->{password})) ? shift(@{$self->{option_results}->{password}}) : undef;
     $self->{sql_errors_exit} = $self->{option_results}->{sql_errors_exit};
@@ -138,6 +141,10 @@ sub check_options {
     if (defined($self->{password}) && $self->{password} ne '') {
         push @{$self->{args}}, "-p" . $self->{password};
     }
+    if (defined($self->{socket}) && $self->{socket} ne '') {
+        push @{$self->{args}}, "--socket", $self->{socket};
+    }
+
 
     if (scalar(@{$self->{option_results}->{host}}) == 0) {
         return 0;
@@ -192,7 +199,7 @@ sub quote {
 
 sub command_execution {
     my ($self, %options) = @_;
-    
+   
     my ($lerror, $stdout, $exit_code) = centreon::plugins::misc::backtick(
                                                  command => $self->{mysql_cmd},
                                                  arguments =>  [@{$self->{args}}, '-e', $options{request}],

--- a/database/mysql/plugin.pm
+++ b/database/mysql/plugin.pm
@@ -73,6 +73,7 @@ sub init {
                                    arguments => {
                                                 'host:s@'  => { name => 'db_host' },
                                                 'port:s@'  => { name => 'db_port' },
+                                                'socket:s@'  => { name => 'db_socket' },
                                                 }
                                   );
     $self->{options}->parse_options();
@@ -89,6 +90,11 @@ sub init {
                 $self->{sqldefault}->{dbi}[$i]->{data_source} .= ';port=' . $options_result->{db_port}[$i];
                 $self->{sqldefault}->{mysqlcmd}[$i]->{port} = $options_result->{db_port}[$i];
             }
+	    # "DBI:mysql:database=dbname;host=localhost;mysql_socket=/path/to/mysql.sock"
+	    if (defined($options_result->{db_socket}[$i])) {
+	    	$self->{sqldefault}->{dbi}[$i]->{data_source} .= ';mysql_socket=' . $options_result->{db_socket}[$i];
+                $self->{sqldefault}->{mysqlcmd}[$i]->{socket} = $options_result->{db_socket}[$i];
+	    }
         }
     }
 
@@ -114,6 +120,10 @@ Hostname to query.
 =item B<--port>
 
 Database Server Port.
+
+=item B<--socket>
+
+Database Server Socket.
 
 =back
 


### PR DESCRIPTION
On my servers I have MySQL installed without networking support ("skip-networking" in my.cnf), so I need way to check MySQL via Unix-socket.
This commit allows to specify "--socket" option. Option supported in "dbi" and "mysqlcmd" sqlmode`s.

Example: 

```bash
./centreon_plugins.pl --plugin database::mysql::plugin --username='root' --host localhost --socket=/tmp/mysql1.sock --mode queries --sqlmode mysqlcmd
```