### PR TITLE
update hardware.pm

### DIFF
--- a/network/bluecoat/snmp/mode/hardware.pm
+++ b/network/bluecoat/snmp/mode/hardware.pm
@@ -38,11 +38,12 @@ sub set_system {
             ['ok', 'OK'],
             ['unavailable', 'UNKNOWN'],
             ['nonoperational', 'UNKNOWN'],
+            ['unknown', 'UNKNOWN'],
         ],
         sensor => [    
             ['ok', 'OK'],
             ['unknown', 'UNKNOWN'],
-            ['nonInstalled', 'OK'],
+            ['notInstalled', 'OK'],
             ['voltageLowWarning', 'WARNING'],
             ['voltageLowCritical', 'CRITICAL'],
             ['noPower', 'CRITICAL'],


### PR DESCRIPTION
# Statuts différent pour les operationnal status et sensor 

[root@server~]# /usr/lib/nagios/plugins/centreon_plugins.pl --plugin=network::bluecoat::snmp::plugin --mode=hardware --hostname='x.x.x.x' --snmp-version='2c' --snmp-community='neuronesit_csc_ro' --snmp-timeout='30' --verbose
OK: All 71 components are ok [8/8 disks, 63/63 sensors]. | 'DIMM A1 temperature'=34C;;;; 'DIMM A2 temperature'=34C;;;; 'DIMM B1 temperature'=32C;;;; 'DIMM B2 temperature'=151C;;;; 'DIMM C1 temperature'=151C;;;; 'DIMM C2 temperature'=151C;;;; 'Front panel temperature'=23C;;;; 'Midplane center temperature'=27C;;;; 'Midplane left temperature'=26C;;;; 'Midplane right temperature'=26C;;;; 'PCH temperature'=46C;;;; 'Power supply 1 core temperature'=31C;;;; 'Power supply 2 core temperature'=29C;;;; 'Power supply inlet temperature'=26C;;;; 'SAS controller temperature'=39C;;;; 'SSL card temperature'=26C;;;; 'System center temperature'=39C;;;; 'System left temperature'=34C;;;; 'System right temperature'=35C;;;; 'CPU temperature'=42C;;;; 'Power supply 1 fan speed'=12000rpm;;;; 'Power supply 2 fan speed'=12100rpm;;;; 'Power supply 1 front fan speed'=15100rpm;;;; 'Power supply 1 rear fan speed'=15100rpm;;;; 'Power supply 2 front fan speed'=15100rpm;;;; 'Power supply 2 rear fan speed'=15100rpm;;;; 'System fan 1 front speed'=8100rpm;;;; 'System fan 1 rear speed'=6900rpm;;;; 'System fan 2 front speed'=8000rpm;;;; 'System fan 2 rear speed'=6800rpm;;;; 'System fan 3 front speed'=8100rpm;;;; 'System fan 3 rear speed'=6800rpm;;;; 'System fan 4 front speed'=8100rpm;;;; 'System fan 4 rear speed'=6800rpm;;;; 'System fan 5 front speed'=8100rpm;;;; 'System fan 5 rear speed'=6800rpm;;;; 'System fan 6 front speed'=8000rpm;;;; 'System fan 6 rear speed'=6900rpm;;;; '+1.1V standby voltage'=1.1172V;;;; '+12V main bus 1 voltage'=12.155V;;;; '+12V main bus 2 voltage'=12.09V;;;; '+3.3V main bus voltage'=3.292V;;;; '+3.3V standby voltage'=3.247V;;;; '+5V main bus voltage'=5.0232V;;;; '+5V standby voltage'=5.0508V;;;; '+3V battery voltage'=3.072V;;;; 'BMC memory voltage'=1.552V;;;; 'BMC PLL voltage'=1.264V;;;; 'CPU core voltage'=0.8134V;;;; 'CPU PLL voltage'=1.8326V;;;; 'CPU system agent voltage'=0.9016V;;;; 'CPU termination voltage'=1.064V;;;; 'Memory I/O voltage'=1.52V;;;; 'Memory termination voltage'=0.744V;;;; 'PCH core voltage'=1.12V;;;; 'PCH SAS voltage'=1.52V;;;; 'SAS core voltage'=1.048V;;;; 'SAS I/O voltage'=1.8326V;;;; 'SSL core voltage'=0.904V;;;; 'SSL PLL voltage'=1.8V;;;; 'SSL VPTX voltage'=1.8V;;;;
Checking sensors
Sensor 'DIMM A1 temperature' status is 'ok' [instance: 1, operational status: ok, value: 34, scale: 0, unit: C]
Sensor 'DIMM A2 temperature' status is 'ok' [instance: 2, operational status: ok, value: 34, scale: 0, unit: C]
Sensor 'DIMM B1 temperature' status is 'ok' [instance: 3, operational status: ok, value: 32, scale: 0, unit: C]
Sensor 'DIMM B2 temperature' status is 'notInstalled' [instance: 4, operational status: unknown, value: 151, scale: 0, unit: C]
Sensor 'DIMM C1 temperature' status is 'notInstalled' [instance: 5, operational status: unknown, value: 151, scale: 0, unit: C]
Sensor 'DIMM C2 temperature' status is 'notInstalled' [instance: 6, operational status: unknown, value: 151, scale: 0, unit: C]
Sensor 'Front panel temperature' status is 'ok' [instance: 7, operational status: ok, value: 23, scale: 0, unit: C]
Sensor 'Midplane center temperature' status is 'ok' [instance: 8, operational status: ok, value: 27, scale: 0, unit: C]
Sensor 'Midplane left temperature' status is 'ok' [instance: 9, operational status: ok, value: 26, scale: 0, unit: C]
Sensor 'Midplane right temperature' status is 'ok' [instance: 10, operational status: ok, value: 26, scale: 0, unit: C]
Sensor 'PCH temperature' status is 'ok' [instance: 11, operational status: ok, value: 46, scale: 0, unit: C]
Sensor 'Power supply 1 core temperature' status is 'ok' [instance: 12, operational status: ok, value: 31, scale: 0, unit: C]
Sensor 'Power supply 2 core temperature' status is 'ok' [instance: 13, operational status: ok, value: 29, scale: 0, unit: C]
Sensor 'Power supply inlet temperature' status is 'ok' [instance: 14, operational status: ok, value: 26, scale: 0, unit: C]
Sensor 'SAS controller temperature' status is 'ok' [instance: 15, operational status: ok, value: 39, scale: 0, unit: C]
Sensor 'SSL card temperature' status is 'notInstalled' [instance: 16, operational status: unknown, value: 26, scale: 0, unit: C]
Sensor 'System center temperature' status is 'ok' [instance: 17, operational status: ok, value: 39, scale: 0, unit: C]
Sensor 'System left temperature' status is 'ok' [instance: 18, operational status: ok, value: 34, scale: 0, unit: C]
Sensor 'System right temperature' status is 'ok' [instance: 19, operational status: ok, value: 35, scale: 0, unit: C]
Sensor 'CPU temperature' status is 'ok' [instance: 20, operational status: ok, value: 42, scale: 0, unit: C]
Sensor 'Power supply 1 fan speed' status is 'ok' [instance: 21, operational status: ok, value: 12000, scale: 0, unit: rpm]
Sensor 'Power supply 2 fan speed' status is 'ok' [instance: 22, operational status: ok, value: 12100, scale: 0, unit: rpm]
Sensor 'Power supply 1 front fan speed' status is 'notInstalled' [instance: 23, operational status: unknown, value: 15100, scale: 0, unit: rpm]
Sensor 'Power supply 1 rear fan speed' status is 'notInstalled' [instance: 24, operational status: unknown, value: 15100, scale: 0, unit: rpm]
Sensor 'Power supply 2 front fan speed' status is 'notInstalled' [instance: 25, operational status: unknown, value: 15100, scale: 0, unit: rpm]
Sensor 'Power supply 2 rear fan speed' status is 'notInstalled' [instance: 26, operational status: unknown, value: 15100, scale: 0, unit: rpm]
Sensor 'System fan 1 front speed' status is 'ok' [instance: 27, operational status: ok, value: 8100, scale: 0, unit: rpm]
Sensor 'System fan 1 rear speed' status is 'ok' [instance: 28, operational status: ok, value: 6900, scale: 0, unit: rpm]
Sensor 'System fan 2 front speed' status is 'ok' [instance: 29, operational status: ok, value: 8000, scale: 0, unit: rpm]
Sensor 'System fan 2 rear speed' status is 'ok' [instance: 30, operational status: ok, value: 6800, scale: 0, unit: rpm]
Sensor 'System fan 3 front speed' status is 'ok' [instance: 31, operational status: ok, value: 8100, scale: 0, unit: rpm]
Sensor 'System fan 3 rear speed' status is 'ok' [instance: 32, operational status: ok, value: 6800, scale: 0, unit: rpm]
Sensor 'System fan 4 front speed' status is 'ok' [instance: 33, operational status: ok, value: 8100, scale: 0, unit: rpm]
Sensor 'System fan 4 rear speed' status is 'ok' [instance: 34, operational status: ok, value: 6800, scale: 0, unit: rpm]
Sensor 'System fan 5 front speed' status is 'ok' [instance: 35, operational status: ok, value: 8100, scale: 0, unit: rpm]
Sensor 'System fan 5 rear speed' status is 'ok' [instance: 36, operational status: ok, value: 6800, scale: 0, unit: rpm]
Sensor 'System fan 6 front speed' status is 'ok' [instance: 37, operational status: ok, value: 8000, scale: 0, unit: rpm]
Sensor 'System fan 6 rear speed' status is 'ok' [instance: 38, operational status: ok, value: 6900, scale: 0, unit: rpm]
Sensor '+1.1V standby voltage' status is 'ok' [instance: 39, operational status: ok, value: 11172, scale: -4, unit: V]
Sensor '+12V main bus 1 voltage' status is 'ok' [instance: 40, operational status: ok, value: 12155, scale: -3, unit: V]
Sensor '+12V main bus 2 voltage' status is 'ok' [instance: 41, operational status: ok, value: 12090, scale: -3, unit: V]
Sensor '+3.3V main bus voltage' status is 'ok' [instance: 42, operational status: ok, value: 3292, scale: -3, unit: V]
Sensor '+3.3V standby voltage' status is 'ok' [instance: 43, operational status: ok, value: 3247, scale: -3, unit: V]
Sensor '+5V main bus voltage' status is 'ok' [instance: 44, operational status: ok, value: 50232, scale: -4, unit: V]
Sensor '+5V standby voltage' status is 'ok' [instance: 45, operational status: ok, value: 50508, scale: -4, unit: V]
Sensor '+3V battery voltage' status is 'ok' [instance: 46, operational status: ok, value: 3072, scale: -3, unit: V]
Sensor 'BMC memory voltage' status is 'ok' [instance: 47, operational status: ok, value: 1552, scale: -3, unit: V]
Sensor 'BMC PLL voltage' status is 'ok' [instance: 48, operational status: ok, value: 1264, scale: -3, unit: V]
Sensor 'CPU core voltage' status is 'ok' [instance: 49, operational status: ok, value: 8134, scale: -4, unit: V]
Sensor 'CPU PLL voltage' status is 'ok' [instance: 50, operational status: ok, value: 18326, scale: -4, unit: V]
Sensor 'CPU system agent voltage' status is 'ok' [instance: 51, operational status: ok, value: 9016, scale: -4, unit: V]
Sensor 'CPU termination voltage' status is 'ok' [instance: 52, operational status: ok, value: 1064, scale: -3, unit: V]
Sensor 'Memory I/O voltage' status is 'ok' [instance: 53, operational status: ok, value: 1520, scale: -3, unit: V]
Sensor 'Memory termination voltage' status is 'ok' [instance: 54, operational status: ok, value: 744, scale: -3, unit: V]
Sensor 'PCH core voltage' status is 'ok' [instance: 55, operational status: ok, value: 1120, scale: -3, unit: V]
Sensor 'PCH SAS voltage' status is 'ok' [instance: 56, operational status: ok, value: 1520, scale: -3, unit: V]
Sensor 'SAS core voltage' status is 'ok' [instance: 57, operational status: ok, value: 1048, scale: -3, unit: V]
Sensor 'SAS I/O voltage' status is 'ok' [instance: 58, operational status: ok, value: 18326, scale: -4, unit: V]
Sensor 'SSL core voltage' status is 'notInstalled' [instance: 59, operational status: unknown, value: 904, scale: -3, unit: V]
Sensor 'SSL PLL voltage' status is 'notInstalled' [instance: 60, operational status: unknown, value: 1800, scale: -3, unit: V]
Sensor 'SSL VPTX voltage' status is 'notInstalled' [instance: 61, operational status: unknown, value: 1800, scale: -3, unit: V]
Sensor 'Power supply 1 status' status is 'ok' [instance: 62, operational status: ok, value: 8, scale: 0, unit: ]
Sensor 'Power supply 2 status' status is 'ok' [instance: 63, operational status: ok, value: 8, scale: 0, unit: ]
Checking disks
Disk 'KZKN5AAH' status is 'present' [instance: 1]
Disk 'KZJK3XJG' status is 'present' [instance: 2]
Disk 'KZKJM81H' status is 'present' [instance: 3]
Disk 'KZKN9KPH' status is 'present' [instance: 4]
Disk 'KZKNVT2G' status is 'present' [instance: 5]
Disk 'KZKNNLZH' status is 'present' [instance: 6]
Disk '' status is 'notpresent' [instance: 7]
Disk '' status is 'notpresent' [instance: 8]