### PR TITLE
Cannot find physical memory informations fix #994

### DIFF
--- a/os/windows/snmp/mode/memory.pm
+++ b/os/windows/snmp/mode/memory.pm
@@ -145,7 +145,7 @@ sub manage_selection {
     foreach my $key (keys %$result) {
         next if ($key !~ /\.([0-9]+)$/);
         my $oid = $1;
-        if ($result->{$key} =~ /^Physical memory$/i) {
+        if ($result->{$key} =~ /^Physical (memory|RAM)$/i) {
             $self->{physical_memory_id} = $oid;
         }
     }


### PR DESCRIPTION
hi there @maksoy74, I have same scenario, windows servers can reply with either _Physical memory_ or _Physical RAM_
Didn't have time before to create a pr with the fix but now that I saw your issue here it is. fixes #994 
Hope it helps, thanks