### PR TITLE
To remove the line breaks in the description.

### DIFF
--- a/centreon/common/cisco/standard/snmp/mode/environment.pm
+++ b/centreon/common/cisco/standard/snmp/mode/environment.pm
@@ -123,8 +123,8 @@ sub snmp_execute {
     
     push @{$self->{request}}, { oid => $oid_entPhysicalDescr }, { oid => $oid_ciscoEnvMonPresent };
     $self->{results} = $self->{snmp}->get_multiple_table(oids => $self->{request});
-    foreach my $k (keys(%{$self->{results}->{$oid_entPhysicalDescr}})) {
-        $self->{results}->{$oid_entPhysicalDescr}->{$k} =~ s/^\s+|\s+$|[\n\r]+//g;
+    while (my ($key, $value) = each %{$self->{results}->{$oid_entPhysicalDescr}}) {
+        $self->{results}->{$oid_entPhysicalDescr}->{$key} = centreon::plugins::misc::trim($value);
     }
     $self->{output}->output_add(long_msg => sprintf("Environment type: %s", 
                                 defined($self->{results}->{$oid_ciscoEnvMonPresent}->{$oid_ciscoEnvMonPresent . '.0'}) && defined($map_type_mon{$self->{results}->{$oid_ciscoEnvMonPresent}->{$oid_ciscoEnvMonPresent . '.0'}} ) ? 

--- a/centreon/common/cisco/standard/snmp/mode/environment.pm
+++ b/centreon/common/cisco/standard/snmp/mode/environment.pm
@@ -123,6 +123,9 @@ sub snmp_execute {
     
     push @{$self->{request}}, { oid => $oid_entPhysicalDescr }, { oid => $oid_ciscoEnvMonPresent };
     $self->{results} = $self->{snmp}->get_multiple_table(oids => $self->{request});
+    foreach my $k (keys(%{$self->{results}->{$oid_entPhysicalDescr}})) {
+        $self->{results}->{$oid_entPhysicalDescr}->{$k} =~ s/^\s+|\s+$|[\n\r]+//g;
+    }
     $self->{output}->output_add(long_msg => sprintf("Environment type: %s", 
                                 defined($self->{results}->{$oid_ciscoEnvMonPresent}->{$oid_ciscoEnvMonPresent . '.0'}) && defined($map_type_mon{$self->{results}->{$oid_ciscoEnvMonPresent}->{$oid_ciscoEnvMonPresent . '.0'}} ) ? 
                                 $map_type_mon{$self->{results}->{$oid_ciscoEnvMonPresent}->{$oid_ciscoEnvMonPresent . '.0'}} : 'unknown'));

--- a/centreon/common/cisco/standard/snmp/mode/environment.pm
+++ b/centreon/common/cisco/standard/snmp/mode/environment.pm
@@ -24,6 +24,7 @@ use base qw(centreon::plugins::templates::hardware);
 
 use strict;
 use warnings;
+use centreon::plugins::misc;
 
 sub set_system {
     my ($self, %options) = @_;

--- a/centreon/plugins/misc.pm
+++ b/centreon/plugins/misc.pm
@@ -314,8 +314,8 @@ sub trim {
     
     # Sometimes there is a null character
     $value =~ s/\x00$//;
-    $value =~ s/^[ \t]+//;
-    $value =~ s/[ \t]+$//;
+    $value =~ s/^[ \t\n]+//;
+    $value =~ s/[ \t\n]+$//;
     return $value;
 }
 


### PR DESCRIPTION
Example:

```

          '.1.3.6.1.2.1.47.1.1.1.1.2.4954' => 'FixedModule-1 Port-5',
          '.1.3.6.1.2.1.47.1.1.1.1.2.21598' => 'PowerSupply-1 Sensor-1
',
          '.1.3.6.1.2.1.47.1.1.1.1.2.4953' => 'FixedModule-1 Port-4',
          '.1.3.6.1.2.1.47.1.1.1.1.2.149' => 'Nexus5020 Chassis',
```

![capture](https://cloud.githubusercontent.com/assets/16583698/21424889/f4e7ad2a-c845-11e6-93c1-1f8ea53cbab1.PNG)
