### PR TITLE
Update sonus plugin package namespace

### DIFF
--- a/network/sonus/sbc/plugin.pm
+++ b/network/sonus/sbc/plugin.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package network::sonus::sbc::snmp::plugin;
+package network::sonus::sbc::plugin;
 
 use strict;
 use warnings;


### PR DESCRIPTION
Sonus plugin had an incorrect package namespace which was causing it to load incorrectly.