### PR TITLE
Fix nsclient++ new API

### DIFF
--- a/apps/protocols/nrpe/custom/nsclient.pm
+++ b/apps/protocols/nrpe/custom/nsclient.pm
@@ -142,7 +142,7 @@ sub output_perf {
 
     my $result = 'UNKNOWN';
     $result = $errors_num{$options{result}} if ($options{result} =~ /[0-3]/);
-    $result = $options{result}if ($options{result} =~ /\w+/);
+    $result = $options{result} if ($options{result} =~ /[A-Z]+/);
 
     my %result = (
         code => $result,


### PR DESCRIPTION
Hi,

`--plugin=apps::protocols::nrpe::plugin --custommode=nsclient --mode=query --new-api`

Without this PR, output looks like :
 ` | 'total 10s'=2%;80;90;0;0`
With :
`OK: CPU load is ok. | 'total 10s'=2%;80;90;0;0`

Thank you 👍