### PR TITLE
MikroTik, add proper disk mode

### DIFF
--- a/network/mikrotik/snmp/mode/disk.pm
+++ b/network/mikrotik/snmp/mode/disk.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package network::mikrotik::snmp::mode::memory;
+package network::mikrotik::snmp::mode::disk;
 
 use base qw(snmp_standard::mode::storage);
 
@@ -28,13 +28,13 @@ use warnings;
 sub default_storage_type {
     my ($self, %options) = @_;
     
-    return '^hrStorageRam$';
+    return '^(?!(hrStorageRam)$)';
 }
 
 sub prefix_storage_output {
     my ($self, %options) = @_;
     
-    return "RAM '" . $options{instance_value}->{display} . "' ";
+    return "Disk '" . $options{instance_value}->{display} . "' ";
 }
 
 sub new {
@@ -97,7 +97,7 @@ Display cache storage datas.
 
 =item B<--filter-storage-type>
 
-Filter storage types with a regexp (Default: '^hrStorageRam$').
+Filter storage types with a regexp (Default: '^(?!(hrStorageRam)$)').
 
 =back
 

--- a/network/mikrotik/snmp/mode/disk.pm
+++ b/network/mikrotik/snmp/mode/disk.pm
@@ -51,7 +51,7 @@ __END__
 
 =head1 MODE
 
-Check memory.
+Check disk.
 
 =over 8
 

--- a/network/mikrotik/snmp/plugin.pm
+++ b/network/mikrotik/snmp/plugin.pm
@@ -32,6 +32,7 @@ sub new {
     $self->{version} = '1.0';
     %{$self->{modes}} = (
         'cpu'               => 'snmp_standard::mode::cpu',
+        'disk'              => 'network::mikrotik::snmp::mode::disk',
         'environment'       => 'network::mikrotik::snmp::mode::environment',
         'interfaces'        => 'network::mikrotik::snmp::mode::interfaces',
         'list-interfaces'   => 'snmp_standard::mode::listinterfaces',


### PR DESCRIPTION
Hi,

This PR adds a proper MikroTik disk mode.
Until now we could use the memory mode to achieve this, but then we had to change the "RAM" prefix into "Disk" in the short output, and this is not possible in the long output.

As it's almost a copy of the `memory` mode, I hesitated to rename `memory` mode to `storage` mode, and to add a sort of `--type` option, which would allow to tune the prefix, `RAM`, `Disk`, or whatever...

Feel free to tell me what's the best method.

Thank you 👍 