### PR TITLE
Add UDP rtt to Uptime mode

### DIFF
--- a/snmp_standard/mode/uptime.pm
+++ b/snmp_standard/mode/uptime.pm
@@ -116,6 +116,7 @@ sub run {
         }
     }
     my $elapsed = tv_interval ($t0, [gettimeofday]);
+    $elapsed *= 1000;
     
     $value = $self->check_overload(timeticks => $value);
     $value = floor($value / 100);
@@ -127,12 +128,12 @@ sub run {
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                   critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical'),
                                   min => 0);
-    $self->{output}->perfdata_add(label => 'rtt', unit => 's',
+    $self->{output}->perfdata_add(label => 'rtt', unit => 'ms',
                                   value => $elapsed);
 
     $self->{output}->output_add(severity => $exit_code,
-                                short_msg => sprintf("System uptime is: %s, rtt is: $elapsed",
-                                                     centreon::plugins::misc::change_seconds(value => $value, start => 'd')));
+                                short_msg => sprintf("System uptime is: %s, rtt is: %sms",
+                                                     centreon::plugins::misc::change_seconds(value => $value, start => 'd'), $elapsed));
 
     $self->{output}->display();
     $self->{output}->exit();


### PR DESCRIPTION
Hi,

This PR adds _round-trip time_ (RTT) info to SNMP _Uptime_ mode.
Sometimes, we can't use ICMP ping, due to remote device / firewall rules.
In this situation, one could still want to be able to build & display RTT graphs.
This PR then adds to the _Uptime_ mode the duration needed to get the Uptime OID, which is a tiny operation, thus can be considered as the _round-trip time_ (difference is less than 0.5ms in my tests).

Thank you :+1: 