### PR TITLE
Ntlmv2

### DIFF
--- a/apps/protocols/http/mode/expectedcontent.pm
+++ b/apps/protocols/http/mode/expectedcontent.pm
@@ -43,7 +43,7 @@ sub new {
             "urlpath:s"             => { name => 'url_path' },
             "credentials"           => { name => 'credentials' },
             "ntlm"                  => { name => 'ntlm' },
-	    "ntlmv2"		    => { name => 'ntlmv2' },
+            "ntlmv2"                => { name => 'ntlmv2' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },

--- a/apps/protocols/http/mode/expectedcontent.pm
+++ b/apps/protocols/http/mode/expectedcontent.pm
@@ -43,6 +43,7 @@ sub new {
             "urlpath:s"             => { name => 'url_path' },
             "credentials"           => { name => 'credentials' },
             "ntlm"                  => { name => 'ntlm' },
+	    "ntlmv2"		    => { name => 'ntlmv2' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
@@ -200,6 +201,10 @@ Specify this option if you access webpage over basic authentication
 =item B<--ntlm>
 
 Specify this option if you access webpage over ntlm authentication (Use with --credentials option)
+
+=item B<--ntlmv2>
+
+Specify this option if you access webpage over ntlmv2 authentication (Use with --credentials and --port options)
 
 =item B<--username>
 

--- a/apps/protocols/http/mode/jsoncontent.pm
+++ b/apps/protocols/http/mode/jsoncontent.pm
@@ -47,6 +47,7 @@ sub new {
             "urlpath:s"             => { name => 'url_path' },
             "credentials"           => { name => 'credentials' },
             "ntlm"                  => { name => 'ntlm' },
+	    "ntlmv2"		    => { name => 'ntlmv2' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
@@ -397,6 +398,10 @@ Specify this option if you access webpage over basic authentication
 =item B<--ntlm>
 
 Specify this option if you access webpage over ntlm authentication (Use with --credentials option)
+
+=item B<--ntlmv2>
+
+Specify this option if you access webpage over ntlmv2 authentication (Use with --credentials and --port options)
 
 =item B<--username>
 

--- a/apps/protocols/http/mode/jsoncontent.pm
+++ b/apps/protocols/http/mode/jsoncontent.pm
@@ -47,7 +47,7 @@ sub new {
             "urlpath:s"             => { name => 'url_path' },
             "credentials"           => { name => 'credentials' },
             "ntlm"                  => { name => 'ntlm' },
-	    "ntlmv2"		    => { name => 'ntlmv2' },
+            "ntlmv2"                => { name => 'ntlmv2' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },

--- a/apps/protocols/http/mode/response.pm
+++ b/apps/protocols/http/mode/response.pm
@@ -43,6 +43,7 @@ sub new {
          "urlpath:s"     => { name => 'url_path' },
          "credentials"   => { name => 'credentials' },
          "ntlm"          => { name => 'ntlm' },
+	 "ntlmv2"	 => { name => 'ntlmv2' },
          "username:s"    => { name => 'username' },
          "password:s"    => { name => 'password' },
          "proxyurl:s"    => { name => 'proxyurl' },
@@ -178,6 +179,10 @@ Specify this option if you access webpage over basic authentication
 =item B<--ntlm>
 
 Specify this option if you access webpage over ntlm authentication (Use with --credentials option)
+
+=item B<--ntlmv2>
+
+Specify this option if you access webpage over ntlmv2 authentication (Use with --credentials and --port options)
 
 =item B<--username>
 

--- a/apps/protocols/http/mode/response.pm
+++ b/apps/protocols/http/mode/response.pm
@@ -43,7 +43,7 @@ sub new {
          "urlpath:s"     => { name => 'url_path' },
          "credentials"   => { name => 'credentials' },
          "ntlm"          => { name => 'ntlm' },
-	 "ntlmv2"	 => { name => 'ntlmv2' },
+         "ntlmv2"        => { name => 'ntlmv2' },
          "username:s"    => { name => 'username' },
          "password:s"    => { name => 'password' },
          "proxyurl:s"    => { name => 'proxyurl' },

--- a/apps/protocols/http/mode/soapcontent.pm
+++ b/apps/protocols/http/mode/soapcontent.pm
@@ -47,6 +47,7 @@ sub new {
             "urlpath:s"             => { name => 'url_path' },
             "credentials"           => { name => 'credentials' },
             "ntlm"                  => { name => 'ntlm' },
+	    "ntlmv2"		    => { name => 'ntlmv2' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
@@ -424,6 +425,10 @@ Specify this option if you access webpage over basic authentication
 =item B<--ntlm>
 
 Specify this option if you access webpage over ntlm authentication (Use with --credentials option)
+
+=item B<--ntlmv2>
+
+Specify this option if you access webpage over ntlmv2 authentication (Use with --credentials and --port options)
 
 =item B<--username>
 

--- a/apps/protocols/http/mode/soapcontent.pm
+++ b/apps/protocols/http/mode/soapcontent.pm
@@ -47,7 +47,7 @@ sub new {
             "urlpath:s"             => { name => 'url_path' },
             "credentials"           => { name => 'credentials' },
             "ntlm"                  => { name => 'ntlm' },
-	    "ntlmv2"		    => { name => 'ntlmv2' },
+            "ntlmv2"                => { name => 'ntlmv2' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },

--- a/centreon/plugins/http.pm
+++ b/centreon/plugins/http.pm
@@ -26,6 +26,7 @@ use LWP::UserAgent;
 use HTTP::Cookies;
 use URI;
 use IO::Socket::SSL;
+use Data::Dumper;
 
 sub new {
     my ($class, %options) = @_;
@@ -264,9 +265,13 @@ sub request {
             $req->content($uri_post->query);
         }
     }
-
+    
     if (defined($request_options->{credentials}) && defined($request_options->{ntlm})) {
         $self->{ua}->credentials($request_options->{hostname} . ':' . $request_options->{port}, '', $request_options->{username}, $request_options->{password});
+    } elsif (defined($request_options->{credentials}) && defined($request_options->{ntlmv2})) {
+	eval "use Authen::NTLM"; die $@ if $@;
+	ntlmv2(1);
+	$self->{ua}->credentials($request_options->{hostname} . ':' . $request_options->{port}, '', $request_options->{username}, $request_options->{password});
     } elsif (defined($request_options->{credentials})) {
         $req->authorization_basic($request_options->{username}, $request_options->{password});
     }

--- a/centreon/plugins/http.pm
+++ b/centreon/plugins/http.pm
@@ -26,7 +26,6 @@ use LWP::UserAgent;
 use HTTP::Cookies;
 use URI;
 use IO::Socket::SSL;
-use Data::Dumper;
 
 sub new {
     my ($class, %options) = @_;
@@ -269,9 +268,10 @@ sub request {
     if (defined($request_options->{credentials}) && defined($request_options->{ntlm})) {
         $self->{ua}->credentials($request_options->{hostname} . ':' . $request_options->{port}, '', $request_options->{username}, $request_options->{password});
     } elsif (defined($request_options->{credentials}) && defined($request_options->{ntlmv2})) {
-	eval "use Authen::NTLM"; die $@ if $@;
-	ntlmv2(1);
-	$self->{ua}->credentials($request_options->{hostname} . ':' . $request_options->{port}, '', $request_options->{username}, $request_options->{password});
+        centreon::plugins::misc::mymodule_load(output => $self->{output}, module => 'Authen::NTLM',
+                                               error_msg => "Cannot load module 'Authen::NTLM'.");
+        Authen::NTLM::ntlmv2(1);
+        $self->{ua}->credentials($request_options->{hostname} . ':' . $request_options->{port}, '', $request_options->{username}, $request_options->{password});
     } elsif (defined($request_options->{credentials})) {
         $req->authorization_basic($request_options->{username}, $request_options->{password});
     }


### PR DESCRIPTION
Add support of NTLMv2 authentication.

You will need to install perl-NTLM-1.09-5.el7.noarch from EPEL repository to use the 1.09 version of Authen::NTLM to support V2 authentication.