### PR TITLE
allowing to select right threshold-overload section

### DIFF
--- a/hardware/devices/cisco/ces/restapi/mode/components.pm
+++ b/hardware/devices/cisco/ces/restapi/mode/components.pm
@@ -29,7 +29,7 @@ sub set_system {
     my ($self, %options) = @_;
         
     $self->{regexp_threshold_overload_check_section_option} =
-        '^(?:ad|aic|aoc|camera|st|software|temperature|vic|vis|voc|webex)$';
+        '^(?:ad|aic|aoc|camera|st|software|temperature|vic|vis|voc|webex)';
     $self->{regexp_threshold_numeric_check_section_option} = '^(?:aiclatency|aocdelay)$';
 
     $self->{cb_hook2} = 'execute_custom';


### PR DESCRIPTION
Allowing threshold-overload selection for each components:
- ad.status
- vic.signal_state
- vic.status
- etc.
