### PR TITLE
Add time mode to FreeBSD plugin

### DIFF
--- a/os/freebsd/snmp/plugin.pm
+++ b/os/freebsd/snmp/plugin.pm
@@ -45,6 +45,7 @@ sub new {
                          'processcount'     => 'snmp_standard::mode::processcount',
                          'storage'          => 'snmp_standard::mode::storage',
                          'swap'             => 'snmp_standard::mode::swap',
+                         'time'             => 'snmp_standard::mode::ntp',
                          'tcpcon'           => 'snmp_standard::mode::tcpcon',
                          'uptime'           => 'snmp_standard::mode::uptime',
                          );


### PR DESCRIPTION
Hi,

This PR adds time mode to FreeBSD SNMP plugin, as in Linux SNMP plugin.
Tested, and of course it works.

Thank you :+1: 