### PR TITLE
change snmp behavior depending on which parameter are supplied

### DIFF
--- a/centreon/plugins/snmp.pm
+++ b/centreon/plugins/snmp.pm
@@ -788,8 +788,8 @@ sub check_options {
         # unauthenticated and unencrypted
         if ((!defined($options{option_results}->{snmp_auth_passphrase})
             && !defined($options{option_results}->{snmp_priv_passphrase}))
-            || ($options{option_results}->{snmp_auth_passphrase} ne ""
-            && $options{option_results}->{snmp_priv_passphrase} ne "" )) {
+            || ($options{option_results}->{snmp_auth_passphrase} eq ""
+            && $options{option_results}->{snmp_priv_passphrase} eq "" )) {
             $self->{snmp_params}->{SecLevel} = 'noAuthNoPriv';
             return ;
         }

--- a/centreon/plugins/snmp.pm
+++ b/centreon/plugins/snmp.pm
@@ -786,7 +786,10 @@ sub check_options {
         }
         
         # unauthenticated and unencrypted
-        if (!defined($options{option_results}->{snmp_auth_passphrase}) && !defined($options{option_results}->{snmp_priv_passphrase})) {
+        if (!defined($options{option_results}->{snmp_auth_passphrase})
+            && !defined($options{option_results}->{snmp_priv_passphrase})
+            && $options{option_results}->{snmp_auth_passphrase} ne ""
+            && $options{option_results}->{snmp_priv_passphrase} ne "" ) {
             $self->{snmp_params}->{SecLevel} = 'noAuthNoPriv';
             return ;
         }
@@ -810,7 +813,7 @@ sub check_options {
             $self->{output}->option_exit();
         }
         
-        if (defined($options{option_results}->{snmp_priv_protocol})) {
+        if (defined($options{option_results}->{snmp_priv_protocol}) && $options{option_results}->{snmp_priv_protocol} ne "") {
             $options{option_results}->{snmp_priv_protocol} = uc($options{option_results}->{snmp_priv_protocol});
             if ($options{option_results}->{snmp_priv_protocol} ne 'DES' && $options{option_results}->{snmp_priv_protocol} ne 'AES') {
                 $self->{output}->add_option_msg(short_msg => "Wrong privacy protocol. Must be DES or AES.");

--- a/centreon/plugins/snmp.pm
+++ b/centreon/plugins/snmp.pm
@@ -786,10 +786,10 @@ sub check_options {
         }
         
         # unauthenticated and unencrypted
-        if (!defined($options{option_results}->{snmp_auth_passphrase})
-            && !defined($options{option_results}->{snmp_priv_passphrase})
-            && $options{option_results}->{snmp_auth_passphrase} ne ""
-            && $options{option_results}->{snmp_priv_passphrase} ne "" ) {
+        if ((!defined($options{option_results}->{snmp_auth_passphrase})
+            && !defined($options{option_results}->{snmp_priv_passphrase}))
+            || ($options{option_results}->{snmp_auth_passphrase} ne ""
+            && $options{option_results}->{snmp_priv_passphrase} ne "" )) {
             $self->{snmp_params}->{SecLevel} = 'noAuthNoPriv';
             return ;
         }


### PR DESCRIPTION
This PR enable the user to provide some parameters on the command line with empty value. If there is empty value, then it is seen as no parameter at all for this switch, allowing a single command in Centreon that fit all case in SNMPv3.