### PR TITLE
storage::synology::snmp: handle raidStatus values over 12

### DIFF
--- a/storage/synology/snmp/mode/components/raid.pm
+++ b/storage/synology/snmp/mode/components/raid.pm
@@ -36,6 +36,15 @@ my %map_raid_status = (
     10 => 'Canceling',
     11 => 'Degrade',
     12 => 'Crashed',
+    13 => 'DataScrubbing',
+    14 => 'RaidDeploying',
+    15 => 'RaidUnDeploying',
+    16 => 'RaidMountCache',
+    17 => 'RaidUnmountCache',
+    18 => 'RaidExpandingUnfinishedSHR',
+    19 => 'RaidConvertSHRToPool',
+    20 => 'RaidMigrateSHR1ToSHR2',
+    21 => 'RaidUnknownStatus',
 );
 
 my $mapping = {

--- a/storage/synology/snmp/mode/hardware.pm
+++ b/storage/synology/snmp/mode/hardware.pm
@@ -58,6 +58,15 @@ sub set_system {
             ['Canceling', 'OK'],
             ['Degrade', 'WARNING'],
             ['Crashed', 'CRITICAL'],
+            ['DataScrubbing', 'OK'],
+            ['RaidDeploying', 'OK'],
+            ['RaidUnDeploying', 'OK'],
+            ['RaidMountCache', 'OK'],
+            ['RaidUnmountCache', 'OK'],
+            ['RaidExpandingUnfinishedSHR', 'OK'],
+            ['RaidConvertSHRToPool', 'OK'],
+            ['RaidMigrateSHR1ToSHR2', 'OK'],
+            ['RaidUnknownStatus', 'UNKNOWN'],
         ],
     };
     


### PR DESCRIPTION
These additional statuses are documented [here](https://global.download.synology.com/download/Document/Software/DeveloperGuide/Firmware/DSM/All/enu/Synology_DiskStation_MIB_Guide.pdf):

* DataScrubbing (13): RAID is DataScrubbing
* RaidDeploying (14): RAID is deploying Single volume on pool
* RaidUnDeploying (15): RAID is not deploying Single volume on pool
* RaidMountCache (16): RAID is mounting SSD cache
* RaidUnmountCache (17): RAID is not mounting SSD cache
* RaidExpandingUnfinishedSHR (18): RAID continue expanding SHR if interrupted
* RaidConvertSHRToPool (19): RAID is converting Single volume on SHR to multiple volume on SHR
* RaidMigrateSHR1ToSHR2 (20): RAID is migrating SHR1 to SHR2
* RaidUnknownStatus (21): RAID status is not included in the status above


Everything other than `RaidUnknownStatus` seemed OK to me, let me know if some need to be changed.