### PR TITLE
+ fix oracle asmdiskgroupusage mode

### DIFF
--- a/database/oracle/mode/asmdiskgroupusage.pm
+++ b/database/oracle/mode/asmdiskgroupusage.pm
@@ -399,7 +399,7 @@ sub manage_selection {
         
         
         $self->{dg}->{$name} = { display => $name, total => $total_mb * 1024 * 1024,
-                                 used => $usable_file_mb * 1024 * 1024,
+                                 used => ($total_mb * 1024 * 1024) - ($usable_file_mb * 1024 * 1024),
                                  state => $state, type => lc($type), offline_disks => $offline_disks };                        
     }
     


### PR DESCRIPTION
usable_file_mb is not used_mb => SABLE_FILE_MB indicates the amount of free space, adjusted for mirroring, that is available for new files to restore redundancy after a disk failure. (http://docs.oracle.com/cd/B28359_01/server.111/b31107/asmdiskgrps.htm)

used = total - usable_file_mb

