### PR TITLE
Improve ntp mode empty ntp_hostname option

### DIFF
--- a/snmp_standard/mode/ntp.pm
+++ b/snmp_standard/mode/ntp.pm
@@ -75,7 +75,7 @@ sub run {
         $self->{output}->display();
         $self->{output}->exit();
     }
-    if (defined($self->{option_results}->{ntp_hostname})) {
+    if (defined($self->{option_results}->{ntp_hostname}) && $self->{option_results}->{ntp_hostname} ne '') {
         my %ntp;
         
         eval {


### PR DESCRIPTION
Add check of empty value for --ntp-hostname option.