### PR TITLE
bug correction

### DIFF
--- a/apps/apcupsd/local/mode/libgetdata.pm
+++ b/apps/apcupsd/local/mode/libgetdata.pm
@@ -41,7 +41,7 @@ sub getdata {
     my ($value);
     #print $stdout;
     foreach (split(/\n/, $stdout)) {
-        if (/^$searchpattern\s*:\s*(.*)\s(Percent Load Capacity|Percent|Minutes|Seconds|Volts|Hz|seconds|C Internal|F Internal)/i) {
+        if (/^$searchpattern\s*:\s*(.*)\s(Percent Load Capacity|Percent|Minutes|Seconds|Volts|Hz|seconds|C|F Internal)/i) {
             $valueok = "1";
             $value = $1;
             #print $value;


### PR DESCRIPTION
the ITEMP information is write " 23 C" not " 23 C internal". correct the bug: 
#/usr/lib/nagios/plugins/Centreon/SNMP/centreon-plugins/centreon_plugins.pl --plugin=apps::apcupsd::local::plugin  --mode=temperature
Use of uninitialized value $valueok in numeric eq (==) at /usr/lib/nagios/plugins/Centreon/SNMP/centreon-plugins/apps/apcupsd/local/mode/libgetdata.pm line 52.
CRITICAL: NO DATA FOUND |