### PR TITLE
add basic option to mode using http lib

### DIFF
--- a/apps/apache/serverstatus/mode/cpuload.pm
+++ b/apps/apache/serverstatus/mode/cpuload.pm
@@ -39,6 +39,7 @@ sub new {
             "proto:s"           => { name => 'proto' },
             "urlpath:s"         => { name => 'url_path', default => "/server-status/?auto" },
             "credentials"       => { name => 'credentials' },
+            "basic"             => { name => 'basic' },
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
             "proxyurl:s"        => { name => 'proxyurl' },
@@ -131,15 +132,23 @@ Set path to get server-status page in auto mode (Default: '/server-status/?auto'
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/apache/serverstatus/mode/requests.pm
+++ b/apps/apache/serverstatus/mode/requests.pm
@@ -40,6 +40,7 @@ sub new {
             "proto:s"           => { name => 'proto' },
             "urlpath:s"         => { name => 'url_path', default => "/server-status/?auto" },
             "credentials"       => { name => 'credentials' },
+            "basic"             => { name => 'basic' },
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
             "proxyurl:s"        => { name => 'proxyurl' },
@@ -220,15 +221,23 @@ Set path to get server-status page in auto mode (Default: '/server-status/?auto'
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/apache/serverstatus/mode/responsetime.pm
+++ b/apps/apache/serverstatus/mode/responsetime.pm
@@ -40,6 +40,7 @@ sub new {
          "proto:s"      => { name => 'proto' },
          "urlpath:s"    => { name => 'url_path', default => "/server-status/?auto" },
          "credentials"  => { name => 'credentials' },
+         "basic"        => { name => 'basic' },
          "username:s"   => { name => 'username' },
          "password:s"   => { name => 'password' },
          "proxyurl:s"   => { name => 'proxyurl' },
@@ -123,15 +124,23 @@ Set path to get server-status page in auto mode (Default: '/server-status/?auto'
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--proxyurl>
 

--- a/apps/apache/serverstatus/mode/slotstates.pm
+++ b/apps/apache/serverstatus/mode/slotstates.pm
@@ -201,6 +201,7 @@ sub new {
                                 "proto:s"       => { name => 'proto' },
                                 "urlpath:s"     => { name => 'url_path', default => "/server-status/?auto" },
                                 "credentials"   => { name => 'credentials' },
+                                "basic"         => { name => 'basic' },
                                 "username:s"    => { name => 'username' },
                                 "password:s"    => { name => 'password' },
                                 "proxyurl:s"    => { name => 'proxyurl' },
@@ -344,15 +345,23 @@ Set path to get server-status page in auto mode (Default: '/server-status/?auto'
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/apache/serverstatus/mode/workers.pm
+++ b/apps/apache/serverstatus/mode/workers.pm
@@ -39,6 +39,7 @@ sub new {
             "proto:s"       => { name => 'proto' },
             "urlpath:s"     => { name => 'url_path', default => "/server-status/?auto" },
             "credentials"   => { name => 'credentials' },
+            "basic"         => { name => 'basic' },
             "username:s"    => { name => 'username' },
             "password:s"    => { name => 'password' },
             "proxyurl:s"    => { name => 'proxyurl' },
@@ -135,15 +136,23 @@ Set path to get server-status page in auto mode (Default: '/server-status/?auto'
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/elasticsearch/restapi/custom/api.pm
+++ b/apps/elasticsearch/restapi/custom/api.pm
@@ -116,6 +116,7 @@ sub build_options_for_httplib {
     $self->{option_results}->{proto} = $self->{proto};
     $self->{option_results}->{proxyurl} = $self->{proxyurl};
     $self->{option_results}->{credentials} = 1;
+    $self->{option_results}->{basic} = 1;
     $self->{option_results}->{username} = $self->{username};
     $self->{option_results}->{password} = $self->{password};
 }

--- a/apps/github/mode/commits.pm
+++ b/apps/github/mode/commits.pm
@@ -40,9 +40,6 @@ sub new {
             "hostname:s"        => { name => 'hostname', default => 'api.github.com' },
             "port:s"            => { name => 'port', default => '443'},
             "proto:s"           => { name => 'proto', default => 'https' },
-            "credentials"       => { name => 'credentials' },
-            "username:s"        => { name => 'username' },
-            "password:s"        => { name => 'password' },
             "timeout:s"         => { name => 'timeout' },
             "proxyurl:s"        => { name => 'proxyurl' },
             "ssl-opt:s@"        => { name => 'ssl_opt' },
@@ -142,18 +139,6 @@ Port used by GitHub's API (Default: '443')
 =item B<--proto>
 
 Specify https if needed (Default: 'https')
-
-=item B<--credentials>
-
-Specify this option if you access webpage over basic authentification
-
-=item B<--username>
-
-Specify username
-
-=item B<--password>
-
-Specify password
 
 =item B<--proxyurl>
 

--- a/apps/github/mode/issues.pm
+++ b/apps/github/mode/issues.pm
@@ -38,9 +38,6 @@ sub new {
             "hostname:s"        => { name => 'hostname', default => 'api.github.com' },
             "port:s"            => { name => 'port', default => '443'},
             "proto:s"           => { name => 'proto', default => 'https' },
-            "credentials"       => { name => 'credentials' },
-            "username:s"        => { name => 'username' },
-            "password:s"        => { name => 'password' },
             "timeout:s"         => { name => 'timeout' },
             "proxyurl:s"        => { name => 'proxyurl' },
             "ssl-opt:s@"        => { name => 'ssl_opt' },
@@ -149,18 +146,6 @@ Port used by GitHub's API (Default: '443')
 =item B<--proto>
 
 Specify https if needed (Default: 'https')
-
-=item B<--credentials>
-
-Specify this option if you access webpage over basic authentification
-
-=item B<--username>
-
-Specify username
-
-=item B<--password>
-
-Specify password
 
 =item B<--proxyurl>
 

--- a/apps/github/mode/pullrequests.pm
+++ b/apps/github/mode/pullrequests.pm
@@ -38,12 +38,9 @@ sub new {
             "hostname:s"        => { name => 'hostname', default => 'api.github.com' },
             "port:s"            => { name => 'port', default => '443' },
             "proto:s"           => { name => 'proto', default => 'https' },
-            "credentials"       => { name => 'credentials' },
-            "username:s"        => { name => 'username' },
             "timeout:s"         => { name => 'timeout' },
             "proxyurl:s"        => { name => 'proxyurl' },
             "ssl-opt:s@"        => { name => 'ssl_opt' },
-            "password:s"        => { name => 'password' },
             "warning:s"         => { name => 'warning' },
             "critical:s"        => { name => 'critical' },
             "owner:s"           => { name => 'owner' },
@@ -134,18 +131,6 @@ Port used by GitHub's API (Default: '443')
 =item B<--proto>
 
 Specify https if needed (Default: 'https')
-
-=item B<--credentials>
-
-Specify this option if you access webpage over basic authentification
-
-=item B<--username>
-
-Specify username
-
-=item B<--password>
-
-Specify password
 
 =item B<--proxyurl>
 

--- a/apps/github/mode/stats.pm
+++ b/apps/github/mode/stats.pm
@@ -39,9 +39,6 @@ sub new {
             "hostname:s"        => { name => 'hostname', default => 'api.github.com' },
             "port:s"            => { name => 'port', default => '443'},
             "proto:s"           => { name => 'proto', default => 'https' },
-            "credentials"       => { name => 'credentials' },
-            "username:s"        => { name => 'username' },
-            "password:s"        => { name => 'password' },
             "timeout:s"         => { name => 'timeout' },
             "proxyurl:s"        => { name => 'proxyurl' },
             "ssl-opt:s@"        => { name => 'ssl_opt' },
@@ -133,18 +130,6 @@ Specify https if needed (Default: 'https')
 =item B<--urlpath>
 
 Set path to get GitHub's status information (Default: '/repo/:owner/:repository')
-
-=item B<--credentials>
-
-Specify this option if you access webpage over basic authentification
-
-=item B<--username>
-
-Specify username
-
-=item B<--password>
-
-Specify password
 
 =item B<--proxyurl>
 

--- a/apps/github/mode/status.pm
+++ b/apps/github/mode/status.pm
@@ -47,9 +47,6 @@ sub new {
             "port:s"                    => { name => 'port', default => '443'},
             "proto:s"                   => { name => 'proto', default => 'https' },
             "urlpath:s"                 => { name => 'url_path', default => '/api/last-message.json' },
-            "credentials"               => { name => 'credentials' },
-            "username:s"                => { name => 'username' },
-            "password:s"                => { name => 'password' },
             "timeout:s"                 => { name => 'timeout' },
             "proxyurl:s"                => { name => 'proxyurl' },
             "ssl-opt:s@"                => { name => 'ssl_opt' },
@@ -153,18 +150,6 @@ Specify https if needed (Default: 'https')
 =item B<--urlpath>
 
 Set path to get GitHub's status information (Default: '/api/last-message.json')
-
-=item B<--credentials>
-
-Specify this option if you access webpage over basic authentification
-
-=item B<--username>
-
-Specify username
-
-=item B<--password>
-
-Specify password
 
 =item B<--proxyurl>
 

--- a/apps/jenkins/mode/jobstate.pm
+++ b/apps/jenkins/mode/jobstate.pm
@@ -42,6 +42,7 @@ sub new {
             "urlpath:s"            => { name => 'url_path' },
             "timeout:s"            => { name => 'timeout' },
             "credentials"          => { name => 'credentials' },
+            "basic"                => { name => 'basic' },
             "username:s"           => { name => 'username' },
             "password:s"           => { name => 'password' },
             "proxyurl:s"           => { name => 'proxyurl' },
@@ -162,6 +163,14 @@ Set path to get Jenkins information
 =item B<--credentials>
 
 Required to use username/password authentication method
+
+=item B<--basic>
+
+Specify this option if you access API over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access API over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--username>
 

--- a/apps/kingdee/eas/custom/api.pm
+++ b/apps/kingdee/eas/custom/api.pm
@@ -115,6 +115,7 @@ sub build_options_for_httplib {
     $self->{option_results}->{proto} = $self->{proto};
     $self->{option_results}->{proxyurl} = $self->{proxyurl};
     $self->{option_results}->{credentials} = 1;
+    $self->{option_results}->{basic} = 1;
     $self->{option_results}->{username} = $self->{username};
     $self->{option_results}->{password} = $self->{password};
 }

--- a/apps/nginx/serverstatus/mode/connections.pm
+++ b/apps/nginx/serverstatus/mode/connections.pm
@@ -46,6 +46,7 @@ sub new {
             "proto:s"       => { name => 'proto' },
             "urlpath:s"     => { name => 'url_path', default => "/nginx_status" },
             "credentials"   => { name => 'credentials' },
+            "basic"         => { name => 'basic' },
             "username:s"    => { name => 'username' },
             "password:s"    => { name => 'password' },
             "proxyurl:s"    => { name => 'proxyurl' },
@@ -140,15 +141,23 @@ Set path to get server-status page in auto mode (Default: '/nginx_status')
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/nginx/serverstatus/mode/requests.pm
+++ b/apps/nginx/serverstatus/mode/requests.pm
@@ -46,6 +46,7 @@ sub new {
             "proto:s"           => { name => 'proto' },
             "urlpath:s"         => { name => 'url_path', default => "/nginx_status" },
             "credentials"       => { name => 'credentials' },
+            "basic"             => { name => 'basic' },
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
             "proxyurl:s"        => { name => 'proxyurl' },
@@ -188,15 +189,23 @@ Set path to get server-status page in auto mode (Default: '/nginx_status')
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/nginx/serverstatus/mode/responsetime.pm
+++ b/apps/nginx/serverstatus/mode/responsetime.pm
@@ -40,6 +40,7 @@ sub new {
          "proto:s"      => { name => 'proto' },
          "urlpath:s"    => { name => 'url_path', default => "/nginx_status" },
          "credentials"  => { name => 'credentials' },
+         "basic"        => { name => 'basic' },
          "username:s"   => { name => 'username' },
          "password:s"   => { name => 'password' },
          "proxyurl:s"   => { name => 'proxyurl' },
@@ -121,15 +122,23 @@ Set path to get server-status page in auto mode (Default: '/nginx_status')
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--proxyurl>
 

--- a/apps/nsclient/restapi/mode/query.pm
+++ b/apps/nsclient/restapi/mode/query.pm
@@ -36,11 +36,12 @@ sub new {
     $self->{version} = '1.1';
     $options{options}->add_options(arguments =>
          {
-         "hostname:s"       => { name => 'hostname' },
-         "http-peer-addr:s" => { name => 'http_peer_addr' },
-         "port:s"           => { name => 'port', default => 8443 },
-         "proto:s"          => { name => 'proto', default => 'https' },
+         "hostname:s"           => { name => 'hostname' },
+         "http-peer-addr:s"     => { name => 'http_peer_addr' },
+         "port:s"               => { name => 'port', default => 8443 },
+         "proto:s"              => { name => 'proto', default => 'https' },
          "credentials"          => { name => 'credentials' },
+         "basic"                => { name => 'basic' },
          "username:s"           => { name => 'username' },
          "password:s"           => { name => 'password' },
          "legacy-password:s"    => { name => 'legacy_password' },
@@ -193,15 +194,23 @@ Specify https if needed (Default: 'https')
 
 =item B<--credentials>
 
-Specify this option if you access webpage over basic authentification
+Specify this option if you access webpage with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access webpage over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access webpage over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--legacy-password>
 

--- a/apps/php/apc/web/mode/filecache.pm
+++ b/apps/php/apc/web/mode/filecache.pm
@@ -207,6 +207,7 @@ sub new {
                                 "proto:s"           => { name => 'proto' },
                                 "urlpath:s"         => { name => 'url_path', default => "/apc.php" },
                                 "credentials"       => { name => 'credentials' },
+                                "basic"             => { name => 'basic' },
                                 "username:s"        => { name => 'username' },
                                 "password:s"        => { name => 'password' },
                                 "proxyurl:s"        => { name => 'proxyurl' },
@@ -275,15 +276,23 @@ Set path to get server-status page in auto mode (Default: '/apc.php')
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/php/apc/web/mode/memory.pm
+++ b/apps/php/apc/web/mode/memory.pm
@@ -103,6 +103,7 @@ sub new {
                                 "proto:s"           => { name => 'proto' },
                                 "urlpath:s"         => { name => 'url_path', default => "/apc.php" },
                                 "credentials"       => { name => 'credentials' },
+                                "basic"             => { name => 'basic' },
                                 "username:s"        => { name => 'username' },
                                 "password:s"        => { name => 'password' },
                                 "proxyurl:s"        => { name => 'proxyurl' },
@@ -172,15 +173,23 @@ Set path to get server-status page in auto mode (Default: '/apc.php')
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/php/fpm/web/mode/usage.pm
+++ b/apps/php/fpm/web/mode/usage.pm
@@ -147,6 +147,7 @@ sub new {
                                 "proto:s"           => { name => 'proto' },
                                 "urlpath:s"         => { name => 'url_path', default => "/fpm-status" },
                                 "credentials"       => { name => 'credentials' },
+                                "basic"             => { name => 'basic' },
                                 "username:s"        => { name => 'username' },
                                 "password:s"        => { name => 'password' },
                                 "proxyurl:s"        => { name => 'proxyurl' },
@@ -215,15 +216,23 @@ Set path to get server-status page in auto mode (Default: '/fpm-status')
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/redis/restapi/custom/api.pm
+++ b/apps/redis/restapi/custom/api.pm
@@ -121,6 +121,7 @@ sub build_options_for_httplib {
     $self->{option_results}->{proto} = $self->{proto};
     $self->{option_results}->{proxyurl} = $self->{proxyurl};
     $self->{option_results}->{credentials} = 1;
+    $self->{option_results}->{basic} = 1;
     $self->{option_results}->{username} = $self->{username};
     $self->{option_results}->{password} = $self->{password};
     $self->{option_results}->{ssl} = $self->{ssl};

--- a/apps/tomcat/web/mode/applications.pm
+++ b/apps/tomcat/web/mode/applications.pm
@@ -37,6 +37,7 @@ sub new {
             "port:s"                => { name => 'port', default => '8080' },
             "proto:s"               => { name => 'proto' },
             "credentials"           => { name => 'credentials' },
+            "basic"                 => { name => 'basic' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
@@ -164,15 +165,23 @@ Protocol used http or https
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/tomcat/web/mode/listapplication.pm
+++ b/apps/tomcat/web/mode/listapplication.pm
@@ -37,6 +37,7 @@ sub new {
             "port:s"                => { name => 'port', default => '8080' },
             "proto:s"               => { name => 'proto' },
             "credentials"           => { name => 'credentials' },
+            "basic"                 => { name => 'basic' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
@@ -147,15 +148,23 @@ Protocol used http or https
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/tomcat/web/mode/memory.pm
+++ b/apps/tomcat/web/mode/memory.pm
@@ -38,6 +38,7 @@ sub new {
             "port:s"                => { name => 'port', default => '8080' },
             "proto:s"               => { name => 'proto' },
             "credentials"           => { name => 'credentials' },
+            "basic"                 => { name => 'basic' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
@@ -199,15 +200,23 @@ Protocol used http or https
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/tomcat/web/mode/requestinfo.pm
+++ b/apps/tomcat/web/mode/requestinfo.pm
@@ -41,6 +41,7 @@ sub new {
             "port:s"                     => { name => 'port', default => '8080' },
             "proto:s"                    => { name => 'proto' },
             "credentials"                => { name => 'credentials' },
+            "basic"                      => { name => 'basic' },
             "username:s"                 => { name => 'username' },
             "password:s"                 => { name => 'password' },
             "proxyurl:s"                 => { name => 'proxyurl' },
@@ -341,15 +342,23 @@ Protocol used http or https
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/tomcat/web/mode/sessions.pm
+++ b/apps/tomcat/web/mode/sessions.pm
@@ -37,6 +37,7 @@ sub new {
             "port:s"                => { name => 'port', default => '8080' },
             "proto:s"               => { name => 'proto' },
             "credentials"           => { name => 'credentials' },
+            "basic"                 => { name => 'basic' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
@@ -167,15 +168,23 @@ Protocol used http or https
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/tomcat/web/mode/threads.pm
+++ b/apps/tomcat/web/mode/threads.pm
@@ -39,6 +39,7 @@ sub new {
             "port:s"                => { name => 'port', default => '8080' },
             "proto:s"               => { name => 'proto' },
             "credentials"           => { name => 'credentials' },
+            "basic"                 => { name => 'basic' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
@@ -235,15 +236,23 @@ Protocol used http or https
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/tomcat/web/mode/traffic.pm
+++ b/apps/tomcat/web/mode/traffic.pm
@@ -144,6 +144,7 @@ sub new {
             "port:s"                => { name => 'port', default => '8080' },
             "proto:s"               => { name => 'proto' },
             "credentials"           => { name => 'credentials' },
+            "basic"                 => { name => 'basic' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
             "proxyurl:s"            => { name => 'proxyurl' },
@@ -294,15 +295,23 @@ Protocol used http or https
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/apps/video/zixi/restapi/custom/api.pm
+++ b/apps/video/zixi/restapi/custom/api.pm
@@ -123,6 +123,7 @@ sub build_options_for_httplib {
     $self->{option_results}->{proto} = $self->{proto};
     $self->{option_results}->{proxyurl} = $self->{proxyurl};
     $self->{option_results}->{credentials} = 1;
+    $self->{option_results}->{basic} = 1;
     $self->{option_results}->{username} = $self->{username};
     $self->{option_results}->{password} = $self->{password};
 }

--- a/apps/vtom/restapi/custom/api.pm
+++ b/apps/vtom/restapi/custom/api.pm
@@ -123,6 +123,7 @@ sub build_options_for_httplib {
     $self->{option_results}->{proto} = $self->{proto};
     $self->{option_results}->{proxyurl} = $self->{proxyurl};
     $self->{option_results}->{credentials} = 1;
+    $self->{option_results}->{basic} = 1;
     $self->{option_results}->{username} = $self->{username};
     $self->{option_results}->{password} = $self->{password};
 }

--- a/cloud/docker/restapi/custom/api.pm
+++ b/cloud/docker/restapi/custom/api.pm
@@ -48,6 +48,7 @@ sub new {
                         "port:s"        => { name => 'port', default => 8080 },
                         "proto:s"       => { name => 'proto' },
 						"credentials"   => { name => 'credentials' },
+                        "basic"         => { name => 'basic' },
 						"username:s"    => { name => 'username' },
 						"password:s"    => { name => 'password' },
 						"proxyurl:s"    => { name => 'proxyurl' },
@@ -391,15 +392,23 @@ Specify https if needed (Default: 'http')
 
 =item B<--credentials>
 
-Specify this option if you access webpage over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--proxyurl>
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/contact.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/contact.pm
@@ -39,6 +39,7 @@ sub new {
             "proto:s"           => { name => 'proto' },
             "urlpath:s"         => { name => 'url_path', default => "/index.htm?eL" },
             "credentials"       => { name => 'credentials' },
+            "basic"             => { name => 'basic' },
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
             "proxyurl:s"        => { name => 'proxyurl' },
@@ -125,15 +126,23 @@ Set path to get server-status page in auto mode (Default: '/index.htm?eL')
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/flood.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/flood.pm
@@ -39,6 +39,7 @@ sub new {
             "proto:s"           => { name => 'proto' },
             "urlpath:s"         => { name => 'url_path' },
             "credentials"       => { name => 'credentials' },
+            "basic"             => { name => 'basic' },
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
             "proxyurl:s"        => { name => 'proxyurl' },
@@ -125,15 +126,23 @@ Set path to get server-status page in auto mode (Default: '/')
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/humidity.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/humidity.pm
@@ -39,6 +39,7 @@ sub new {
             "proto:s"           => { name => 'proto' },
             "urlpath:s"         => { name => 'url_path', default => "/index.htm?em" },
             "credentials"       => { name => 'credentials' },
+            "basic"             => { name => 'basic' },
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
             "proxyurl:s"        => { name => 'proxyurl' },
@@ -126,15 +127,23 @@ Set path to get server-status page in auto mode (Default: '/index.htm?em')
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/illumination.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/illumination.pm
@@ -39,6 +39,7 @@ sub new {
             "proto:s"           => { name => 'proto' },
             "urlpath:s"         => { name => 'url_path', default => "/index.htm?em" },
             "credentials"       => { name => 'credentials' },
+            "basic"             => { name => 'basic' },
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
             "proxyurl:s"        => { name => 'proxyurl' },
@@ -126,15 +127,23 @@ Set path to get server-status page in auto mode (Default: '/index.htm?em')
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/temperature.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/temperature.pm
@@ -39,6 +39,7 @@ sub new {
             "proto:s"           => { name => 'proto' },
             "urlpath:s"         => { name => 'url_path', default => "/index.htm?em" },
             "credentials"       => { name => 'credentials' },
+            "basic"             => { name => 'basic' },
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
             "proxyurl:s"        => { name => 'proxyurl' },
@@ -125,15 +126,23 @@ Set path to get server-status page in auto mode (Default: '/index.htm?em')
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/thermistor.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/thermistor.pm
@@ -39,6 +39,7 @@ sub new {
             "proto:s"           => { name => 'proto' },
             "urlpath:s"         => { name => 'url_path', default => "/index.htm?eR" },
             "credentials"       => { name => 'credentials' },
+            "basic"             => { name => 'basic' },
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
             "proxyurl:s"        => { name => 'proxyurl' },
@@ -125,15 +126,23 @@ Set path to get server-status page in auto mode (Default: '/index.htm?eR')
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/hardware/sensors/sensormetrix/em01/web/mode/voltage.pm
+++ b/hardware/sensors/sensormetrix/em01/web/mode/voltage.pm
@@ -39,6 +39,7 @@ sub new {
             "proto:s"           => { name => 'proto' },
             "urlpath:s"         => { name => 'url_path', default => "/index.htm?ev" },
             "credentials"       => { name => 'credentials' },
+            "basic"             => { name => 'basic' },
             "username:s"        => { name => 'username' },
             "password:s"        => { name => 'password' },
             "proxyurl:s"        => { name => 'proxyurl' },
@@ -126,15 +127,23 @@ Set path to get server-status page in auto mode (Default: '/index.htm?ev')
 
 =item B<--credentials>
 
-Specify this option if you access server-status page over basic authentification
+Specify this option if you access server-status page with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specified)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specified)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access server-status page over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access server-status page over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/network/cisco/prime/restapi/custom/api.pm
+++ b/network/cisco/prime/restapi/custom/api.pm
@@ -125,6 +125,7 @@ sub build_options_for_httplib {
     $self->{option_results}->{proto} = $self->{proto};
     $self->{option_results}->{proxyurl} = $self->{proxyurl};
     $self->{option_results}->{credentials} = 1;
+    $self->{option_results}->{basic} = 1;
     $self->{option_results}->{username} = $self->{username};
     $self->{option_results}->{password} = $self->{password};
 }

--- a/notification/slack/mode/alert.pm
+++ b/notification/slack/mode/alert.pm
@@ -65,6 +65,7 @@ sub new {
             "centreon-url:s"        => { name => 'centreon_url' },
             "centreon-token:s"      => { name => 'centreon_token' },
             "credentials"           => { name => 'credentials' },
+            "basic"                 => { name => 'basic' },
             "ntlm"                  => { name => 'ntlm' },
             "username:s"            => { name => 'username' },
             "password:s"            => { name => 'password' },
@@ -326,15 +327,23 @@ Proxy pac file (can be an url or local file)
 
 =item B<--credentials>
 
-Specify this option if you access webpage over basic authentification
+Specify this option if you access webpage with authentication
 
 =item B<--username>
 
-Specify username for basic authentification (Mandatory if --credentials is specidied)
+Specify username for authentication (Mandatory if --credentials is specified)
 
 =item B<--password>
 
-Specify password for basic authentification (Mandatory if --credentials is specidied)
+Specify password for authentication (Mandatory if --credentials is specified)
+
+=item B<--basic>
+
+Specify this option if you access webpage over basic authentication and don't want a '401 UNAUTHORIZED' error to be logged on your webserver.
+
+Specify this option if you access webpage over hidden basic authentication or you'll get a '404 NOT FOUND' error.
+
+(Use with --credentials)
 
 =item B<--timeout>
 

--- a/storage/hp/storeonce/restapi/custom/api.pm
+++ b/storage/hp/storeonce/restapi/custom/api.pm
@@ -112,6 +112,7 @@ sub build_options_for_httplib {
     $self->{option_results}->{proto} = 'https';
     $self->{option_results}->{proxyurl} = $self->{proxyurl};
     $self->{option_results}->{credentials} = 1;
+    $self->{option_results}->{basic} = 1;
     $self->{option_results}->{username} = $self->{username};
     $self->{option_results}->{password} = $self->{password};
 }

--- a/storage/kaminario/restapi/custom/api.pm
+++ b/storage/kaminario/restapi/custom/api.pm
@@ -114,6 +114,7 @@ sub build_options_for_httplib {
     $self->{option_results}->{proto} = 'https';
     $self->{option_results}->{proxyurl} = $self->{proxyurl};
     $self->{option_results}->{credentials} = 1;
+    $self->{option_results}->{basic} = 1;
     $self->{option_results}->{username} = $self->{username};
     $self->{option_results}->{password} = $self->{password};
 }

--- a/storage/netapp/restapi/custom/restapi.pm
+++ b/storage/netapp/restapi/custom/restapi.pm
@@ -122,6 +122,7 @@ sub build_options_for_httplib {
     $self->{option_results}->{proto} = $self->{proto};
     $self->{option_results}->{proxyurl} = $self->{proxyurl};
     $self->{option_results}->{credentials} = 1;
+    $self->{option_results}->{basic} = 1;
     $self->{option_results}->{username} = $self->{username};
     $self->{option_results}->{password} = $self->{password};
     $self->{option_results}->{ssl} = $self->{ssl};


### PR DESCRIPTION
Put --basic as an option when authentication can be Basic or something else.
Put this option to 1 when it is known as being Basic (or hidden Basic), mostly REST API.
Remove credentials from GitHub plugin as they are not handled this way.