### PR TITLE
add support for ACS8000 series (psu oid differs from ACS6000 series)

### DIFF
--- a/hardware/kvm/avocent/acs/8000/snmp/mode/components/psu.pm
+++ b/hardware/kvm/avocent/acs/8000/snmp/mode/components/psu.pm
@@ -1,0 +1,71 @@
+#
+# Copyright 2019 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package hardware::kvm::avocent::acs::8000::snmp::mode::components::psu;
+
+use strict;
+use warnings;
+
+my %map_states = (1 => 'statePowerOn', 2 => 'statePowerOff', 9999 => 'powerNotInstalled');
+
+my $mapping = {
+    acsPowerSupplyStatePw1 => { oid => '.1.3.6.1.4.1.10418.26.2.1.8.2', map => \%map_states },
+    acsPowerSupplyStatePw2 => { oid => '.1.3.6.1.4.1.10418.26.2.1.8.3', map => \%map_states },
+};
+my $oid_acsPowerSupply = '.1.3.6.1.4.1.10418.26.2.1.8';
+
+sub load {
+    my ($self) = @_;
+    
+    push @{$self->{request}}, { oid => $oid_acsPowerSupply };
+}
+
+sub check_psu {
+    my ($self, %options) = @_;
+    
+    return if ($self->check_filter(section => 'psu', instance => $options{instance}));
+    return if ($options{state} eq 'powerNotInstalled' && 
+               $self->absent_problem(section => 'psu', instance => $options{instance}));
+    $self->{components}->{psu}->{total}++;
+
+    $self->{output}->output_add(long_msg => sprintf("power supply '%s' status is %s.",
+                                $options{instance}, $options{state}
+                                ));
+    my $exit = $self->get_severity(section => 'psu', value => $options{state});
+    if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
+        $self->{output}->output_add(severity =>  $exit,
+                                    short_msg => sprintf("Power supply '%s' status is %s",
+                                                         $options{instance}, $options{state}));
+    }
+}
+
+sub check {
+    my ($self) = @_;
+    
+    $self->{output}->output_add(long_msg => "Checking power supplies");
+    $self->{components}->{psu} = {name => 'psus', total => 0, skip => 0};
+    return if ($self->check_filter(section => 'psu'));
+
+    my $result = $self->{snmp}->map_instance(mapping => $mapping, results => $self->{results}->{$oid_acsPowerSupply}, instance => '0');
+    check_psu($self, state => $result->{acsPowerSupplyStatePw1}, instance => '1');
+    check_psu($self, state => $result->{acsPowerSupplyStatePw2}, instance => '2');
+}
+
+1;

--- a/hardware/kvm/avocent/acs/8000/snmp/mode/hardware.pm
+++ b/hardware/kvm/avocent/acs/8000/snmp/mode/hardware.pm
@@ -1,0 +1,104 @@
+#
+# Copyright 2019 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package hardware::kvm::avocent::acs::8000::snmp::mode::hardware;
+
+use base qw(centreon::plugins::templates::hardware);
+
+use strict;
+use warnings;
+
+sub set_system {
+    my ($self, %options) = @_;
+    
+    $self->{regexp_threshold_overload_check_section_option} = '^(psu)$';
+    
+    $self->{cb_hook2} = 'snmp_execute';
+    
+    $self->{thresholds} = {
+        psu => [
+            ['statePowerOn', 'OK'],
+            ['statePowerOff', 'CRITICAL'],
+            ['powerNotInstalled', 'OK'],
+        ],
+    };
+    
+    $self->{components_path} = 'hardware::kvm::avocent::acs::8000::snmp::mode::components';
+    $self->{components_module} = ['psu'];
+}
+
+sub snmp_execute {
+    my ($self, %options) = @_;
+    
+    $self->{snmp} = $options{snmp};
+    $self->{results} = $self->{snmp}->get_multiple_table(oids => $self->{request});
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, no_performance => 1);
+    bless $self, $class;
+    
+    $options{options}->add_options(arguments =>
+                                {
+                                });
+
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check hardware.
+
+=over 8
+
+=item B<--component>
+
+Which component to check (Default: '.*').
+Can be: 'psu'.
+
+=item B<--filter>
+
+Exclude some parts (comma seperated list) (Example: --filter=psu)
+Can also exclude specific instance: --filter=psu,1
+
+=item B<--absent-problem>
+
+Return an error if an entity is not 'present' (default is skipping) (comma seperated list)
+Can be specific or global: --absent-problem=psu
+
+=item B<--no-component>
+
+Return an error if no compenents are checked.
+If total (with skipped) is 0. (Default: 'critical' returns).
+
+=item B<--threshold-overload>
+
+Set to overload default threshold values (syntax: section,[instance,]status,regexp)
+It used before default thresholds (order stays).
+Example: --threshold-overload='psu,CRITICAL,^(?!(statePowerOn)$)'
+
+=back
+
+=cut

--- a/hardware/kvm/avocent/acs/8000/snmp/plugin.pm
+++ b/hardware/kvm/avocent/acs/8000/snmp/plugin.pm
@@ -1,0 +1,51 @@
+#
+# Copyright 2019 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package hardware::kvm::avocent::acs::8000::snmp::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_snmp);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{version} = '1.0';
+    %{$self->{modes}} = (
+        'cpu-detailed'  => 'snmp_standard::mode::cpudetailed',
+        'hardware'      => 'hardware::kvm::avocent::acs::8000::snmp::mode::hardware',
+        'load'          => 'snmp_standard::mode::loadaverage',
+        'memory'        => 'snmp_standard::mode::memory',
+    );
+
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 PLUGIN DESCRIPTION
+
+Check Avocent ACS 8000 series in SNMP.
+
+=cut


### PR DESCRIPTION
This is mostly a copy of the ACS6000 module with few changes, to support ACS8000 series. Changes are of course the naming (6000 > 8000) and the new OIDs of the power supplys. Tested with all modes against an ACS8000 of course.