### PR TITLE
Add support for fetching perfdatas and format, from the JSON

### DIFF
--- a/apps/protocols/http/mode/jsoncontent.pm
+++ b/apps/protocols/http/mode/jsoncontent.pm
@@ -262,14 +262,12 @@ sub lookup {
 
         foreach my $perfdata_string (@perfdata_strings) {
             my @metrics = split(/ /, $perfdata_string);
-            # Parse each metric line
             foreach my $single_metric (@metrics) {
-                # Cut each metric into parts
                 my ($label, $perfdatas) = split(/=/, $single_metric);
                 my ($value_w_unit, $warn, $crit, $min, $max) = split(/;/, $perfdatas);
                 # separate the value from the unit
                 my ($value, $unit) = $value_w_unit =~ /(^[0-9]+\.*\,*[0-9]*)(.*)/g;
-                # Adding perfdata to the list
+
                 $self->{output}->perfdata_add(label => $label, unit => $unit,
                                               value => $value,
                                               warning => $warn,

--- a/apps/protocols/http/mode/jsoncontent.pm
+++ b/apps/protocols/http/mode/jsoncontent.pm
@@ -79,8 +79,8 @@ sub new {
             "format-critical:s"       => { name => 'format_critical', default => '%{count} element(s) found' },
             "format-unknown:s"        => { name => 'format_unknown', default => '%{count} element(s) found' },
             "values-separator:s"      => { name => 'values_separator', default => ', ' },
-            "lookup-perfdatas:s"      => { name => 'lookup_perfdatas'},
-            "lookup-format:s"        => { name => 'lookup_format'},
+            "lookup-perfdatas-nagios:s"      => { name => 'lookup_perfdatas_nagios'},
+            "lookup-format:s"         => { name => 'lookup_format'},
             });
     $self->{count} = 0;
     $self->{count_ok} = 0;
@@ -253,9 +253,9 @@ sub lookup {
         }
     }
 
-    if (defined($self->{option_results}->{lookup_perfdatas}) && $self->{option_results}->{lookup_perfdatas} ne '') {
+    if (defined($self->{option_results}->{lookup_perfdatas_nagios}) && $self->{option_results}->{lookup_perfdatas_nagios} ne '') {
         my $perfdata_string;
-        my $xpath_find = $self->{option_results}->{lookup_perfdatas};
+        my $xpath_find = $self->{option_results}->{lookup_perfdatas_nagios};
         eval {
             my $jpath = JSON::Path->new($xpath_find);
             $perfdata_string = $jpath->value($content);
@@ -357,7 +357,7 @@ Set file with JSON request
 What to lookup in JSON response (JSON XPath string) (can be multiple)
 See: http://goessner.net/articles/JsonPath/
 
-=item B<--lookup-perfdatas>
+=item B<--lookup-perfdatas-nagios>
 
 Take perfdatas from the JSON response (JSON XPath string)
 Chain must be formated in Nagios format.

--- a/apps/protocols/http/mode/jsoncontent.pm
+++ b/apps/protocols/http/mode/jsoncontent.pm
@@ -254,11 +254,11 @@ sub lookup {
     }
 
     if (defined($self->{option_results}->{lookup_perfdatas}) && $self->{option_results}->{lookup_perfdatas} ne '') {
-        my (@perfdata_strings);
+        my $perfdata_string;
         my $xpath_find = $self->{option_results}->{lookup_perfdatas};
         eval {
             my $jpath = JSON::Path->new($xpath_find);
-            @perfdata_strings = $jpath->values($content);
+            $perfdata_string = $jpath->value($content);
         };
         if ($@) {
             $self->{output}->add_option_msg(short_msg => "Cannot lookup perfdatas: $@");
@@ -267,21 +267,19 @@ sub lookup {
 
         $self->{output}->output_add(long_msg => "Lookup perfdatas XPath $xpath_find:");
 
-        foreach my $perfdata_string (@perfdata_strings) {
-            my @metrics = split(/ /, $perfdata_string);
-            foreach my $single_metric (@metrics) {
-                my ($label, $perfdatas) = split(/=/, $single_metric);
-                my ($value_w_unit, $warn, $crit, $min, $max) = split(/;/, $perfdatas);
-                # separate the value from the unit
-                my ($value, $unit) = $value_w_unit =~ /(^[0-9]+\.*\,*[0-9]*)(.*)/g;
+        my @metrics = split(/ /, $perfdata_string);
+        foreach my $single_metric (@metrics) {
+            my ($label, $perfdatas) = split(/=/, $single_metric);
+            my ($value_w_unit, $warn, $crit, $min, $max) = split(/;/, $perfdatas);
+            # separate the value from the unit
+            my ($value, $unit) = $value_w_unit =~ /(^[0-9]+\.*\,*[0-9]*)(.*)/g;
 
-                $self->{output}->perfdata_add(label => $label, unit => $unit,
-                                              value => $value,
-                                              warning => $warn,
-                                              critical => $crit,
-                                              min => $min,
-                                              max => $max);
-            }
+            $self->{output}->perfdata_add(label => $label, unit => $unit,
+                                          value => $value,
+                                          warning => $warn,
+                                          critical => $crit,
+                                          min => $min,
+                                          max => $max);
         }
     }
 
@@ -394,7 +392,7 @@ Output unknown format (Default: %{count} element(s) found')
 =item B<--lookup-format>
 
 Take the output message from the JSON response (JSON XPath string)
-Override all the format options but sustitute are still applied.
+Override all the format options but substitute are still applied.
 
 =item B<--values-separator>
 


### PR DESCRIPTION
Hello,

We added support for fetching perfdatas and the message format from the JSON.
This extend the plugin, so we can check a JSON as if the JSON was a check result.

This can be used to check a service who is made in a asynchonous way, and who expose his result in JSON on a web server.

Example with this screenshot :
![capture_json](https://user-images.githubusercontent.com/2464712/52790244-61602880-3066-11e9-98db-187a1f637341.PNG)


The JSON contain information status. "Etat : OK", and some perfdata.

So with this command, i can check if i got "KO" as "Etat" and use the perfdata from the JSON :

$ ./centreon_plugins.pl --plugin=apps::protocols::http::plugin --mode=json-content --hostname="10.66.113.52" --urlpath='/monitoring.json' --lookup="$.Status.Etat" --header="Content-Type: application/json" --proto=https --critical-string "KO" --format-critical="Houston, we have a problem" --format-ok "All is fine" --timeout 10 --lookup-perfdatas="$.Perf.Datas" --filter-perfdata='^((?!count|time).)*$'
OK: All is fine | 'rta'=10.752ms;50.000;100.000;0; 'pl'=0%;20;40;; 'rtmax'=10.802ms;;;; 'rtmin'=10.709ms;;;; 'rym'=4;;;;

Regards