### PR TITLE
Typo in interfaces perfdata new label

### DIFF
--- a/snmp_standard/mode/interfaces.pm
+++ b/snmp_standard/mode/interfaces.pm
@@ -201,7 +201,7 @@ sub custom_errors_perfdata {
     if ($self->{instance_mode}->{option_results}->{units_errors} eq '%') {
         $self->{output}->perfdata_add(
             label => 'packets_' . $self->{result_values}->{label2} . '_' . $self->{result_values}->{label1}, unit => '%',
-            nlabel => 'interface.packets.' . $self->{result_values}->{label1} . '.' . $self->{result_values}->{label2} . 's.percentage',
+            nlabel => 'interface.packets.' . $self->{result_values}->{label1} . '.' . $self->{result_values}->{label2} . '.percentage',
             instances => $self->use_instances(extra_instance => $options{extra_instance}) ? $self->{result_values}->{display} : undef,
             value => sprintf("%.2f", $self->{result_values}->{prct}),
             warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{label}),


### PR DESCRIPTION
Hi,

This PR corrects a typo in perfdata newlabel of `interfaces` mode.

Here's an example of a perfdata newlabel :

- with `--units-errors=absolute` :
`interface.packets.in.alignerror.count`

- with `--units-errors=%` :
`interface.packets.in.alignerrors.percentage`

Issue is with the additional `s` character added before `percentage`.
This PR removes it.

Thx 👍 