### PR TITLE
Allow newline character in parameters

### DIFF
--- a/centreon/plugins/alternative/Getopt.pm
+++ b/centreon/plugins/alternative/Getopt.pm
@@ -59,7 +59,7 @@ sub GetOptions {
     my $search_str = ',' . join(',', keys %opts) . ',';
     my $num_args = scalar(@ARGV);
     for (my $i = 0; $i < $num_args;) {
-        if (defined($ARGV[$i]) && $ARGV[$i] =~ /^--(.*?)(?:=|$)(.*)/) {
+        if (defined($ARGV[$i]) && $ARGV[$i] =~ /^--(.*?)(?:=|$)((?s).*)/) {
             my ($option, $value) = ($1, $2);
             
             # find type of option


### PR DESCRIPTION
Hi,

This PR allows to use parameters with embedded newlines.
This works when using Perl `Getopt` (`$alternative = 0` in `centreon/plugins/options.pm`).
But it was not working with `centreon::plugins::alternative::Getopt`.

This is now fixed thanks to this PR 👍

Thx !