### PR TITLE
Add missing option to set SSL options

### DIFF
--- a/network/cisco/prime/restapi/custom/api.pm
+++ b/network/cisco/prime/restapi/custom/api.pm
@@ -48,7 +48,7 @@ sub new {
             "username:s@" => { name => 'username' },
             "password:s@" => { name => 'password' },
             "timeout:s@"  => { name => 'timeout' },
-			"ssl-opt:s@"  => { name => 'ssl_opt' },
+            "ssl-opt:s@"  => { name => 'ssl_opt' },
         });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);

--- a/network/cisco/prime/restapi/custom/api.pm
+++ b/network/cisco/prime/restapi/custom/api.pm
@@ -48,6 +48,7 @@ sub new {
             "username:s@" => { name => 'username' },
             "password:s@" => { name => 'password' },
             "timeout:s@"  => { name => 'timeout' },
+			"ssl-opt:s@"  => { name => 'ssl_opt' },
         });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -231,6 +232,10 @@ Cisco Prime password.
 =item B<--timeout>
 
 Set HTTP timeout
+
+=item B<--ssl-opt>
+
+Set SSL options (--ssl-opt="SSL_version => TLSv1" --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE").
 
 =back
 


### PR DESCRIPTION
When using this plugin I noticed that since our prime had a self-signed certificate, the plugin was not taking this into account and this fixes the issue.