### PR TITLE
fix(disk/storage): output size skipped disks only in debug mode

### DIFF
--- a/snmp_standard/mode/diskusage.pm
+++ b/snmp_standard/mode/diskusage.pm
@@ -188,7 +188,9 @@ sub manage_selection {
         
         my $total_size = (($result->{$oid_dskTotalHigh . "." . $_} << 32) + $result->{$oid_dskTotalLow . "." . $_}) * 1024;
         if ($total_size == 0) {
-            $self->{output}->output_add(long_msg => sprintf("skipping partition '%s' (total size is 0)", $name_diskpath));
+            if ($self->{output}->is_debug()) {
+                $self->{output}->output_add(long_msg => sprintf("skipping partition '%s' (total size is 0)", $name_diskpath));
+            }
             next;
         }
         my $total_used = (($result->{$oid_dskUsedHigh . "." . $_} << 32) + $result->{$oid_dskUsedLow . "." . $_}) * 1024;

--- a/snmp_standard/mode/storage.pm
+++ b/snmp_standard/mode/storage.pm
@@ -330,13 +330,15 @@ sub manage_selection {
         # in bytes hrStorageAllocationUnits
         my $total_size = $result->{$oid_hrStorageSize . "." . $_} * $result->{$oid_hrStorageAllocationUnits . "." . $_};
         if ($total_size <= 0) {
-            $self->{output}->add_option_msg(
-                long_msg => sprintf(
-                    "skipping storage '%s': total size is <= 0 (%s)", 
-                    $name_storage,
-                    int($total_size)
-                )
-            );
+            if ($self->{output}->is_debug()) {
+                $self->{output}->add_option_msg(
+                    long_msg => sprintf(
+                        "skipping storage '%s': total size is <= 0 (%s)",
+                        $name_storage,
+                        int($total_size)
+                    )
+                );
+            }
             next;
         }
         


### PR DESCRIPTION
Hi,

Some systems may return a lot of 0 byte size disks.
It can then be hard to filter all them out.
Which then messes-up the verbose output.

This PR then solves this.

Thank you 👍 