### PR TITLE
Correct RADIUS help

### DIFF
--- a/apps/protocols/radius/mode/login.pm
+++ b/apps/protocols/radius/mode/login.pm
@@ -282,7 +282,7 @@ Specify password for authentication
 
 Connection timeout in seconds (Default: 5)
 
-=item B<--timeout>
+=item B<--retry>
 
 Number of retry connection (Default: 0)
 


### PR DESCRIPTION
Correct option '--retry' instead of '--timeout' in help of plugin