### PR TITLE
Improve Juniper CPU / memory modes

### DIFF
--- a/network/juniper/common/junos/mode/cpu.pm
+++ b/network/juniper/common/junos/mode/cpu.pm
@@ -67,14 +67,14 @@ sub run {
     my $routing_engine_find = 0;
     my @oids_routing_engine = ();
     foreach my $oid (keys %$result) {        
-        if ($result->{$oid} =~ /$filter/i) {
+        if ($result->{$oid} =~ /$self->{option_results}->{filter}/i) {
             $routing_engine_find = 1;
             push @oids_routing_engine, $oid;
         }
     }
     
     if ($routing_engine_find == 0) {
-        $self->{output}->add_option_msg(short_msg => "Cannot find operating with '$filter' in description.");
+        $self->{output}->add_option_msg(short_msg => "Cannot find operating with '$self->{option_results}->{filter}' in description.");
         $self->{output}->option_exit();
     }
     my $multiple = 0;

--- a/network/juniper/common/junos/mode/cpu.pm
+++ b/network/juniper/common/junos/mode/cpu.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package network::juniper::common::junos::mode::cpurouting;
+package network::juniper::common::junos::mode::cpu;
 
 use base qw(centreon::plugins::mode);
 

--- a/network/juniper/common/junos/mode/cpu.pm
+++ b/network/juniper/common/junos/mode/cpu.pm
@@ -34,6 +34,7 @@ sub new {
                                 { 
                                   "warning:s"               => { name => 'warning', },
                                   "critical:s"              => { name => 'critical', },
+                                  "filter:s"                => { name => 'filter', default => 'routing|fpc'}
                                 });
 
     return $self;
@@ -66,14 +67,14 @@ sub run {
     my $routing_engine_find = 0;
     my @oids_routing_engine = ();
     foreach my $oid (keys %$result) {        
-        if ($result->{$oid} =~ /routing/i) {
+        if ($result->{$oid} =~ /$filter/i) {
             $routing_engine_find = 1;
             push @oids_routing_engine, $oid;
         }
     }
     
     if ($routing_engine_find == 0) {
-        $self->{output}->add_option_msg(short_msg => "Cannot find operating with 'routing' in description.");
+        $self->{output}->add_option_msg(short_msg => "Cannot find operating with '$filter' in description.");
         $self->{output}->option_exit();
     }
     my $multiple = 0;
@@ -115,15 +116,17 @@ sub run {
                                       warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                       critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical'),
                                       min => 0, max => 100);
-        $self->{output}->perfdata_add(label => 'load1' . $extra_label,
-                                      value => $cpu_load1,
-                                      min => 0);
-        $self->{output}->perfdata_add(label => 'load5' . $extra_label,
-                                      value => $cpu_load5,
-                                      min => 0);
-        $self->{output}->perfdata_add(label => 'load15' . $extra_label,
-                                      value => $cpu_load15,
-                                      min => 0);
+        if ($cpu_load1 != 0) {
+            $self->{output}->perfdata_add(label => 'load1' . $extra_label,
+                                          value => $cpu_load1,
+                                          min => 0);
+            $self->{output}->perfdata_add(label => 'load5' . $extra_label,
+                                          value => $cpu_load5,
+                                          min => 0);
+            $self->{output}->perfdata_add(label => 'load15' . $extra_label,
+                                          value => $cpu_load15,
+                                          min => 0);
+        }
     }
 
     $self->{output}->display();
@@ -136,9 +139,13 @@ __END__
 
 =head1 MODE
 
-Check CPU Usage of routing engine.
+Check CPU Usage.
 
 =over 8
+
+=item B<--filter>
+
+Filter operating (Default: 'routing|fpc').
 
 =item B<--warning>
 

--- a/network/juniper/common/junos/mode/memory.pm
+++ b/network/juniper/common/junos/mode/memory.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package network::juniper::common::junos::mode::memoryrouting;
+package network::juniper::common::junos::mode::memory;
 
 use base qw(centreon::plugins::mode);
 

--- a/network/juniper/common/junos/mode/memory.pm
+++ b/network/juniper/common/junos/mode/memory.pm
@@ -34,6 +34,7 @@ sub new {
                                 { 
                                   "warning:s"               => { name => 'warning', },
                                   "critical:s"              => { name => 'critical', },
+                                  "filter:s"                => { name => 'filter', default => 'routing|fpc'}
                                 });
 
     return $self;
@@ -65,14 +66,14 @@ sub run {
     my $routing_engine_find = 0;
     my @oids_routing_engine = ();
     foreach my $oid (keys %$result) {        
-        if ($result->{$oid} =~ /routing/i) {
+        if ($result->{$oid} =~ /$filter/i) {
             $routing_engine_find = 1;
             push @oids_routing_engine, $oid;
         }
     }
     
     if ($routing_engine_find == 0) {
-        $self->{output}->add_option_msg(short_msg => "Cannot find operating with 'routing' in description.");
+        $self->{output}->add_option_msg(short_msg => "Cannot find operating with '$filter' in description.");
         $self->{output}->option_exit();
     }
     
@@ -137,6 +138,10 @@ __END__
 Check Memory Usage of routing engine.
 
 =over 8
+
+=item B<--filter>
+
+Filter operating (Default: 'routing|fpc').
 
 =item B<--warning>
 

--- a/network/juniper/common/junos/mode/memory.pm
+++ b/network/juniper/common/junos/mode/memory.pm
@@ -66,14 +66,14 @@ sub run {
     my $routing_engine_find = 0;
     my @oids_routing_engine = ();
     foreach my $oid (keys %$result) {        
-        if ($result->{$oid} =~ /$filter/i) {
+        if ($result->{$oid} =~ /$self->{option_results}->{filter}/i) {
             $routing_engine_find = 1;
             push @oids_routing_engine, $oid;
         }
     }
     
     if ($routing_engine_find == 0) {
-        $self->{output}->add_option_msg(short_msg => "Cannot find operating with '$filter' in description.");
+        $self->{output}->add_option_msg(short_msg => "Cannot find operating with '$self->{option_results}->{filter}' in description.");
         $self->{output}->option_exit();
     }
     

--- a/network/juniper/common/junos/mode/memory.pm
+++ b/network/juniper/common/junos/mode/memory.pm
@@ -135,7 +135,7 @@ __END__
 
 =head1 MODE
 
-Check Memory Usage of routing engine.
+Check Memory Usage.
 
 =over 8
 

--- a/network/juniper/ex/plugin.pm
+++ b/network/juniper/ex/plugin.pm
@@ -31,11 +31,11 @@ sub new {
 
     $self->{version} = '1.0';
     %{$self->{modes}} = (
-        'cpu-routing'       => 'network::juniper::common::junos::mode::cpurouting', # routing engine
+        'cpu'               => 'network::juniper::common::junos::mode::cpu',
         'hardware'          => 'network::juniper::common::junos::mode::hardware',
         'interfaces'        => 'snmp_standard::mode::interfaces',
         'list-interfaces'   => 'snmp_standard::mode::listinterfaces', 
-        'memory-routing'    => 'network::juniper::common::junos::mode::memoryrouting', # routing engine
+        'memory'            => 'network::juniper::common::junos::mode::memory',
         'list-storages'     => 'snmp_standard::mode::liststorages',
         'stack'             => 'network::juniper::common::junos::mode::stack',
         'storage'           => 'snmp_standard::mode::storage',

--- a/network/juniper/mseries/plugin.pm
+++ b/network/juniper/mseries/plugin.pm
@@ -33,7 +33,7 @@ sub new {
     %{$self->{modes}} = (
         'bgp-peer-state'                => 'network::juniper::common::junos::mode::bgppeerstate',
         'bgp-peer-prefix-statistics'    => 'network::juniper::common::junos::mode::bgppeerprefixstatistics',
-        'cpu-routing'                   => 'network::juniper::common::junos::mode::cpurouting', # routing engine
+        'cpu'                           => 'network::juniper::common::junos::mode::cpu',
         'hardware'                      => 'network::juniper::common::junos::mode::hardware',
         'interfaces'                    => 'network::juniper::common::junos::mode::interfaces', 
         'ldp-session-status'            => 'network::juniper::common::junos::mode::ldpsessionstatus',
@@ -41,7 +41,7 @@ sub new {
         'list-bgp-peers'                => 'network::juniper::common::junos::mode::listbgppeers',
         'list-interfaces'               => 'snmp_standard::mode::listinterfaces',
         'list-storages'                 => 'snmp_standard::mode::liststorages',
-        'memory-routing'                => 'network::juniper::common::junos::mode::memoryrouting', # routing engine
+        'memory'                        => 'network::juniper::common::junos::mode::memory',
         'rsvp-session-status'           => 'network::juniper::common::junos::mode::rsvpsessionstatus',
         'storage'                       => 'snmp_standard::mode::storage',
     );

--- a/network/juniper/srx/plugin.pm
+++ b/network/juniper/srx/plugin.pm
@@ -32,9 +32,9 @@ sub new {
     $self->{version} = '1.0';
     %{$self->{modes}} = (
         'hardware'          => 'network::juniper::common::junos::mode::hardware',
-        'cpu-routing'       => 'network::juniper::common::junos::mode::cpurouting', # routing engine
+        'cpu'               => 'network::juniper::common::junos::mode::cpu',
         'cpu-forwarding'    => 'network::juniper::common::junos::mode::cpuforwarding', # packet forwarding engine
-        'memory-routing'    => 'network::juniper::common::junos::mode::memoryrouting', # routing engine
+        'memory'            => 'network::juniper::common::junos::mode::memory',
         'memory-forwarding' => 'network::juniper::common::junos::mode::memoryforwarding', # packet forwarding engine
         'cp-sessions'       => 'network::juniper::common::junos::mode::cpsessions', # CP = 'central point'
         'flow-sessions'     => 'network::juniper::common::junos::mode::flowsessions',


### PR DESCRIPTION
Hi,

This improves Juniper CPU / memory modes.
These 2 were stuck to the Routing Engine.
Whereas we can also check the FPCs / PICs.

Note that `operating` component of `hardware` mode can already check all of them.
But it is not practical at all, this component is too heavy as we can't easily separate what we want to monitor (states, CPU, memory...). For example we can't monitor temperatures only.
IMO it should be split / rewritten, some items such as CPU and memory checks, which are already done here, could perhaps simply be removed, limiting the `operating` component to check state only, as with `alarm` and `fru` components. This would also make it much faster.

Thank you 👍 
