### PR TITLE
(wip) add ec2 spot fleet instance count ref #172

### DIFF
--- a/cloud/aws/ec2/mode/spotactiveinstances.pm
+++ b/cloud/aws/ec2/mode/spotactiveinstances.pm
@@ -1,0 +1,122 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::aws::ec2::mode::spotactiveinstances;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+
+sub set_counters {
+    my ($self, %options) = @_;
+    
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0 },
+    ];
+    $self->{maps_counters}->{global} = [
+        { label => 'active', nlabel => 'ec2.spot.instances.active.count', set => {
+                key_values => [ { name => 'active' } ],
+                output_template => 'Active instances : %s',
+                perfdatas => [
+                    { label => 'active', value => 'active_absolute', template => '%s', 
+                      min => 0 },
+                ],
+            }
+        },
+        { label => 'healthy', nlabel => 'ec2.spot.instances.unhealthy.count', set => {
+                key_values => [ { name => 'healthy' } ],
+                output_template => 'Healthy instances : %s',
+                perfdatas => [
+                    { label => 'healthy', value => 'healthy_absolute', template => '%s',
+                      min => 0 },
+                ],
+            }
+        },
+        { label => 'unhealthy', nlabel => 'ec2.spot.instances.unhealthy.count', set => {
+                key_values => [ { name => 'unhealthy' } ],
+                output_template => 'Unhealty instances : %s',
+                perfdatas => [
+                    { label => 'unhealthy', value => 'unhealthy_absolute', template => '%s',
+                      min => 0 },
+                ],
+            }
+        },
+    ]
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments =>  {
+        'region:s'                      => { name => 'region' },
+        'spot-fleet-request-id:s'       => { name => 'spot_fleet_request_id' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{region}) || $self->{option_results}->{region} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --region option.");
+        $self->{output}->option_exit();
+    }
+
+    if (!defined($self->{option_results}->{spot_fleet_request_id}) || $self->{option_results}->{spot_fleet_request_id} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --spot-fleet-request-id option.");
+        $self->{output}->option_exit();
+    }
+
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+ 
+    $self->{global} = { active => 0, healthy => 0, unhealthy => 0 };
+    $self->{instances} = $options{custom}->ec2spot_get_active_instances_status(region => $self->{option_results}->{region}, spot_fleet_request_id => $self->{option_results}->{spot_fleet_request_id});
+
+    foreach my $instance_id (keys %{$self->{instances}}) {
+        $self->{global}->{active}++;
+        $self->{global}->{lc($self->{instances}->{$instance_id}->{health})}++;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check EC2 Spot active instance for a specific fleet
+
+=over 8
+
+=item B<--warning-*> B<--critical-*>
+
+Warning and Critical thresholds. You can use 'active', 'healthy', 'unhealthy'
+
+=back
+
+=cut

--- a/cloud/aws/ec2/plugin.pm
+++ b/cloud/aws/ec2/plugin.pm
@@ -31,16 +31,17 @@ sub new {
 
     $self->{version} = '0.1';
     %{ $self->{modes} } = (
-        'asg-status'        => 'cloud::aws::ec2::mode::asgstatus',
-        'cpu'               => 'cloud::aws::ec2::mode::cpu',
-        'discovery'         => 'cloud::aws::ec2::mode::discovery',
-        'diskio'            => 'cloud::aws::ec2::mode::diskio',
-        'instances-status'  => 'cloud::aws::ec2::mode::instancesstatus',
-        'instances-types'   => 'cloud::aws::ec2::mode::instancestypes',
-        'list-asg'          => 'cloud::aws::ec2::mode::listasg',
-        'list-instances'    => 'cloud::aws::ec2::mode::listinstances',
-        'network'           => 'cloud::aws::ec2::mode::network',
-        'status'            => 'cloud::aws::ec2::mode::status',
+        'asg-status'            => 'cloud::aws::ec2::mode::asgstatus',
+        'cpu'                   => 'cloud::aws::ec2::mode::cpu',
+        'discovery'             => 'cloud::aws::ec2::mode::discovery',
+        'diskio'                => 'cloud::aws::ec2::mode::diskio',
+        'instances-status'      => 'cloud::aws::ec2::mode::instancesstatus',
+        'instances-types'       => 'cloud::aws::ec2::mode::instancestypes',
+        'list-asg'              => 'cloud::aws::ec2::mode::listasg',
+        'list-instances'        => 'cloud::aws::ec2::mode::listinstances',
+        'network'               => 'cloud::aws::ec2::mode::network',
+        'status'                => 'cloud::aws::ec2::mode::status',
+        'spot-active-instances' => 'cloud::aws::ec2::mode::spotactiveinstances'
     );
 
     $self->{custom_modes}{paws} = 'cloud::aws::custom::paws';


### PR DESCRIPTION
New mode to monitor a spot fleet request: 

```
perl centreon_plugins.pl --plugin=cloud::aws::ec2::plugin --mode=spot-active-instances --custommode=awscli --region='eu-west-1' --spot-fleet-request-id=sfr-6b333-EXAMPLE

OK: Active instances : 50, Healthy instances : 50, Unhealty instances : 0 | 'ec2.spot.active.instance.count'=50;;;0; 'ec2.spot.unhealthy.instance.count'=50;;;0; 'ec2.spot.unhealthy.instance.count'=0;;;0;
```