### PR TITLE
Take into account non HTTP samples

### DIFF
--- a/apps/jmeter/mode/scenario.pm
+++ b/apps/jmeter/mode/scenario.pm
@@ -103,7 +103,7 @@ sub run {
     my $p = XML::Parser->new(NoLWP => 1);
     my $xp = XML::XPath->new(parser => $p, xml => $stdout);
 
-    my $listHttpSampleNode = $xp->findnodes('/testResults/httpSample');
+    my $listHttpSampleNode = $xp->findnodes('/testResults/httpSample|/testResults/sample');
 
     my $timing0 = 0;
     my $timing1 = 0;


### PR DESCRIPTION
XML output is slightly different when using non HTTP scenarios with JMeter (for instance for a database test plan).

The attributes of the XML nodes are still the sames.