### PR TITLE
enh(disk): support 32 bits counters

### DIFF
--- a/snmp_standard/mode/diskusage.pm
+++ b/snmp_standard/mode/diskusage.pm
@@ -111,7 +111,7 @@ sub new {
     bless $self, $class;
     
     $options{options}->add_options(arguments => { 
-        'force-counters32'        => { name => 'force_counters32' }
+        'force-counters32'        => { name => 'force_counters32' },
         'units:s'                 => { name => 'units', default => '%' },
         'free'                    => { name => 'free' },
         'reload-cache-time:s'     => { name => 'reload_cache_time', default => 180 },


### PR DESCRIPTION
Hi,

Some (old ?) systems do not provide `High` and `Low` disk usage counters.
Let's then detect if 64 bits counters are available, and use 32 bits ones if not.

Thank you 👍