### PR TITLE
enhance template counter

### DIFF
--- a/centreon/common/aruba/snmp/mode/apconnections.pm
+++ b/centreon/common/aruba/snmp/mode/apconnections.pm
@@ -210,7 +210,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $maps_counters->{ap}->{$_}->{obj}->perfdata(extra_instance => $multiple);
+            $maps_counters->{ap}->{$_}->{obj}->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "AP [bssid: '$self->{ap}->{$id}->{bssid}', essid: $self->{ap}->{$id}->{apESSID}, ip: $self->{ap}->{$id}->{apIpAddress}] Usage $long_msg");

--- a/centreon/common/cisco/standard/snmp/mode/memoryflash.pm
+++ b/centreon/common/cisco/standard/snmp/mode/memoryflash.pm
@@ -162,7 +162,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $obj->perfdata(extra_instance => $multiple);
+            $obj->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Partition '" . $self->{memory_selected}->{$id}->{display} . "' $long_msg");

--- a/centreon/common/force10/snmp/mode/cpu.pm
+++ b/centreon/common/force10/snmp/mode/cpu.pm
@@ -142,7 +142,7 @@ sub run_instances {
                 $short_msg_append = ', ';
             }
             
-            $obj->perfdata(extra_instance => $multiple);
+            $obj->perfdata(level => 1, extra_instance => $multiple);
         }
 
         my $prefix = "CPU Usage ";

--- a/centreon/common/force10/snmp/mode/memory.pm
+++ b/centreon/common/force10/snmp/mode/memory.pm
@@ -122,7 +122,7 @@ sub run_instances {
                 $short_msg_append = ', ';
             }
             
-            $obj->perfdata(extra_instance => $multiple);
+            $obj->perfdata(level => 1, extra_instance => $multiple);
         }
 
         my $prefix = "Memory Usage ";

--- a/centreon/common/fortinet/fortigate/mode/ipsstats.pm
+++ b/centreon/common/fortinet/fortigate/mode/ipsstats.pm
@@ -200,7 +200,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $maps_counters->{$_}->{obj}->perfdata(extra_instance => $multiple);
+            $maps_counters->{$_}->{obj}->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Domain '" . $self->{domain_selected}->{$id}->{display} . "' $long_msg");

