### PR TITLE
Mikrotik, improve error label

### DIFF
--- a/network/mikrotik/snmp/mode/interfaces.pm
+++ b/network/mikrotik/snmp/mode/interfaces.pm
@@ -61,6 +61,15 @@ sub set_oids_errors {
     $self->{oids_errors}->{oid_ifOutFragment} = '.1.3.6.1.4.1.14988.1.1.14.1.1.89';
 }
 
+sub custom_errors_output {
+    my ($self, %options) = @_;
+
+    my $msg = sprintf("Packets %s : %.2f%% (%s)",
+                      $self->{result_values}->{label},
+                      $self->{result_values}->{prct}, $self->{result_values}->{used});
+    return $msg;
+}
+
 sub set_counters_errors {
     my ($self, %options) = @_;
 
@@ -71,7 +80,7 @@ sub set_counters_errors {
         push @{$self->{maps_counters}->{int}}, 
             { label => lc($1) . '-' . lc($2), filter => 'add_errors', nlabel => 'interface.packets.' . lc($1) . '.' . lc($2) . '.count', set => {
                     key_values => [ { name => lc($1.$2), diff => 1 }, { name => 'total_' . lc($1) . '_packets', diff => 1 }, { name => 'display' }, { name => 'mode_cast' } ],
-                    closure_custom_calc => $self->can('custom_errors_calc'), closure_custom_calc_extra_options => { label_ref1 => lc($1), label_ref2 => lc($2) },
+                    closure_custom_calc => $self->can('custom_errors_calc'), closure_custom_calc_extra_options => { label => $1 . ' ' . $2, label_ref1 => lc($1), label_ref2 => lc($2) },
                     closure_custom_output => $self->can('custom_errors_output'), output_error_template => 'Packets ' . $1 . ' ' . $2 . ' : %s',
                     closure_custom_perfdata => $self->can('custom_errors_perfdata'),
                     closure_custom_threshold_check => $self->can('custom_errors_threshold'),

--- a/snmp_standard/mode/interfaces.pm
+++ b/snmp_standard/mode/interfaces.pm
@@ -263,6 +263,7 @@ sub custom_errors_calc {
     $self->{result_values}->{prct} = $total == 0 ? 0 : $diff * 100 / $total;
     $self->{result_values}->{used} = $diff;
     $self->{result_values}->{total} = $total;
+    $self->{result_values}->{label} = $options{extra_options}->{label};
     $self->{result_values}->{label1} = $options{extra_options}->{label_ref1};
     $self->{result_values}->{label2} = $options{extra_options}->{label_ref2};
     $self->{result_values}->{display} = $options{new_datas}->{$self->{instance} . '_display'};


### PR DESCRIPTION
Hi,

Here's a little improvement to Mikrotik errors' output.
Every Mikrotik error label is given thanks to its OID label in `$self->{oids_errors}`, for example :
`oid_ifInFCSError`
`oid_ifInAlignError`

Without this PR, output would lead to :
`In Fcserror`
`In Alignerror`

With this PR, uppercase is correctly kept, making output easier to read :
`In FCSError`
`In AlignError`

I'm not sure this is the proper way to do this, so feel free to comment or modify.
Edit : see an alternate method in #1545.

Thx 👍 