### PR TITLE
Provide user feedback thu echo command

### DIFF
--- a/apps/selenium/mode/scenario.pm
+++ b/apps/selenium/mode/scenario.pm
@@ -124,8 +124,7 @@ sub run {
     my $step = $listActionNode->get_nodelist;
     my $temp_step = 0;
     my $stepOk = 0;
-    my $last_echo_msg = undef;
-    my $last_cmd = undef;
+    my ($last_echo_msg, $last_cmd);
     my $exit1 = 'UNKNOWN';
     foreach my $actionNode ($listActionNode->get_nodelist) {
         ($action, $filter, $value) = $xp->find('./td', $actionNode)->get_nodelist;
@@ -149,6 +148,8 @@ sub run {
         # in case of a failure as an info message
         } elsif ($trim_action eq 'echo'){
             $last_echo_msg = $trim_filter;
+            # Prevent output breakage in case of echo message contains invalid chars
+            $last_echo_msg =~ s/\||\n/ - /msg;
             $stepOk += 1;
         } else {
             my $exit_command;

--- a/apps/selenium/mode/scenario.pm
+++ b/apps/selenium/mode/scenario.pm
@@ -91,7 +91,7 @@ sub check_options {
         alarm($self->{option_results}->{timeout});
     }
     if (!defined($self->{option_results}->{scenario})) { 
-        $self->{output}->add_option_msg(short_msg => "Please specify a scenario name" . $self->{option_results}->{scenario} . ".");
+        $self->{output}->add_option_msg(short_msg => "Please specify a scenario name.");
         $self->{output}->option_exit();
     }
 }
@@ -124,6 +124,8 @@ sub run {
     my $step = $listActionNode->get_nodelist;
     my $temp_step = 0;
     my $stepOk = 0;
+    my $last_echo_msg = undef;
+    my $last_cmd = undef;
     my $exit1 = 'UNKNOWN';
     foreach my $actionNode ($listActionNode->get_nodelist) {
         ($action, $filter, $value) = $xp->find('./td', $actionNode)->get_nodelist;
@@ -142,11 +144,16 @@ sub run {
             sleep($sleepTime / 1000);
             $stepOk++;
             $self->{output}->output_add(long_msg => "Step " . $temp_step . " - Pause : " . $sleepTime . "ms");
+        # It's an echo command => do not send it to Selenium server
+        # and store the associated string so that it can be displayed
+        # in case of a failure as an info message
         } elsif ($trim_action eq 'echo'){
-            next;
+            $last_echo_msg = $trim_filter;
+            $stepOk += 1;
         } else {
             my $exit_command;
             
+            $last_cmd = $trim_action . ' ' . $trim_filter . ' ' . $trim_value;
             eval {
                 $exit_command = $sel->do_command($trim_action, $trim_filter, $trim_value);
             };
@@ -172,8 +179,17 @@ sub run {
     my $exit2 = $self->{perfdata}->threshold_check(value => $timeelapsed,
                                                    threshold => [ { label => 'critical', exit_litteral => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
     my $exit = $self->{output}->get_most_critical(status => [ $exit1, $exit2 ]);
-    $self->{output}->output_add(severity => $exit,
-                                short_msg => sprintf("%d/%d steps (%.3fs)", $stepOk, $step, $timeelapsed));
+    if ($exit eq 'OK') {
+        $self->{output}->output_add(severity => $exit,
+                                    short_msg => sprintf("%d/%d steps (%.3fs)", $stepOk, $step, $timeelapsed));
+    } else {
+        my $extra_info = $last_cmd;
+        if (defined($last_echo_msg)) {
+            $extra_info .= " - $last_echo_msg";
+        }
+        $self->{output}->output_add(severity => $exit,
+                                    short_msg => sprintf("%d/%d steps (%.3fs) - %s", $stepOk, $step, $timeelapsed, $extra_info));
+    }
     $self->{output}->perfdata_add(label => "time", unit => 's',
                                   value => sprintf('%.3f', $timeelapsed),
                                   min => 0,


### PR DESCRIPTION
This PR adds information in the output in case of "non OK" status (last command + last echo command if provided in the scenario)

Note that the way to use "echo" in scenario is documented in WAA on doc-dev (not yet on documentation.centreon.com)

Output:

```bash
# Nouvelle sonde, scenario OK, sans echo
 ./centreon_plugins.pl  --plugin=apps::selenium::plugin --mode=scenario --selenium-hostname=192.168.56.211 --selenium-port=4444 --directory=/var/lib/centreon_waa --scenario=scenario-local --warning=15 --critical=20
OK: 7/7 steps (6.775s) | 'time'=6.775s;0:15;0:20;0; 'steps'=7;;;0;7 'availability'=100%;;;0;100

# Nouvelle sonde, scenario KO, sans echo
 ./centreon_plugins.pl  --plugin=apps::selenium::plugin --mode=scenario --selenium-hostname=192.168.56.211 --selenium-port=4444 --directory=/var/lib/centreon_waa --scenario=scenario-local --warning=15 --critical=20
CRITICAL: 5/7 steps (6.816s) - clickAndWait link=Srvices  | 'time'=6.816s;0:15;0:20;0; 'steps'=5;;;0;7 'availability'=71%;;;0;100

# Nouvelle sonde, scenario OK, avec echo
./centreon_plugins.pl  --plugin=apps::selenium::plugin --mode=scenario --selenium-hostname=192.168.56.211 --selenium-port=4444 --directory=/var/lib/centreon_waa --scenario=scenario-local-avec-echo --warning=15 --critical=20
OK: 11/11 steps (13.092s) | 'time'=13.092s;0:15;0:20;0; 'steps'=11;;;0;11 'availability'=100%;;;0;100

# Nouvelle sonde, scenario KO



, avec echo
 ./centreon_plugins.pl  --plugin=apps::selenium::plugin --mode=scenario --selenium-hostname=192.168.56.211 --selenium-port=4444 --directory=/var/lib/centreon_waa --scenario=scenario-local-avec-echo --warning=15 --critical=20
CRITICAL: 8/11 steps (2.359s) - clickAndWait link=Srvices  - Ouverture services | 'time'=2.359s;0:15;0:20;0; 'steps'=8;;;0;11 'availability'=72%;;;0;100
```

Also remove a Perl warning if no scenario file is given as param.
