### PR TITLE
HTTP expected-content, treat the string as single line

### DIFF
--- a/apps/protocols/http/mode/expectedcontent.pm
+++ b/apps/protocols/http/mode/expectedcontent.pm
@@ -111,7 +111,7 @@ sub run {
     
     $self->{output}->output_add(long_msg => $webcontent);
 
-    if ($webcontent =~ /$self->{option_results}->{expected_string}/mi) {
+    if ($webcontent =~ /$self->{option_results}->{expected_string}/msi) {
         $self->{output}->output_add(severity => 'OK',
                                     short_msg => sprintf("'%s' is present in content.", $self->{option_results}->{expected_string}));
     } else {


### PR DESCRIPTION
Hi,

This PR treats the HTTP expected-string as single line.
This then allows to do things like this :
`--expected-string='My nice site</title>.*</html>'`

Thank you :+1: 