### PR TITLE
Add thresholds on http expected-string extracted value

### DIFF
--- a/apps/protocols/http/mode/expectedcontent.pm
+++ b/apps/protocols/http/mode/expectedcontent.pm
@@ -130,7 +130,7 @@ sub run {
                                                           threshold => [ { label => 'critical-extracted', exit_litteral => 'critical' }, { label => 'warning-extracted', exit_litteral => 'warning' } ]);
             $self->{output}->output_add(severity => $exit,
                                         short_msg => sprintf("Extracted value : %s", $extracted));
-            $self->{output}->perfdata_add(label => "extracted",
+            $self->{output}->perfdata_add(label => "value",
                                           value => $extracted,
                                           warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-extracted'),
                                           critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-extracted'));

--- a/apps/protocols/http/mode/expectedcontent.pm
+++ b/apps/protocols/http/mode/expectedcontent.pm
@@ -129,7 +129,7 @@ sub run {
             my $exit = $self->{perfdata}->threshold_check(value => $extracted,
                                                           threshold => [ { label => 'critical-extracted', exit_litteral => 'critical' }, { label => 'warning-extracted', exit_litteral => 'warning' } ]);
             $self->{output}->output_add(severity => $exit,
-                                        short_msg => sprintf("Extracted value : %s", $extracted));
+                                        short_msg => sprintf("'%s' is present in content, value : %s", $self->{option_results}->{expected_string}, $extracted));
             $self->{output}->perfdata_add(label => "value",
                                           value => $extracted,
                                           warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-extracted'),


### PR DESCRIPTION
Hi,

This PR closes #1211.

It adds 2 new thresholds in `apps::protocols::http::plugin`, `expected-content` mode.

Let's assume a web page contains the following :
`Node: 1, Status: OK, Ping: 10, Connections: 34, Load: 100`

And we want less than 100 connections.

We can now do the following :
`--expected-string=",Connections: ([0-9]*)," --warning-extracted=80 --critical-extracted=100`

Thank you very much :+1: 