### PR TITLE
enh(nsclient): default to SSL_VERIFY_NONE

### DIFF
--- a/apps/protocols/nrpe/custom/nsclient.pm
+++ b/apps/protocols/nrpe/custom/nsclient.pm
@@ -100,6 +100,10 @@ sub check_options {
     $self->{password} = (defined($self->{option_results}->{password})) ? $self->{option_results}->{password} : undef;
     $self->{legacy_password} = (defined($self->{option_results}->{legacy_password})) ? $self->{option_results}->{legacy_password} : undef;
 
+    if (!defined($self->{option_results}->{ssl_opt})) {
+        $self->{option_results}->{ssl_opt} = ['SSL_verify_mode => SSL_VERIFY_NONE'];
+    }
+
     if (!defined($self->{hostname}) || $self->{hostname} eq '') {
         $self->{output}->add_option_msg(short_msg => "Need to specify --hostname option.");
         $self->{output}->option_exit();


### PR DESCRIPTION
Hi,

This defaults NSClient++ API to `SSL_VERIFY_NONE`.
Who replace their self-signed certificate by a CA-signed one ? ^^

Thx 👍 