### PR TITLE
Enhancement json co

### DIFF
--- a/apps/protocols/http/mode/jsoncontent.pm
+++ b/apps/protocols/http/mode/jsoncontent.pm
@@ -28,7 +28,6 @@ use Time::HiRes qw(gettimeofday tv_interval);
 use centreon::plugins::http;
 use JSON::Path;
 use JSON;
-use Data::Dumper;
 
 sub new {
     my ($class, %options) = @_;


### PR DESCRIPTION
add --extra-informations in json-content mode to have the possibility to get other informations for the output.

e.g : 
```json
[root@Central-2-8 dev]# curl http://10.0.2.15:8080/posts
[
  {
    "id": 1,
    "title": "Post 1"
  },
  {
    "id": 2,
    "title": "Post 2"
  },
  {
    "id": 3,
    "title": "Post 3"
  }
][root@Central-2-8 dev]#
perl centreon_plugins.pl --plugin apps::protocols::http::plugin --mode json-content --hostname=10.0.2.15 --port=8080 --urlpath=/posts --lookup="$..title"  --extra-informations="$..title" --format-ok="%{values}"

OK: Post 1, Post 2, Post 3 | 'count'=3;;;0; 'time'=0.049s;;;0;
```
I'm at the office if you want to discuss about this PR.