--- a/centreon/plugins/templates/counter.pm
+++ b/centreon/plugins/templates/counter.pm
@@ -221,6 +221,7 @@ sub run_instances {
     my $display_status_long_output = defined($options{display_status_long_output}) && $options{display_status_long_output} == 1 ? 1 : 0;
     my $resume = defined($options{resume}) && $options{resume} == 1 ? 1 : 0;
     
+    $self->{problems} = 0;
     my $level = 1;
     my $multiple_lvl2 = 0;
     my $instances = $self->{$options{config}->{name}};
@@ -272,6 +273,7 @@ sub run_instances {
             $long_msg_append = $message_separator;
             
             if (!$self->{output}->is_status(litteral => 1, value => $exit, compare => 'ok')) {
+                $self->{problems}++;
                 $short_msg .= $short_msg_append . $output;
                 $short_msg_append = $message_separator;
             }
@@ -296,7 +298,7 @@ sub run_instances {
         # in mode grouped, we don't display 'ok'
         my $debug = 0;
         $debug = 1 if ($display_status_long_output == 1 && $self->{output}->is_status(value => $exit, compare => 'OK', litteral => 1));
-        $self->{output}->output_add(long_msg => ($display_status_long_output == 1 ? lc($exit) . ': ' : '') . "${prefix_output}${long_msg}${suffix_output}", debug => $debug);
+        $self->{output}->output_add(long_msg => ($display_status_long_output == 1 ? lc($exit) . ': ' : '') . $prefix_output . $long_msg . $suffix_output, debug => $debug);
         if ($resume == 1) {
             $self->{most_critical_instance} = $self->{output}->get_most_critical(status => [ $self->{most_critical_instance},  $exit ]);  
             next;
@@ -361,7 +363,7 @@ sub run_group {
             
             if ($multiple == 0) {
                 $self->{output}->output_add(severity => $self->{most_critical_instance},
-                                            short_msg => "${prefix_output}$self->{problems} problem(s) detected");
+                                            short_msg => $prefix_output . $self->{problems} . " problem(s) detected");
             }
         }
     }

--- a/centreon/plugins/templates/counter.pm
+++ b/centreon/plugins/templates/counter.pm
@@ -99,7 +99,7 @@ sub new {
         foreach (@{$self->{maps_counters}->{$key}}) {
             if (!defined($_->{threshold}) || $_->{threshold} != 0) {
                 $options{options}->add_options(arguments => {
-                                                    'warning-' . $_->{label} . ':s'    => { name => 'warning-' . $_->{label} },
+                                                    'warning-' . $_->{label} . ':s'     => { name => 'warning-' . $_->{label} },
                                                     'critical-' . $_->{label} . ':s'    => { name => 'critical-' . $_->{label} },
                                                });
             }
@@ -144,57 +144,71 @@ sub run_global {
     
     return undef if (defined($options{config}->{cb_init}) && $self->call_object_callback(method_name => $options{config}->{cb_init}) == 1);
     
-    my $message_separator = defined($options{config}->{message_separator}) ? 
-        $options{config}->{message_separator}: ', ';
+    my $message_separator = defined($options{config}->{message_separator}) ? $options{config}->{message_separator} : ', ';
     my ($short_msg, $short_msg_append, $long_msg, $long_msg_append) = ('', '', '', '');
     my @exits;
+
+    my $multiple = 0;
+
     foreach (@{$self->{maps_counters}->{$options{config}->{name}}}) {
         my $obj = $_->{obj};
 
         next if (defined($self->{option_results}->{filter_counters}) && $self->{option_results}->{filter_counters} ne '' &&
             $_->{label} !~ /$self->{option_results}->{filter_counters}/);
         
-        $obj->set(instance => $options{config}->{name});
+        my $value_check;
+        if (defined($options{instance}) && $options{instance} ne '') {
+            $obj->set(instance => $options{instance});
+            if (scalar(keys %{$self->{$options{counter_name}}}) > 1) {
+                $multiple = 1;
+            }
+            $value_check = $obj->execute(new_datas => $self->{new_datas}, values => $self->{$options{counter_name}}->{$options{instance}}->{$options{config}->{name}});
+        } else {
+            $obj->set(instance => $options{config}->{name});
+            $value_check = $obj->execute(new_datas => $self->{new_datas}, values => $self->{$options{config}->{name}});
+        }
     
-        my ($value_check) = $obj->execute(new_datas => $self->{new_datas}, values => $self->{$options{config}->{name}});
-
         next if (defined($options{config}->{skipped_code}) && defined($options{config}->{skipped_code}->{$value_check}));
         if ($value_check != 0) {
             $long_msg .= $long_msg_append . $obj->output_error();
             $long_msg_append = $message_separator;
             next;
         }
-        my $exit2 = $obj->threshold_check();
-        push @exits, $exit2;
+        my $exit = $obj->threshold_check();
+        push @exits, $exit;
 
         my $output = $obj->output();
         $long_msg .= $long_msg_append . $output;
         $long_msg_append = $message_separator;
         
-        if (!$self->{output}->is_status(litteral => 1, value => $exit2, compare => 'ok')) {
+        if (!$self->{output}->is_status(litteral => 1, value => $exit, compare => 'ok')) {
             $short_msg .= $short_msg_append . $output;
             $short_msg_append = $message_separator;
         }
         
-        $obj->perfdata();
+        $obj->perfdata(level => 1, extra_instance => $multiple);
     }
-
-    my ($prefix_output, $suffix_output);
-    $prefix_output = $self->call_object_callback(method_name => $options{config}->{cb_prefix_output}) 
-        if (defined($options{config}->{cb_prefix_output}));
-    $prefix_output = '' if (!defined($prefix_output));
     
-    $suffix_output = $self->call_object_callback(method_name => $options{config}->{cb_suffix_output}) 
-        if (defined($options{config}->{cb_suffix_output}));
+    my ($prefix_output, $suffix_output);
+    if (defined($options{config}->{cb_prefix_output})) {
+        if (defined($options{instance}) && $options{instance} ne '') {
+            $prefix_output = $self->call_object_callback(method_name => $options{config}->{cb_prefix_output},
+                                                         instance_value => $self->{$options{counter_name}}->{$options{instance}});
+        } else {
+            $prefix_output = $self->call_object_callback(method_name => $options{config}->{cb_prefix_output}) if (defined($options{config}->{cb_prefix_output}));
+        }
+    }
+    $prefix_output = '' if (!defined($prefix_output));
+    $suffix_output = $self->call_object_callback(method_name => $options{config}->{cb_suffix_output}) if (defined($options{config}->{cb_suffix_output}));
     $suffix_output = '' if (!defined($suffix_output));
     
     my $exit = $self->{output}->get_most_critical(status => [ @exits ]);
     if (!$self->{output}->is_status(litteral => 1, value => $exit, compare => 'ok')) {
         $self->{output}->output_add(severity => $exit,
-                                    short_msg => "${prefix_output}${short_msg}${suffix_output}"
+                                    short_msg => $prefix_output . $short_msg . $suffix_output
                                     );
     } else {
-        $self->{output}->output_add(short_msg => "${prefix_output}${long_msg}${suffix_output}") if ($long_msg ne '');
+        $self->{output}->output_add(short_msg => $prefix_output . $long_msg . $suffix_output) if ($long_msg ne '' && $multiple == 0);
     }
 }
 
@@ -202,71 +216,87 @@ sub run_instances {
     my ($self, %options) = @_;
     
     return undef if (defined($options{config}->{cb_init}) && $self->call_object_callback(method_name => $options{config}->{cb_init}) == 1);
-    my $display_status_lo = defined($options{display_status_long_output}) && $options{display_status_long_output} == 1 ? 1 : 0;
+
+    my $message_separator = defined($options{config}->{message_separator}) ? $options{config}->{message_separator} : ', ';
+    my $display_status_long_output = defined($options{display_status_long_output}) && $options{display_status_long_output} == 1 ? 1 : 0;
     my $resume = defined($options{resume}) && $options{resume} == 1 ? 1 : 0;
     
-    $self->{lproblems} = 0;
-    $self->{multiple} = 1;
-    if (scalar(keys %{$self->{$options{config}->{name}}}) == 1) {
-        $self->{multiple} = 0;
+    my $level = 1;
+    my $multiple_lvl2 = 0;
+    my $instances = $self->{$options{config}->{name}};
+
+    if (defined($options{instance}) && $options{instance} ne '') {
+        $level = 2;
+        if (scalar(keys %{$self->{$options{counter_name}}->{$options{instance}}->{$options{config}->{name}}}) > 1) {
+            $multiple_lvl2 = 1;
+        }
+        $instances = $self->{$options{counter_name}}->{$options{instance}}->{$options{config}->{name}};
+    } else {
+        $self->{multiple_lvl1} = 0;
+        if (scalar(keys %{$self->{$options{config}->{name}}}) > 1) {
+            $self->{multiple_lvl1} = 1;
+        }
     }
-    
-    if ($self->{multiple} == 1 && $resume == 0) {
+    if ($self->{multiple_lvl1} > 0 && $resume == 0) {
         $self->{output}->output_add(severity => 'OK',
                                     short_msg => $options{config}->{message_multiple});
     }
-    
-    my $message_separator = defined($options{config}->{message_separator}) ? 
-        $options{config}->{message_separator}: ', ';
-    foreach my $id (sort keys %{$self->{$options{config}->{name}}}) {
+
+    foreach my $instance (sort keys %{$instances}) {
         my ($short_msg, $short_msg_append, $long_msg, $long_msg_append) = ('', '', '', '');
-        my @exits = ();
+        my @exits;
         foreach (@{$self->{maps_counters}->{$options{config}->{name}}}) {
             my $obj = $_->{obj};
             
             next if (defined($self->{option_results}->{filter_counters}) && $self->{option_results}->{filter_counters} ne '' &&
                 $_->{label} !~ /$self->{option_results}->{filter_counters}/);
             
-            $obj->set(instance => $id);
+            $obj->set(instance => $instance);
+            
+            if (defined($options{instance}) && $options{instance} ne '') {
+                $obj->set(instance => $options{instance} . '_' . $instance);
+            }
         
-            my ($value_check) = $obj->execute(new_datas => $self->{new_datas},
-                                              values => $self->{$options{config}->{name}}->{$id});
+            my $value_check = $obj->execute(new_datas => $self->{new_datas}, values => $instances->{$instance});
             next if (defined($options{config}->{skipped_code}) && defined($options{config}->{skipped_code}->{$value_check}));
             if ($value_check != 0) {
                 $long_msg .= $long_msg_append . $obj->output_error();
                 $long_msg_append = $message_separator;
                 next;
             }
-            my $exit2 = $obj->threshold_check();
-            push @exits, $exit2;
+            my $exit = $obj->threshold_check();
+            push @exits, $exit;
 
             my $output = $obj->output();
             $long_msg .= $long_msg_append . $output;
             $long_msg_append = $message_separator;
             
-            if (!$self->{output}->is_status(litteral => 1, value => $exit2, compare => 'ok')) {
-                $self->{lproblems}++;
+            if (!$self->{output}->is_status(litteral => 1, value => $exit, compare => 'ok')) {
                 $short_msg .= $short_msg_append . $output;
                 $short_msg_append = $message_separator;
             }
             
-            $obj->perfdata(extra_instance => $self->{multiple});
+            $obj->perfdata(level => $level, extra_instance => $self->{multiple_lvl1}, extra_instance_lvl2 => $multiple_lvl2);
         }
 
         my ($prefix_output, $suffix_output);
-        $prefix_output = $self->call_object_callback(method_name => $options{config}->{cb_prefix_output}, instance_value => $self->{$options{config}->{name}}->{$id})
-            if (defined($options{config}->{cb_prefix_output}));
-        $prefix_output = '' if (!defined($prefix_output));
-        
-        $suffix_output = $self->call_object_callback(method_name => $options{config}->{cb_suffix_output}) 
-        if (defined($options{config}->{cb_suffix_output}));
+        if (defined($options{config}->{cb_prefix_output})) {
+            if (defined($options{instance}) && $options{instance} ne '') {
+                $prefix_output = $self->call_object_callback(method_name => $options{config}->{cb_prefix_output},
+                                                             instance_value => $self->{$options{counter_name}}->{$options{instance}}->{$options{config}->{name}}->{$instance});
+            } else {
+                $prefix_output = $self->call_object_callback(method_name => $options{config}->{cb_prefix_output}, instance_value => $self->{$options{config}->{name}}->{$instance}) if (defined($options{config}->{cb_prefix_output}));
+            }
+        }
+        $prefix_output = '' if (!defined($prefix_output));        
+        $suffix_output = $self->call_object_callback(method_name => $options{config}->{cb_suffix_output}) if (defined($options{config}->{cb_suffix_output}));
         $suffix_output = '' if (!defined($suffix_output));
 
         my $exit = $self->{output}->get_most_critical(status => [ @exits ]);
         # in mode grouped, we don't display 'ok'
         my $debug = 0;
-        $debug = 1 if ($display_status_lo == 1 && $self->{output}->is_status(value => $exit, compare => 'OK', litteral => 1));
-        $self->{output}->output_add(long_msg => ($display_status_lo == 1 ? lc($exit) . ': ' : '') . "${prefix_output}${long_msg}${suffix_output}", debug => $debug);
+        $debug = 1 if ($display_status_long_output == 1 && $self->{output}->is_status(value => $exit, compare => 'OK', litteral => 1));
+        $self->{output}->output_add(long_msg => ($display_status_long_output == 1 ? lc($exit) . ': ' : '') . "${prefix_output}${long_msg}${suffix_output}", debug => $debug);
         if ($resume == 1) {
             $self->{most_critical_instance} = $self->{output}->get_most_critical(status => [ $self->{most_critical_instance},  $exit ]);  
             next;
@@ -274,12 +304,22 @@ sub run_instances {
         
         if (!$self->{output}->is_status(litteral => 1, value => $exit, compare => 'ok')) {
             $self->{output}->output_add(severity => $exit,
-                                        short_msg => "${prefix_output}${short_msg}${suffix_output}"
+                                        short_msg => $prefix_output . $short_msg . $suffix_output
                                         );
         }
         
-        if ($self->{multiple} == 0) {
-            $self->{output}->output_add(short_msg => "${prefix_output}${long_msg}${suffix_output}");
+        if ($self->{multiple_lvl1} == 0 && $multiple_lvl2 == 0) {
+            $self->{output}->output_add(short_msg => $prefix_output . $long_msg . $suffix_output);
+        }
+
+        if ($options{multi}) {
+            foreach my $counter (@{$options{config}->{counters}}) {
+                if ($counter->{type} == 0) {
+                    $self->run_global(config => $counter, counter_name => $options{config}->{name}, instance => $instance);
+                } elsif ($counter->{type} == 1) {
+                    $self->run_instances(config => $counter, counter_name => $options{config}->{name}, instance => $instance);
+                }
+            }
         }
     }
 }
@@ -298,30 +338,30 @@ sub run_group {
     }
     
     my ($global_exit, $total_problems) = ([], 0);
-    foreach my $id (sort keys %{$self->{$options{config}->{name}}}) {
+    foreach my $instance (sort keys %{$self->{$options{config}->{name}}}) {
         $self->{most_critical_instance} = 'ok';
         if (defined($options{config}->{cb_long_output})) {
             $self->{output}->output_add(long_msg => $self->call_object_callback(method_name => $options{config}->{cb_long_output},
-                                                                                instance_value => $self->{$options{config}->{name}}->{$id}));
+                                                                                instance_value => $self->{$options{config}->{name}}->{$instance}));
         }
         
         foreach my $group (@{$options{config}->{group}}) {
-            $self->{$group->{name}} = $self->{$options{config}->{name}}->{$id}->{$group->{name}};
+            $self->{$group->{name}} = $self->{$options{config}->{name}}->{$instance}->{$group->{name}};
             
             # we resume datas
             $self->run_instances(config => $group, display_status_long_output => 1, resume => 1);
             
             push @{$global_exit}, $self->{most_critical_instance};
-            $total_problems += $self->{lproblems};
+            $total_problems += $self->{problems};
             
             my $prefix_output;
-            $prefix_output = $self->call_object_callback(method_name => $options{config}->{cb_prefix_output}, instance_value => $self->{$options{config}->{name}}->{$id})
+            $prefix_output = $self->call_object_callback(method_name => $options{config}->{cb_prefix_output}, instance_value => $self->{$options{config}->{name}}->{$instance})
             if (defined($options{config}->{cb_prefix_output}));
             $prefix_output = '' if (!defined($prefix_output));
             
             if ($multiple == 0) {
                 $self->{output}->output_add(severity => $self->{most_critical_instance},
-                                            short_msg => "${prefix_output}$self->{lproblems} problem(s) detected");
+                                            short_msg => "${prefix_output}$self->{problems} problem(s) detected");
             }
         }
     }
@@ -360,6 +400,8 @@ sub run {
             $self->run_instances(config => $entry);
         } elsif ($entry->{type} == 2) {
             $self->run_group(config => $entry);
+        } elsif ($entry->{type} == 3) {
+            $self->run_instances(config => $entry, multi => 1);
         }
     }
         

--- a/centreon/plugins/values.pm
+++ b/centreon/plugins/values.pm
@@ -186,10 +186,15 @@ sub perfdata {
         if (defined($perf->{threshold_total})) {
             $th_total = ($perf->{threshold_total} =~ /[^0-9]/) ? $self->{result_values}->{$perf->{threshold_total}} : $perf->{threshold_total};
         }
+
+        if (defined($perf->{label_multi_instances}) && $perf->{label_multi_instances} == 1 && (defined($options{level}) && $options{level} == 2 && defined($options{extra_instance}) && $options{extra_instance} == 1)) {
+            if (defined($perf->{multi_use})) {
+                $extra_label .= '_' . $self->{result_values}->{$perf->{multi_use}};
+            }
+        }
         
-        if (defined($perf->{label_extra_instance}) && $perf->{label_extra_instance} == 1 && 
-           (!defined($options{extra_instance}) || $options{extra_instance} != 0)) {
-          
+        if (defined($perf->{label_extra_instance}) && $perf->{label_extra_instance} == 1 && (defined($options{level}) && $options{level} == 1 && defined($options{extra_instance}) && $options{extra_instance} == 1) ||
+            (defined($options{level}) && $options{level} == 2 && defined($options{extra_instance_lvl2}) && $options{extra_instance_lvl2} == 1)) {
             if (defined($perf->{instance_use})) {
                 $extra_label .= '_' . $self->{result_values}->{$perf->{instance_use}};
             } else {

--- a/database/oracle/mode/asmdiskgroupusage.pm
+++ b/database/oracle/mode/asmdiskgroupusage.pm
@@ -337,7 +337,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $obj->perfdata(extra_instance => $multiple);
+            $obj->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Diskgroup '$self->{dg}->{$id}->{display}' $long_msg");

--- a/database/postgres/mode/statistics.pm
+++ b/database/postgres/mode/statistics.pm
@@ -260,7 +260,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $maps_counters->{database}->{$_}->{obj}->perfdata(extra_instance => $multiple);
+            $maps_counters->{database}->{$_}->{obj}->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Database '" . $self->{db_selected}->{$id}->{name} . "' $long_msg");

--- a/hardware/ups/mge/snmp/mode/inputlines.pm
+++ b/hardware/ups/mge/snmp/mode/inputlines.pm
@@ -143,7 +143,7 @@ sub manage_counters {
             $short_msg_append = ', ';
         }
         
-        $options{maps_counters}->{$_}->{obj}->perfdata(extra_instance => $self->{multiple});
+        $options{maps_counters}->{$_}->{obj}->perfdata(level => 1, extra_instance => $self->{multiple});
     }
 
     $self->{output}->output_add(long_msg => $options{label} . " " . $long_msg);

--- a/hardware/ups/mge/snmp/mode/outputlines.pm
+++ b/hardware/ups/mge/snmp/mode/outputlines.pm
@@ -175,7 +175,7 @@ sub manage_counters {
             $short_msg_append = ', ';
         }
         
-        $options{maps_counters}->{$_}->{obj}->perfdata(extra_instance => $self->{multiple});
+        $options{maps_counters}->{$_}->{obj}->perfdata(level => 1, extra_instance => $self->{multiple});
     }
 
     $self->{output}->output_add(long_msg => $options{label} . " " . $long_msg);

--- a/hardware/ups/powerware/snmp/mode/inputlines.pm
+++ b/hardware/ups/powerware/snmp/mode/inputlines.pm
@@ -163,7 +163,7 @@ sub manage_counters {
             $short_msg_append = ', ';
         }
         
-        $options{maps_counters}->{$_}->{obj}->perfdata(extra_instance => $self->{multiple});
+        $options{maps_counters}->{$_}->{obj}->perfdata(level => 1, extra_instance => $self->{multiple});
     }
 
     $self->{output}->output_add(long_msg => $options{label} . " " . $long_msg);

--- a/hardware/ups/powerware/snmp/mode/outputlines.pm
+++ b/hardware/ups/powerware/snmp/mode/outputlines.pm
@@ -177,7 +177,7 @@ sub manage_counters {
             $short_msg_append = ', ';
         }
         
-        $options{maps_counters}->{$_}->{obj}->perfdata(extra_instance => $self->{multiple});
+        $options{maps_counters}->{$_}->{obj}->perfdata(level => 1, extra_instance => $self->{multiple});
     }
 
     $self->{output}->output_add(long_msg => $options{label} . " " . $long_msg);

--- a/network/alcatel/oxe/snmp/mode/domainusage.pm
+++ b/network/alcatel/oxe/snmp/mode/domainusage.pm
@@ -211,7 +211,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $obj->perfdata(extra_instance => $multiple);
+            $obj->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Domain '$self->{domain}->{$id}->{display}' $long_msg");

--- a/network/h3c/snmp/mode/cpu.pm
+++ b/network/h3c/snmp/mode/cpu.pm
@@ -134,7 +134,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $maps_counters->{cpu}->{$_}->{obj}->perfdata(extra_instance => $multiple);
+            $maps_counters->{cpu}->{$_}->{obj}->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "CPU '" . $self->{cpu}->{$id}->{num} . "' Usage $long_msg [entity = '" . $self->{cpu}->{$id}->{name} . "']");

--- a/network/h3c/snmp/mode/memory.pm
+++ b/network/h3c/snmp/mode/memory.pm
@@ -190,7 +190,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $maps_counters->{$_}->{obj}->perfdata(extra_instance => $multiple);
+            $maps_counters->{$_}->{obj}->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Memory '" . $self->{memory_selected}->{$id}->{display} . "' $long_msg [entity = '" . $self->{memory_selected}->{$id}->{name} . "']");

--- a/network/juniper/ggsn/mode/apnstats.pm
+++ b/network/juniper/ggsn/mode/apnstats.pm
@@ -305,7 +305,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $maps_counters->{$_}->{obj}->perfdata(extra_instance => $multiple);
+            $maps_counters->{$_}->{obj}->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "APN '" . $self->{apn_selected}->{$id}->{ggsnApnName} . "' $long_msg");

--- a/network/stormshield/snmp/mode/vpnstatus.pm
+++ b/network/stormshield/snmp/mode/vpnstatus.pm
@@ -193,7 +193,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $maps_counters->{vpn}->{$_}->{obj}->perfdata(extra_instance => $multiple);
+            $maps_counters->{vpn}->{$_}->{obj}->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "VPN '$self->{vpn}->{$id}->{num}/$self->{vpn}->{$id}->{ntqVPNIPSrc}/$self->{vpn}->{$id}->{ntqVPNIPDst}' $long_msg");

--- a/snmp_standard/mode/interfaces.pm
+++ b/snmp_standard/mode/interfaces.pm
@@ -934,7 +934,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $obj->perfdata(extra_instance => $multiple);
+            $obj->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Interface '" . $self->{interface_selected}->{$id}->{display} . "'$self->{interface_selected}->{$id}->{extra_display} $long_msg");

--- a/storage/dell/equallogic/snmp/mode/arraystats.pm
+++ b/storage/dell/equallogic/snmp/mode/arraystats.pm
@@ -244,7 +244,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $maps_counters->{$_}->{obj}->perfdata(extra_instance => $multiple);
+            $maps_counters->{$_}->{obj}->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "'" . $self->{member_selected}->{$id}->{display} . "' $long_msg");

--- a/storage/dell/equallogic/snmp/mode/diskusage.pm
+++ b/storage/dell/equallogic/snmp/mode/diskusage.pm
@@ -181,7 +181,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $maps_counters->{$_}->{obj}->perfdata(extra_instance => $multiple);
+            $maps_counters->{$_}->{obj}->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Disk '" . $self->{member_selected}->{$id}->{display} . "' $long_msg");

--- a/storage/dell/equallogic/snmp/mode/poolusage.pm
+++ b/storage/dell/equallogic/snmp/mode/poolusage.pm
@@ -161,7 +161,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $maps_counters->{$_}->{obj}->perfdata(extra_instance => $multiple);
+            $maps_counters->{$_}->{obj}->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Pool '" . $self->{pool_selected}->{$id}->{display} . "' $long_msg");

--- a/storage/emc/xtremio/restapi/mode/ssdiops.pm
+++ b/storage/emc/xtremio/restapi/mode/ssdiops.pm
@@ -140,7 +140,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $obj->perfdata(extra_instance => $multiple);
+            $obj->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "SSD '" . $self->{ssd}->{$id}->{display} . "' Usage $long_msg");

--- a/storage/fujitsu/eternus/dx/ssh/mode/cpu.pm
+++ b/storage/fujitsu/eternus/dx/ssh/mode/cpu.pm
@@ -144,7 +144,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $obj->perfdata(extra_instance => $multiple);
+            $obj->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "CPU '$self->{cpu}->{$id}->{display}' $long_msg");

--- a/storage/fujitsu/eternus/dx/ssh/mode/portstats.pm
+++ b/storage/fujitsu/eternus/dx/ssh/mode/portstats.pm
@@ -174,7 +174,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $obj->perfdata(extra_instance => $multiple);
+            $obj->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Port '$self->{port}->{$id}->{display}' $long_msg");

--- a/storage/fujitsu/eternus/dx/ssh/mode/raidgroups.pm
+++ b/storage/fujitsu/eternus/dx/ssh/mode/raidgroups.pm
@@ -239,7 +239,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $obj->perfdata(extra_instance => $multiple);
+            $obj->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Raid Group '$self->{rg}->{$id}->{display}' $long_msg");

--- a/storage/fujitsu/eternus/dx/ssh/mode/volumestats.pm
+++ b/storage/fujitsu/eternus/dx/ssh/mode/volumestats.pm
@@ -234,7 +234,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $obj->perfdata(extra_instance => $multiple);
+            $obj->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Volume '$self->{vol}->{$id}->{display}' $long_msg");

--- a/storage/hp/p2000/xmlapi/mode/volumesstats.pm
+++ b/storage/hp/p2000/xmlapi/mode/volumesstats.pm
@@ -246,7 +246,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $maps_counters->{$_}->{obj}->perfdata(extra_instance => $multiple);
+            $maps_counters->{$_}->{obj}->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Volume '$name' $long_msg");

--- a/storage/netapp/snmp/mode/aggregatestate.pm
+++ b/storage/netapp/snmp/mode/aggregatestate.pm
@@ -188,7 +188,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $maps_counters->{agg}->{$_}->{obj}->perfdata(extra_instance => $multiple);
+            $maps_counters->{agg}->{$_}->{obj}->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Aggregate '$self->{agg}->{$id}->{aggrName}' $long_msg");

--- a/storage/nimble/snmp/mode/volumeusage.pm
+++ b/storage/nimble/snmp/mode/volumeusage.pm
@@ -169,7 +169,7 @@ sub run_instances {
                 $short_msg_append = ', ';
             }
             
-            $obj->perfdata(extra_instance => $multiple);
+            $obj->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Volume '$self->{vol}->{$id}->{display}' $long_msg");

--- a/storage/qnap/snmp/mode/volumeusage.pm
+++ b/storage/qnap/snmp/mode/volumeusage.pm
@@ -185,7 +185,7 @@ sub run {
                 $short_msg_append = ', ';
             }
             
-            $maps_counters->{$_}->{obj}->perfdata(extra_instance => $multiple);
+            $maps_counters->{$_}->{obj}->perfdata(level => 1, extra_instance => $multiple);
         }
 
         $self->{output}->output_add(long_msg => "Volume '" . $self->{volumes_selected}->{$id}->{display} . "' $long_msg");


### PR DESCRIPTION
Add "type 3" counter.
This counter type acts like a type 1, but allows to loop into types 1 and 2 with a _counters_ tab.
It is supposed to be used for "instances of instances".
```
$self->{maps_counters_type} = [
    { name => 'nodes', type => 3, cb_prefix_output => 'prefix_nodes_output', message_multiple => 'All nodes CPU usage are ok',
      counters => [ { name => 'cpu', type => 1, cb_prefix_output => 'prefix_cpu_output' },
                    { name => 'global', type => 0 } ] },
];
```

```
$self->{maps_counters}->{cpu} = [
    { label => 'cpu', set => {
            key_values => [ { name => 'average' }, { name => 'multi' }, { name => 'display' } ],
            output_template => 'usage %.2f %%',
            perfdatas => [
                { label => 'cpu', value => 'average_absolute', template => '%.2f',
                  min => 0, max => 100, unit => '%',
                  label_multi_instances => 1, multi_use => 'multi_absolute',
                  label_extra_instance => 1, instance_use => 'display_absolute' },
            ],
        }
    },
];
$self->{maps_counters}->{global} = [
    { label => 'count', set => {
            key_values => [ { name => 'count' }, { name => 'display' } ],
            output_template => 'Count : %s',
            perfdatas => [
                { label => 'count', value => 'count_absolute', template => '%s',
                  min => 0, label_extra_instance => 1, instance_use => 'display_absolute' },
            ],
        }
    },
];
```

For type 1 "child" instances, the _label_multi_instances_ option should be set as well as the _multi_use_ option to build perfdata.
For type 0, the _label_extra_instance_ and _instance_use_ should be used for the same reason.