### PR TITLE
add ssl opt harmonization

### DIFF
--- a/apps/apache/serverstatus/mode/cpuload.pm
+++ b/apps/apache/serverstatus/mode/cpuload.pm
@@ -46,6 +46,7 @@ sub new {
             "warning:s"         => { name => 'warning' },
             "critical:s"        => { name => 'critical' },
             "timeout:s"         => { name => 'timeout' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             });
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     return $self;
@@ -134,15 +135,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--header>
 

--- a/apps/apache/serverstatus/mode/requests.pm
+++ b/apps/apache/serverstatus/mode/requests.pm
@@ -51,6 +51,7 @@ sub new {
             "warning-access:s"  => { name => 'warning_access' },
             "critical-access:s" => { name => 'critical_access' },
             "timeout:s"         => { name => 'timeout' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             });
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     $self->{statefile_value} = centreon::plugins::statefile->new(%options);
@@ -223,15 +224,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--header>
 

--- a/apps/apache/serverstatus/mode/responsetime.pm
+++ b/apps/apache/serverstatus/mode/responsetime.pm
@@ -47,6 +47,7 @@ sub new {
          "warning:s"    => { name => 'warning' },
          "critical:s"   => { name => 'critical' },
          "timeout:s"    => { name => 'timeout' },
+         "ssl-opt:s@"   => { name => 'ssl_opt' },
          "unknown-status:s"     => { name => 'unknown_status', default => '' },
          "warning-status:s"     => { name => 'warning_status' },
          "critical-status:s"    => { name => 'critical_status', default => '%{http_code} < 200 or %{http_code} >= 300' },
@@ -126,11 +127,11 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--proxyurl>
 
@@ -139,6 +140,10 @@ Proxy URL if any
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--header>
 

--- a/apps/apache/serverstatus/mode/slotstates.pm
+++ b/apps/apache/serverstatus/mode/slotstates.pm
@@ -206,6 +206,7 @@ sub new {
                                 "proxyurl:s"    => { name => 'proxyurl' },
                                 "header:s@"     => { name => 'header' },
                                 "timeout:s"     => { name => 'timeout' },
+                                "ssl-opt:s@"    => { name => 'ssl_opt' },
                                 "units:s"       => { name => 'units', default => '%' },
                                 });
     
@@ -347,15 +348,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--header>
 

--- a/apps/apache/serverstatus/mode/workers.pm
+++ b/apps/apache/serverstatus/mode/workers.pm
@@ -46,6 +46,7 @@ sub new {
             "warning:s"     => { name => 'warning' },
             "critical:s"    => { name => 'critical' },
             "timeout:s"     => { name => 'timeout' },
+            "ssl-opt:s@"    => { name => 'ssl_opt' },
             });
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     return $self;
@@ -138,15 +139,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--header>
 

--- a/apps/bluemind/mode/incoming.pm
+++ b/apps/bluemind/mode/incoming.pm
@@ -43,9 +43,11 @@ sub new {
             "database:s"        => { name => 'database' },
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
+            "timeout:s"         => { name => 'timeout' },
+            "proxyurl:s"        => { name => 'proxyurl' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             "warning:s"         => { name => 'warning' },
             "critical:s"        => { name => 'critical' },
-            "timeout:s"         => { name => 'timeout' },
         });
 
     $self->{statefile_value} = centreon::plugins::statefile->new(%options);
@@ -196,9 +198,17 @@ Specify username for API authentification
 
 Specify password for API authentification
 
+=item B<--proxyurl>
+
+Proxy URL if any
+
 =item B<--timeout>
 
-Threshold for HTTP timeout (Default: 3)
+Threshold for HTTP timeout (Default: 5)
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning>
 

--- a/apps/checkmyws/mode/status.pm
+++ b/apps/checkmyws/mode/status.pm
@@ -51,6 +51,7 @@ sub new {
             "proxyurl:s"            => { name => 'proxyurl' },
             "uid:s"                 => { name => 'uid' },
             "timeout:s"             => { name => 'timeout' },
+            "ssl-opt:s@"            => { name => 'ssl_opt' },
             "threshold-overload:s@" => { name => 'threshold_overload' },
         });
 
@@ -203,19 +204,23 @@ Specify https if needed (Default: 'https')
 
 =item B<--urlpath>
 
-Set path to get checkmyws information (Default: 'api/status')
+Set path to get checkmyws information (Default: '/api/status')
 
 =item B<--proxyurl>
 
 Proxy URL if any
 
-=item B<--uid>
-
-ID for checkmyws API
-
 =item B<--timeout>
 
 Threshold for HTTP timeout (Default: 5)
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
+
+=item B<--uid>
+
+ID for checkmyws API
 
 =item B<--threshold-overload>
 

--- a/apps/github/mode/commits.pm
+++ b/apps/github/mode/commits.pm
@@ -43,9 +43,11 @@ sub new {
             "credentials"       => { name => 'credentials' },
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
+            "timeout:s"         => { name => 'timeout' },
+            "proxyurl:s"        => { name => 'proxyurl' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             "owner:s"           => { name => 'owner' },
             "repository:s"      => { name => 'repository' },
-            "timeout:s"         => { name => 'timeout' },
         });
 
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
@@ -153,6 +155,18 @@ Specify username
 
 Specify password
 
+=item B<--proxyurl>
+
+Proxy URL if any
+
+=item B<--timeout>
+
+Threshold for HTTP timeout (Default: 5)
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
+
 =item B<--owner>
 
 Specify GitHub's owner
@@ -160,10 +174,6 @@ Specify GitHub's owner
 =item B<--repository>
 
 Specify GitHub's repository
-
-=item B<--timeout>
-
-Threshold for HTTP timeout (Default: 5)
 
 =back
 

--- a/apps/github/mode/issues.pm
+++ b/apps/github/mode/issues.pm
@@ -41,12 +41,14 @@ sub new {
             "credentials"       => { name => 'credentials' },
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
+            "timeout:s"         => { name => 'timeout' },
+            "proxyurl:s"        => { name => 'proxyurl' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             "warning:s"         => { name => 'warning' },
             "critical:s"        => { name => 'critical' },
             "owner:s"           => { name => 'owner' },
             "repository:s"      => { name => 'repository' },
             "label:s"           => { name => 'label', default => '' },
-            "timeout:s"         => { name => 'timeout' },
         });
 
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
@@ -160,6 +162,18 @@ Specify username
 
 Specify password
 
