### PR TITLE
Fix warning for stack ports

### DIFF
--- a/snmp_standard/mode/interfaces.pm
+++ b/snmp_standard/mode/interfaces.pm
@@ -1217,6 +1217,13 @@ sub add_result_cast {
         }
     }
     
+    $self->{interface_selected}->{$options{instance}}->{iucast} = 0 unless defined $self->{interface_selected}->{$options{instance}}->{iucast};
+    $self->{interface_selected}->{$options{instance}}->{imcast} = 0 unless defined $self->{interface_selected}->{$options{instance}}->{imcast};
+    $self->{interface_selected}->{$options{instance}}->{ibcast} = 0 unless defined $self->{interface_selected}->{$options{instance}}->{ibcast};
+    $self->{interface_selected}->{$options{instance}}->{oucast} = 0 unless defined $self->{interface_selected}->{$options{instance}}->{oucast};
+    $self->{interface_selected}->{$options{instance}}->{omcast} = 0 unless defined $self->{interface_selected}->{$options{instance}}->{omcast};
+    $self->{interface_selected}->{$options{instance}}->{obcast} = 0 unless defined $self->{interface_selected}->{$options{instance}}->{obcast};
+    
     $self->{interface_selected}->{$options{instance}}->{total_in_packets} = $self->{interface_selected}->{$options{instance}}->{iucast} + $self->{interface_selected}->{$options{instance}}->{imcast} + $self->{interface_selected}->{$options{instance}}->{ibcast};
     $self->{interface_selected}->{$options{instance}}->{total_out_packets} = $self->{interface_selected}->{$options{instance}}->{oucast} + $self->{interface_selected}->{$options{instance}}->{omcast} + $self->{interface_selected}->{$options{instance}}->{obcast};
 }


### PR DESCRIPTION
Fixing Use of uninitialized value in addition (+) at /usr/local/plugins/libexec/snmp_standard/mode/interfaces.pm line 1220.

Problem occurs on CBS31X0 running Version 15.0(2)SE6:
IfName reports specific interfaces for stack port whitch doesn't exists in the counters:
IF-MIB::ifName.5195 = STRING: "StackPort1"
IF-MIB::ifName.5196 = STRING: "StackSub-St1-1"
IF-MIB::ifName.5197 = STRING: "StackSub-St1-2"
IF-MIB::ifName.5198 = STRING: "StackPort2"
IF-MIB::ifName.5199 = STRING: "StackSub-St2-1"
IF-MIB::ifName.5200 = STRING: "StackSub-St2-2"

IF-MIB::ifOutErrors.5195 = Counter32: 0
IF-MIB::ifOutErrors.5198 = Counter32: 0


This solution sets the missing values to 0.