### PR TITLE
snmp-windows-memory | Include Physical RAM in calling memory OID

### DIFF
--- a/os/windows/snmp/mode/memory.pm
+++ b/os/windows/snmp/mode/memory.pm
@@ -145,7 +145,8 @@ sub manage_selection {
     foreach my $key (keys %$result) {
         next if ($key !~ /\.([0-9]+)$/);
         my $oid = $1;
-        if ($result->{$key} =~ /^Physical memory$/i) {
+        #if ($result->{$key} =~ /^Physical memory$/i) {
+        if ($result->{$key} =~ /^Physical (memory|RAM)$/i) {
             $self->{physical_memory_id} = $oid;
         }
     }


### PR DESCRIPTION
Windows sometimes is using Physical RAM instead of Physical memory.

This small correction would allow to call either one and assign the OID