### PR TITLE
Flexsystem typo

### DIFF
--- a/network/lenovo/flexsystem/snmp/mode/components/temperature.pm
+++ b/network/lenovo/flexsystem/snmp/mode/components/temperature.pm
@@ -96,7 +96,7 @@ sub check {
         }
         $self->{output}->perfdata_add(
             nlabel => 'hardware.temperature.celsius', unit => 'C',
-            instances => 'switch=' . $instance,
+            instances => 'switch' . $instance,
             value => $temperature,
             warning => $warn,
             critical => $crit


### PR DESCRIPTION
Hi,

Better not to use equal sign in instance name.

Thx 👍 