### PR TITLE
Report idrac installed CPUs only

### DIFF
--- a/hardware/server/dell/idrac/snmp/mode/components/processor.pm
+++ b/hardware/server/dell/idrac/snmp/mode/components/processor.pm
@@ -25,11 +25,11 @@ use warnings;
 use hardware::server::dell::idrac::snmp::mode::components::resources qw(%map_status %map_state);
 
 my $mapping = {
-    processorDeviceStatusStateSettings  => { oid => '.1.3.6.1.4.1.674.10892.5.4.1100.32.1.4', map => \%map_state },
-    processorDeviceStatusStatus         => { oid => '.1.3.6.1.4.1.674.10892.5.4.1100.32.1.5', map => \%map_status },
-    processorDeviceStatusLocationName   => { oid => '.1.3.6.1.4.1.674.10892.5.4.1100.32.1.7' },
+    processorDeviceStatusStateSettings  => { oid => '.1.3.6.1.4.1.674.10892.5.4.1100.30.1.4', map => \%map_state },
+    processorDeviceStatusStatus         => { oid => '.1.3.6.1.4.1.674.10892.5.4.1100.30.1.5', map => \%map_status },
+    processorDeviceStatusLocationName   => { oid => '.1.3.6.1.4.1.674.10892.5.4.1100.30.1.26' },
 };
-my $oid_processorDeviceStatusTableEntry = '.1.3.6.1.4.1.674.10892.5.4.1100.32.1';
+my $oid_processorDeviceStatusTableEntry = '.1.3.6.1.4.1.674.10892.5.4.1100.30.1';
 
 sub load {
     my ($self) = @_;

--- a/hardware/server/dell/idrac/snmp/mode/components/processor.pm
+++ b/hardware/server/dell/idrac/snmp/mode/components/processor.pm
@@ -25,16 +25,16 @@ use warnings;
 use hardware::server::dell::idrac::snmp::mode::components::resources qw(%map_status %map_state);
 
 my $mapping = {
-    processorDeviceStatusStateSettings  => { oid => '.1.3.6.1.4.1.674.10892.5.4.1100.30.1.4', map => \%map_state },
-    processorDeviceStatusStatus         => { oid => '.1.3.6.1.4.1.674.10892.5.4.1100.30.1.5', map => \%map_status },
-    processorDeviceStatusLocationName   => { oid => '.1.3.6.1.4.1.674.10892.5.4.1100.30.1.26' },
+    processorDeviceStateSettings  => { oid => '.1.3.6.1.4.1.674.10892.5.4.1100.30.1.4', map => \%map_state },
+    processorDeviceStatus         => { oid => '.1.3.6.1.4.1.674.10892.5.4.1100.30.1.5', map => \%map_status },
+    processorDeviceFQDD           => { oid => '.1.3.6.1.4.1.674.10892.5.4.1100.30.1.26' },
 };
-my $oid_processorDeviceStatusTableEntry = '.1.3.6.1.4.1.674.10892.5.4.1100.30.1';
+my $oid_processorDeviceTableEntry = '.1.3.6.1.4.1.674.10892.5.4.1100.30.1';
 
 sub load {
     my ($self) = @_;
     
-    push @{$self->{request}}, { oid => $oid_processorDeviceStatusTableEntry };
+    push @{$self->{request}}, { oid => $oid_processorDeviceTableEntry };
 }
 
 sub check {
@@ -44,29 +44,29 @@ sub check {
     $self->{components}->{processor} = {name => 'processors', total => 0, skip => 0};
     return if ($self->check_filter(section => 'processor'));
 
-    foreach my $oid ($self->{snmp}->oid_lex_sort(keys %{$self->{results}->{$oid_processorDeviceStatusTableEntry}})) {
-        next if ($oid !~ /^$mapping->{processorDeviceStatusStatus}->{oid}\.(.*)$/);
+    foreach my $oid ($self->{snmp}->oid_lex_sort(keys %{$self->{results}->{$oid_processorDeviceTableEntry}})) {
+        next if ($oid !~ /^$mapping->{processorDeviceStatus}->{oid}\.(.*)$/);
         my $instance = $1;
-        my $result = $self->{snmp}->map_instance(mapping => $mapping, results => $self->{results}->{$oid_processorDeviceStatusTableEntry}, instance => $instance);
+        my $result = $self->{snmp}->map_instance(mapping => $mapping, results => $self->{results}->{$oid_processorDeviceTableEntry}, instance => $instance);
         
         next if ($self->check_filter(section => 'processor', instance => $instance));
         $self->{components}->{processor}->{total}++;
 
         $self->{output}->output_add(long_msg => sprintf("processor '%s' status is '%s' [instance = %s] [state = %s]",
-                                    $result->{processorDeviceStatusLocationName}, $result->{processorDeviceStatusStatus}, $instance, 
-                                    $result->{processorDeviceStatusStateSettings}));
+                                    $result->{processorDeviceFQDD}, $result->{processorDeviceStatus}, $instance, 
+                                    $result->{processorDeviceStateSettings}));
         
-        my $exit = $self->get_severity(label => 'default.state', section => 'processor.state', value => $result->{processorDeviceStatusStateSettings});
+        my $exit = $self->get_severity(label => 'default.state', section => 'processor.state', value => $result->{processorDeviceStateSettings});
         if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
             $self->{output}->output_add(severity => $exit,
-                                        short_msg => sprintf("Processor '%s' state is '%s'", $result->{processorDeviceStatusLocationName}, $result->{processorDeviceStatusStateSettings}));
+                                        short_msg => sprintf("Processor '%s' state is '%s'", $result->{processorDeviceFQDD}, $result->{processorDeviceStateSettings}));
             next;
         }
 
-        $exit = $self->get_severity(label => 'default.status', section => 'processor.status', value => $result->{processorDeviceStatusStatus});
+        $exit = $self->get_severity(label => 'default.status', section => 'processor.status', value => $result->{processorDeviceStatus});
         if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
             $self->{output}->output_add(severity => $exit,
-                                        short_msg => sprintf("Processor '%s' status is '%s'", $result->{processorDeviceStatusLocationName}, $result->{processorDeviceStatusStatus}));
+                                        short_msg => sprintf("Processor '%s' status is '%s'", $result->{processorDeviceFQDD}, $result->{processorDeviceStatus}));
         }
     }
 }


