### PR TITLE
Typos

### DIFF
--- a/network/juniper/common/junos/mode/interfaces.pm
+++ b/network/juniper/common/junos/mode/interfaces.pm
@@ -41,7 +41,7 @@ sub set_counters {
     $self->SUPER::set_counters(%options);
     
     push @{$self->{maps_counters}->{int}}, 
-        { label => 'fcs-errors', filter => 'add_errors', nlabel => 'interface.packets.in.fcs.errors.count', set => {
+        { label => 'in-fcserror', filter => 'add_errors', nlabel => 'interface.packets.in.fcserror.count', set => {
                 key_values => [ { name => 'infcserror', diff => 1 }, { name => 'total_in_packets', diff => 1 }, { name => 'display' }, { name => 'mode_cast' } ],
                 closure_custom_calc => $self->can('custom_errors_calc'),
                 closure_custom_calc_extra_options => { label_ref1 => 'in', label_ref2 => 'fcserror' },
@@ -66,7 +66,7 @@ sub set_counters {
                 key_values => [ { name => 'bias_current' }, { name => 'display' } ],
                 output_template => 'Bias Current : %s mA',
                 perfdatas => [
-                    { value => 'bias_current_absolute', template => '%s'
+                    { value => 'bias_current_absolute', template => '%s',
                       unit => 'mA', label_extra_instance => 1, instance_use => 'display_absolute' },
                 ]
             }
@@ -259,7 +259,7 @@ Set critical threshold for all error counters.
 
 Threshold warning (will superseed --warning-errors).
 Can be: 'total-port', 'total-admin-up', 'total-admin-down', 'total-oper-up', 'total-oper-down',
-'in-traffic', 'out-traffic', 'in-error', 'in-discard', 'out-error', 'out-discard', 'fcs-errors',
+'in-traffic', 'out-traffic', 'in-error', 'in-discard', 'out-error', 'out-discard',
 'in-ucast' (%), 'in-bcast' (%), 'in-mcast' (%), 'out-ucast' (%), 'out-bcast' (%), 'out-mcast' (%),
 'speed' (b/s).
 
@@ -269,11 +269,11 @@ And also: 'fcs-errors (%)', 'input-power' (dBm), 'bias-current' (mA), 'output-po
 
 Threshold critical (will superseed --warning-errors).
 Can be: 'total-port', 'total-admin-up', 'total-admin-down', 'total-oper-up', 'total-oper-down',
-'in-traffic', 'out-traffic', 'in-error', 'in-discard', 'out-error', 'out-discard', 'fcs-errors',
+'in-traffic', 'out-traffic', 'in-error', 'in-discard', 'out-error', 'out-discard',
 'in-ucast' (%), 'in-bcast' (%), 'in-mcast' (%), 'out-ucast' (%), 'out-bcast' (%), 'out-mcast' (%),
 'speed' (b/s).
 
-And also: 'fcs-errors (%)', 'input-power' (dBm), 'bias-current' (mA), 'output-power' (dBm), 'module-temperature' (C).
+And also: 'in-fcserror' (%), 'input-power' (dBm), 'bias-current' (mA), 'output-power' (dBm), 'module-temperature' (C).
 
 =item B<--units-traffic>
 

--- a/snmp_standard/mode/interfaces.pm
+++ b/snmp_standard/mode/interfaces.pm
@@ -201,7 +201,7 @@ sub custom_errors_perfdata {
 
     if ($self->{instance_mode}->{option_results}->{units_errors} eq '%') {
         my $nlabel = $self->{nlabel};
-        $nlabel =~ s/count/percentage/;
+        $nlabel =~ s/count$/percentage/;
         $self->{output}->perfdata_add(
             label => 'packets_' . $self->{result_values}->{label2} . '_' . $self->{result_values}->{label1}, unit => '%',
             nlabel => $nlabel,
@@ -395,7 +395,7 @@ sub set_counters_errors {
     return if ($self->{no_errors} != 0 && $self->{no_set_errors} != 0);
 
     push @{$self->{maps_counters}->{int}}, 
-        { label => 'in-discard', filter => 'add_errors', nlabel => 'interface.packets.in.discards.count', set => {
+        { label => 'in-discard', filter => 'add_errors', nlabel => 'interface.packets.in.discard.count', set => {
                 key_values => [ { name => 'indiscard', diff => 1 }, { name => 'total_in_packets', diff => 1 }, { name => 'display' }, { name => 'mode_cast' } ],
                 closure_custom_calc => $self->can('custom_errors_calc'), closure_custom_calc_extra_options => { label_ref1 => 'in', label_ref2 => 'discard' },
                 closure_custom_output => $self->can('custom_errors_output'), output_error_template => 'Packets In Discard : %s',
@@ -403,7 +403,7 @@ sub set_counters_errors {
                 closure_custom_threshold_check => $self->can('custom_errors_threshold')
             }
         },
-        { label => 'in-error', filter => 'add_errors', nlabel => 'interface.packets.in.errors.count', set => {
+        { label => 'in-error', filter => 'add_errors', nlabel => 'interface.packets.in.error.count', set => {
                 key_values => [ { name => 'inerror', diff => 1 }, { name => 'total_in_packets', diff => 1 }, { name => 'display' }, { name => 'mode_cast' } ],
                 closure_custom_calc => $self->can('custom_errors_calc'), closure_custom_calc_extra_options => { label_ref1 => 'in', label_ref2 => 'error' },
                 closure_custom_output => $self->can('custom_errors_output'), output_error_template => 'Packets In Error : %s',
@@ -411,7 +411,7 @@ sub set_counters_errors {
                 closure_custom_threshold_check => $self->can('custom_errors_threshold')
             }
         },
-        { label => 'out-discard', filter => 'add_errors', nlabel => 'interface.packets.out.discards.count', set => {
+        { label => 'out-discard', filter => 'add_errors', nlabel => 'interface.packets.out.discard.count', set => {
                 key_values => [ { name => 'outdiscard', diff => 1 }, { name => 'total_out_packets', diff => 1 }, { name => 'display' }, { name => 'mode_cast' } ],
                 closure_custom_calc => $self->can('custom_errors_calc'), closure_custom_calc_extra_options => { label_ref1 => 'out', label_ref2 => 'discard' },
                 closure_custom_output => $self->can('custom_errors_output'), output_error_template => 'Packets Out Discard : %s',
@@ -419,7 +419,7 @@ sub set_counters_errors {
                 closure_custom_threshold_check => $self->can('custom_errors_threshold')
             }
         },
-        { label => 'out-error', filter => 'add_errors', nlabel => 'interface.packets.out.errors.count', set => {
+        { label => 'out-error', filter => 'add_errors', nlabel => 'interface.packets.out.error.count', set => {
                 key_values => [ { name => 'outerror', diff => 1 }, { name => 'total_out_packets', diff => 1 }, { name => 'display' }, { name => 'mode_cast' } ],
                 closure_custom_calc => $self->can('custom_errors_calc'), closure_custom_calc_extra_options => { label_ref1 => 'out', label_ref2 => 'error' },
                 closure_custom_output => $self->can('custom_errors_output'), output_error_template => 'Packets Out Error : %s',


### PR DESCRIPTION
Hi,

Some typos corrected, following https://github.com/centreon/centreon-plugins/commit/8490122c4fc571e43525230df2ec4b23a2384c21.
I also changed some `nlabel`, moving from `dicards` and `errors` to `discard` and `error`.
Singular everywhere.
As for the new `fcserror` counter.
And as in MikroTik interfaces mode.
So that `nlabel` and filter names are equal.

Thx 👍 