+=item B<--proxyurl>
+
+Proxy URL if any
+
+=item B<--timeout>
+
+Threshold for HTTP timeout (Default: 5)
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
+
 =item B<--warning>
 
 Threshold warning.
@@ -179,10 +193,6 @@ Specify GitHub's repository
 =item B<--label>
 
 Specify label for issues
-
-=item B<--timeout>
-
-Threshold for HTTP timeout (Default: 3)
 
 =back
 

--- a/apps/github/mode/pullrequests.pm
+++ b/apps/github/mode/pullrequests.pm
@@ -40,12 +40,14 @@ sub new {
             "proto:s"           => { name => 'proto', default => 'https' },
             "credentials"       => { name => 'credentials' },
             "username:s"        => { name => 'username' },
+            "timeout:s"         => { name => 'timeout' },
+            "proxyurl:s"        => { name => 'proxyurl' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             "password:s"        => { name => 'password' },
             "warning:s"         => { name => 'warning' },
             "critical:s"        => { name => 'critical' },
             "owner:s"           => { name => 'owner' },
             "repository:s"      => { name => 'repository' },
-            "timeout:s"         => { name => 'timeout' },
         });
 
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
@@ -145,6 +147,18 @@ Specify username
 
 Specify password
 
+=item B<--proxyurl>
+
+Proxy URL if any
+
+=item B<--timeout>
+
+Threshold for HTTP timeout (Default: 5)
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
+
 =item B<--warning>
 
 Threshold warning.
@@ -160,10 +174,6 @@ Specify GitHub's owner
 =item B<--repository>
 
 Specify GitHub's repository
-
-=item B<--timeout>
-
-Threshold for HTTP timeout (Default: 5)
 
 =back
 

--- a/apps/github/mode/stats.pm
+++ b/apps/github/mode/stats.pm
@@ -43,6 +43,8 @@ sub new {
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
             "timeout:s"         => { name => 'timeout' },
+            "proxyurl:s"        => { name => 'proxyurl' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             "owner:s"           => { name => 'owner' },
             "repository:s"      => { name => 'repository' },
         });
@@ -144,9 +146,17 @@ Specify username
 
 Specify password
 
+=item B<--proxyurl>
+
+Proxy URL if any
+
 =item B<--timeout>
 
 Threshold for HTTP timeout (Default: 5)
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =back
 

--- a/apps/github/mode/status.pm
+++ b/apps/github/mode/status.pm
@@ -43,15 +43,17 @@ sub new {
     $self->{version} = '1.0';
     $options{options}->add_options(arguments =>
         {
-            "hostname:s"        => { name => 'hostname', default => 'status.github.com' },
-            "port:s"            => { name => 'port', default => '443'},
-            "proto:s"           => { name => 'proto', default => 'https' },
-            "urlpath:s"         => { name => 'url_path', default => '/api/last-message.json' },
-            "credentials"       => { name => 'credentials' },
-            "username:s"        => { name => 'username' },
-            "password:s"        => { name => 'password' },
-            "timeout:s"         => { name => 'timeout' },
-            "threshold-overload:s@"   => { name => 'threshold_overload' },
+            "hostname:s"                => { name => 'hostname', default => 'status.github.com' },
+            "port:s"                    => { name => 'port', default => '443'},
+            "proto:s"                   => { name => 'proto', default => 'https' },
+            "urlpath:s"                 => { name => 'url_path', default => '/api/last-message.json' },
+            "credentials"               => { name => 'credentials' },
+            "username:s"                => { name => 'username' },
+            "password:s"                => { name => 'password' },
+            "timeout:s"                 => { name => 'timeout' },
+            "proxyurl:s"                => { name => 'proxyurl' },
+            "ssl-opt:s@"                => { name => 'ssl_opt' },
+            "threshold-overload:s@"     => { name => 'threshold_overload' },
         });
 
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
@@ -164,9 +166,17 @@ Specify username
 
 Specify password
 
+=item B<--proxyurl>
+
+Proxy URL if any
+
 =item B<--timeout>
 
-Threshold for HTTP timeout (Default: 5
+Threshold for HTTP timeout (Default: 5)
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--threshold-overload>
 

--- a/apps/jenkins/mode/jobstate.pm
+++ b/apps/jenkins/mode/jobstate.pm
@@ -40,14 +40,16 @@ sub new {
             "port:s"               => { name => 'port' },
             "proto:s"              => { name => 'proto' },
             "urlpath:s"            => { name => 'url_path' },
-            "jobname:s"            => { name => 'jobname' },
+            "timeout:s"            => { name => 'timeout' },
             "credentials"          => { name => 'credentials' },
             "username:s"           => { name => 'username' },
             "password:s"           => { name => 'password' },
+            "proxyurl:s"           => { name => 'proxyurl' },
+            "ssl-opt:s@"           => { name => 'ssl_opt' },
+            "jobname:s"            => { name => 'jobname' },
             "warning:s"            => { name => 'warning' },
             "critical:s"           => { name => 'critical' },
-            "checkstyle"            => { name => 'checkstyle' },
-            "timeout:s"            => { name => 'timeout' },
+            "checkstyle"           => { name => 'checkstyle' },
         });
 
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
@@ -157,7 +159,7 @@ Specify https if needed (Default: 'http')
 
 Set path to get Jenkins information
 
-=item B <--credentials>
+=item B<--credentials>
 
 Required to use username/password authentication method
 
@@ -168,6 +170,18 @@ Specify username for API authentification
 =item B<--password>
 
 Specify password for API authentification
+
+=item B<--proxyurl>
+
+Proxy URL if any
+
+=item B<--timeout>
+
+Threshold for HTTP timeout (Default: 5)
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning>
 
@@ -180,10 +194,6 @@ Critical Threshold for tendency score
 =item B<--checkstyle>
 
 Add checkstyle's violation output and perfdata
-
-=item B<--timeout>
-
-Threshold for HTTP timeout (Default: 5)
 
 =back
 

--- a/apps/kayako/api/mode/listdepartment.pm
+++ b/apps/kayako/api/mode/listdepartment.pm
@@ -37,14 +37,18 @@ sub new {
 
     $self->{version} = '1.0';
     $options{options}->add_options(arguments =>
-         {
-      "hostname:s"            => { name => 'hostname' },
-      "port:s"                => { name => 'port' },
-      "proto:s"               => { name => 'proto' },
-      "urlpath:s"             => { name => 'url_path', default => '/api/index.php?' },
-      "kayako-api-key:s"      => { name => 'kayako_api_key' },
-      "kayako-secret-key:s"   => { name => 'kayako_secret_key' },
-         });
+            {
+                "hostname:s"            => { name => 'hostname' },
+                "port:s"                => { name => 'port' },
+                "proto:s"               => { name => 'proto' },
+                "urlpath:s"             => { name => 'url_path', default => '/api/index.php?' },
+                "proxyurl:s"            => { name => 'proxyurl' },
+                "timeout:s"             => { name => 'timeout' },
+                "ssl-opt:s@"            => { name => 'ssl_opt' },
+                "kayako-api-key:s"      => { name => 'kayako_api_key' },
+                "kayako-secret-key:s"   => { name => 'kayako_secret_key' },
+            });
+            
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     return $self;
 }
