### PR TITLE
fix qnap hardware thresholds overload

### DIFF
--- a/storage/qnap/snmp/mode/hardware.pm
+++ b/storage/qnap/snmp/mode/hardware.pm
@@ -28,8 +28,8 @@ use warnings;
 sub set_system {
     my ($self, %options) = @_;
     
-    $self->{regexp_threshold_overload_check_section_option} = '^(temperature|disk|fan)$';
-    $self->{regexp_threshold_numeric_check_section_option} = '^(temperature|disk|fan)$';
+    $self->{regexp_threshold_overload_check_section_option} = '^(temperature|disk|smartdisk|fan)$';
+    $self->{regexp_threshold_numeric_check_section_option} = '^(temperature|disk|smartdisk|fan)$';
     
     $self->{cb_hook2} = 'snmp_execute';
     


### PR DESCRIPTION
Add smartdisk section to allow threshold overload

Fix: https://github.com/centreon/centreon-plugins/issues/1008