### PR TITLE
fix problem with metric name in network mode for ec2

### DIFF
--- a/cloud/aws/ec2/mode/network.pm
+++ b/cloud/aws/ec2/mode/network.pm
@@ -39,8 +39,8 @@ my %metrics_mapping = (
         'output' => 'Network Out',
         'label' => 'network-out',
         'nlabel' => {
-            'absolute' => 'ec2.network.in.bytes',
-            'per_second' => 'ec2.network.in.bytespersecond',
+            'absolute' => 'ec2.network.out.bytes',
+            'per_second' => 'ec2.network.out.bytespersecond',
         },
         'unit' => 'B',
     },


### PR DESCRIPTION
bad metric name for network out