### PR TITLE
fixed time calculation

### DIFF
--- a/os/aix/local/mode/process.pm
+++ b/os/aix/local/mode/process.pm
@@ -128,7 +128,14 @@ sub get_time_seconds {
     my ($seconds, $min, $lpart) = (pop @values, pop @values, pop @values);
     my $total_seconds_elapsed = $seconds + ($min * 60);
     if (defined($lpart)) {
-        my ($day, $hour) = split /-/, $lpart;
+        my $day;
+        my $hour;
+        if (index($lpart, '-') != -1) {
+            ($day, $hour) = split /-/, $lpart;
+        }
+        else {
+            $hour = $lpart;
+        }
         if (defined($hour)) {
             $total_seconds_elapsed += ($hour * 60 * 60);
         }


### PR DESCRIPTION
There is a flaw in time calculation : 
the split put the value in $day instead of $hour if there is no day in the string to be splitted, resulting in wrong time calulation.
this PR fix this bug