### PR TITLE
3CX, add HTTP status options

### DIFF
--- a/apps/voip/3cx/restapi/custom/api.pm
+++ b/apps/voip/3cx/restapi/custom/api.pm
@@ -344,7 +344,7 @@ Set 3CX Password.
 Threshold for HTTP timeout (Default: '30').
 
 =item B<--unknown-http-status>
-Threshold warning for http response code.
+Threshold unknown for http response code.
 (Default: '%{http_code} < 200 or %{http_code} >= 300')
 
 =item B<--warning-http-status>

--- a/apps/voip/3cx/restapi/custom/api.pm
+++ b/apps/voip/3cx/restapi/custom/api.pm
@@ -51,6 +51,9 @@ sub new {
             "api-username:s"        => { name => 'api_username' },
             "api-password:s"        => { name => 'api_password' },
             "timeout:s"             => { name => 'timeout', default => 30 },
+            'unknown-http-status:s'  => { name => 'unknown_http_status' },
+            'warning-http-status:s'  => { name => 'warning_http_status' },
+            'critical-http-status:s' => { name => 'critical_http_status' },
         });
     }
     
@@ -96,6 +99,9 @@ sub check_options {
     $self->{ssl_opt} = (defined($self->{option_results}->{ssl_opt})) ? $self->{option_results}->{ssl_opt} : undef;
     $self->{api_username} = (defined($self->{option_results}->{api_username})) ? $self->{option_results}->{api_username} : undef;
     $self->{api_password} = (defined($self->{option_results}->{api_password})) ? $self->{option_results}->{api_password} : undef;
+    $self->{unknown_http_status} = (defined($self->{option_results}->{unknown_http_status})) ? $self->{option_results}->{unknown_http_status} : '%{http_code} < 200 or %{http_code} >= 300' ;
+    $self->{warning_http_status} = (defined($self->{option_results}->{warning_http_status})) ? $self->{option_results}->{warning_http_status} : '';
+    $self->{critical_http_status} = (defined($self->{option_results}->{critical_http_status})) ? $self->{option_results}->{critical_http_status} : '';
 
     if (!defined($self->{hostname}) || $self->{hostname} eq '') {
         $self->{output}->add_option_msg(short_msg => "Need to specify --hostname option.");
@@ -190,8 +196,11 @@ sub request_api {
 
     $self->settings();
 
-    my $content = $self->{http}->request(%options, 
-        warning_status => '', unknown_status => '', critical_status => '%{http_code} < 200 or %{http_code} >= 300'
+    my $content = $self->{http}->request(
+        %options,
+        unknown_status => $self->{unknown_http_status},
+        warning_status => $self->{warning_http_status},
+        critical_status => $self->{critical_http_status},
     );
 
     # Some content may be strangely returned, for example :
@@ -333,6 +342,16 @@ Set 3CX Password.
 =item B<--timeout>
 
 Threshold for HTTP timeout (Default: '30').
+
+=item B<--unknown-http-status>
+Threshold warning for http response code.
+(Default: '%{http_code} < 200 or %{http_code} >= 300')
+
+=item B<--warning-http-status>
+Threshold warning for http response code.
+
+=item B<--critical-http-status>
+Threshold critical for http response code.
 
 =back
 

--- a/apps/voip/3cx/restapi/mode/system.pm
+++ b/apps/voip/3cx/restapi/mode/system.pm
@@ -24,7 +24,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
-use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold);
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold catalog_status_calc);
 
 sub custom_status_output { 
     my ($self, %options) = @_;
@@ -35,14 +35,6 @@ sub custom_status_output {
     }
     $msg .= ': ' . $self->{result_values}->{error};
     return $msg;
-}
-
-sub custom_status_calc {
-    my ($self, %options) = @_;
-
-    $self->{result_values}->{error} = $options{new_datas}->{$self->{instance} . '_error'};
-    $self->{result_values}->{service} = $options{new_datas}->{$self->{instance} . '_service'};
-    return 0;
 }
 
 sub set_counters {
@@ -77,7 +69,7 @@ sub set_counters {
     $self->{maps_counters}->{service} = [
         { label => 'status', threshold => 0, set => {
                 key_values => [ { name => 'error' }, { name => 'service' } ],
-                closure_custom_calc => $self->can('custom_status_calc'),
+                closure_custom_calc => \&catalog_status_calc,
                 closure_custom_output => $self->can('custom_status_output'),
                 closure_custom_perfdata => sub { return 0; },
                 closure_custom_threshold_check => \&catalog_status_threshold,


### PR DESCRIPTION
Hi,

This PR adds HTTP options to the 3CX plugin, as done in the InfluxDB plugin.

While here, simplify the `catalog_status_calc` call.

Thank you 👍 