### PR TITLE
Improve snmp-autoreduce in case device does not reply tooBig

### DIFF
--- a/centreon/plugins/snmp.pm
+++ b/centreon/plugins/snmp.pm
@@ -324,6 +324,11 @@ sub get_leef {
             return undef;
         }
 
+        # Some devices could not send "tooBig" ErrorNum ?
+        if(($self->{snmp_autoreduce} == 1) && scalar($vb) && (scalar(@{@$vb[-1]}) < 3)) {
+            next if ($self->autoreduce_leef(current => $entry) == 0);
+        }
+
         foreach my $entry (@$vb) {
             if ($#$entry < 3) {
                 # Can be snmpv1 not find
@@ -729,6 +734,7 @@ sub check_options {
     $self->{subsetleef} = (defined($options{option_results}->{subsetleef}) && $options{option_results}->{subsetleef} =~ /^[0-9]+$/) ? $options{option_results}->{subsetleef} : 50;
     $self->{subsettable} = (defined($options{option_results}->{subsettable}) && $options{option_results}->{subsettable} =~ /^[0-9]+$/) ? $options{option_results}->{subsettable} : 100;
     $self->{snmp_errors_exit} = $options{option_results}->{snmp_errors_exit};
+    $self->{snmp_autoreduce} = 0;
     $self->{snmp_autoreduce_divisor} = 2;
     if (defined($options{option_results}->{snmp_autoreduce})) {
         $self->{snmp_autoreduce} = 1;

--- a/centreon/plugins/snmp.pm
+++ b/centreon/plugins/snmp.pm
@@ -324,8 +324,8 @@ sub get_leef {
             return undef;
         }
 
-        # Some devices could not send "tooBig" ErrorNum ?
-        if(($self->{snmp_autoreduce} == 1) && scalar($vb) && (scalar(@{@$vb[-1]}) < 3)) {
+        # Some devices may not send "tooBig" ErrorNum ?
+        if(($self->{snmp_autoreduce} == 1) && scalar(@$vb) && (scalar(@{@$vb[-1]}) < 3)) {
             next if ($self->autoreduce_leef(current => $entry) == 0);
         }
 


### PR DESCRIPTION
Hi,

I faced issue described in #880 :
`--plugin=storage::netapp::snmp::plugin --mode=volumeoptions` asks for info for let's say 25 volumes.
The Netapp device replies but only for the X first volumes (certainly until a fixed packet size is reached, around 4000 bytes as per my tests).
There is no SNMP error : `$self->{session}->get($vb)` in `get_leef()` does not return error.
But then some elements are missing in the answer, which then leads to errors (and undefined values) described in #880.

I'm then quite surprised that the Netapp device does not reply with the `tooBig` error message.
This PR then fixes this when `--snmp-autoreduce` is used.

I wonder if we would have to apply the same fix into `get_table()` and `get_multiple_table()`.
According to their loop through `@$vb` I would say no as `${$entry}[2]` is checked there without testing `@{$entry}` length.
But perhaps this is an issue...

Thank you :+1: