### PR TITLE
fix metric name in meta service mode

### DIFF
--- a/apps/centreon/local/mode/metaservice.pm
+++ b/apps/centreon/local/mode/metaservice.pm
@@ -219,7 +219,7 @@ sub run {
     my $display = defined($row->{meta_display}) ? $row->{meta_display} : $row->{calcul_type} . ' - value : %f';
     $self->{output}->output_add(severity => $exit,
                                 short_msg => sprintf($display, $result));
-    $self->{output}->perfdata_add(label => (defined($DSTYPE{$row->{data_source_type}}) ? $DSTYPE{$row->{data_source_type}} : 'g') . '[value]', 
+    $self->{output}->perfdata_add(label => (defined($DSTYPE{$row->{data_source_type}}) ? $DSTYPE{$row->{data_source_type}} : 'g') . '[' . $row->{metric} . ']', 
                                   value => sprintf("%02.2f", $result),
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                   critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical')


### PR DESCRIPTION
Change metric name from 'value' to real metric name.

Ref.: https://github.com/centreon/centreon-plugins/issues/874