### PR TITLE
improve authentification handling

### DIFF
--- a/apps/protocols/http/mode/expectedcontent.pm
+++ b/apps/protocols/http/mode/expectedcontent.pm
@@ -198,10 +198,6 @@ Set path to get Webpage (Default: '/')
 
 Specify this option if you access webpage over basic authentication
 
-=item B<--ntlm>
-
-Specify this option if you access webpage over ntlm authentication (Use with --credentials option)
-
 =item B<--ntlmv2>
 
 Specify this option if you access webpage over ntlmv2 authentication (Use with --credentials and --port options)

--- a/apps/protocols/http/mode/jsoncontent.pm
+++ b/apps/protocols/http/mode/jsoncontent.pm
@@ -395,10 +395,6 @@ Set path to get Webpage (Default: '/')
 
 Specify this option if you access webpage over basic authentication
 
-=item B<--ntlm>
-
-Specify this option if you access webpage over ntlm authentication (Use with --credentials option)
-
 =item B<--ntlmv2>
 
 Specify this option if you access webpage over ntlmv2 authentication (Use with --credentials and --port options)

--- a/apps/protocols/http/mode/response.pm
+++ b/apps/protocols/http/mode/response.pm
@@ -176,10 +176,6 @@ Set path to get webpage (Default: '/')
 
 Specify this option if you access webpage over basic authentication
 
-=item B<--ntlm>
-
-Specify this option if you access webpage over ntlm authentication (Use with --credentials option)
-
 =item B<--ntlmv2>
 
 Specify this option if you access webpage over ntlmv2 authentication (Use with --credentials and --port options)

--- a/apps/protocols/http/mode/soapcontent.pm
+++ b/apps/protocols/http/mode/soapcontent.pm
@@ -422,10 +422,6 @@ Set path to get Webpage (Default: '/')
 
 Specify this option if you access webpage over basic authentication
 
-=item B<--ntlm>
-
-Specify this option if you access webpage over ntlm authentication (Use with --credentials option)
-
 =item B<--ntlmv2>
 
 Specify this option if you access webpage over ntlmv2 authentication (Use with --credentials and --port options)

--- a/centreon/plugins/useragent.pm
+++ b/centreon/plugins/useragent.pm
@@ -42,8 +42,9 @@ sub new {
 sub get_basic_credentials {
     my($self, $realm, $uri, $proxy) = @_;
     return if $proxy;
-    return $self->{username}, $self->{password} if $self->{credentials};
-    return undef, undef;
+    return $self->{username}, $self->{password} if $self->{credentials} and wantarray;
+    return $self->{username}.":".$self->{password} if $self->{credentials};
+    return undef;
 }
 
 1;

--- a/centreon/plugins/useragent.pm
+++ b/centreon/plugins/useragent.pm
@@ -1,0 +1,49 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::plugins::useragent;
+
+use strict;
+use warnings;
+use base 'LWP::UserAgent';
+
+sub new {
+    my ($class, %options) = @_;
+    my $self  = {};
+    bless $self, $class;
+
+    $self = LWP::UserAgent::new(@_);
+    $self->agent("centreon::plugins::useragent");
+
+    $self->{credentials} = $options{credentials} if defined($options{credentials});
+    $self->{username} = $options{username} if defined($options{username});
+    $self->{password} = $options{password} if defined($options{password});
+
+    return $self;
+}
+
+sub get_basic_credentials {
+    my($self, $realm, $uri, $proxy) = @_;
+    return if $proxy;
+    return $self->{username}, $self->{password} if $self->{credentials};
+    return undef, undef;
+}
+
+1;


### PR DESCRIPTION
Subclassed _get_basic_credentials_ so it gives back the credentials provided in command line, and doesn't store them in the basic_authentication hash (http://search.cpan.org/~ether/libwww-perl-6.31/lib/LWP/UserAgent.pm#get_basic_credentials). 
This way, requests can be done on web servers asking for Basic, NTLM, NTLMv2 or Digest authentification.

Authen::NTLM > 1.04 is still needed for NTLMv2 authentification (cf @pkriko commits https://github.com/centreon/centreon-plugins/commit/d33a1c217eabc63158cab5e38a3cd56526940dac).

Option _--ntlm_ is now useless but remains for compatibility.

In case of _401_ error, the output will show you the expected authentification type.