### PR TITLE
fix(checkpoint) unknown if can't compute thresholds

### DIFF
--- a/network/checkpoint/snmp/mode/connections.pm
+++ b/network/checkpoint/snmp/mode/connections.pm
@@ -76,6 +76,13 @@ sub run {
             $value = $prct_used;
             %total_options = ( total => $result->{$oid_fwConnTableLimit}, cast_int => 1);
         }
+    } elsif ($self->{option_results}->{units} eq '%') {
+        $self->{output}->output_add(
+            severity => 'UNKNOWN',
+            short_msg => "Couldn't get fwConnTableLimit OID ($oid_fwConnTableLimit) to compute thresholds"
+        );
+        $self->{output}->display();
+        $self->{output}->exit();
     }
 
     my $exit = $self->{perfdata}->threshold_check(value => $value, 


### PR DESCRIPTION
Hi,

This PR fixes the `connections` mode of `checkpoint` plugin.
If returns `UNKNOWN` in case it is called with `%` thresholds, but can't compute these thresholds, because of a missing max value.
User then knows he must properly configure max value at device level, before playing with `%` thresholds.

Thx 👍