### PR TITLE
Problème avec la gestion des seuils

### DIFF
--- a/database/postgres/mode/timesync.pm
+++ b/database/postgres/mode/timesync.pm
@@ -74,7 +74,7 @@ SELECT extract(epoch FROM now()) AS epok
     }
     
     my $diff = $result - $ltime;
-    my $exit_code = $self->{perfdata}->threshold_check(value => $result, threshold => [ { label => 'critical', 'exit_litteral' => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
+    my $exit_code = $self->{perfdata}->threshold_check(value => $diff, threshold => [ { label => 'critical', 'exit_litteral' => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
     
     $self->{output}->output_add(severity => $exit_code,
                                 short_msg => sprintf("%.3fs time diff between servers", $diff));


### PR DESCRIPTION
Bug: on comparait le timestamp avec les seuils alors qu'il faut comparer la différence (timestamp - localtime)