### PR TITLE
[influxdb] Remove 3 redefined lines

### DIFF
--- a/database/influxdb/custom/api.pm
+++ b/database/influxdb/custom/api.pm
@@ -125,9 +125,6 @@ sub build_options_for_httplib {
     $self->{option_results}->{port} = $self->{port};
     $self->{option_results}->{proto} = $self->{proto};
     $self->{option_results}->{timeout} = $self->{timeout};
-    $self->{option_results}->{warning_status} = '';
-    $self->{option_results}->{critical_status} = '';
-    $self->{option_results}->{unknown_status} = '%{http_code} < 200 or %{http_code} >= 300';
 
     if (defined($self->{username}) && $self->{username} ne '') {
         $self->{option_results}->{credentials} = 1;

--- a/database/influxdb/custom/api.pm
+++ b/database/influxdb/custom/api.pm
@@ -269,7 +269,7 @@ Set timeout in seconds (Default: 10).
 
 =item B<--unknown-http-status>
 
-Threshold warning for http response code.
+Threshold unknown for http response code.
 (Default: '%{http_code} < 200 or %{http_code} >= 300')
 
 =item B<--warning-http-status>


### PR DESCRIPTION
Hi,

Let's remove these 3 lines, as they are redefined below ?

```
    my $content = $self->{http}->request(
        %options,
        unknown_status => $self->{unknown_http_status},
        warning_status => $self->{warning_http_status},
        critical_status => $self->{critical_http_status},
    );
```

Thx !