### PR TITLE
Update diskio.pm : sum of reads and writes

### DIFF
--- a/snmp_standard/mode/diskio.pm
+++ b/snmp_standard/mode/diskio.pm
@@ -115,6 +115,29 @@ my $maps_counters = {
                       unit => 'iops', min => 0 },
                 ],
             }
+        },  
+    },
+    sum => {
+	'000_sum-read-write'   => { set => {
+		key_values => [ { name => 'sum_read_write', diff => 1 } ],
+		per_second => 1,
+		output_template => 'R+W I/O : %s %s/s', output_error_template => "R+W I/O : %s",
+		output_change_bytes => 1,
+		perfdatas => [
+		    { label => 'sum_read_write', value => 'sum_read_write_per_second', template => '%d',
+		      unit => 'B/s', min => 0 },
+		],
+ 	    }
+	}, 
+        '001_sum-read-write-iops'   => { set => {
+                key_values => [ { name => 'sum_read_write_iops', diff => 1 } ],
+                per_second => 1,
+                output_template => 'R+W IOPs : %.2f', output_error_template => "R+W IOPs : %s",
+                perfdatas => [
+                    { label => 'total_read_write_iops', value => 'total_read_write_iops_per_second', template => '%.2f',
+                      unit => 'iops', min => 0 },
+                ],
+            }
         },
     },
 };