### PR DESCRIPTION
Hi,

On a server with some non-installed CPUs, the `processor` component of the idrac plugin returns `UNKNOWN` for the missing CPUs (empty sockets).
This is due to the fact that `processorDeviceStatusTable` contains entries for the non-existing CPUs.
Let's then use `processorDeviceTable` instead.

Thank you :+1: 

### Before modification :
```
$ centreon_plugins.pl --plugin=hardware::server::dell::idrac::snmp::plugin --mode=hardware --hostname=1.2.3.4 --component='processor'
UNKNOWN: Processor 'CPU2 Status' state is 'unknown' |
```

### After modification :
```
$ centreon_plugins.pl --plugin=hardware::server::dell::idrac::snmp::plugin --mode=hardware --hostname=1.2.3.4 --component='processor'
OK: All 1 components are ok [1/1 processors]. |
```

### snmpwalk data :
```
$ snmpwalk -v2c -c public 1.2.3.4 1.3.6.1.4.1.674.10892.5.4.1100.32
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.1.1.1 = INTEGER: 1
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.1.1.2 = INTEGER: 1
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.2.1.1 = INTEGER: 1
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.2.1.2 = INTEGER: 2
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.3.1.1 = INTEGER: 0
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.3.1.2 = INTEGER: 1
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.4.1.1 = INTEGER: 2
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.4.1.2 = INTEGER: 1
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.5.1.1 = INTEGER: 3
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.5.1.2 = INTEGER: 2
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.6.1.1 = INTEGER: 128
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.6.1.2 = INTEGER: 0
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.7.1.1 = STRING: "CPU1 Status"
SNMPv2-SMI::enterprises.674.10892.5.4.1100.32.1.7.1.2 = STRING: "CPU2 Status"

$ snmpwalk -v2c -c public 1.2.3.4 1.3.6.1.4.1.674.10892.5.4.1100.30
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.1.1.1 = INTEGER: 1
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.2.1.1 = INTEGER: 1
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.3.1.1 = INTEGER: 0
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.4.1.1 = INTEGER: 2
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.5.1.1 = INTEGER: 3
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.7.1.1 = INTEGER: 3
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.8.1.1 = STRING: "Intel"
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.9.1.1 = INTEGER: 3
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.10.1.1 = INTEGER: 21
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.11.1.1 = INTEGER: 4000
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.12.1.1 = INTEGER: 2400
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.13.1.1 = INTEGER: 6400
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.14.1.1 = INTEGER: 1300
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.16.1.1 = STRING: "Model 63 Stepping 2"
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.17.1.1 = INTEGER: 6
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.18.1.1 = INTEGER: 6
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.19.1.1 = INTEGER: 12
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.20.1.1 = INTEGER: 4
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.21.1.1 = INTEGER: 29
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.22.1.1 = INTEGER: 29
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.23.1.1 = STRING: "Intel(R) Xeon(R) CPU E5-2620 v3 @ 2.40GHz"
SNMPv2-SMI::enterprises.674.10892.5.4.1100.30.1.26.1.1 = STRING: "CPU.Socket.1"
```