### PR TITLE
improve processcount

### DIFF
--- a/snmp_standard/mode/processcount.pm
+++ b/snmp_standard/mode/processcount.pm
@@ -42,24 +42,26 @@ sub new {
     $self->{version} = '1.0';
     $options{options}->add_options(arguments =>
                                 { 
-                                  "warning:s"               => { name => 'warning', },
-                                  "critical:s"              => { name => 'critical', },
-                                  "warning-cpu-total:s"     => { name => 'warning_cpu_total', },
-                                  "critical-cpu-total:s"    => { name => 'critical_cpu_total', },
-                                  "warning-mem-total:s"     => { name => 'warning_mem_total', },
-                                  "critical-mem-total:s"    => { name => 'critical_mem_total', },
-                                  "warning-mem-avg:s"       => { name => 'warning_mem_avg', },
-                                  "critical-mem-avg:s"      => { name => 'critical_mem_avg', },
-                                  "process-name:s"          => { name => 'process_name', },
-                                  "regexp-name"             => { name => 'regexp_name', },
-                                  "process-path:s"          => { name => 'process_path', },
-                                  "regexp-path"             => { name => 'regexp_path', },
-                                  "process-args:s"          => { name => 'process_args', },
-                                  "regexp-args"             => { name => 'regexp_args', },
                                   "process-status:s"        => { name => 'process_status', default => 'running|runnable' },
-                                  "memory"                  => { name => 'memory', },
-                                  "cpu"                     => { name => 'cpu', },
-                                  "top"                     => { name => 'top', },
+                                  "process-name:s"          => { name => 'process_name' },
+                                  "regexp-name"             => { name => 'regexp_name' },
+                                  "process-path:s"          => { name => 'process_path' },
+                                  "regexp-path"             => { name => 'regexp_path' },
+                                  "process-args:s"          => { name => 'process_args' },
+                                  "regexp-args"             => { name => 'regexp_args' },
+                                  "warning:s"               => { name => 'warning' },
+                                  "critical:s"              => { name => 'critical' },
+                                  "memory"                  => { name => 'memory' },
+                                  "warning-mem-each:s"      => { name => 'warning_mem_each' },
+                                  "critical-mem-each:s"     => { name => 'critical_mem_each' },
+                                  "warning-mem-total:s"     => { name => 'warning_mem_total' },
+                                  "critical-mem-total:s"    => { name => 'critical_mem_total' },
+                                  "warning-mem-avg:s"       => { name => 'warning_mem_avg' },
+                                  "critical-mem-avg:s"      => { name => 'critical_mem_avg' },
+                                  "cpu"                     => { name => 'cpu' },
+                                  "warning-cpu-total:s"     => { name => 'warning_cpu_total' },
+                                  "critical-cpu-total:s"    => { name => 'critical_cpu_total' },
+                                  "top"                     => { name => 'top' },
                                   "top-num:s"               => { name => 'top_num', default => 5 },
                                   "top-size:s"              => { name => 'top_size', default => 52428800 }, # 50MB
                                 });
@@ -78,6 +80,14 @@ sub check_options {
     }
     if (($self->{perfdata}->threshold_validate(label => 'critical', value => $self->{option_results}->{critical})) == 0) {
         $self->{output}->add_option_msg(short_msg => "Wrong critical threshold '" . $self->{option_results}->{critical} . "'.");
+        $self->{output}->option_exit();
+    }
+    if (($self->{perfdata}->threshold_validate(label => 'warning-mem-each', value => $self->{option_results}->{warning_mem_each})) == 0) {
+        $self->{output}->add_option_msg(short_msg => "Wrong warning-mem-each threshold '" . $self->{warning_mem_each} . "'.");
+        $self->{output}->option_exit();
+    }
+    if (($self->{perfdata}->threshold_validate(label => 'critical-mem-each', value => $self->{option_results}->{critical_mem_each})) == 0) {
+        $self->{output}->add_option_msg(short_msg => "Wrong critical-mem-each threshold '" . $self->{critical_mem_each} . "'.");
         $self->{output}->option_exit();
     }
     if (($self->{perfdata}->threshold_validate(label => 'warning-mem-total', value => $self->{option_results}->{warning_mem_total})) == 0) {
@@ -117,12 +127,15 @@ sub check_options {
     }
 }
 
-my $oids = {
-    name => '.1.3.6.1.2.1.25.4.2.1.2', # hrSWRunName
-    path => '.1.3.6.1.2.1.25.4.2.1.4', # hrSWRunPath
-    args => '.1.3.6.1.2.1.25.4.2.1.5', # hrSWRunParameters (Warning: it's truncated. (128 characters))
-    status => '.1.3.6.1.2.1.25.4.2.1.7', # hrSWRunStatus
+my $filters = {
+    status => { oid => '.1.3.6.1.2.1.25.4.2.1.7', default => 1, value => '', regexp => 1 }, # hrSWRunStatus
+    name => { oid => '.1.3.6.1.2.1.25.4.2.1.2', default => 1, value => '' }, # hrSWRunName (Warning: it's truncated. (15 characters))
+    path => { oid => '.1.3.6.1.2.1.25.4.2.1.4', default => 0, value => '' }, # hrSWRunPath 
+    args => { oid => '.1.3.6.1.2.1.25.4.2.1.5', default => 0, value => '' }, # hrSWRunParameters (Warning: it's truncated. (128 characters))
 };
+
+my $oid_hrSWRunName = '.1.3.6.1.2.1.25.4.2.1.2';
+my $oid_hrSWRunStatus = '.1.3.6.1.2.1.25.4.2.1.7';
 my $oid_hrSWRunPerfMem = '.1.3.6.1.2.1.25.5.1.1.2';
 my $oid_hrSWRunPerfCPU = '.1.3.6.1.2.1.25.5.1.1.1';
 
@@ -130,24 +143,22 @@ sub check_top {
     my ($self, %options) = @_;
     
     my %data = ();
-    foreach (keys %{$self->{results}->{$oids->{name}}}) {
-        if (/^$oids->{name}\.(.*)/ && 
-            defined($self->{results}->{$oid_hrSWRunPerfMem}->{$oid_hrSWRunPerfMem . '.' . $1})) {
-            $data{$self->{results}->{$oids->{name}}->{$_}} = 0 if (!defined($data{$self->{results}->{$oids->{name}}->{$_}}));
-            $data{$self->{results}->{$oids->{name}}->{$_}} += $self->{results}->{$oid_hrSWRunPerfMem}->{$oid_hrSWRunPerfMem . '.' . $1} * 1024;
+    foreach my $key (keys %{$self->{snmp_response}->{$oid_hrSWRunName}}) {
+        if ($key =~ /\.([0-9]+)$/ && defined($self->{snmp_response}->{$oid_hrSWRunPerfMem}->{$oid_hrSWRunPerfMem . '.' . $1})) {
+            $data{$self->{snmp_response}->{$oid_hrSWRunName}->{$key}} = 0 if (!defined($data{$self->{snmp_response}->{$oid_hrSWRunName}->{$key}}));
+            $data{$self->{snmp_response}->{$oid_hrSWRunName}->{$key}} += $self->{snmp_response}->{$oid_hrSWRunPerfMem}->{$oid_hrSWRunPerfMem . '.' . $1} * 1024;
         }
     }
-    
+
     my $i = 1;
     foreach my $name (sort { $data{$b} <=> $data{$a} } keys %data) {
         last if ($i > $self->{option_results}->{top_num});
         last if ($data{$name} < $self->{option_results}->{top_size});
         
-        my ($mem_value, $amem_unit) = $self->{perfdata}->change_bytes(value => $data{$name});
-        $self->{output}->output_add(long_msg => sprintf("Top %d '%s' memory usage: %s %s", $i, $name, $mem_value, $amem_unit));
+        my ($mem_value, $mem_unit) = $self->{perfdata}->change_bytes(value => $data{$name});
+        $self->{output}->output_add(long_msg => sprintf("Top %d '%s' memory usage: %s %s", $i, $name, $mem_value, $mem_unit));
         $self->{output}->perfdata_add(label => 'top_' . $name, unit => 'B',
-                                      value => $data{$name},
-                                      min => 0);        
+                                      value => $data{$name}, min => 0);        
         $i++;
     }
 }
@@ -156,94 +167,74 @@ sub run {
     my ($self, %options) = @_;
     $self->{snmp} = $options{snmp};
 
-    my $oid2check_filter = 'status';
-    # To have a better order
-    foreach (('name', 'path', 'args', 'status')) {
-        if (defined($self->{option_results}->{'process_' . $_}) && $self->{option_results}->{'process_' . $_} ne '') {
-            $oid2check_filter = $_;
-            last;
+    my $extra_oids = [];
+    foreach my $filter (keys %$filters) {
+        if (defined($self->{option_results}->{'process_' . $filter}) && $self->{option_results}->{'process_' . $filter} ne '') {
+            $filters->{$filter}->{value} = $self->{option_results}->{'process_' . $filter};
+
+            if ($filters->{$filter}->{default} == 0) {
+                push @{$extra_oids}, $filters->{$filter}->{oid};
+            }
+        }
+        if (defined($self->{option_results}->{'regexp_' . $filter})) {
+            $filters->{$filter}->{regexp} = 1;
         }
     }
-    # Build other
-    my $mores_filters = {};
-    my $more_oids = [];
     if (defined($self->{option_results}->{memory})) {
-        push @{$more_oids}, $oid_hrSWRunPerfMem;
+        push @{$extra_oids}, $oid_hrSWRunPerfMem;
     }
     if (defined($self->{option_results}->{cpu})) {
-        push @{$more_oids}, $oid_hrSWRunPerfCPU;
-    }
-    foreach (keys %$oids) {
-        if ($_ ne $oid2check_filter && defined($self->{option_results}->{'process_' . $_}) && $self->{option_results}->{'process_' . $_} ne '') {
-            push @{$more_oids}, $oids->{$_};
-            $mores_filters->{$_} = 1;
-        }
+        push @{$extra_oids}, $oid_hrSWRunPerfCPU;
     }
 
-    my $oids_multiple_table = [ { oid => $oids->{$oid2check_filter} } ];
+    my $oids_multiple_table = [ { oid => $oid_hrSWRunName }, { oid => $oid_hrSWRunStatus } ];
     if (defined($self->{option_results}->{top})) {
-        push @{$oids_multiple_table}, { oid => $oids->{name} };
         push @{$oids_multiple_table}, { oid => $oid_hrSWRunPerfMem };
     }
-    $self->{results} = $self->{snmp}->get_multiple_table(oids => $oids_multiple_table);
-    my $result = $self->{results}->{$oids->{$oid2check_filter}};
-    my $instances_keep = {};
-    foreach my $key ($self->{snmp}->oid_lex_sort(keys %{$result})) {
-        my $option_val = $self->{option_results}->{'process_' . $oid2check_filter};
-        
-        if ($oid2check_filter eq 'status') {
-            if ($map_process_status{$result->{$key}} =~ /$option_val/) {
-                $key =~ /\.([0-9]+)$/;
-                $instances_keep->{$1} = 1;
+
+    # First lookup on name and status
+    $self->{snmp_response} = $self->{snmp}->get_multiple_table(oids => $oids_multiple_table);
+    foreach my $key ($self->{snmp}->oid_lex_sort(keys %{$self->{snmp_response}->{$oid_hrSWRunName}})) {
+        $key =~ /\.([0-9]+)$/;
+        my $pid = $1;
+        $self->{results}->{$pid}->{name} = $self->{snmp_response}->{$oid_hrSWRunName}->{$oid_hrSWRunName.'.'.$pid};
+        $self->{results}->{$pid}->{status} = $map_process_status{$self->{snmp_response}->{$oid_hrSWRunStatus}->{$oid_hrSWRunStatus.'.'.$pid}};
+
+        foreach my $filter (keys %$filters) {
+            next if !defined($self->{results}->{$pid}) || $filters->{$filter}->{value} eq '' || $filters->{$filter}->{default} == 0;
+            
+            if ((defined($filters->{$filter}->{regexp}) && $self->{results}->{$pid}->{$filter} !~ /$filters->{$filter}->{value}/)
+                || (!defined($filters->{$filter}->{regexp}) && $self->{results}->{$pid}->{$filter} ne $filters->{$filter}->{value})) {
+                    delete $self->{results}->{$pid};
             }
-        } elsif ((defined($self->{option_results}->{'regexp_' . $oid2check_filter}) && $result->{$key} =~ /$option_val/)
-                 || (!defined($self->{option_results}->{'regexp_' . $oid2check_filter}) && $result->{$key} eq $option_val)) {
-            $key =~ /\.([0-9]+)$/;
-            $instances_keep->{$1} = 1;
+        }
+    }
+    
+    # Second lookup on extra oids
+    if (scalar(keys %{$self->{results}}) > 0) {
+        if (scalar(@$extra_oids) > 0) {
+            $self->{snmp}->load(oids => $extra_oids, instances => [ keys %{$self->{results}} ]);
+            $self->{snmp_response_extra} = $self->{snmp}->get_leef();
+
+            foreach my $pid (keys %{$self->{results}}) {
+                foreach my $filter (keys %$filters) {
+                    next if !defined($self->{results}->{$pid}) || $filters->{$filter}->{value} eq '' || $filters->{$filter}->{default} == 1;
+
+                    if ((defined($filters->{$filter}->{regexp}) && $self->{snmp_response_extra}->{$filters->{$filter}->{oid}.'.'.$pid} !~ /$filters->{$filter}->{value}/)
+                        || (!defined($filters->{$filter}->{regexp}) && $self->{snmp_response_extra}->{$filters->{$filter}->{oid}.'.'.$pid} ne $filters->{$filter}->{value})) {
+                            delete $self->{results}->{$pid};
+                    } else {
+                        $self->{results}->{$pid}->{$filter} = $self->{snmp_response_extra}->{$filters->{$filter}->{oid}.'.'.$pid};
+                    }
+                }
+            }
         }
     }
 
-    my $result2;
-    my $datas = {};
-    $datas->{last_timestamp} = time();
-    if (scalar(keys %$instances_keep) > 0) {
-        if (scalar(@$more_oids) > 0) {
-            $self->{snmp}->load(oids => $more_oids, instances => [ keys %$instances_keep ]);
-            $result2 = $self->{snmp}->get_leef();
-        }
-    
-        foreach my $key (keys %$instances_keep) {
-            my $value = ($oid2check_filter eq 'status') ? $map_process_status{$result->{$oids->{$oid2check_filter} . '.' . $key}} : $result->{$oids->{$oid2check_filter} . '.' . $key};       
-            my $long_value = '[ ' . $oid2check_filter . ' => ' . $value . ' ]';
-            my $deleted = 0;
-            foreach (keys %$mores_filters) {
-                my $opt_val = $self->{option_results}->{'process_' . $_};
-                $value = ($_ eq 'status') ? $map_process_status{$result2->{$oids->{$_} . '.' . $key}} : $result2->{$oids->{$_} . '.' . $key};
-                
-                if ($_ eq 'status') {
-                    if ($value !~ /$opt_val/) {
-                        delete $instances_keep->{$key};
-                        $deleted = 1;
-                        last;
-                    }
-                } elsif ((defined($self->{option_results}->{'regexp_' . $_}) && $value !~ /$opt_val/)
-                    || (!defined($self->{option_results}->{'regexp_' . $_}) && $value ne $opt_val)) {
-                    delete $instances_keep->{$key};
-                    $deleted = 1;
-                    last;
-                }
-                
-                $long_value .= ' [ ' . $_ . ' => ' . $value . ' ]';
-            }
-            
-            if ($deleted == 0) {
-                $self->{output}->output_add(long_msg => 'Process: ' . $long_value);
-            }
-        }
-    }
-    
-    my $num_processes_match = scalar(keys(%$instances_keep));
-    my $exit = $self->{perfdata}->threshold_check(value => $num_processes_match, threshold => [ { label => 'critical', 'exit_litteral' => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
+    my $num_processes_match = scalar(keys(%{$self->{results}}));
+    my $exit = $self->{perfdata}->threshold_check(value => $num_processes_match, 
+                                                  threshold => [ { label => 'critical', exit_litteral => 'critical' }, 
+                                                                 { label => 'warning', exit_litteral => 'warning' } ]);
     $self->{output}->output_add(severity => $exit,
                                 short_msg => "Number of current processes running: $num_processes_match");
     $self->{output}->perfdata_add(label => 'nbproc',
@@ -251,14 +242,27 @@ sub run {
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                   critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical'),
                                   min => 0);
+
     # Check memory
     if (defined($self->{option_results}->{memory}) && $num_processes_match > 0) {
         my $total_memory = 0;
-        foreach my $key (keys %$instances_keep) {
-            $total_memory += ($result2->{$oid_hrSWRunPerfMem . "." . $key} * 1024);
+        foreach my $pid (keys %{$self->{results}}) {
+            $total_memory += ($self->{snmp_response_extra}->{$oid_hrSWRunPerfMem . "." . $pid} * 1024);
+            my ($memory_value, $memory_unit) = $self->{perfdata}->change_bytes(value => $self->{snmp_response_extra}->{$oid_hrSWRunPerfMem.'.'.$pid} * 1024);
+            $self->{results}->{$pid}->{memory} = $memory_value . " " . $memory_unit;
+
+            $exit = $self->{perfdata}->threshold_check(value => $self->{snmp_response_extra}->{$oid_hrSWRunPerfMem.'.'.$pid} * 1024, 
+                                                       threshold => [ { label => 'critical-mem-each', exit_litteral => 'critical' }, 
+                                                                      { label => 'warning-mem-each', exit_litteral => 'warning' } ]);
+            if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
+                $self->{output}->output_add(severity => $exit,
+                                            short_msg => sprintf("Process '%s' [pid: %s] memory usage: %.2f %s", $self->{results}->{$pid}->{name}, $pid, $memory_value, $memory_unit));
+            }
         }
         
-        $exit = $self->{perfdata}->threshold_check(value => $total_memory, threshold => [ { label => 'critical-mem-total', 'exit_litteral' => 'critical' }, { label => 'warning-mem-total', exit_litteral => 'warning' } ]);
+        my $exit = $self->{perfdata}->threshold_check(value => $total_memory, 
+                                                      threshold => [ { label => 'critical-mem-total', exit_litteral => 'critical' }, 
+                                                                     { label => 'warning-mem-total', exit_litteral => 'warning' } ]);
         my ($total_mem_value, $total_mem_unit) = $self->{perfdata}->change_bytes(value => $total_memory);
         $self->{output}->output_add(severity => $exit,
                                     short_msg => sprintf("Total memory usage: %s", $total_mem_value . " " . $total_mem_unit));
@@ -268,7 +272,9 @@ sub run {
                                       critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical_mem_total'),
                                       min => 0);
                                       
-        $exit = $self->{perfdata}->threshold_check(value => $total_memory / $num_processes_match, threshold => [ { label => 'critical-mem-avg', 'exit_litteral' => 'critical' }, { label => 'warning-mem-avg', exit_litteral => 'warning' } ]);
+        $exit = $self->{perfdata}->threshold_check(value => $total_memory / $num_processes_match, 
+                                                   threshold => [ { label => 'critical-mem-avg', exit_litteral => 'critical' }, 
+                                                                  { label => 'warning-mem-avg', exit_litteral => 'warning' } ]);
         my ($avg_mem_value, $avg_mem_unit) = $self->{perfdata}->change_bytes(value => $total_memory / $num_processes_match);
         $self->{output}->output_add(severity => $exit,
                                     short_msg => sprintf("Average memory usage: %.2f %s", $avg_mem_value, $avg_mem_unit));
@@ -278,27 +284,28 @@ sub run {
                                       critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical_avg_total'),
                                       min => 0);
     }
-    
+
     # Check cpu
     if (defined($self->{option_results}->{cpu}) && $num_processes_match > 0) {
-        $self->{hostname} = $self->{snmp}->get_hostname();
-        $self->{snmp_port} = $self->{snmp}->get_port();
+        my $datas = {};
+        $datas->{last_timestamp} = time();
 
-        $self->{statefile_cache}->read(statefile => "snmpstandard_" . $self->{hostname}  . '_' . $self->{snmp_port} . '_' . $self->{mode} . '_' . md5_hex($self->{filter4md5}));
+        $self->{statefile_cache}->read(statefile => "snmpstandard_" . $self->{snmp}->get_hostname() . '_' . 
+                                        $self->{snmp}->get_port() . '_' . $self->{mode} . '_' . md5_hex($self->{filter4md5}));
         my $old_timestamp = $self->{statefile_cache}->get(name => 'last_timestamp');
         
         my $total_cpu = 0;
         my $checked = 0;
-        foreach my $key (keys %$instances_keep) {
-            $datas->{'cpu_' . $key} = $result2->{$oid_hrSWRunPerfCPU . "." . $key};
-            my $old_cpu = $self->{statefile_cache}->get(name => 'cpu_' . $key);
+        foreach my $pid (keys %{$self->{results}}) {
+            $datas->{'cpu_' . $pid} = $self->{snmp_response_extra}->{$oid_hrSWRunPerfCPU . "." . $pid};
+            my $old_cpu = $self->{statefile_cache}->get(name => 'cpu_' . $pid);
             # No value added
             if (!defined($old_cpu) || !defined($old_timestamp)) {
-                $self->{output}->output_add(long_msg => 'Buffer creation for process pid ' . $key . '...');
+                $self->{results}->{$pid}->{cpu} = 'Buffer creation...';
                 next;
             }
             # Go back to zero
-            if ($old_cpu > $datas->{'cpu_' . $key}) {
+            if ($old_cpu > $datas->{'cpu_' . $pid}) {
                 $old_cpu = 0;
             }
             my $time_delta = ($datas->{last_timestamp} - $old_timestamp);
@@ -307,14 +314,16 @@ sub run {
                 $time_delta = 1;
             }
             
-            $total_cpu += (($datas->{'cpu_' . $key} - $old_cpu) / $time_delta);
+            $total_cpu += (($datas->{'cpu_' . $pid} - $old_cpu) / $time_delta);
+            $self->{results}->{$pid}->{cpu} = sprintf("%.2f %%", ($datas->{'cpu_' . $pid} - $old_cpu) / $time_delta);
             $checked = 1;
         }
         
         if ($checked == 1) {
-            $exit = $self->{perfdata}->threshold_check(value => $total_cpu, threshold => [ { label => 'critical-cpu-total', 'exit_litteral' => 'critical' }, { label => 'warning-cpu-total', exit_litteral => 'warning' } ]);
+            $exit = $self->{perfdata}->threshold_check(value => $total_cpu, threshold => [ { label => 'critical-cpu-total', exit_litteral => 'critical' }, 
+                                                                                           { label => 'warning-cpu-total', exit_litteral => 'warning' } ]);
             $self->{output}->output_add(severity => $exit,
-                                        short_msg => sprintf("CPU Total Usage: %.2f %%", $total_cpu));
+                                        short_msg => sprintf("Total CPU usage: %.2f %%", $total_cpu));
             $self->{output}->perfdata_add(label => 'cpu_total', unit => '%',
                                           value => sprintf("%.2f", $total_cpu),
                                           warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning_cpu_total'),
@@ -326,6 +335,15 @@ sub run {
     }
     
     $self->check_top() if (defined($self->{option_results}->{top}));
+
+    foreach my $pid (keys %{$self->{results}}) {
+        my $long_msg = sprintf("Process '%s' [pid: %s]", $self->{results}->{$pid}->{name}, $pid);
+        for my $key (keys $self->{results}->{$pid}) {
+            next if ($key eq 'name');
+            $long_msg .= sprintf(" [%s: %s]", $key, $self->{results}->{$pid}->{$key});
+        }
+        $self->{output}->output_add(long_msg => $long_msg);
+    }
     
     $self->{output}->display();
     $self->{output}->exit();
@@ -342,78 +360,96 @@ Can also check memory usage and cpu usage.
 
 =over 8
 
+=item B<--process-status>
+
+Filter process status. Can be a regexp. 
+(Default: 'running|runnable').
+
+=item B<--process-name>
+
+Filter process name.
+
+=item B<--regexp-name>
+
+Allows to use regexp to filter process 
+name (with option --process-name).
+
+=item B<--process-path>
+
+Filter process path.
+
+=item B<--regexp-path>
+
+Allows to use regexp to filter process 
+path (with option --process-path).
+
+=item B<--process-args>
+
+Filter process arguments.
+
+=item B<--regexp-args>
+
+Allows to use regexp to filter process 
+arguments (with option --process-args).
+
 =item B<--warning>
 
-Threshold warning (process count).
+Threshold warning of matching processes count.
 
 =item B<--critical>
 
-Threshold critical (process count).
+Threshold critical of matching processes count.
+
+=item B<--memory>
+
+Check memory usage.
+
+=item B<--warning-mem-each>
+
+Threshold warning of memory 
+used by each matching processes (in Bytes).
+
+=item B<--critical-mem-each>
+
+Threshold critical of memory 
+used by each matching processes (in Bytes).
 
 =item B<--warning-mem-total>
 
-Threshold warning in Bytes of total memory usage processes.
+Threshold warning of total 
+memory used by matching processes (in Bytes).
 
 =item B<--critical-mem-total>
 
-Threshold warning in Bytes of total memory usage processes.
+Threshold critical of total 
+memory used by matching processes (in Bytes).
 
 =item B<--warning-mem-avg>
 
-Threshold warning in Bytes of average memory usage processes.
+Threshold warning of average 
+memory used by matching processes (in Bytes).
 
 =item B<--critical-mem-avg>
 
-Threshold warning in Bytes of average memory usage processes.
+Threshold critical of average 
+memory used by matching processes (in Bytes).
+
+=item B<--cpu>
+
+Check cpu usage. Should be used with fix processes.
+If processes pid changes too much, the plugin can't compute values.
 
 =item B<--warning-cpu-total>
 
-Threshold warning in percent of cpu usage for all processes (sum).
+Threshold warning of cpu usage for all processes (in percent).
 CPU usage is in % of one cpu, so maximum can be 100% * number of CPU 
 and a process can have a value greater than 100%.
 
 =item B<--critical-cpu-total>
 
-Threshold critical in percent of cpu usage for all processes (sum).
+Threshold critical of cpu usage for all processes (in percent).
 CPU usage is in % of one cpu, so maximum can be 100% * number of CPU 
 and a process can have a value greater than 100%.
-
-=item B<--process-name>
-
-Check process name.
-
-=item B<--regexp-name>
-
-Allows to use regexp to filter process name (with option --process-name).
-
-=item B<--process-path>
-
-Check process path.
-
-=item B<--regexp-path>
-
-Allows to use regexp to filter process path (with option --process-path).
-
-=item B<--process-args>
-
-Check process args.
-
-=item B<--regexp-args>
-
-Allows to use regexp to filter process args (with option --process-args).
-
-=item B<--process-status>
-
-Check process status (Default: 'running|runnable'). Can be a regexp.
-
-=item B<--memory>
-
-Check memory.
-
-=item B<--cpu>
-
-Check cpu usage. Should be used with fix processes.
-if processes pid changes too much, the plugin can compute values.
 
 =item B<--top>
 
@@ -421,11 +457,12 @@ Enable top memory usage display.
 
 =item B<--top-num>
 
-Number of processes in the top (Default: 5).
+Number of processes in top memory display (Default: 5).
 
 =item B<--top-size>
 
-Minimum memory usage to be in the top (Default: 52428800 -> 50 MB).
+Minimum memory usage to be in top memory display 
+(Default: 52428800 -> 50 MB).
 
 =back
 


### PR DESCRIPTION
- Add name lookup each time to make long output better. Also add PID.
```
# perl /usr/lib/centreon/plugins/centreon-plugins/centreon_plugins.pl --plugin=os::linux::snmp::plugin --mode=processcount --hostname=localhost --process-name='cbd' --regexp-name --verbose
OK: Number of current processes running: 2 | 'nbproc'=2;;;0;
Process 'cbd' [pid: 113682] [status: runnable]
Process 'cbd' [pid: 888] [status: runnable]
```

- Add memory and CPU usage to long output.
```
# perl /usr/lib/centreon/plugins/centreon-plugins/centreon_plugins.pl --plugin=os::linux::snmp::plugin --mode=processcount --hostname=localhost --process-name='cbd' --regexp-name --memory --cpu --verbose
OK: Number of current processes running: 2 - Total memory usage: 18.23 MB - Average memory usage: 9.12 MB - Total CPU usage: 0.00 % | 'nbproc'=2;;;0; 'mem_total'=19120128B;;;0; 'mem_avg'=9560064.00B;;;0; 'cpu_total'=0.00%;;;0;
Process 'cbd' [pid: 113682] [memory: 13.83 MB] [cpu: 0.00 %] [status: runnable]
Process 'cbd' [pid: 888] [memory: 4.40 MB] [cpu: 0.00 %] [status: runnable]
```

- Add the possibility to put thresholds on memory usage per processes. And show the problem in short output.
```
# perl /usr/lib/centreon/plugins/centreon-plugins/centreon_plugins.pl --plugin=os::linux::snmp::plugin --mode=processcount --hostname=localhost --process-name='cbd' --regexp-name --process-args='.*' --regexp-args --process-path='.*' --regexp-path --critical='2:2' --memory --warning-mem-each=12000000 --cpu --verbose
WARNING: Process 'cbd' [pid: 113682] memory usage: 13.83 MB | 'nbproc'=2;;2:2;0; 'mem_total'=19120128B;;;0; 'mem_avg'=9560064.00B;;;0; 'cpu_total'=0.65%;;;0;
Process 'cbd' [pid: 113682] [memory: 13.83 MB] [cpu: 0.47 %] [status: runnable] [args: /etc/centreon-broker/central-broker.xml] [path: /usr/sbin/cbd]
Process 'cbd' [pid: 888] [memory: 4.40 MB] [cpu: 0.18 %] [status: runnable] [args: /etc/centreon-broker/central-rrd.xml] [path: /usr/sbin/cbd]
```

- Rearrange options listing and improve help message.