### PR TITLE
Remove useless proxyurl handling from cURL HTTP backend

### DIFF
--- a/centreon/plugins/backend/http/curl.pm
+++ b/centreon/plugins/backend/http/curl.pm
@@ -212,12 +212,6 @@ sub set_proxy {
     my ($self, %options) = @_;
 
     if (defined($options{request}->{proxyurl}) && $options{request}->{proxyurl} ne '') {
-        if ($options{request}->{proxyurl} =~ /^(?:http|https):\/\/(.*?):(.*?)@/) {
-            $self->curl_setopt(option => $self->{constant_cb}->(name => 'CURLOPT_PROXYUSERNAME'), parameter => $1);
-            $self->curl_setopt(option => $self->{constant_cb}->(name => 'CURLOPT_PROXYPASSWORD'), parameter => $2);
-            $options{request}->{proxyurl} =~ s/\/\/$1:$2@//;
-        }
-
         $self->curl_setopt(option => $self->{constant_cb}->(name => 'CURLOPT_PROXY'), parameter => $options{request}->{proxyurl});
     }
 


### PR DESCRIPTION
If I use `--proxyurl http://user:pass@a.b.c.d:8080` there's a bug in that bit of code:
https://github.com/centreon/centreon-plugins/blob/157eb81cfabf94bb31130697d4bb8ef006f60b77/centreon/plugins/backend/http/curl.pm#L218
It sets `$options{request}->{proxyurl}` to `http:user:pass@a.b.c.d:8080` which makes cURL fail.

```
UNKNOWN: curl perform error : Couldn't resolve proxy name
```

It looks like you do not need that bit of code since [the documentation for `CURLOPT_PROXY`](https://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html) specifies that
> A proxy host string can also include protocol scheme (http://) and embedded user + password. 

I have tested these changes on my CentOS 7 Centreon Poller and proxy authentication works as expected.