### PR TITLE
Modified network::dell::sseries for cpu, hardware and memory

### DIFF
--- a/network/dell/sseries/snmp/plugin.pm
+++ b/network/dell/sseries/snmp/plugin.pm
@@ -31,11 +31,11 @@ sub new {
 
     $self->{version} = '1.0';
     %{$self->{modes}} = (
-        'cpu'             => 'centreon::common::force10::snmp::mode::cpu',
-        'hardware'        => 'centreon::common::force10::snmp::mode::hardware',
+        'cpu'             => 'snmp_standard::mode::cpu',
+        'hardware'        => 'snmp_standard::mode::hardwaredevice',
         'interfaces'      => 'snmp_standard::mode::interfaces',
         'list-interfaces' => 'snmp_standard::mode::listinterfaces',
-        'memory'          => 'centreon::common::force10::snmp::mode::memory',
+        'memory'          => 'snmp_standard::mode::memory',
     );
 
     return $self;


### PR DESCRIPTION
tested on switches DELL S-SERIES => model S4112F

SNMPv2-MIB::sysDescr.0 = STRING: Dell EMC Networking OS10 Enterprise
SNMPv2-MIB::sysObjectID.0 = OID: SNMPv2-SMI::enterprises.674.11000.5000.100.2.1.16

cpu and memory mode did not work. The 'hardware' mode did not return any component: now this one (with snmp_standard) returns the operating status of the processors.

thanks