### PR TITLE
All counters are enabled by default

### DIFF
--- a/snmp_standard/mode/diskusage.pm
+++ b/snmp_standard/mode/diskusage.pm
@@ -329,7 +329,7 @@ Need to enable "includeAllDisks 10%" on snmpd.conf.
 
 =item B<--filter-counters>
 
-Filter counters to be displayed (Default: 'usage', Can be: 'usage', 'count', 'inodes').
+Filter counters to be displayed (Can be: 'usage', 'count', 'inodes').
 
 =item B<--warning-*> B<--critical-*>
 


### PR DESCRIPTION
Hi,

According to my tests, sounds like all `diskusage` counters are enabled by default ?

Thank you 👍