### PR TITLE
Use true given window range, not twice

### DIFF
--- a/snmp_standard/mode/uptime.pm
+++ b/snmp_standard/mode/uptime.pm
@@ -80,8 +80,8 @@ sub check_overload {
         my $overflow = ($old_uptime + $diff_time) % 4294967296;
         my $division = ($old_uptime + $diff_time) / 4294967296;
         if ($division >= 1 && 
-            $overflow >= ($options{timeticks} - $self->{option_results}->{reboot_window}) &&
-            $overflow <= ($options{timeticks} + $self->{option_results}->{reboot_window})) {
+            $overflow >= ($options{timeticks} - ($self->{option_results}->{reboot_window} / 2)) &&
+            $overflow <= ($options{timeticks} + ($self->{option_results}->{reboot_window} / 2))) {
             $self->{new_datas}->{overload}++;
         } else {
             $self->{new_datas}->{overload} = 0;


### PR DESCRIPTION
Hi,

This PR addresses a small bug / typo, where reboot window is in reality twice as `--reboot-window` parameter.
This PR then corrects this so that the window has now the expected correct range.

Thank you :+1: 