### PR TITLE
Uptime, reduce chances to miss a reboot

### DIFF
--- a/snmp_standard/mode/uptime.pm
+++ b/snmp_standard/mode/uptime.pm
@@ -69,7 +69,7 @@ sub check_overload {
     return $options{timeticks} if (!defined($self->{option_results}->{check_overload}));
     
     my $current_time = floor(time() * 100);
-    $self->{new_datas} = { last_time => $current_time, uptime => $options{timeticks}};
+    $self->{new_datas} = { last_time => $current_time, uptime => $options{timeticks} };
     $self->{statefile_cache}->read(statefile => "cache_" . $self->{snmp}->get_hostname()  . '_' . $self->{snmp}->get_port() . '_' . $self->{mode});
     my $old_uptime = $self->{statefile_cache}->get(name => 'uptime');
     my $last_time = $self->{statefile_cache}->get(name => 'last_time');
@@ -81,6 +81,8 @@ sub check_overload {
         if ((($old_uptime + $diff_time - 250) <  4294967296) || ($options{timeticks} >= (($old_uptime + $diff_time - 250) % 4294967296)) &&
             (($old_uptime + $diff_time + 250) >= 4294967296) && ($options{timeticks} <= (($old_uptime + $diff_time + 250) % 4294967296))) {
             $overload++;
+        } else {
+            $overload = 0;
         }
     }
     $options{timeticks} += ($overload * 4294967296);

--- a/snmp_standard/mode/uptime.pm
+++ b/snmp_standard/mode/uptime.pm
@@ -78,9 +78,8 @@ sub check_overload {
     if (defined($old_uptime) && $options{timeticks} < $old_uptime) {
         my $diff_time = $current_time - $last_time;
         # Time window (5s here) must surround or be after the limit (4294967296), and new uptime must be inside this window
-        if ((($old_uptime + $diff_time - 250) <  4294967296) || ($options{timeticks} >= (($old_uptime + $diff_time - 250) % 4294967296)) &&
-            (($old_uptime + $diff_time + 250) >= 4294967296) && ($options{timeticks} <= (($old_uptime + $diff_time + 250) % 4294967296))) {
-            $overload++;
+        if (((($old_uptime + $diff_time - 250) <  4294967296) || ($options{timeticks} >= (($old_uptime + $diff_time - 250) % 4294967296))) &&
+            ((($old_uptime + $diff_time + 250) >= 4294967296) && ($options{timeticks} <= (($old_uptime + $diff_time + 250) % 4294967296)))) {            $overload++;
         } else {
             $overload = 0;
         }


### PR DESCRIPTION
Hi,

This PR reduces the chances to miss a reboot when uptime `--check-overload` is used.
I'm not sure why a +/- 50 seconds window would be required, which seems overkill.
A +/- 2.5 seconds window is IMO enough, and we should not miss any reboot then (as generally they last longer).

Many thanks :+1: 