### PR TITLE
MikroTik, return -273°C as UNKNOWN

### DIFF
--- a/network/mikrotik/snmp/mode/components/temperature.pm
+++ b/network/mikrotik/snmp/mode/components/temperature.pm
@@ -46,6 +46,9 @@ sub check {
         $self->{output}->output_add(long_msg => sprintf("System temperature (SoC or PCB) is '%s' C", $result->{mtxrHlTemperature} / 10));
 
         ($exit, $warn, $crit, $checked) = $self->get_severity_numeric(section => 'temperature', instance => '1', value => $result->{mtxrHlTemperature} / 10);
+	if ($result->{mtxrHlTemperature} == -2730) { # RouterOS returns this when the SNMP agent hangs...
+		$exit = 'UNKNOWN';
+	}
         if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
             $self->{output}->output_add(severity => $exit,
                                         short_msg => sprintf("System temperature (SoC or PCB) is '%s' C", $result->{mtxrHlTemperature} / 10));
@@ -65,6 +68,9 @@ sub check {
         $self->{output}->output_add(long_msg => sprintf("Processor temperature is '%s' C", $result->{mtxrHlProcessorTemperature} / 10));
 
         ($exit, $warn, $crit, $checked) = $self->get_severity_numeric(section => 'temperature', instance => '2', value => $result->{mtxrHlProcessorTemperature} / 10);
+	if ($result->{mtxrHlProcessorTemperature} == -2730) { # RouterOS returns this when the SNMP agent hangs...
+		$exit = 'UNKNOWN';
+	}
         if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
             $self->{output}->output_add(severity => $exit,
                                         short_msg => sprintf("Processor temperature is '%s' C", $result->{mtxrHlProcessorTemperature} / 10));


### PR DESCRIPTION
Hi,

Sometimes, MikroTik SNMP agent hangs...
And returns -273°C as the temperature.
Let's then return UNKNOWN exit code for this lowest temperature scale value.

Thx 👍