### PR TITLE
Add an autoreduce option to adapt UDP packet size

### DIFF
--- a/centreon/plugins/snmp.pm
+++ b/centreon/plugins/snmp.pm
@@ -255,8 +255,8 @@ RETRY:
                     } else {
                         $self->{subsetleef} -= 1;
                     }
-                    if ($self->{snmp_params}->{Retries} > 0) {
-                        $self->{snmp_params}->{Retries} = 0;
+                    if ($self->{snmp_params}->{Retries} > 1) {
+                        $self->{snmp_params}->{Retries} = 1;
                         $self->connect();
                     }
                     goto RETRY;
@@ -406,8 +406,8 @@ RETRY:
                     } else {
                         $self->{repeat_count} -= 1;
                     }
-                    if ($self->{snmp_params}->{Retries} > 0) {
-                        $self->{snmp_params}->{Retries} = 0;
+                    if ($self->{snmp_params}->{Retries} > 1) {
+                        $self->{snmp_params}->{Retries} = 1;
                         $self->connect();
                     }
                     goto RETRY;
@@ -567,8 +567,8 @@ RETRY:
                     } else {
                         $self->{repeat_count} -= 1;
                     }
-                    if ($self->{snmp_params}->{Retries} > 0) {
-                        $self->{snmp_params}->{Retries} = 0;
+                    if ($self->{snmp_params}->{Retries} > 1) {
+                        $self->{snmp_params}->{Retries} = 1;
                         $self->connect();
                     }
                     goto RETRY;

--- a/centreon/plugins/snmp.pm
+++ b/centreon/plugins/snmp.pm
@@ -400,11 +400,11 @@ RETRY:
             # snmp.h     : #define SNMP_ERR_TOOBIG (1)
             # snmp_api.h : #define SNMPERR_TIMEOUT (-24)
             if (($self->{session}->{ErrorNum} == 1) || ($self->{session}->{ErrorNum} == -24)) {
-                if (!defined($self->{snmp_force_getnext}) && defined($self->{autoreduce}) && ($self->{repeat_count} > 1)) {
-                    if ($self->{repeat_count} >= 10) {
-                        $self->{repeat_count} -= 5;
+                if (!defined($self->{snmp_force_getnext}) && defined($self->{autoreduce}) && ($repeat_count > 1)) {
+                    if ($repeat_count >= 10) {
+                        $repeat_count -= 5;
                     } else {
-                        $self->{repeat_count} -= 1;
+                        $repeat_count -= 1;
                     }
                     if ($self->{snmp_params}->{Retries} > 1) {
                         $self->{snmp_params}->{Retries} = 1;
@@ -561,11 +561,11 @@ RETRY:
             # snmp.h     : #define SNMP_ERR_TOOBIG (1)
             # snmp_api.h : #define SNMPERR_TIMEOUT (-24)
             if (($self->{session}->{ErrorNum} == 1) || ($self->{session}->{ErrorNum} == -24)) {
-                if (!defined($self->{snmp_force_getnext}) && defined($self->{autoreduce}) && ($self->{repeat_count} > 1)) {
-                    if ($self->{repeat_count} >= 10) {
-                        $self->{repeat_count} -= 5;
+                if (!defined($self->{snmp_force_getnext}) && defined($self->{autoreduce}) && ($repeat_count > 1)) {
+                    if ($repeat_count >= 10) {
+                        $repeat_count -= 5;
                     } else {
-                        $self->{repeat_count} -= 1;
+                        $repeat_count -= 1;
                     }
                     if ($self->{snmp_params}->{Retries} > 1) {
                         $self->{snmp_params}->{Retries} = 1;


### PR DESCRIPTION
Hi,

Here is a PR to add a new `--autoreduce` SNMP option.
If a SNMP request fails because it was too big, `--autoreduce` will automatically retry a smaller request.

Even if we use for example `--maxrepetitions=20 --subsetleef=20` (which are fairly low values), Centreon Plugins may fail from time to time, depending on what is running on the requested device.
`--autoreduce` then helps here.

Thank you 👍 