### PR TITLE
fix traffic for RHEL7

### DIFF
--- a/os/linux/local/mode/traffic.pm
+++ b/os/linux/local/mode/traffic.pm
@@ -128,8 +128,25 @@ sub manage_selection {
         next if (defined($self->{option_results}->{name}) && !defined($self->{option_results}->{use_regexp}) && !defined($self->{option_results}->{use_regexpi})
             && $interface_name ne $self->{option_results}->{name});
 
-        $values =~ /RX bytes:(\S+).*?TX bytes:(\S+)/msi;
-        $self->{result}->{$interface_name} = {state => $states, in => $1, out => $2};
+        my $in=undef;
+        my $out=undef;
+
+        if ($values =~ /(?:(?:RX bytes)(?:[[\sa-zA-Z:]+)([0-9]+)(?:\sbytes){0,1})|(?:RX)(?:[[\sa-zA-Z0-9:]+)(?:bytes\s)([0-9]+)/ms){
+            $in = $1;
+            if ($1 eq "")
+            {
+                $in = $2;
+            }
+        }
+
+        if ($values =~ /(?:(?:TX bytes)(?:[[\sa-zA-Z:]+)([0-9]+)(?:\sbytes){0,1})|(?:TX)(?:[[\sa-zA-Z0-9:]+)(?:bytes\s)([0-9]+)/ms){
+            $out = $1;
+            if ($1 eq "")
+            {
+                $out = $2;
+            }
+        }
+        $self->{result}->{$interface_name} = {state => $states, in => $in, out => $out};
     }
     
     if (scalar(keys %{$self->{result}}) <= 0) {


### PR DESCRIPTION
the network check is not working with rhel7 systems.

RHEL7 ifconfig:
RX packets 130978614  bytes 93552141514 (87.1 GiB)
RX errors 0  dropped 86  overruns 0  frame 0
TX packets 123621691  bytes 109981907800 (102.4 GiB)
TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0

RHEL6 ifconfig:
RX packets:15109919 errors:0 dropped:0 overruns:0 frame:0
TX packets:13222273 errors:0 dropped:0 overruns:0 carrier:0
collisions:0 txqueuelen:1000
RX bytes:8451113127 (7.8 GiB)  TX bytes:28249980454 (26.3 GiB)


The regex is wrong because the output of ifconfig is changed.
