### PR TITLE
Added Oracle Linux 7.7 exception in --autodetect-redhat options

### DIFF
--- a/snmp_standard/mode/memory.pm
+++ b/snmp_standard/mode/memory.pm
@@ -200,7 +200,8 @@ sub autodetect_rhel7 {
     # https://access.redhat.com/articles/3078#RHEL7
     # rhel 7.6: "Linux dev 3.10.0-957.10.1.el7.x86_64 #1 SMP Mon Mar 18 15:06:45 UTC 2019 x86_64"
     # rhel 7.7: "Linux dev 3.10.0-1062.1.1.el7.x86_64 #1 SMP Fri Sep 13 22:55:44 UTC 2019 x86_64"
-    return if (!defined($options{result}->{sysDescr}) || $options{result}->{sysDescr} !~ /3\.10\.0-(\d+)\..*?el7\./);
+    # oracle 7.7: "Linux dev 4.14.35-1902.6.6.el7uek.x86_64 #2 SMP Tue Oct 8 07:32:21 PDT 2019 x86_64 x86_64 x86_64"
+    return if (!defined($options{result}->{sysDescr}) || $options{result}->{sysDescr} !~ /.*\..*\..*-(\d+)\..*?\.el7/);
     my $build = $1;
     if ($build >= 1062) {
         $self->{option_results}->{redhat} = 1;

--- a/snmp_standard/mode/memory.pm
+++ b/snmp_standard/mode/memory.pm
@@ -200,12 +200,17 @@ sub autodetect_rhel7 {
     # https://access.redhat.com/articles/3078#RHEL7
     # rhel 7.6: "Linux dev 3.10.0-957.10.1.el7.x86_64 #1 SMP Mon Mar 18 15:06:45 UTC 2019 x86_64"
     # rhel 7.7: "Linux dev 3.10.0-1062.1.1.el7.x86_64 #1 SMP Fri Sep 13 22:55:44 UTC 2019 x86_64"
+    # oracle 7.6: "Linux dev 4.14.35-1844.3.2.el7uek.x86_64 #2 SMP Mon Feb 25 17:43:37 PST 2019 x86_64"
     # oracle 7.7: "Linux dev 4.14.35-1902.6.6.el7uek.x86_64 #2 SMP Tue Oct 8 07:32:21 PDT 2019 x86_64 x86_64 x86_64"
-    return if (!defined($options{result}->{sysDescr}) || $options{result}->{sysDescr} !~ /.*\..*\..*-(\d+)\..*?\.el7/);
-    my $build = $1;
-    if ($build >= 1062) {
-        $self->{option_results}->{redhat} = 1;
-    }
+    return if (!defined($options{result}->{sysDescr})); 
+    if ($options{result}->{sysDescr} =~ /3\.10\.0-(\d+)\..*?el7\./) {
+      my $build = $1;
+      if ($build >= 1062) {
+        $self->{option_results}->{redhat} = 1; }}
+    if ($options{result}->{sysDescr} =~ /4\.14\.35-(\d+)\..*?\.el7uek\./) {
+         my $build = $1;
+         if ($build >= 1902) {
+         $self->{option_results}->{redhat} = 1; }}
 }
 
 sub memory_calc {


### PR DESCRIPTION
Hello,

I modified the regex in "--autodetect-redhat" to permit to match Oracle Linux servers (redhat like)

snmpwalk -cpublic -v2c dev
SNMPv2-MIB::sysDescr.0 = STRING: Linux dev 4.14.35-1902.6.6.el7uek.x86_64 #2 SMP Tue Oct 8 07:32:21 PDT 2019 x86_64

$ cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 7.7 (Maipo)

thanks
Arnaud