### PR TITLE
x509, do not remove subject from alt_subjects

### DIFF
--- a/apps/protocols/x509/mode/certificate.pm
+++ b/apps/protocols/x509/mode/certificate.pm
@@ -201,7 +201,6 @@ sub manage_selection {
     my $alt_subjects = '';
     for (my $i =  0; $i < $#subject_alt_names; $i += 2) {
         my ($type, $name) = ($subject_alt_names[$i], $subject_alt_names[$i + 1]);
-        next if ($name eq $subject);
         if ($type == GEN_IPADD) {
             $name = inet_ntoa($name);
         }


### PR DESCRIPTION
Hi,

This PR prevents removing `subject` from `alt_subjects` in certificate plugin.
This leads to errors where `alt_subjects` is used for example in a Centreon service template to simply check that certificates at least contain the expected domain.

Thank you :+1: 