### PR TITLE
Bugfix on infinite loop

### DIFF
--- a/network/cisco/prime/restapi/custom/api.pm
+++ b/network/cisco/prime/restapi/custom/api.pm
@@ -183,7 +183,7 @@ sub get {
         }
         
         $first_result += $max_results;
-        last if ($max_results > $content->{queryResponse}->{'@count'});
+        last if ($first_result > $content->{queryResponse}->{'@count'});
     }
     return $result;
 }


### PR DESCRIPTION
When testing with a ciscoprime with more than 1000 APs, the function stays in an infinite loop.
This is blocked by the setting "nbi.rateLimit.perUserThreshold" and issues the error:
"NBI Rate limit for user exceeded (More than 5 in 1,000 ms)"