### PR TITLE
Display number of partitions

### DIFF
--- a/snmp_standard/mode/diskusage.pm
+++ b/snmp_standard/mode/diskusage.pm
@@ -49,7 +49,7 @@ sub set_counters {
     ];
     
     $self->{maps_counters}->{global} = [
-        { label => 'count', nlabel => 'storages.partitions.count', display_ok => 0, set => {
+        { label => 'count', nlabel => 'storages.partitions.count', display_ok => 1, set => {
                 key_values => [ { name => 'count' } ],
                 output_template => 'Partitions count : %d',
                 perfdatas => [


### PR DESCRIPTION
Hi,

This PR re-enables the display of number of partitions monitored in plugin short output.
Useful when regex-selecting FS, so that we can quickly know whether or not the right number of FS is monitored.

Thank you 👍 