@@ -116,9 +120,17 @@ Specify https if needed
 
 Proxy URL if any
 
-=item B<--kayako-api-url>
+=item B<--urlpath>
 
-This is the URL you should dispatch all GET, POST, PUT & DELETE requests to.
+This is the URL you should dispatch all GET, POST, PUT & DELETE requests to (Default: '/api/index.php?')
+
+=item B<--timeout>
+
+Threshold for HTTP timeout.
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--kayako-api-key>
 

--- a/apps/kayako/api/mode/listpriority.pm
+++ b/apps/kayako/api/mode/listpriority.pm
@@ -37,14 +37,18 @@ sub new {
 
     $self->{version} = '1.0';
     $options{options}->add_options(arguments =>
-         {
-      "hostname:s"            => { name => 'hostname' },
-      "port:s"                => { name => 'port' },
-      "proto:s"               => { name => 'proto' },
-      "urlpath:s"             => { name => 'url_path', default => '/api/index.php?' },
-      "kayako-api-key:s"      => { name => 'kayako_api_key' },
-      "kayako-secret-key:s"   => { name => 'kayako_secret_key' },
-         });
+            {
+                "hostname:s"            => { name => 'hostname' },
+                "port:s"                => { name => 'port' },
+                "proto:s"               => { name => 'proto' },
+                "urlpath:s"             => { name => 'url_path', default => '/api/index.php?' },
+                "proxyurl:s"            => { name => 'proxyurl' },
+                "timeout:s"             => { name => 'timeout' },
+                "ssl-opt:s@"            => { name => 'ssl_opt' },
+                "kayako-api-key:s"      => { name => 'kayako_api_key' },
+                "kayako-secret-key:s"   => { name => 'kayako_secret_key' },
+            });
+            
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     return $self;
 }
@@ -116,9 +120,17 @@ Specify https if needed
 
 Proxy URL if any
 
-=item B<--kayako-api-url>
+=item B<--urlpath>
 
-This is the URL you should dispatch all GET, POST, PUT & DELETE requests to.
+This is the URL you should dispatch all GET, POST, PUT & DELETE requests to (Default: '/api/index.php?')
+
+=item B<--timeout>
+
+Threshold for HTTP timeout.
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--kayako-api-key>
 

--- a/apps/kayako/api/mode/liststaff.pm
+++ b/apps/kayako/api/mode/liststaff.pm
@@ -35,14 +35,17 @@ sub new {
 
     $self->{version} = '1.0';
     $options{options}->add_options(arguments =>
-         {
-      "hostname:s"            => { name => 'hostname' },
-      "port:s"                => { name => 'port' },
-      "proto:s"               => { name => 'proto' },
-      "urlpath:s"             => { name => 'url_path', default => '/api/index.php?' },
-      "kayako-api-key:s"      => { name => 'kayako_api_key' },
-      "kayako-secret-key:s"   => { name => 'kayako_secret_key' },
-         });
+            {
+                "hostname:s"            => { name => 'hostname' },
+                "port:s"                => { name => 'port' },
+                "proto:s"               => { name => 'proto' },
+                "urlpath:s"             => { name => 'url_path', default => '/api/index.php?' },
+                "proxyurl:s"            => { name => 'proxyurl' },
+                "timeout:s"             => { name => 'timeout' },
+                "ssl-opt:s@"            => { name => 'ssl_opt' },
+                "kayako-api-key:s"      => { name => 'kayako_api_key' },
+                "kayako-secret-key:s"   => { name => 'kayako_secret_key' },
+            });
 
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     return $self;
@@ -115,9 +118,17 @@ Specify https if needed
 
 Proxy URL if any
 
-=item B<--kayako-api-url>
+=item B<--urlpath>
 
-This is the URL you should dispatch all GET, POST, PUT & DELETE requests to.
+This is the URL you should dispatch all GET, POST, PUT & DELETE requests to (Default: '/api/index.php?')
+
+=item B<--timeout>
+
+Threshold for HTTP timeout.
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--kayako-api-key>
 

--- a/apps/kayako/api/mode/liststatus.pm
+++ b/apps/kayako/api/mode/liststatus.pm
@@ -35,14 +35,17 @@ sub new {
 
     $self->{version} = '1.0';
     $options{options}->add_options(arguments =>
-         {
-      "hostname:s"            => { name => 'hostname' },
-      "port:s"                => { name => 'port' },
-      "proto:s"               => { name => 'proto' },
-      "urlpath:s"             => { name => 'url_path', default => '/api/index.php?' },
-      "kayako-api-key:s"      => { name => 'kayako_api_key' },
-      "kayako-secret-key:s"   => { name => 'kayako_secret_key' },
-         });
+            {
+                "hostname:s"            => { name => 'hostname' },
+                "port:s"                => { name => 'port' },
+                "proto:s"               => { name => 'proto' },
+                "urlpath:s"             => { name => 'url_path', default => '/api/index.php?' },
+                "proxyurl:s"            => { name => 'proxyurl' },
+                "timeout:s"             => { name => 'timeout' },
+                "ssl-opt:s@"            => { name => 'ssl_opt' },
+                "kayako-api-key:s"      => { name => 'kayako_api_key' },
+                "kayako-secret-key:s"   => { name => 'kayako_secret_key' },
+            });
     
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     return $self;
@@ -115,9 +118,17 @@ Specify https if needed
 
 Proxy URL if any
 
