### PR TITLE
Mikrotik, add uptime mode

### DIFF
--- a/network/mikrotik/snmp/mode/environment.pm
+++ b/network/mikrotik/snmp/mode/environment.pm
@@ -69,7 +69,7 @@ Check hardware.
 =item B<--component>
 
 Which component to check (Default: '.*').
-Can be: 'voltage', 'temperature', 'fan'.
+Can be: 'current', 'fan', 'power', 'temperature', 'voltage'.
 
 =item B<--filter>
 

--- a/network/mikrotik/snmp/plugin.pm
+++ b/network/mikrotik/snmp/plugin.pm
@@ -39,6 +39,7 @@ sub new {
                          'list-ssids'        => 'network::mikrotik::snmp::mode::listssids',
                          'memory'            => 'network::mikrotik::snmp::mode::memory',
                          'signal'            => 'network::mikrotik::snmp::mode::signal',
+                         'uptime'            => 'snmp_standard::mode::uptime',
                          );
 
     return $self;


### PR DESCRIPTION
Hi,

This PR adds uptime mode to `network::mikrotik::snmp` plugin.

Thank you :+1: 