### PR TITLE
Add an UNKNOWN option for 0 timestamps

### DIFF
--- a/snmp_standard/mode/ntp.pm
+++ b/snmp_standard/mode/ntp.pm
@@ -62,9 +62,10 @@ sub new {
     bless $self, $class;
     
     $options{options}->add_options(arguments => { 
-        'ntp-hostname:s' => { name => 'ntp_hostname' },
-        'ntp-port:s'     => { name => 'ntp_port', default => 123 },
-        'timezone:s'     => { name => 'timezone' },
+        'ntp-hostname:s'  => { name => 'ntp_hostname' },
+        'ntp-port:s'      => { name => 'ntp_port', default => 123 },
+        'timezone:s'      => { name => 'timezone' },
+        'unknown-if-zero' => { name => 'unknown_if_zero' },
     });
 
     return $self;
@@ -145,7 +146,16 @@ sub manage_selection {
     $self->{offset} = { 
         offset => sprintf("%d", $offset),
         date => $remote_date_formated,
-    };    
+    };
+
+    if (($disant_time == 0) && defined($self->{option_results}->{unknown_if_zero})) {
+        $self->{output}->output_add(
+            severity => 'UNKNOWN',
+            short_msg => $remote_date_formated
+        );
+        $self->{output}->display();
+        $self->{output}->exit();
+    }
 }
 
 1;

--- a/snmp_standard/mode/uptime.pm
+++ b/snmp_standard/mode/uptime.pm
@@ -40,6 +40,7 @@ sub new {
         'force-oid:s'     => { name => 'force_oid' },
         'check-overload'  => { name => 'check_overload' },
         'reboot-window:s' => { name => 'reboot_window', default => 5000 },
+        'unknown-if-zero' => { name => 'unknown_if_zero' },
         'unit:s'          => { name => 'unit', default => 's' },
     });
 
@@ -127,6 +128,9 @@ sub run {
         value => floor($value / $unitdiv->{$self->{option_results}->{unit}}), 
         threshold => [ { label => 'critical', exit_litteral => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]
     );
+    if (($value == 0) && defined($self->{option_results}->{unknown_if_zero})) {
+        $exit_code = 'UNKONWN';
+    }
     $self->{output}->perfdata_add(
         label => 'uptime', unit => $self->{option_results}->{unit},
         value => floor($value / $unitdiv->{$self->{option_results}->{unit}}),


### PR DESCRIPTION
Hi,

This PR is a proposal which follows our conversation there : https://github.com/centreon/centreon-plugins/issues/1846

It adds an `--unknown-if-zero` option with allows `uptime` and `ntp` nodes to return `UNKNOWN` if time returned by the SNMP agent is 0.

Of course feel free to comment :)

Thx 👍 