### PR TITLE
Update HTTP default message

### DIFF
--- a/apps/protocols/http/mode/expectedcontent.pm
+++ b/apps/protocols/http/mode/expectedcontent.pm
@@ -39,7 +39,7 @@ sub custom_content_threshold {
 sub custom_content_output {
     my ($self, %options) = @_;
 
-    my $msg = 'Content test';
+    my $msg = 'HTTP test(s)';
     if (!$self->{output}->is_status(value => $self->{instance_mode}->{content_status}, compare => 'ok', litteral => 1)) {
         my $filter = $self->{instance_mode}->{option_results}->{lc($self->{instance_mode}->{content_status}) . '_content'};
         $filter =~ s/\$self->\{result_values\}->/%/g;


### PR DESCRIPTION
Hi,

Due to the the wide range of tests HTTP expected-content mode is able to perform (content, value, return code, response time, size...), let's update the default OK short message to a more generic one.

Thank you :+1: 