### PR TITLE
enhance http lib to handle hidden basic authent

### DIFF
--- a/apps/protocols/http/mode/expectedcontent.pm
+++ b/apps/protocols/http/mode/expectedcontent.pm
@@ -42,7 +42,8 @@ sub new {
             "proto:s"               => { name => 'proto' },
             "urlpath:s"             => { name => 'url_path' },
             "credentials"           => { name => 'credentials' },
-            "ntlm"                  => { name => 'ntlm' },
+            "basic"                 => { name => 'basic' },
+            "ntlm"                  => { name => 'ntlm' }, # Deprecated
             "ntlmv2"                => { name => 'ntlmv2' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
@@ -196,19 +197,27 @@ Set path to get Webpage (Default: '/')
 
 =item B<--credentials>
 
-Specify this option if you access webpage over basic authentication
+Specify this option if you access webpage with authentication
+
+=item B<--username>
+
+Specify username for authentication (Mandatory if --credentials is specified)
+
+=item B<--password>
+
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access webpage over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access webpage over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--ntlmv2>
 
 Specify this option if you access webpage over ntlmv2 authentication (Use with --credentials and --port options)
-
-=item B<--username>
-
-Specify username for basic authentication (Mandatory if --credentials is specidied)
-
-=item B<--password>
-
-Specify password for basic authentication (Mandatory if --credentials is specidied)
 
 =item B<--timeout>
 

--- a/apps/protocols/http/mode/jsoncontent.pm
+++ b/apps/protocols/http/mode/jsoncontent.pm
@@ -46,7 +46,8 @@ sub new {
             "proto:s"               => { name => 'proto' },
             "urlpath:s"             => { name => 'url_path' },
             "credentials"           => { name => 'credentials' },
-            "ntlm"                  => { name => 'ntlm' },
+            "basic"                 => { name => 'basic' },
+            "ntlm"                  => { name => 'ntlm' }, # Deprecated
             "ntlmv2"                => { name => 'ntlmv2' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
@@ -393,19 +394,27 @@ Set path to get Webpage (Default: '/')
 
 =item B<--credentials>
 
-Specify this option if you access webpage over basic authentication
+Specify this option if you access webpage with authentication
+
+=item B<--username>
+
+Specify username for authentication (Mandatory if --credentials is specified)
+
+=item B<--password>
+
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access webpage over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access webpage over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--ntlmv2>
 
 Specify this option if you access webpage over ntlmv2 authentication (Use with --credentials and --port options)
-
-=item B<--username>
-
-Specify username for basic authentication (Mandatory if --credentials is specidied)
-
-=item B<--password>
-
-Specify password for basic authentication (Mandatory if --credentials is specidied)
 
 =item B<--timeout>
 

--- a/apps/protocols/http/mode/response.pm
+++ b/apps/protocols/http/mode/response.pm
@@ -42,7 +42,8 @@ sub new {
          "proto:s"       => { name => 'proto' },
          "urlpath:s"     => { name => 'url_path' },
          "credentials"   => { name => 'credentials' },
-         "ntlm"          => { name => 'ntlm' },
+         "basic"         => { name => 'basic' },
+         "ntlm"          => { name => 'ntlm' }, # Deprecated
          "ntlmv2"        => { name => 'ntlmv2' },
          "username:s"    => { name => 'username' },
          "password:s"    => { name => 'password' },
@@ -174,19 +175,27 @@ Set path to get webpage (Default: '/')
 
 =item B<--credentials>
 
-Specify this option if you access webpage over basic authentication
+Specify this option if you access webpage with authentication
+
+=item B<--username>
+
+Specify username for authentication (Mandatory if --credentials is specified)
+
+=item B<--password>
+
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access webpage over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access webpage over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--ntlmv2>
 
 Specify this option if you access webpage over ntlmv2 authentication (Use with --credentials and --port options)
-
-=item B<--username>
-
-Specify username for basic authentication (Mandatory if --credentials is specidied)
-
-=item B<--password>
-
-Specify password for basic authentication (Mandatory if --credentials is specidied)
 
 =item B<--proxyurl>
 

--- a/apps/protocols/http/mode/soapcontent.pm
+++ b/apps/protocols/http/mode/soapcontent.pm
@@ -46,7 +46,8 @@ sub new {
             "proto:s"               => { name => 'proto' },
             "urlpath:s"             => { name => 'url_path' },
             "credentials"           => { name => 'credentials' },
-            "ntlm"                  => { name => 'ntlm' },
+            "basic"                 => { name => 'basic' },
+            "ntlm"                  => { name => 'ntlm' }, # Deprecated
             "ntlmv2"                => { name => 'ntlmv2' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
@@ -64,7 +65,6 @@ sub new {
             "unknown-status:s"      => { name => 'unknown_status' },
             "warning-status:s"      => { name => 'warning_status' },
             "critical-status:s"     => { name => 'critical_status' },
-
             "warning-numeric:s"       => { name => 'warning_numeric' },
             "critical-numeric:s"      => { name => 'critical_numeric' },
             "warning-string:s"        => { name => 'warning_string' },
@@ -420,19 +420,27 @@ Set path to get Webpage (Default: '/')
 
 =item B<--credentials>
 
-Specify this option if you access webpage over basic authentication
+Specify this option if you access webpage with authentication
+
+=item B<--username>
+
+Specify username for authentication (Mandatory if --credentials is specified)
+
+=item B<--password>
+
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access webpage over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access webpage over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--ntlmv2>
 
 Specify this option if you access webpage over ntlmv2 authentication (Use with --credentials and --port options)
-
-=item B<--username>
-
-Specify username for basic authentication (Mandatory if --credentials is specidied)
-
-=item B<--password>
-
-Specify password for basic authentication (Mandatory if --credentials is specidied)
 
 =item B<--timeout>
 

--- a/centreon/plugins/http.pm
+++ b/centreon/plugins/http.pm
@@ -265,11 +265,15 @@ sub request {
             $req->content($uri_post->query);
         }
     }
-        
+
     if (defined($request_options->{credentials}) && defined($request_options->{ntlmv2})) {
         centreon::plugins::misc::mymodule_load(output => $self->{output}, module => 'Authen::NTLM',
                                                error_msg => "Cannot load module 'Authen::NTLM'.");
         Authen::NTLM::ntlmv2(1);
+    }
+
+    if (defined($request_options->{credentials}) && defined($request_options->{basic})) {
+        $req->authorization_basic($request_options->{username}, $request_options->{password});
     }
 
     $self->set_proxy(request => $request_options, url => $url);
@@ -315,7 +319,7 @@ sub request {
         my $short_msg = $response->status_line;
         if ($short_msg =~ /^401/) {
             my ($authenticate) = $response->www_authenticate =~ /(\S+)/;
-            $short_msg .= ' (' . $authenticate . ' authentification expected)';
+            $short_msg .= ' (' . $authenticate . ' authentication expected)';
         }
 
         $self->{output}->output_add(long_msg => $response->content, debug => 1);


### PR DESCRIPTION
Kind of roll back https://github.com/centreon/centreon-plugins/pull/860 to get back transparent behaviour we had before when it comes to basic authentication.
By adding --basic option, we can handle hidden basic authentication and also prevent webserver to respond 401 errors for basic authentication.
Digest and NTLM authentication still don't need any options.