@@ -141,8 +164,8 @@ sub new {
 
     $self->{device_id_selected} = {};
     $self->{statefile_value} = centreon::plugins::statefile->new(%options);
-     
-    foreach my $key (('total', 'disk')) {
+    
+    foreach my $key (('total', 'disk', 'sum')) {
         foreach (keys %{$maps_counters->{$key}}) {
             my ($id, $name) = split /_/;
             if (!defined($maps_counters->{$key}->{$_}->{threshold}) || $maps_counters->{$key}->{$_}->{threshold} != 0) {
@@ -165,7 +188,7 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::init(%options);
     
-    foreach my $key (('total', 'disk')) {
+    foreach my $key (('total', 'disk', 'sum')) {
         foreach (keys %{$maps_counters->{$key}}) {
             $maps_counters->{$key}->{$_}->{obj}->init(option_results => $self->{option_results});
         }
@@ -182,7 +205,7 @@ sub check_total {
     foreach (sort keys %{$maps_counters->{total}}) {
         my $obj = $maps_counters->{total}->{$_}->{obj};
         $obj->set(instance => 'global');
-    
+ 	
         my ($value_check) = $obj->execute(values => $self->{global},
                                           new_datas => $self->{new_datas});
 
@@ -192,8 +215,8 @@ sub check_total {
             next;
         }
         my $exit2 = $obj->threshold_check();
-        push @exits, $exit2;
-
+ 	push @exits, $exit2;
+       
         my $output = $obj->output();
         $long_msg .= $long_msg_append . $output;
         $long_msg_append = ', ';
@@ -207,12 +230,57 @@ sub check_total {
     }
 
     my $exit = $self->{output}->get_most_critical(status => [ @exits ]);
+
     if (!$self->{output}->is_status(litteral => 1, value => $exit, compare => 'ok')) {
-        $self->{output}->output_add(severity => $exit,
-                                    short_msg => "Total $short_msg"
+       $self->{output}->output_add(severity => $exit,
+                                    short_msg => "All devices [$short_msg]"
                                     );
     } else {
-        $self->{output}->output_add(short_msg => "Total $long_msg");
+        $self->{output}->output_add(short_msg => "All devices [$long_msg]");
+    }
+}
+
+sub check_sum {
+    my ($self, %options) = @_;
+
+    my ($short_msg, $short_msg_append, $long_msg, $long_msg_append) = ('', '', '', '');
+    my @exits = ();
+    foreach (sort keys %{$maps_counters->{sum}}) {
+        my $obj = $maps_counters->{sum}->{$_}->{obj};
+        $obj->set(instance => 'sum');
+        
+        my ($value_check) = $obj->execute(values => $self->{sum_global},
+                                          new_datas => $self->{new_datas});
+
+        if ($value_check != 0) {
+            $long_msg .= $long_msg_append . $obj->output_error();
+            $long_msg_append = ', ';
+            next;
+        }
+        my $exit2 = $obj->threshold_check();
+        push @exits, $exit2;
+	
+        my $output = $obj->output();
+	
+	$long_msg .= $long_msg_append . $output;
+        $long_msg_append = ', ';
+
+        if (!$self->{output}->is_status(litteral => 1, value => $exit2, compare => 'ok')) {
+            $short_msg .= $short_msg_append . $output;
+            $short_msg_append = ', ';
+        }
+
+        $obj->perfdata();
+    }
+
+    my $exit = $self->{output}->get_most_critical(status => [ @exits ]);
+
+    if (!$self->{output}->is_status(litteral => 1, value => $exit, compare => 'ok')) {
+        $self->{output}->output_add(severity => $exit,
+                                    short_msg => "Server overall [$short_msg]"
+                                    );
+    } else {
+        $self->{output}->output_add(short_msg => "Server overall [$long_msg]");
     }
 }
 
@@ -241,6 +309,7 @@ sub run {
     
     if ($multiple == 1) {
         $self->check_total();
+	$self->check_sum();
         $self->{output}->output_add(severity => 'OK',
                                     short_msg => 'All devices are ok.');
     }
@@ -250,7 +319,7 @@ sub run {
         my @exits;
         foreach (sort keys %{$maps_counters->{disk}}) {
             my $obj = $maps_counters->{disk}->{$_}->{obj};
-        
+            
             $obj->set(instance => $id);
             my ($value_check) = $obj->execute(values => $self->{device_id_selected}->{$id},
                                               new_datas => $self->{new_datas});
@@ -287,7 +356,8 @@ sub run {
             $self->{output}->output_add(short_msg => "Device '" . $self->{device_id_selected}->{$id}->{display} . "' $long_msg");
         }
     }
-    
+ 
+
     $self->{statefile_value}->write(data => $self->{new_datas});
     $self->{output}->display();
     $self->{output}->exit();
@@ -314,12 +384,20 @@ sub add_result {
         $self->{device_id_selected}->{$options{instance}}->{write_iops} = $self->{results}->{$oid_diskIOWrites}->{$oid_diskIOWrites . '.' . $options{instance}};
         $self->{global}->{total_write_iops} += $self->{device_id_selected}->{$options{instance}}->{write_iops};
     }
+
+    if ($self->{global}->{total_read} && $self->{global}->{total_write}) {
+    	$self->{sum_global}->{sum_read_write} = $self->{global}->{total_read} + $self->{global}->{total_write};
+    }
+    if ($self->{global}->{total_read_iops} && $self->{global}->{total_write_iops}) {
+	$self->{sum_global}->{sum_read_write_iops} = $self->{global}->{total_read_iops} + $self->{global}->{total_write_iops};
+    }
 }
 
 sub manage_selection {
     my ($self, %options) = @_;
     
     $self->{global} = { total_read => 0, total_write => 0, total_read_iops => 0, total_write_iops => 0 };
+    $self->{sum_global} = { sum_read_write => 0, sum_read_write_iops => 0 };
     $self->{results} = $self->{snmp}->get_multiple_table(oids => [
                                                             { oid => $oid_diskIODevice },
                                                             { oid => $oid_diskIOReads },
@@ -340,7 +418,7 @@ sub manage_selection {
             $oid =~ /\.(\d+)$/;
             my $instance = $1;
             my $filter_name = $self->{results}->{$oid_diskIODevice}->{$oid}; 
-            if (!defined($self->{option_results}->{device}) || $self->{option_results}->{device} eq '') {
+            if (!defined($self->{option_results}->{device})) {
                 $self->add_result(instance => $instance);
                 next;
             }
@@ -400,13 +478,15 @@ Check read/write I/O disks (bytes per secondes, IOPs).
 
 Threshold warning.
 Can be: 'read', 'write', 'read-iops', 'write-iops',
-'total-read', 'total-write', 'total-read-iops', 'total-write-iops'.
+'total-read', 'total-write', 'total-read-iops', 'total-write-iops',
+'sum-read-write', 'sum-read-write-iops'.
 
 =item B<--critical-*>
 
 Threshold critical.
 Can be: 'read', 'write', 'read-iops', 'write-iops',
-'total-read', 'total-write', 'total-read-iops', 'total-write-iops'.
+'total-read', 'total-write', 'total-read-iops', 'total-write-iops',
+'sum-read-write', 'sum-read-write-iops'.
 
 =item B<--device>
 

--- a/snmp_standard/mode/diskio.pm
+++ b/snmp_standard/mode/diskio.pm
@@ -134,7 +134,7 @@ my $maps_counters = {
                 per_second => 1,
                 output_template => 'R+W IOPs : %.2f', output_error_template => "R+W IOPs : %s",
                 perfdatas => [
-                    { label => 'total_read_write_iops', value => 'total_read_write_iops_per_second', template => '%.2f',
+                    { label => 'sum_read_write_iops', value => 'sum_read_write_iops_per_second', template => '%.2f',
                       unit => 'iops', min => 0 },
                 ],
             }


### PR DESCRIPTION
Hello,

I made a modification of this plugin in order to have the sum of reads and writes (IO and IOps) on different disks.

Example : 
OK: All devices [Read I/O : 0.00 B/s, Write I/O : 529.63 KB/s, Read IOPs : 0.00, Write IOPs : 19.61] - Server overall [R+W I/O : 529.63 KB/s, R+W IOPs : 19.61] - All devices are ok. | 'total_read'=0B/s;;;0; 'total_write'=542344B/s;;;0; 'total_read_iops'=0.00iops;;;0; 'total_write_iops'=19.61iops;;;0; 'sum_read_write'=542344B/s;;;0; 'sum_read_write_iops'=19.61iops;;;0; 'read_sda'=0B/s;;;0; 'write_sda'=438626B/s;;;0; 'read_iops_sda'=0.00iops;;;0; 'write_iops_sda'=10.45iops;;;0; 'read_sdb'=0B/s;;;0; 'write_sdb'=103718B/s;;;0; 'read_iops_sdb'=0.00iops;;;0; 'write_iops_sdb'=9.16iops;;;0;

In the first part "All devices", we have the sum of reads on all disks and the sum of writes on all disks (IO and IOPs) as it is in the actual plugin.

In the second part "Server overall", we have the sum of reads and writes on all disks (IO and IOPs).

If you have any question don't hesitate to contact me.
Best regards.
Rym R.