### PR TITLE
Add an autoreduce option to adapt UDP packet size

### DIFF
--- a/centreon/plugins/snmp.pm
+++ b/centreon/plugins/snmp.pm
@@ -255,8 +255,8 @@ RETRY:
                     } else {
                         $self->{subsetleef} -= 1;
                     }
-                    if ($self->{snmp_params}->{Retries} > 0) {
-                        $self->{snmp_params}->{Retries} = 0;
+                    if ($self->{snmp_params}->{Retries} > 1) {
+                        $self->{snmp_params}->{Retries} = 1;
                         $self->connect();
                     }
                     goto RETRY;
@@ -406,8 +406,8 @@ RETRY:
                     } else {
                         $self->{repeat_count} -= 1;
                     }
-                    if ($self->{snmp_params}->{Retries} > 0) {
-                        $self->{snmp_params}->{Retries} = 0;
+                    if ($self->{snmp_params}->{Retries} > 1) {
+                        $self->{snmp_params}->{Retries} = 1;
                         $self->connect();
                     }
                     goto RETRY;
@@ -567,8 +567,8 @@ RETRY:
                     } else {
                         $self->{repeat_count} -= 1;
                     }
-                    if ($self->{snmp_params}->{Retries} > 0) {
-                        $self->{snmp_params}->{Retries} = 0;
+                    if ($self->{snmp_params}->{Retries} > 1) {
+                        $self->{snmp_params}->{Retries} = 1;
                         $self->connect();
                     }
                     goto RETRY;

--- a/centreon/plugins/snmp.pm
+++ b/centreon/plugins/snmp.pm
@@ -400,11 +400,11 @@ RETRY:
             # snmp.h     : #define SNMP_ERR_TOOBIG (1)
             # snmp_api.h : #define SNMPERR_TIMEOUT (-24)
             if (($self->{session}->{ErrorNum} == 1) || ($self->{session}->{ErrorNum} == -24)) {
-                if (!defined($self->{snmp_force_getnext}) && defined($self->{autoreduce}) && ($self->{repeat_count} > 1)) {
-                    if ($self->{repeat_count} >= 10) {
-                        $self->{repeat_count} -= 5;
+                if (!defined($self->{snmp_force_getnext}) && defined($self->{autoreduce}) && ($repeat_count > 1)) {
+                    if ($repeat_count >= 10) {
+                        $repeat_count -= 5;
                     } else {
-                        $self->{repeat_count} -= 1;
+                        $repeat_count -= 1;
                     }
                     if ($self->{snmp_params}->{Retries} > 1) {
                         $self->{snmp_params}->{Retries} = 1;
@@ -561,11 +561,11 @@ RETRY:
             # snmp.h     : #define SNMP_ERR_TOOBIG (1)
             # snmp_api.h : #define SNMPERR_TIMEOUT (-24)
             if (($self->{session}->{ErrorNum} == 1) || ($self->{session}->{ErrorNum} == -24)) {
-                if (!defined($self->{snmp_force_getnext}) && defined($self->{autoreduce}) && ($self->{repeat_count} > 1)) {
-                    if ($self->{repeat_count} >= 10) {
-                        $self->{repeat_count} -= 5;
+                if (!defined($self->{snmp_force_getnext}) && defined($self->{autoreduce}) && ($repeat_count > 1)) {
+                    if ($repeat_count >= 10) {
+                        $repeat_count -= 5;
                     } else {
-                        $self->{repeat_count} -= 1;
+                        $repeat_count -= 1;
                     }
                     if ($self->{snmp_params}->{Retries} > 1) {
                         $self->{snmp_params}->{Retries} = 1;


### PR DESCRIPTION
Hi,

Here is a rework of #1124, which perhaps has been "quickly" closed,
without giving much technical & detailed info.

This PR then adds a new `--autoreduce` SNMP option.
If a SNMP request fails because it was too big, `--autoreduce` will automatically retry a smaller request.

Here is why I wrote this feature.
I faced `UNKNOWN` checks from time to time, especially with (but also with others) :
`os::linux::snmp::plugin --mode=processcount`
`os::linux::snmp::plugin --mode=diskusage`
Depending on what is running on the host at the time of the check, some SNMP answer packets were too big, and then were dropped by some firewalls in the path, leading to sporadic `UNKNOWN` checks.
I then had to use very low `maxrepetitions` and `subsetleef` values so that checks would not fail.
But perhaps one day, these values could be too low again, again depending on the length of the answer, the order in which elements are given in the answer etc... So this workaround was not a good and generic solution.
In addition, these low values impact all the hosts running this command with such low `maxrepetitions` and `subsetleef` values. Perhaps there are only some hosts which would require them, but all are impacted. Furthermore, who knows, perhaps one host does not need such values today, but could require them tomorrow. So setting them host by host does not seem to be a good solution...

Think about such command :
```
os-linux-snmp.pl --plugin=os::linux::snmp::plugin --hostname=$HOSTADDRESS$ --maxrepetitions=25 --subsetleef=25 --autoreduce --snmp-timeout=1 --snmp-retries=7 $_SERVICEMODE$ $_SERVICEWARNING$ $_SERVICECRITICAL$
```
This is the one I use.
I have `maxrepetitions` and `subsetleef` values which work with 99% of my checks, giving quite big SNMP packets, thus improving checks' performance, perfect.
And for the remaining 1%, `--autoreduce` does the trick, avoiding `UNKNOWN` checks.
It works perfectly fine.
Look at the related following firewall log :
```
Sep 20 08:34:48 IN=eth0 OUT= LEN=2239 TOS=0x00 PREC=0x00 TTL=48 ID=46494 PROTO=UDP SPT=161 DPT=45220 LEN=2219 
Sep 20 08:34:49 IN=eth0 OUT= LEN=2239 TOS=0x00 PREC=0x00 TTL=48 ID=46584 PROTO=UDP SPT=161 DPT=45220 LEN=2219 
Sep 20 08:34:50 IN=eth0 OUT= LEN=2239 TOS=0x00 PREC=0x00 TTL=48 ID=46751 PROTO=UDP SPT=161 DPT=45220 LEN=2219 
Sep 20 08:34:51 IN=eth0 OUT= LEN=2239 TOS=0x00 PREC=0x00 TTL=48 ID=46778 PROTO=UDP SPT=161 DPT=45220 LEN=2219 
Sep 20 08:34:52 IN=eth0 OUT= LEN=2239 TOS=0x00 PREC=0x00 TTL=48 ID=46880 PROTO=UDP SPT=161 DPT=45220 LEN=2219 
Sep 20 08:34:53 IN=eth0 OUT= LEN=2239 TOS=0x00 PREC=0x00 TTL=48 ID=46919 PROTO=UDP SPT=161 DPT=45220 LEN=2219 
Sep 20 08:34:54 IN=eth0 OUT= LEN=2239 TOS=0x00 PREC=0x00 TTL=48 ID=46969 PROTO=UDP SPT=161 DPT=45220 LEN=2219 
Sep 20 08:34:55 IN=eth0 OUT= LEN=2239 TOS=0x00 PREC=0x00 TTL=48 ID=47158 PROTO=UDP SPT=161 DPT=45220 LEN=2219 
Sep 20 08:34:56 IN=eth0 OUT= LEN=1741 TOS=0x00 PREC=0x00 TTL=48 ID=47392 PROTO=UDP SPT=161 DPT=34867 LEN=1721 
Sep 20 08:34:57 IN=eth0 OUT= LEN=1741 TOS=0x00 PREC=0x00 TTL=48 ID=47408 PROTO=UDP SPT=161 DPT=34867 LEN=1721 
```
SNMP answer was too big, but SNMP library retries 7 times, with a 1 second delay, as per the command above. SNMP library then asks for 20 elements instead of 25. Still too big, as you can see. But next request, with 15 elements, will be OK (not logged by FW as packets' size is then OK).
We've then avoided here an `UNKNOWN` check, an alert etc... improving monitoring quality :)

I really think this modification is worth it.
I've really improved my checks quality, and do not face `UNKNOWN` anymore.
On huge installations with thousands of checks, I really expect it to be useful.
Everyone is dealing with this SNMP/UDP limitation, and here we have a solution to mitigate this.

_Originally implemented with `GOTO` instructions to avoid code re-indent, finally removed (code re-indent had to be done for one of the 3 retry sections)._

Thank you very much 👍