-=item B<--kayako-api-url>
+=item B<--urlpath>
 
-This is the URL you should dispatch all GET, POST, PUT & DELETE requests to.
+This is the URL you should dispatch all GET, POST, PUT & DELETE requests to (Default: '/api/index.php?')
+
+=item B<--timeout>
+
+Threshold for HTTP timeout.
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--kayako-api-key>
 

--- a/apps/kayako/api/mode/ticketcount.pm
+++ b/apps/kayako/api/mode/ticketcount.pm
@@ -46,23 +46,26 @@ sub new {
 
     $self->{version} = '1.0';
     $options{options}->add_options(arguments =>
-         {
-		"hostname:s"            => { name => 'hostname' },
-		"port:s"                => { name => 'port' },
-		"proto:s"               => { name => 'proto' },
-		"urlpath:s"             => { name => 'url_path', default => '/api/index.php?' },
-		"kayako-api-key:s"		=> { name => 'kayako_api_key' },
-		"kayako-secret-key:s"	=> { name => 'kayako_secret_key' },
-		"reload-cache-time:s"   => { name => 'reload_cache_time', default => 180 },
-		"department-id:s"		=> { name => 'department_id' },
-        "staff-id:s"			=> { name => 'staff_id' },
-        "status-id:s"			=> { name => 'status_id' },
-		"priority-id:s"			=> { name => 'priority_id' },
-		"warning:s"				=> { name => 'warning' },
-        "critical:s"            => { name => 'critical' },
-		"start-date:s"			=> { name => 'start_date' },
-        "end-date:s"			=> { name => 'end_date' },
-         });
+            {
+                "hostname:s"            => { name => 'hostname' },
+                "port:s"                => { name => 'port' },
+                "proto:s"               => { name => 'proto' },
+                "urlpath:s"             => { name => 'url_path', default => '/api/index.php?' },
+                "proxyurl:s"            => { name => 'proxyurl' },
+                "timeout:s"             => { name => 'timeout' },
+                "ssl-opt:s@"            => { name => 'ssl_opt' },
+                "kayako-api-key:s"		=> { name => 'kayako_api_key' },
+                "kayako-secret-key:s"	=> { name => 'kayako_secret_key' },
+                "reload-cache-time:s"   => { name => 'reload_cache_time', default => 180 },
+                "department-id:s"		=> { name => 'department_id' },
+                "staff-id:s"			=> { name => 'staff_id' },
+                "status-id:s"			=> { name => 'status_id' },
+                "priority-id:s"			=> { name => 'priority_id' },
+                "warning:s"				=> { name => 'warning' },
+                "critical:s"            => { name => 'critical' },
+                "start-date:s"			=> { name => 'start_date' },
+                "end-date:s"			=> { name => 'end_date' },
+            });
     $self->{statefile_cache} = centreon::plugins::statefile->new(%options);
     $self->{statefile_value} = centreon::plugins::statefile->new(%options);
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
@@ -340,9 +343,17 @@ Specify https if needed
 
 Proxy URL if any
 
-=item B<--kayako-api-url>
+=item B<--urlpath>
 
-This is the URL you should dispatch all GET, POST, PUT & DELETE requests to. (required)
+This is the URL you should dispatch all GET, POST, PUT & DELETE requests to (Default: '/api/index.php?')
+
+=item B<--timeout>
+
+Threshold for HTTP timeout.
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--kayako-api-key>
 

