### PR TITLE
Add time mode to Mikrotik

### DIFF
--- a/network/mikrotik/snmp/plugin.pm
+++ b/network/mikrotik/snmp/plugin.pm
@@ -39,6 +39,7 @@ sub new {
                          'list-ssids'        => 'network::mikrotik::snmp::mode::listssids',
                          'memory'            => 'network::mikrotik::snmp::mode::memory',
                          'signal'            => 'network::mikrotik::snmp::mode::signal',
+                         'time'              => 'snmp_standard::mode::ntp',
                          'uptime'            => 'snmp_standard::mode::uptime',
                          );
 


### PR DESCRIPTION
Hi,

This mode simply adds time mode to `network::mikrotik::snmp::plugin`.

Thank you :+1: 