### PR TITLE
Re-calculating Virtual Memory for Windows machines

### DIFF
--- a/os/windows/snmp/mode/swap.pm
+++ b/os/windows/snmp/mode/swap.pm
@@ -29,16 +29,16 @@ sub new {
     my ($class, %options) = @_;
     my $self = $class->SUPER::new(package => __PACKAGE__, %options);
     bless $self, $class;
-    
+
     $self->{version} = '1.0';
     $options{options}->add_options(arguments =>
-                                { 
+                                {
                                   "warning:s"               => { name => 'warning' },
                                   "critical:s"              => { name => 'critical' },
                                 });
 
     $self->{swap_memory_id} = undef;
-    
+
     return $self;
 }
 
@@ -53,7 +53,7 @@ sub check_options {
     if (($self->{perfdata}->threshold_validate(label => 'critical', value => $self->{option_results}->{critical})) == 0) {
        $self->{output}->add_option_msg(short_msg => "Wrong critical threshold '" . $self->{option_results}->{critical} . "'.");
        $self->{output}->option_exit();
-    }    
+    }
 }
 
 sub run {
@@ -61,40 +61,53 @@ sub run {
     $self->{snmp} = $options{snmp};
 
     my $oid_hrStorageDescr = '.1.3.6.1.2.1.25.2.3.1.3';
-    
+
     my $result = $self->{snmp}->get_table(oid => $oid_hrStorageDescr);
-    
+
     foreach my $key (keys %$result) {
         next if ($key !~ /\.([0-9]+)$/);
         my $oid = $1;
         if ($result->{$key} =~ /^Virtual memory$/i) {
             $self->{swap_memory_id} = $oid;
         }
+        if ($result->{$key} =~ /^Physical memory$/i) {
+            $self->{physical_memory_id} = $oid;
+        }
     }
-    
+
     if (!defined($self->{swap_memory_id})) {
+        $self->{output}->add_option_msg(short_msg => "Cannot find virtual memory informations.");
+        $self->{output}->option_exit();
+    }
+    if (!defined($self->{physical_memory_id})) {
         $self->{output}->add_option_msg(short_msg => "Cannot find physical memory informations.");
         $self->{output}->option_exit();
     }
-    
+
     my $oid_hrStorageAllocationUnits = '.1.3.6.1.2.1.25.2.3.1.4';
     my $oid_hrStorageSize = '.1.3.6.1.2.1.25.2.3.1.5';
     my $oid_hrStorageUsed = '.1.3.6.1.2.1.25.2.3.1.6';
 
-    $self->{snmp}->load(oids => [$oid_hrStorageAllocationUnits, $oid_hrStorageSize, $oid_hrStorageUsed], 
+    $self->{snmp}->load(oids => [$oid_hrStorageAllocationUnits, $oid_hrStorageSize, $oid_hrStorageUsed],
+                        instances => [$self->{physical_memory_id}]);
+    $result = $self->{snmp}->get_leef();
+    my $physicalSize = $result->{$oid_hrStorageSize . "." . $self->{physical_memory_id}};
+    my $physicalUsed = $result->{$oid_hrStorageUsed . "." . $self->{physical_memory_id}};
+
+    $self->{snmp}->load(oids => [$oid_hrStorageAllocationUnits, $oid_hrStorageSize, $oid_hrStorageUsed],
                         instances => [$self->{swap_memory_id}]);
     $result = $self->{snmp}->get_leef();
 
-    my $swap_used = $result->{$oid_hrStorageUsed . "." . $self->{swap_memory_id}} * $result->{$oid_hrStorageAllocationUnits . "." . $self->{swap_memory_id}};
-    my $total_size = $result->{$oid_hrStorageSize . "." . $self->{swap_memory_id}} * $result->{$oid_hrStorageAllocationUnits . "." . $self->{swap_memory_id}};
-    
+    my $swap_used = ($result->{$oid_hrStorageUsed . "." . $self->{swap_memory_id}} - $physicalUsed) * $result->{$oid_hrStorageAllocationUnits . "." . $self->{swap_memory_id}};
+    my $total_size = ($result->{$oid_hrStorageSize . "." . $self->{swap_memory_id}} - $physicalSize) * $result->{$oid_hrStorageAllocationUnits . "." . $self->{swap_memory_id}};
+
     my $prct_used = $swap_used * 100 / $total_size;
     my $exit = $self->{perfdata}->threshold_check(value => $prct_used, threshold => [ { label => 'critical', 'exit_litteral' => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
 
     my ($swap_used_value, $swap_used_unit) = $self->{perfdata}->change_bytes(value => $swap_used);
     my ($swap_free_value, $swap_free_unit) = $self->{perfdata}->change_bytes(value => $total_size - $swap_used);
     my ($total_value, $total_unit) = $self->{perfdata}->change_bytes(value => $total_size);
-    
+
     $self->{output}->output_add(severity => $exit,
                                 short_msg => sprintf("Swap Total: %s Used: %s (%.2f%%) Free: %s (%.2f%%)",
                                             $total_value . " " . $total_unit,


### PR DESCRIPTION
For some reason, the virtual memory for windows hosts are not correctly defined in windows machines with SNMP. When you do a request of OID .1.3.6.1.2.1.25.2.3.1.5 instead of gives you the INTEGER for the Virtual memory only, it gives you the sum of all the memory in the System (physycal + virtual)

I've edited the Swap module for windows OS in order to re-calculate the Virtual Memory correctly substracting the physical memory from the virtual memory (.1.3.6.1.2.1.25.2.3.1.5 and .1.3.6.1.2.1.25.2.3.1.6) in order to get the real Virtual Memory.