--- a/apps/kingdee/eas/custom/api.pm
+++ b/apps/kingdee/eas/custom/api.pm
@@ -41,13 +41,14 @@ sub new {
     if (!defined($options{noptions})) {
         $options{options}->add_options(arguments => 
                     {
-                      "hostname:s@"     => { name => 'hostname', },
+                      "hostname:s@"     => { name => 'hostname' },
                       "proto:s@"        => { name => 'proto' },
-                      "port:s@"         => { name => 'port', },
-                      "username:s@"     => { name => 'username', },
-                      "password:s@"     => { name => 'password', },
-                      "proxyurl:s@"     => { name => 'proxyurl', },
-                      "timeout:s@"      => { name => 'timeout', },
+                      "port:s@"         => { name => 'port' },
+                      "username:s@"     => { name => 'username' },
+                      "password:s@"     => { name => 'password' },
+                      "proxyurl:s@"     => { name => 'proxyurl' },
+                      "timeout:s@"      => { name => 'timeout' },
+                      "ssl-opt:s@"      => { name => 'ssl_opt' },
                     });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -174,6 +175,10 @@ Proxy URL if any.
 =item B<--timeout>
 
 Set HTTP timeout in seconds (Default: '10').
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =back
 

--- a/apps/nginx/serverstatus/mode/connections.pm
+++ b/apps/nginx/serverstatus/mode/connections.pm
@@ -50,6 +50,7 @@ sub new {
             "password:s"    => { name => 'password' },
             "proxyurl:s"    => { name => 'proxyurl' },
             "timeout:s"     => { name => 'timeout' },
+            "ssl-opt:s@"    => { name => 'ssl_opt' },
             });
     foreach (@{$maps}) {
         $options{options}->add_options(arguments => {
@@ -143,15 +144,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning-*>
 

--- a/apps/nginx/serverstatus/mode/requests.pm
+++ b/apps/nginx/serverstatus/mode/requests.pm
@@ -50,6 +50,7 @@ sub new {
             "password:s"        => { name => 'password' },
             "proxyurl:s"        => { name => 'proxyurl' },
             "timeout:s"         => { name => 'timeout' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             });
     foreach (@{$maps}) {
         $options{options}->add_options(arguments => {
@@ -191,15 +192,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning-*>
 

--- a/apps/nginx/serverstatus/mode/responsetime.pm
+++ b/apps/nginx/serverstatus/mode/responsetime.pm
@@ -46,6 +46,7 @@ sub new {
          "warning:s"    => { name => 'warning' },
          "critical:s"   => { name => 'critical' },
          "timeout:s"    => { name => 'timeout' },
+         "ssl-opt:s@"   => { name => 'ssl_opt' },
          "unknown-status:s"     => { name => 'unknown_status', default => '' },
          "warning-status:s"     => { name => 'warning_status' },
          "critical-status:s"    => { name => 'critical_status', default => '%{http_code} < 200 or %{http_code} >= 300' },
@@ -124,11 +125,11 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--proxyurl>
 
@@ -137,6 +138,10 @@ Proxy URL if any
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--unknown-status>
 

--- a/apps/nsclient/restapi/mode/query.pm
+++ b/apps/nsclient/restapi/mode/query.pm
@@ -197,11 +197,11 @@ Specify this option if you access webpage over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--legacy-password>
 

--- a/apps/php/apc/web/mode/filecache.pm
+++ b/apps/php/apc/web/mode/filecache.pm
@@ -211,6 +211,7 @@ sub new {
                                 "password:s"        => { name => 'password' },
                                 "proxyurl:s"        => { name => 'proxyurl' },
                                 "timeout:s"         => { name => 'timeout', default => 30 },
+                                "ssl-opt:s@"        => { name => 'ssl_opt' },
                                 });
 
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
@@ -278,15 +279,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout (Default: 30)
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning-*>
 

--- a/apps/php/apc/web/mode/memory.pm
+++ b/apps/php/apc/web/mode/memory.pm
@@ -107,6 +107,7 @@ sub new {
                                 "password:s"        => { name => 'password' },
                                 "proxyurl:s"        => { name => 'proxyurl' },
                                 "timeout:s"         => { name => 'timeout', default => 30 },
+                                "ssl-opt:s@"        => { name => 'ssl_opt' },
                                 });
     
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
@@ -175,15 +176,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout (Default: 30)
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning-*>
 

--- a/apps/php/fpm/web/mode/usage.pm
+++ b/apps/php/fpm/web/mode/usage.pm
@@ -151,6 +151,7 @@ sub new {
                                 "password:s"        => { name => 'password' },
                                 "proxyurl:s"        => { name => 'proxyurl' },
                                 "timeout:s"         => { name => 'timeout', default => 5 },
+                                "ssl-opt:s@"        => { name => 'ssl_opt' },
                                 });
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     
@@ -227,6 +228,10 @@ Specify password for basic authentification (Mandatory if --credentials is speci
 =item B<--timeout>
 
 Threshold for HTTP timeout (Default: 5)
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning-*>
 

--- a/apps/redis/restapi/custom/api.pm
+++ b/apps/redis/restapi/custom/api.pm
@@ -51,6 +51,7 @@ sub new {
                         "proxyurl:s@" => { name => 'proxyurl' },
                         "timeout:s@"  => { name => 'timeout' },
                         "ssl:s@"      => { name => 'ssl' },
+                        "ssl-opt:s@"  => { name => 'ssl_opt' },
                     });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -232,9 +233,9 @@ Proxy URL if any
 
 Set HTTP timeout
 
-=item B<--ssl>
+=item B<--ssl-opt>
 
-SSL version (Default: tlsv1)
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =back
 

--- a/apps/tomcat/web/mode/applications.pm
+++ b/apps/tomcat/web/mode/applications.pm
@@ -41,6 +41,7 @@ sub new {
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
             "timeout:s"             => { name => 'timeout' },
+            "ssl-opt:s@"            => { name => 'ssl_opt' },
             "urlpath:s"             => { name => 'url_path', default => '/manager/text/list' },
             "name:s"                => { name => 'name' },
             "regexp"                => { name => 'use_regexp' },
@@ -167,15 +168,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--urlpath>
 

--- a/apps/tomcat/web/mode/listapplication.pm
+++ b/apps/tomcat/web/mode/listapplication.pm
@@ -41,6 +41,7 @@ sub new {
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
             "timeout:s"             => { name => 'timeout' },
+            "ssl-opt:s@"            => { name => 'ssl_opt' },
             "urlpath:s"             => { name => 'url_path', default => '/manager/text/list' },
             "filter-name:s"         => { name => 'filter_name', },
             "filter-state:s"        => { name => 'filter_state', },
@@ -150,15 +151,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--url-path>
 

--- a/apps/tomcat/web/mode/memory.pm
+++ b/apps/tomcat/web/mode/memory.pm
@@ -42,6 +42,7 @@ sub new {
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
             "timeout:s"             => { name => 'timeout' },
+            "ssl-opt:s@"            => { name => 'ssl_opt' },
             "urlpath:s"             => { name => 'url_path', default => '/manager/status?XML=true' },
             "warning:s"             => { name => 'warning' },
             "critical:s"            => { name => 'critical' },
@@ -202,15 +203,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--urlpath>
 

--- a/apps/tomcat/web/mode/requestinfo.pm
+++ b/apps/tomcat/web/mode/requestinfo.pm
@@ -45,6 +45,7 @@ sub new {
             "password:s"                 => { name => 'password' },
             "proxyurl:s"                 => { name => 'proxyurl' },
             "timeout:s"                  => { name => 'timeout' },
+            "ssl-opt:s@"                 => { name => 'ssl_opt' },
             "urlpath:s"                  => { name => 'url_path', default => '/manager/status?XML=true' },
             "name:s"                     => { name => 'name' },
             "regexp"                     => { name => 'use_regexp' },
@@ -344,15 +345,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--urlpath>
 

--- a/apps/tomcat/web/mode/sessions.pm
+++ b/apps/tomcat/web/mode/sessions.pm
@@ -41,6 +41,7 @@ sub new {
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
             "timeout:s"             => { name => 'timeout' },
+            "ssl-opt:s@"            => { name => 'ssl_opt' },
             "urlpath:s"             => { name => 'url_path', default => '/manager/text/list' },
             "warning:s"             => { name => 'warning' },
             "critical:s"            => { name => 'critical' },
@@ -170,15 +171,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--urlpath>
 

--- a/apps/tomcat/web/mode/threads.pm
+++ b/apps/tomcat/web/mode/threads.pm
@@ -43,6 +43,7 @@ sub new {
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
             "timeout:s"             => { name => 'timeout' },
+            "ssl-opt:s@"            => { name => 'ssl_opt' },
             "urlpath:s"             => { name => 'url_path', default => '/manager/status?XML=true' },
             "warning:s"             => { name => 'warning' },
             "critical:s"            => { name => 'critical' },
@@ -238,15 +239,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--urlpath>
 

--- a/apps/tomcat/web/mode/traffic.pm
+++ b/apps/tomcat/web/mode/traffic.pm
@@ -148,6 +148,7 @@ sub new {
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
             "timeout:s"             => { name => 'timeout' },
+            "ssl-opt:s@"            => { name => 'ssl_opt' },
             "urlpath:s"             => { name => 'url_path', default => '/manager/status?XML=true' },
             "filter-name:s"         => { name => 'filter_name' },
             "speed-in:s"            => { name => 'speed_in' },
@@ -297,15 +298,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--urlpath>
 

--- a/apps/video/zixi/restapi/custom/api.pm
+++ b/apps/video/zixi/restapi/custom/api.pm
@@ -49,6 +49,7 @@ sub new {
                       "password:s@" => { name => 'password' },
                       "proxyurl:s@" => { name => 'proxyurl' },
                       "timeout:s@"  => { name => 'timeout' },
+                      "ssl-opt:s@"  => { name => 'ssl_opt' },
                     });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -199,6 +200,10 @@ Proxy URL if any
 =item B<--timeout>
 
 Set HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =back
 

--- a/apps/vtom/restapi/custom/api.pm
+++ b/apps/vtom/restapi/custom/api.pm
@@ -49,6 +49,7 @@ sub new {
                       "password:s@" => { name => 'password' },
                       "proxyurl:s@" => { name => 'proxyurl' },
                       "timeout:s@"  => { name => 'timeout' },
+                      "ssl-opt:s@"  => { name => 'ssl_opt' },
                     });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -241,6 +242,10 @@ Proxy URL if any
 =item B<--timeout>
 
 Set HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =back
 

--- a/cloud/docker/restapi/custom/api.pm
+++ b/cloud/docker/restapi/custom/api.pm
@@ -54,6 +54,7 @@ sub new {
                         "proxypac:s"    => { name => 'proxypac' },
                         "timeout:s"     => { name => 'timeout', default => 10 },
                         "ssl:s"         => { name => 'ssl' },
+                        "ssl-opt:s@"    => { name => 'ssl_opt' },
                         "cert-file:s"   => { name => 'cert_file' },
                         "key-file:s"    => { name => 'key_file' },
                         "cacert-file:s" => { name => 'cacert_file' },
@@ -412,9 +413,9 @@ Proxy pac file (can be an url or local file)
 
 Threshold for HTTP timeout (Default: 10)
 
-=item B<--ssl>
+=item B<--ssl-opt>
 
-Specify SSL version (example : 'sslv3', 'tlsv1'...)
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--cert-file>
 

--- a/cloud/ovh/restapi/custom/api.pm
+++ b/cloud/ovh/restapi/custom/api.pm
@@ -48,12 +48,13 @@ sub new {
     if (!defined($options{noptions})) {
         $options{options}->add_options(arguments => 
                     {
-                      "ovh-type:s@"                 => { name => 'ovh_type', },
-                      "ovh-application-key:s@"      => { name => 'ovh_application_key', },
-                      "ovh-application-secret:s@"   => { name => 'ovh_application_secret', },
-                      "ovh-consumer-key:s@"         => { name => 'ovh_consumer_key', },
-                      "proxyurl:s@" => { name => 'proxyurl', },
-                      "timeout:s@"  => { name => 'timeout', },
+                      "ovh-type:s@"                 => { name => 'ovh_type' },
+                      "ovh-application-key:s@"      => { name => 'ovh_application_key' },
+                      "ovh-application-secret:s@"   => { name => 'ovh_application_secret' },
+                      "ovh-consumer-key:s@"         => { name => 'ovh_consumer_key' },
+                      "proxyurl:s@"                 => { name => 'proxyurl' },
+                      "timeout:s@"                  => { name => 'timeout' },
+                      "ssl-opt:s@"                  => { name => 'ssl_opt' },
                     });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -249,6 +250,10 @@ Proxy URL if any
 =item B<--timeout>
 
 Set HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =back
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/contact.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/contact.pm
@@ -46,6 +46,7 @@ sub new {
             "critical"          => { name => 'critical' },
             "closed"            => { name => 'closed' },
             "timeout:s"         => { name => 'timeout' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             });
     $self->{status} = { closed => 'ok', opened => 'ok' };
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
@@ -128,15 +129,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning>
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/flood.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/flood.pm
@@ -46,6 +46,7 @@ sub new {
             "critical"          => { name => 'critical' },
             "dry"               => { name => 'dry' },
             "timeout:s"         => { name => 'timeout' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             });
     $self->{status} = { dry => 'ok', wet => 'ok' };
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
@@ -128,15 +129,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning>
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/humidity.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/humidity.pm
@@ -45,6 +45,7 @@ sub new {
             "warning:s"         => { name => 'warning' },
             "critical:s"        => { name => 'critical' },
             "timeout:s"         => { name => 'timeout' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             });
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     return $self;
@@ -129,15 +130,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning>
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/illumination.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/illumination.pm
@@ -45,6 +45,7 @@ sub new {
             "warning:s"         => { name => 'warning' },
             "critical:s"        => { name => 'critical' },
             "timeout:s"         => { name => 'timeout' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             });
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     return $self;
@@ -129,15 +130,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning>
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/temperature.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/temperature.pm
@@ -45,6 +45,7 @@ sub new {
             "warning:s"         => { name => 'warning' },
             "critical:s"        => { name => 'critical' },
             "timeout:s"         => { name => 'timeout' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             });
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     return $self;
@@ -128,15 +129,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning>
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/thermistor.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/thermistor.pm
@@ -45,6 +45,7 @@ sub new {
             "warning:s"         => { name => 'warning' },
             "critical:s"        => { name => 'critical' },
             "timeout:s"         => { name => 'timeout' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             });
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     return $self;
@@ -128,15 +129,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning>
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/voltage.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/voltage.pm
@@ -45,6 +45,7 @@ sub new {
             "warning:s"         => { name => 'warning' },
             "critical:s"        => { name => 'critical' },
             "timeout:s"         => { name => 'timeout' },
+            "ssl-opt:s@"        => { name => 'ssl_opt' },
             });
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     return $self;
@@ -129,15 +130,19 @@ Specify this option if you access server-status page over basic authentification
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for basic authentification (Mandatory if --credentials is specified)
 
 =item B<--timeout>
 
 Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--warning>
 

--- a/network/cisco/prime/restapi/custom/api.pm
+++ b/network/cisco/prime/restapi/custom/api.pm
@@ -50,6 +50,7 @@ sub new {
                       "password:s@" => { name => 'password' },
                       "proxyurl:s@" => { name => 'proxyurl' },
                       "timeout:s@"  => { name => 'timeout' },
+                      "ssl-opt:s@"  => { name => 'ssl_opt' },
                     });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -238,6 +239,10 @@ Proxy URL if any
 =item B<--timeout>
 
 Set HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =back
 

--- a/network/freebox/restapi/custom/api.pm
+++ b/network/freebox/restapi/custom/api.pm
@@ -47,9 +47,10 @@ sub new {
                       "freebox-app-id:s@"       => { name => 'freebox_app_id' },
                       "freebox-app-token:s@"    => { name => 'freebox_app_token' },
                       "freebox-api-version:s@"  => { name => 'freebox_api_version', },
-                      "proxyurl:s@"         => { name => 'proxyurl' },
-                      "timeout:s@"          => { name => 'timeout' },
-                      "resolution:s@"       => { name => 'resolution' },
+                      "proxyurl:s@"             => { name => 'proxyurl' },
+                      "timeout:s@"              => { name => 'timeout' },
+                      "ssl-opt:s@"              => { name => 'ssl_opt' },
+                      "resolution:s@"           => { name => 'resolution' },
                     });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -292,6 +293,10 @@ Proxy URL if any.
 =item B<--timeout>
 
 Set HTTP timeout in seconds (Default: '10').
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--resolution>
 

--- a/notification/highsms/mode/alert.pm
+++ b/notification/highsms/mode/alert.pm
@@ -42,6 +42,8 @@ sub new {
                                   "proxypac:s"      => { name => 'proxypac' },
                                   "username:s"      => { name => 'username' },
                                   "password:s"      => { name => 'password' },
+                                  "timeout:s"       => { name => 'timeout' },
+                                  "ssl-opt:s@"      => { name => 'ssl_opt' },
                                   "phonenumber:s"   => { name => 'phonenumber' },
                                   "message:s"       => { name => 'message' },
                                   "sender:s"        => { name => 'sender', default => 'API_HIGHSMS' },
@@ -146,6 +148,14 @@ Specify username for API authentification.
 =item B<--password>
 
 Specify password for API authentification.
+
+=item B<--timeout>
+
+Threshold for HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--phonenumber>
 

--- a/notification/slack/mode/alert.pm
+++ b/notification/slack/mode/alert.pm
@@ -64,7 +64,6 @@ sub new {
             "link-url:s"            => { name => 'link_url' },
             "centreon-url:s"        => { name => 'centreon_url' },
             "centreon-token:s"      => { name => 'centreon_token' },
-            
             "credentials"           => { name => 'credentials' },
             "ntlm"                  => { name => 'ntlm' },
             "username:s"            => { name => 'username' },
@@ -72,6 +71,7 @@ sub new {
             "proxyurl:s"            => { name => 'proxyurl' },
             "proxypac:s"            => { name => 'proxypac' },
             "timeout:s"             => { name => 'timeout' },
+            "ssl-opt:s@"            => { name => 'ssl_opt' },
             });
     $self->{http} = centreon::plugins::http->new(output => $self->{output});
     $self->{payload_attachment} = { fields => [] }; 
@@ -328,10 +328,6 @@ Proxy pac file (can be an url or local file)
 
 Specify this option if you access webpage over basic authentification
 
-=item B<--ntlm>
-
-Specify this option if you access webpage over ntlm authentification (Use with --credentials option)
-
 =item B<--username>
 
 Specify username for basic authentification (Mandatory if --credentials is specidied)
@@ -343,6 +339,10 @@ Specify password for basic authentification (Mandatory if --credentials is speci
 =item B<--timeout>
 
 Threshold for HTTP timeout (Default: 5)
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =back
 

--- a/storage/emc/vplex/restapi/custom/vplexapi.pm
+++ b/storage/emc/vplex/restapi/custom/vplexapi.pm
@@ -46,11 +46,12 @@ sub new {
     if (!defined($options{noptions})) {
         $options{options}->add_options(arguments => 
                     {
-                      "hostname:s@"         => { name => 'hostname', },
-                      "vplex-username:s@"   => { name => 'vplex_username', },
-                      "vplex-password:s@"   => { name => 'vplex_password', },
-                      "proxyurl:s@"         => { name => 'proxyurl', },
-                      "timeout:s@"          => { name => 'timeout', },
+                      "hostname:s@"         => { name => 'hostname' },
+                      "vplex-username:s@"   => { name => 'vplex_username' },
+                      "vplex-password:s@"   => { name => 'vplex_password' },
+                      "proxyurl:s@"         => { name => 'proxyurl' },
+                      "timeout:s@"          => { name => 'timeout' },
+                      "ssl-opt:s@"          => { name => 'ssl_opt' },
                     });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -219,6 +220,10 @@ Proxy URL if any
 =item B<--timeout>
 
 Set HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =back
 

--- a/storage/emc/xtremio/restapi/custom/xtremioapi.pm
+++ b/storage/emc/xtremio/restapi/custom/xtremioapi.pm
@@ -43,11 +43,12 @@ sub new {
     if (!defined($options{noptions})) {
         $options{options}->add_options(arguments => 
                     {
-                      "hostname:s@"         => { name => 'hostname', },
-                      "xtremio-username:s@" => { name => 'xtremio_username', },
-                      "xtremio-password:s@" => { name => 'xtremio_password', },
-                      "proxyurl:s@"         => { name => 'proxyurl', },
-                      "timeout:s@"          => { name => 'timeout', },
+                      "hostname:s@"         => { name => 'hostname' },
+                      "xtremio-username:s@" => { name => 'xtremio_username' },
+                      "xtremio-password:s@" => { name => 'xtremio_password' },
+                      "proxyurl:s@"         => { name => 'proxyurl' },
+                      "timeout:s@"          => { name => 'timeout' },
+                      "ssl-opt:s@"          => { name => 'ssl_opt' },
                       "reload-cache-time:s" => { name => 'reload_cache_time' },
                     });
     }
@@ -283,6 +284,10 @@ Proxy URL if any
 =item B<--timeout>
 
 Set HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--reload-cache-time>
 

--- a/storage/hp/p2000/xmlapi/custom.pm
+++ b/storage/hp/p2000/xmlapi/custom.pm
@@ -47,14 +47,15 @@ sub new {
     if (!defined($options{noptions})) {
         $options{options}->add_options(arguments => 
                     {
-                      "hostname:s@"      => { name => 'hostname', },
-                      "port:s@"          => { name => 'port', },
-                      "proto:s@"         => { name => 'proto', },
-                      "urlpath:s@"       => { name => 'url_path', },
-                      "proxyurl:s@"      => { name => 'proxyurl', },
-                      "username:s@"      => { name => 'username', },
-                      "password:s@"      => { name => 'password', },
-                      "timeout:s@"       => { name => 'timeout', },
+                      "hostname:s@"      => { name => 'hostname' },
+                      "port:s@"          => { name => 'port' },
+                      "proto:s@"         => { name => 'proto' },
+                      "urlpath:s@"       => { name => 'url_path' },
+                      "proxyurl:s@"      => { name => 'proxyurl' },
+                      "username:s@"      => { name => 'username' },
+                      "password:s@"      => { name => 'password' },
+                      "timeout:s@"       => { name => 'timeout' },
+                      "ssl-opt:s@"       => { name => 'ssl_opt' },
                     });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'P2000 OPTIONS', once => 1);
@@ -307,6 +308,10 @@ Password to connect.
 =item B<--timeout>
 
 Set HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =back
 

--- a/storage/hp/storeonce/restapi/custom/api.pm
+++ b/storage/hp/storeonce/restapi/custom/api.pm
@@ -42,11 +42,12 @@ sub new {
     if (!defined($options{noptions})) {
         $options{options}->add_options(arguments => 
                     {
-                      "hostname:s@" => { name => 'hostname', },
-                      "username:s@" => { name => 'username', },
-                      "password:s@" => { name => 'password', },
-                      "proxyurl:s@" => { name => 'proxyurl', },
-                      "timeout:s@"  => { name => 'timeout', },
+                      "hostname:s@" => { name => 'hostname' },
+                      "username:s@" => { name => 'username' },
+                      "password:s@" => { name => 'password' },
+                      "proxyurl:s@" => { name => 'proxyurl' },
+                      "timeout:s@"  => { name => 'timeout' },
+                      "ssl-opt:s@"  => { name => 'ssl_opt' },
                     });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -176,6 +177,10 @@ Proxy URL if any
 =item B<--timeout>
 
 Set HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =back
 

--- a/storage/kaminario/restapi/custom/api.pm
+++ b/storage/kaminario/restapi/custom/api.pm
@@ -42,12 +42,13 @@ sub new {
     if (!defined($options{noptions})) {
         $options{options}->add_options(arguments => 
                     {
-                      "hostname:s@"     => { name => 'hostname', },
-                      "username:s@"     => { name => 'username', },
-                      "password:s@"     => { name => 'password', },
-                      "proxyurl:s@"     => { name => 'proxyurl', },
-                      "timeout:s@"      => { name => 'timeout', },
-                      "resolution:s@"   => { name => 'resolution', },
+                      "hostname:s@"     => { name => 'hostname' },
+                      "username:s@"     => { name => 'username' },
+                      "password:s@"     => { name => 'password' },
+                      "proxyurl:s@"     => { name => 'proxyurl' },
+                      "timeout:s@"      => { name => 'timeout' },
+                      "ssl-opt:s@"      => { name => 'ssl_opt' },
+                      "resolution:s@"   => { name => 'resolution' },
                     });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -185,6 +186,10 @@ Proxy URL if any.
 =item B<--timeout>
 
 Set HTTP timeout in seconds (Default: '10').
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--resolution>
 

--- a/storage/netapp/restapi/custom/restapi.pm
+++ b/storage/netapp/restapi/custom/restapi.pm
@@ -52,6 +52,7 @@ sub new {
                         "proxyurl:s@" => { name => 'proxyurl' },
                         "timeout:s@"  => { name => 'timeout' },
                         "ssl:s@"      => { name => 'ssl' },
+                        "ssl-opt:s@"  => { name => 'ssl_opt' },
                     });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -250,9 +251,9 @@ Proxy URL if any
 
 Set HTTP timeout
 
-=item B<--ssl>
+=item B<--ssl-opt>
 
-SSL version (Default: tlsv1)
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =back
 

--- a/storage/purestorage/restapi/custom/api.pm
+++ b/storage/purestorage/restapi/custom/api.pm
@@ -47,6 +47,7 @@ sub new {
                     "password:s"    => { name => 'password' },
                     "proxyurl:s"    => { name => 'proxyurl' },
                     "timeout:s"     => { name => 'timeout' },
+                    "ssl-opt:s@"    => { name => 'ssl_opt' },
                     "api-path:s"    => { name => 'api_path' },
                     });
     }
@@ -120,7 +121,7 @@ sub build_options_for_httplib {
     $self->{option_results}->{timeout} = $self->{timeout};
     $self->{option_results}->{port} = 443;
     $self->{option_results}->{proto} = 'https';
-    $self->{option_results}->{proxyurl} = $self->{proxyurl};    
+    $self->{option_results}->{proxyurl} = $self->{proxyurl};
 }
 
 sub settings {
@@ -268,6 +269,10 @@ Proxy URL if any.
 =item B<--timeout>
 
 Set HTTP timeout in seconds (Default: '10').
+
+=item B<--ssl-opt>
+
+Set SSL Options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =item B<--api-path>
 


### PR DESCRIPTION
Add --ssl-opt option for plugins using http library. This is made to maintain compatibility with el7.
Also add --timeout and --proxyurl options where missing.

Refs: #961 