### PR TITLE
enh windows snmp swap, physical memory name

### DIFF
--- a/os/windows/snmp/mode/swap.pm
+++ b/os/windows/snmp/mode/swap.pm
@@ -72,7 +72,7 @@ sub run {
         if ($result->{$key} =~ /^Virtual memory$/i) {
             $self->{swap_memory_id} = $oid;
         }
-        if ($result->{$key} =~ /^Physical memory$/i) {
+        if ($result->{$key} =~ /^Physical (memory|RAM)$/i) {
             $self->{physical_memory_id} = $oid;
         }
     }


### PR DESCRIPTION
Matches https://github.com/centreon/centreon-plugins/issues/994 fix