### PR TITLE
Add verbose and regexp for stopped resources

### DIFF
--- a/apps/pacemaker/local/mode/crm.pm
+++ b/apps/pacemaker/local/mode/crm.pm
@@ -102,11 +102,13 @@ sub parse_output {
             # Check Resources pos
             if (defined($self->{resources_check}->{$1}) && $self->{resources_check}->{$1} ne $2) {
                 $self->{output}->output_add(severity => $self->{threshold}, 
-                                            short_msg => "Resource '$1' is on node '$2'");
+                                            short_msg => "Resource '$1' is started on node '$2'");
             }
-        } elsif ($line =~ /\s*([0-9a-zA-Z_\-]+)\s+\(\S+\)\:\s+Stopped/) {
+            $self->{output}->output_add(long_msg => "Resource '$1' is started on node '$2'");
+        } elsif ($line =~ /\s*([0-9a-zA-Z_\-]+)\s+\(\S+\)\:\s+Stopped/ || $line =~ /\s*([0-9a-zA-Z_\-]+)\s+\(\S+\)\:\s+\(\S+\)\s+Stopped/) {
             $self->{output}->output_add(severity => $self->{threshold}, 
-                                        short_msg => "Resource '$1' Stopped");
+                                        short_msg => "Resource '$1' is stopped",
+                                        long_msg => "Resource '$1' is stopped");
         } elsif ($line =~ m/\s*stopped\:\s*\[\s*(.*)\s*\]/i) {
             # Check Master/Slave stopped
             my @stopped = ();


### PR DESCRIPTION
Add 'long_msg' options to extend verbose informations
Add an 'or' on stopped resources regexp test to take into account both unmanaged stop and crm stop as the output is not the same :
centengine (ocf::heartbeat:centengine):    Stopped (unmanaged)
centengine (ocf::heartbeat:centengine):    (target-role:Stopped) Stopped