### PR TITLE
enh(o365) Many enhancements

### DIFF
--- a/cloud/microsoft/office365/custom/graphapi.pm
+++ b/cloud/microsoft/office365/custom/graphapi.pm
@@ -331,6 +331,23 @@ sub office_get_onedrive_usage {
 
     my $full_url = $self->office_get_onedrive_usage_set_url(%options);
     my $response = $self->request_api_csv(method => 'GET', full_url => $full_url, hostname => '');
+
+    return $response;
+}
+
+sub office_get_onedrive_activity_set_url {
+    my ($self, %options) = @_;
+
+    my $url = $self->{graph_endpoint} . "/v1.0/reports/getOneDriveActivityUserDetail(period='D7')";
+
+    return $url;
+}
+
+sub office_get_onedrive_activity {
+    my ($self, %options) = @_;
+
+    my $full_url = $self->office_get_onedrive_activity_set_url(%options);
+    my $response = $self->request_api_csv(method => 'GET', full_url => $full_url, hostname => '');
     
     return $response;
 }

--- a/cloud/microsoft/office365/custom/graphapi.pm
+++ b/cloud/microsoft/office365/custom/graphapi.pm
@@ -287,7 +287,7 @@ sub request_api_csv {
 sub office_get_sharepoint_site_usage_set_url {
     my ($self, %options) = @_;
 
-    my $url = $self->{graph_endpoint} . "/v1.0/reports/getSharePointSiteUsageDetail(period='D7')";
+    my $url = $self->{graph_endpoint} . "/v1.0/reports/getSharePointSiteUsageDetail(" . $options{param} . ")";
 
     return $url;
 }
@@ -304,7 +304,7 @@ sub office_get_sharepoint_site_usage {
 sub office_get_sharepoint_activity_set_url {
     my ($self, %options) = @_;
 
-    my $url = $self->{graph_endpoint} . "/v1.0/reports/getSharePointActivityUserDetail(period='D7')";
+    my $url = $self->{graph_endpoint} . "/v1.0/reports/getSharePointActivityUserDetail(" . $options{param} . ")";
 
     return $url;
 }
@@ -321,7 +321,7 @@ sub office_get_sharepoint_activity {
 sub office_get_onedrive_usage_set_url {
     my ($self, %options) = @_;
 
-    my $url = $self->{graph_endpoint} . "/v1.0/reports/getOneDriveUsageAccountDetail(period='D7')";
+    my $url = $self->{graph_endpoint} . "/v1.0/reports/getOneDriveUsageAccountDetail(" . $options{param} . ")";
 
     return $url;
 }
@@ -338,7 +338,7 @@ sub office_get_onedrive_usage {
 sub office_get_onedrive_activity_set_url {
     my ($self, %options) = @_;
 
-    my $url = $self->{graph_endpoint} . "/v1.0/reports/getOneDriveActivityUserDetail(period='D7')";
+    my $url = $self->{graph_endpoint} . "/v1.0/reports/getOneDriveActivityUserDetail(" . $options{param} . ")";
 
     return $url;
 }
@@ -355,7 +355,7 @@ sub office_get_onedrive_activity {
 sub office_get_exchange_activity_set_url {
     my ($self, %options) = @_;
 
-    my $url = $self->{graph_endpoint} . "/v1.0/reports/getEmailActivityUserDetail(period='D7')";
+    my $url = $self->{graph_endpoint} . "/v1.0/reports/getEmailActivityUserDetail(" . $options{param} . ")";
 
     return $url;
 }
@@ -372,7 +372,7 @@ sub office_get_exchange_activity {
 sub office_get_exchange_mailbox_usage_set_url {
     my ($self, %options) = @_;
 
-    my $url = $self->{graph_endpoint} . "/v1.0/reports/getMailboxUsageDetail(period='D7')";
+    my $url = $self->{graph_endpoint} . "/v1.0/reports/getMailboxUsageDetail(" . $options{param} . ")";
 
     return $url;
 }
@@ -389,7 +389,7 @@ sub office_get_exchange_mailbox_usage {
 sub office_get_teams_activity_set_url {
     my ($self, %options) = @_;
 
-    my $url = $self->{graph_endpoint} . "/v1.0/reports/getTeamsUserActivityUserDetail(period='D7')";
+    my $url = $self->{graph_endpoint} . "/v1.0/reports/getTeamsUserActivityUserDetail(" . $options{param} . ")";
 
     return $url;
 }
@@ -406,7 +406,7 @@ sub office_get_teams_activity {
 sub office_get_teams_device_usage_set_url {
     my ($self, %options) = @_;
 
-    my $url = $self->{graph_endpoint} . "/v1.0/reports/getTeamsDeviceUsageUserDetail(period='D7')";
+    my $url = $self->{graph_endpoint} . "/v1.0/reports/getTeamsDeviceUsageUserDetail(" . $options{param} . ")";
 
     return $url;
 }
@@ -423,7 +423,7 @@ sub office_get_teams_device_usage {
 sub office_get_skype_activity_set_url {
     my ($self, %options) = @_;
 
-    my $url = $self->{graph_endpoint} . "/v1.0/reports/getSkypeForBusinessActivityUserDetail(period='D7')";
+    my $url = $self->{graph_endpoint} . "/v1.0/reports/getSkypeForBusinessActivityUserDetail(" . $options{param} . ")";
 
     return $url;
 }
@@ -440,7 +440,7 @@ sub office_get_skype_activity {
 sub office_get_skype_device_usage_set_url {
     my ($self, %options) = @_;
 
-    my $url = $self->{graph_endpoint} . "/v1.0/reports/getSkypeForBusinessDeviceUsageUserDetail(period='D7')";
+    my $url = $self->{graph_endpoint} . "/v1.0/reports/getSkypeForBusinessDeviceUsageUserDetail(" . $options{param} . ")";
 
     return $url;
 }

--- a/cloud/microsoft/office365/exchange/mode/emailactivity.pm
+++ b/cloud/microsoft/office365/exchange/mode/emailactivity.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'exchange.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/exchange/mode/emailactivity.pm
+++ b/cloud/microsoft/office365/exchange/mode/emailactivity.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,12,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'exchange.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/exchange/mode/emailactivity.pm
+++ b/cloud/microsoft/office365/exchange/mode/emailactivity.pm
@@ -24,6 +24,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use Time::Local;
 
 sub custom_active_perfdata {
     my ($self, %options) = @_;
@@ -33,6 +34,9 @@ sub custom_active_perfdata {
         $total_options{total} = $self->{result_values}->{total};
         $total_options{cast_int} = 1;
     }
+
+    $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
+    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'exchange.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/exchange/mode/emailactivity.pm
+++ b/cloud/microsoft/office365/exchange/mode/emailactivity.pm
@@ -195,6 +195,8 @@ sub manage_selection {
         # Let's lc the instance label to make metrics "clean"...
         $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
 
+        $self->{active}->{report_date} = $user->{'Report Refresh Date'} if ($self->{active}->{report_date} eq '');
+
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping  '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);
@@ -209,7 +211,6 @@ sub manage_selection {
             next;
         }
 
-        $self->{active}->{report_date} = $user->{'Report Refresh Date'};
         $self->{active}->{active}++;
 
         $self->{global}->{send_count} += $user->{'Send Count'};

--- a/cloud/microsoft/office365/exchange/mode/emailactivity.pm
+++ b/cloud/microsoft/office365/exchange/mode/emailactivity.pm
@@ -201,9 +201,6 @@ sub manage_selection {
     }
 
     foreach my $user (@{$results}, @{$results_daily}) {
-        # Let's lc the instance label to make metrics "clean"...
-        $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
-
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping  '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);

--- a/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
+++ b/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
@@ -204,11 +204,11 @@ sub set_counters {
             }
         },
         { label => 'items', nlabel => 'exchange.mailboxes.items.count', set => {
-                key_values => [ { name => 'items' } ],
+                key_values => [ { name => 'items' }, { name => 'name' } ],
                 output_template => 'Items: %d',
                 perfdatas => [
                     { label => 'items', value => 'items', template => '%d',
-                      min => 0 },
+                      min => 0, label_extra_instance => 1, instance_use => 'name' },
                 ],
             }
         },

--- a/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
+++ b/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
@@ -24,6 +24,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use Time::Local;
 
 sub custom_active_perfdata {
     my ($self, %options) = @_;
@@ -33,6 +34,9 @@ sub custom_active_perfdata {
         $total_options{total} = $self->{result_values}->{total};
         $total_options{cast_int} = 1;
     }
+
+    $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
+    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_mailboxes', nlabel => 'exchange.mailboxes.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
+++ b/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
@@ -251,6 +251,8 @@ sub manage_selection {
         # Let's lc the instance label to make metrics "clean"...
         $mailbox->{'User Principal Name'} = lc($mailbox->{'User Principal Name'});
 
+        $self->{active}->{report_date} = $mailbox->{'Report Refresh Date'} if ($self->{active}->{report_date} eq '');
+
         if (defined($self->{option_results}->{filter_mailbox}) && $self->{option_results}->{filter_mailbox} ne '' &&
             $mailbox->{'User Principal Name'} !~ /$self->{option_results}->{filter_mailbox}/) {
             $self->{output}->output_add(long_msg => "skipping  '" . $mailbox->{'User Principal Name'} . "': no matching filter name.", debug => 1);
@@ -266,7 +268,6 @@ sub manage_selection {
             next;
         }
 
-        $self->{active}->{report_date} = $mailbox->{'Report Refresh Date'};
         $self->{active}->{active}++;
         
         $self->{global}->{storage_used_active} += ($mailbox->{'Storage Used (Byte)'} ne '') ? $mailbox->{'Storage Used (Byte)'} : 0;

--- a/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
+++ b/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
@@ -34,7 +34,7 @@ sub custom_active_perfdata {
         $total_options{cast_int} = 1;
     }
 
-    $self->{output}->perfdata_add(label => 'active_mailboxes',
+    $self->{output}->perfdata_add(label => 'active_mailboxes', nlabel => 'exchange.mailboxes.active.count',
                                   value => $self->{result_values}->{active},
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{label}, %total_options),
                                   critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{label}, %total_options),
@@ -83,7 +83,7 @@ sub custom_usage_perfdata {
     my $extra_label = '';
     $extra_label = '_' . $self->{result_values}->{display} if (!defined($options{extra_instance}) || $options{extra_instance} != 0);
     
-    $self->{output}->perfdata_add(label => 'used' . $extra_label,
+    $self->{output}->perfdata_add(label => 'used' . $extra_label, nlabel => $self->{result_values}->{display} . '#exchange.mailboxes.usage.bytes',
                                   unit => 'B',
                                   value => $self->{result_values}->{used},
                                   min => 0);
@@ -172,7 +172,7 @@ sub set_counters {
         },
     ];
     $self->{maps_counters}->{global} = [
-        { label => 'total-usage-active', set => {
+        { label => 'total-usage-active', nlabel => 'exchange.mailboxes.active.usage.total.bytes', set => {
                 key_values => [ { name => 'storage_used_active' } ],
                 output_template => 'Usage (active mailboxes): %s %s',
                 output_change_bytes => 1,
@@ -182,7 +182,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-usage-inactive', set => {
+        { label => 'total-usage-inactive', nlabel => 'exchange.mailboxes.inactive.usage.total.bytes', set => {
                 key_values => [ { name => 'storage_used_inactive' } ],
                 output_template => 'Usage (inactive mailboxes): %s %s',
                 output_change_bytes => 1,
@@ -203,7 +203,7 @@ sub set_counters {
                 closure_custom_threshold_check => $self->can('custom_status_threshold'),
             }
         },
-        { label => 'items', set => {
+        { label => 'items', nlabel => 'exchange.mailboxes.items.count', set => {
                 key_values => [ { name => 'items' } ],
                 output_template => 'Items: %d',
                 perfdatas => [
@@ -248,6 +248,9 @@ sub manage_selection {
     my $results = $options{custom}->office_get_exchange_mailbox_usage();
 
     foreach my $mailbox (@{$results}) {
+        # Let's lc the instance label to make metrics "clean"...
+        $mailbox->{'User Principal Name'} = lc($mailbox->{'User Principal Name'});
+
         if (defined($self->{option_results}->{filter_mailbox}) && $self->{option_results}->{filter_mailbox} ne '' &&
             $mailbox->{'User Principal Name'} !~ /$self->{option_results}->{filter_mailbox}/) {
             $self->{output}->output_add(long_msg => "skipping  '" . $mailbox->{'User Principal Name'} . "': no matching filter name.", debug => 1);

--- a/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
+++ b/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_mailboxes', nlabel => 'exchange.mailboxes.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
+++ b/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
@@ -257,9 +257,6 @@ sub manage_selection {
     }
 
     foreach my $mailbox (@{$results}, @{$results_daily}) {
-        # Let's lc the instance label to make metrics "clean"...
-        $mailbox->{'User Principal Name'} = lc($mailbox->{'User Principal Name'});
-
         if (defined($self->{option_results}->{filter_mailbox}) && $self->{option_results}->{filter_mailbox} ne '' &&
             $mailbox->{'User Principal Name'} !~ /$self->{option_results}->{filter_mailbox}/) {
             $self->{output}->output_add(long_msg => "skipping  '" . $mailbox->{'User Principal Name'} . "': no matching filter name.", debug => 1);

--- a/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
+++ b/cloud/microsoft/office365/exchange/mode/mailboxusage.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,12,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_mailboxes', nlabel => 'exchange.mailboxes.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/onedrive/mode/siteusage.pm
+++ b/cloud/microsoft/office365/onedrive/mode/siteusage.pm
@@ -340,17 +340,17 @@ Can be: 'url', 'owner' (can be a regexp).
 
 Threshold warning.
 Can be: 'active-sites', 'total-usage-active' (count),
-'total-usage-inactive' (count), 'total-file-count' (count),
-'active-file-count' (count), 'usage' (count),
-'file-count' (count), 'active-file-count' (count).
+'total-usage-inactive' (count), 'total-file-count-active' (count),
+'total-file-count-inactive' (count), 'total-active-file-count' (count),
+'usage' (count), 'file-count' (count), 'active-file-count' (count).
 
 =item B<--critical-*>
 
 Threshold critical.
 Can be: 'active-sites', 'total-usage-active' (count),
-'total-usage-inactive' (count), 'total-file-count' (count),
-'active-file-count' (count), 'usage' (count),
-'file-count' (count), 'active-file-count' (count).
+'total-usage-inactive' (count), 'total-file-count-active' (count),
+'total-file-count-inactive' (count), 'total-active-file-count' (count),
+'usage' (count), 'file-count' (count), 'active-file-count' (count).
 
 =item B<--filter-counters>
 

--- a/cloud/microsoft/office365/onedrive/mode/siteusage.pm
+++ b/cloud/microsoft/office365/onedrive/mode/siteusage.pm
@@ -287,9 +287,6 @@ sub manage_selection {
     }
 
     foreach my $site (@{$results}, @{$results_daily}) {
-        # As it's used as the instance label, let's keep the URL as short as possible, removing its domain name...
-        $site->{'Site URL'} =~ s/^[^\/]*\/\/[^\/]*//;
-
         if (defined($self->{option_results}->{filter_url}) && $self->{option_results}->{filter_url} ne '' &&
             $site->{'Site URL'} !~ /$self->{option_results}->{filter_url}/) {
             $self->{output}->output_add(long_msg => "skipping  '" . $site->{'Site URL'} . "': no matching filter name.", debug => 1);

--- a/cloud/microsoft/office365/onedrive/mode/siteusage.pm
+++ b/cloud/microsoft/office365/onedrive/mode/siteusage.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,12,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_sites', nlabel => 'onedrive.sites.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/onedrive/mode/siteusage.pm
+++ b/cloud/microsoft/office365/onedrive/mode/siteusage.pm
@@ -271,7 +271,8 @@ sub manage_selection {
     my ($self, %options) = @_;
     
     $self->{active} = { active => 0, total => 0, report_date => '' };
-    $self->{global} = { storage_used_active => 0, storage_used_inactive => 0, file_count => 0, active_file_count => 0 };
+    $self->{global} = { storage_used_active => 0, storage_used_inactive => 0,
+                        file_count_active => 0, file_count_inactive => 0, active_file_count => 0 };
     $self->{sites} = {};
 
     my $results = $options{custom}->office_get_onedrive_usage();

--- a/cloud/microsoft/office365/onedrive/mode/siteusage.pm
+++ b/cloud/microsoft/office365/onedrive/mode/siteusage.pm
@@ -24,6 +24,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use Time::Local;
 
 sub custom_active_perfdata {
     my ($self, %options) = @_;
@@ -33,6 +34,9 @@ sub custom_active_perfdata {
         $total_options{total} = $self->{result_values}->{total};
         $total_options{cast_int} = 1;
     }
+
+    $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
+    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_sites', nlabel => 'onedrive.sites.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/onedrive/mode/siteusage.pm
+++ b/cloud/microsoft/office365/onedrive/mode/siteusage.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package cloud::microsoft::office365::onedrive::mode::usage;
+package cloud::microsoft::office365::onedrive::mode::siteusage;
 
 use base qw(centreon::plugins::templates::counter);
 
@@ -211,8 +211,6 @@ sub set_counters {
                 ],
             }
         },
-
-
         { label => 'total-active-file-count', nlabel => 'onedrive.sites.files.active.total.count', set => {
                 key_values => [ { name => 'active_file_count' } ],
                 output_template => 'Active File Count (active sites): %d',

--- a/cloud/microsoft/office365/onedrive/mode/siteusage.pm
+++ b/cloud/microsoft/office365/onedrive/mode/siteusage.pm
@@ -178,7 +178,7 @@ sub set_counters {
                 output_template => 'Usage (active sites): %s %s',
                 output_change_bytes => 1,
                 perfdatas => [
-                    { label => 'storage_used_active', value => 'storage_used_active', template => '%d',
+                    { label => 'total_usage_active', value => 'storage_used_active', template => '%d',
                       min => 0, unit => 'B' },
                 ],
             }
@@ -188,7 +188,7 @@ sub set_counters {
                 output_template => 'Usage (inactive sites): %s %s',
                 output_change_bytes => 1,
                 perfdatas => [
-                    { label => 'storage_used_inactive', value => 'storage_used_inactive', template => '%d',
+                    { label => 'total_usage_inactive', value => 'storage_used_inactive', template => '%d',
                       min => 0, unit => 'B' },
                 ],
             }
@@ -275,13 +275,16 @@ sub manage_selection {
                         file_count_active => 0, file_count_inactive => 0, active_file_count => 0 };
     $self->{sites} = {};
 
-    my $results = $options{custom}->office_get_onedrive_usage();
+    my $results = $options{custom}->office_get_onedrive_usage(param => "period='D7'");
+    my $results_daily = [];
+    if (scalar(@{$results})) {
+       $self->{active}->{report_date} = @{$results}[0]->{'Report Refresh Date'};
+       $results_daily = $options{custom}->office_get_onedrive_usage(param => "date=" . $self->{active}->{report_date});
+    }
 
-    foreach my $site (@{$results}) {
+    foreach my $site (@{$results}, @{$results_daily}) {
         # As it's used as the instance label, let's keep the URL as short as possible, removing its domain name...
         $site->{'Site URL'} =~ s/^[^\/]*\/\/[^\/]*//;
-
-        $self->{active}->{report_date} = $site->{'Report Refresh Date'} if ($self->{active}->{report_date} eq '');
 
         if (defined($self->{option_results}->{filter_url}) && $self->{option_results}->{filter_url} ne '' &&
             $site->{'Site URL'} !~ /$self->{option_results}->{filter_url}/) {
@@ -294,16 +297,16 @@ sub manage_selection {
             next;
         }
 
-        $self->{active}->{total}++;
-
-        if (!defined($site->{'Last Activity Date'}) || $site->{'Last Activity Date'} eq '' ||
-            ($site->{'Last Activity Date'} ne $site->{'Report Refresh Date'})) {
-            $self->{global}->{storage_used_inactive} += ($site->{'Storage Used (Byte)'} ne '') ? $site->{'Storage Used (Byte)'} : 0;
-            $self->{global}->{file_count_inactive} += ($site->{'File Count'} ne '') ? $site->{'File Count'} : 0;
-            $self->{output}->output_add(long_msg => "skipping '" . $site->{'Site URL'} . "': no activity.", debug => 1);
+        if ($site->{'Report Period'} != 1) {
+            if (!defined($site->{'Last Activity Date'}) || ($site->{'Last Activity Date'} ne $self->{active}->{report_date})) {
+                $self->{global}->{storage_used_inactive} += ($site->{'Storage Used (Byte)'} ne '') ? $site->{'Storage Used (Byte)'} : 0;
+                $self->{global}->{file_count_inactive} += ($site->{'File Count'} ne '') ? $site->{'File Count'} : 0;
+                $self->{output}->output_add(long_msg => "skipping '" . $site->{'Site URL'} . "': no activity.", debug => 1);
+            }
+            $self->{active}->{total}++;
             next;
         }
-    
+
         $self->{active}->{active}++;
 
         $self->{global}->{storage_used_active} += ($site->{'Storage Used (Byte)'} ne '') ? $site->{'Storage Used (Byte)'} : 0;
@@ -325,10 +328,10 @@ __END__
 
 =head1 MODE
 
-Check usage (reporting period over the last 7 days).
+Check sites usage (reporting period over the last refreshed day).
 
 (See link for details about metrics :
-https://docs.microsoft.com/en-us/office365/admin/activity-reports/onedrive-for-business-usage?view=o365-worldwide)
+https://docs.microsoft.com/en-us/microsoft-365/admin/activity-reports/onedrive-for-business-usage?view=o365-worldwide)
 
 =over 8
 
@@ -340,17 +343,19 @@ Can be: 'url', 'owner' (can be a regexp).
 =item B<--warning-*>
 
 Threshold warning.
-Can be: 'active-sites', 'total-usage-active' (count),
-'total-usage-inactive' (count), 'total-file-count-active' (count),
-'total-file-count-inactive' (count), 'total-active-file-count' (count),
+Can be: 'active-sites',
+'total-usage-active' (count), 'total-usage-inactive' (count),
+'total-file-count-active' (count), 'total-file-count-inactive' (count),
+'total-active-file-count' (count),
 'usage' (count), 'file-count' (count), 'active-file-count' (count).
 
 =item B<--critical-*>
 
 Threshold critical.
-Can be: 'active-sites', 'total-usage-active' (count),
-'total-usage-inactive' (count), 'total-file-count-active' (count),
-'total-file-count-inactive' (count), 'total-active-file-count' (count),
+Can be: 'active-sites',
+'total-usage-active' (count), 'total-usage-inactive' (count),
+'total-file-count-active' (count), 'total-file-count-inactive' (count),
+'total-active-file-count' (count),
 'usage' (count), 'file-count' (count), 'active-file-count' (count).
 
 =item B<--filter-counters>

--- a/cloud/microsoft/office365/onedrive/mode/siteusage.pm
+++ b/cloud/microsoft/office365/onedrive/mode/siteusage.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_sites', nlabel => 'onedrive.sites.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/onedrive/mode/usage.pm
+++ b/cloud/microsoft/office365/onedrive/mode/usage.pm
@@ -193,16 +193,27 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-file-count', nlabel => 'onedrive.sites.active.files.total.count', set => {
-                key_values => [ { name => 'file_count' } ],
+        { label => 'total-file-count-active', nlabel => 'onedrive.sites.active.files.total.count', set => {
+                key_values => [ { name => 'file_count_active' } ],
                 output_template => 'File Count (active sites): %d',
                 perfdatas => [
-                    { label => 'total_file_count', value => 'file_count', template => '%d',
+                    { label => 'total_file_count_active', value => 'file_count_active', template => '%d',
                       min => 0 },
                 ],
             }
         },
-        { label => 'total-active-file-count', nlabel => 'onedrive.sites.active.files.active.total.count', set => {
+        { label => 'total-file-count-inactive', nlabel => 'onedrive.sites.inactive.files.total.count', set => {
+                key_values => [ { name => 'file_count_inactive' } ],
+                output_template => 'File Count (inactive sites): %d',
+                perfdatas => [
+                    { label => 'total_file_count_inactive', value => 'file_count_inactive', template => '%d',
+                      min => 0 },
+                ],
+            }
+        },
+
+
+        { label => 'total-active-file-count', nlabel => 'onedrive.sites.files.active.total.count', set => {
                 key_values => [ { name => 'active_file_count' } ],
                 output_template => 'Active File Count (active sites): %d',
                 perfdatas => [
@@ -289,6 +300,7 @@ sub manage_selection {
         if (!defined($site->{'Last Activity Date'}) || $site->{'Last Activity Date'} eq '' ||
             ($site->{'Last Activity Date'} ne $site->{'Report Refresh Date'})) {
             $self->{global}->{storage_used_inactive} += ($site->{'Storage Used (Byte)'} ne '') ? $site->{'Storage Used (Byte)'} : 0;
+            $self->{global}->{file_count_inactive} += ($site->{'File Count'} ne '') ? $site->{'File Count'} : 0;
             $self->{output}->output_add(long_msg => "skipping '" . $site->{'Site URL'} . "': no activity.", debug => 1);
             next;
         }
@@ -296,7 +308,7 @@ sub manage_selection {
         $self->{active}->{active}++;
 
         $self->{global}->{storage_used_active} += ($site->{'Storage Used (Byte)'} ne '') ? $site->{'Storage Used (Byte)'} : 0;
-        $self->{global}->{file_count} += ($site->{'File Count'} ne '') ? $site->{'File Count'} : 0;
+        $self->{global}->{file_count_active} += ($site->{'File Count'} ne '') ? $site->{'File Count'} : 0;
         $self->{global}->{active_file_count} += ($site->{'Active File Count'} ne '') ? $site->{'Active File Count'} : 0;
 
         $self->{sites}->{$site->{'Site URL'}}->{url} = $site->{'Site URL'};

--- a/cloud/microsoft/office365/onedrive/mode/usage.pm
+++ b/cloud/microsoft/office365/onedrive/mode/usage.pm
@@ -271,6 +271,8 @@ sub manage_selection {
         # As it's used as the instance label, let's keep the URL as short as possible, removing its domain name...
         $site->{'Site URL'} =~ s/^[^\/]*\/\/[^\/]*//;
 
+        $self->{active}->{report_date} = $site->{'Report Refresh Date'} if ($self->{active}->{report_date} eq '');
+
         if (defined($self->{option_results}->{filter_url}) && $self->{option_results}->{filter_url} ne '' &&
             $site->{'Site URL'} !~ /$self->{option_results}->{filter_url}/) {
             $self->{output}->output_add(long_msg => "skipping  '" . $site->{'Site URL'} . "': no matching filter name.", debug => 1);
@@ -291,7 +293,6 @@ sub manage_selection {
             next;
         }
     
-        $self->{active}->{report_date} = $site->{'Report Refresh Date'};
         $self->{active}->{active}++;
 
         $self->{global}->{storage_used_active} += ($site->{'Storage Used (Byte)'} ne '') ? $site->{'Storage Used (Byte)'} : 0;

--- a/cloud/microsoft/office365/onedrive/mode/usage.pm
+++ b/cloud/microsoft/office365/onedrive/mode/usage.pm
@@ -34,7 +34,7 @@ sub custom_active_perfdata {
         $total_options{cast_int} = 1;
     }
 
-    $self->{output}->perfdata_add(label => 'active_sites',
+    $self->{output}->perfdata_add(label => 'active_sites', nlabel => 'onedrive.sites.active.count',
                                   value => $self->{result_values}->{active},
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{label}, %total_options),
                                   critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{label}, %total_options),
@@ -83,7 +83,7 @@ sub custom_usage_perfdata {
     my $extra_label = '';
     $extra_label = '_' . $self->{result_values}->{display} if (!defined($options{extra_instance}) || $options{extra_instance} != 0);
     
-    $self->{output}->perfdata_add(label => 'used' . $extra_label,
+    $self->{output}->perfdata_add(label => 'used' . $extra_label, nlabel => $self->{result_values}->{display} . '#onedrive.sites.usage.bytes',
                                   unit => 'B',
                                   value => $self->{result_values}->{used},
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{label}, total => $self->{result_values}->{total}, cast_int => 1),
@@ -173,7 +173,7 @@ sub set_counters {
         },
     ];
     $self->{maps_counters}->{global} = [
-        { label => 'total-usage-active', set => {
+        { label => 'total-usage-active', nlabel => 'onedrive.sites.active.usage.total.bytes', set => {
                 key_values => [ { name => 'storage_used_active' } ],
                 output_template => 'Usage (active sites): %s %s',
                 output_change_bytes => 1,
@@ -183,7 +183,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-usage-inactive', set => {
+        { label => 'total-usage-inactive', nlabel => 'onedrive.sites.inactive.usage.total.bytes', set => {
                 key_values => [ { name => 'storage_used_inactive' } ],
                 output_template => 'Usage (inactive sites): %s %s',
                 output_change_bytes => 1,
@@ -193,7 +193,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-file-count', set => {
+        { label => 'total-file-count', nlabel => 'onedrive.sites.active.files.total.count', set => {
                 key_values => [ { name => 'file_count' } ],
                 output_template => 'File Count (active sites): %d',
                 perfdatas => [
@@ -202,7 +202,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-active-file-count', set => {
+        { label => 'total-active-file-count', nlabel => 'onedrive.sites.active.files.active.total.count', set => {
                 key_values => [ { name => 'active_file_count' } ],
                 output_template => 'Active File Count (active sites): %d',
                 perfdatas => [
@@ -221,7 +221,7 @@ sub set_counters {
                 closure_custom_threshold_check => $self->can('custom_usage_threshold'),
             }
         },
-        { label => 'file-count', set => {
+        { label => 'file-count', nlabel => 'onedrive.sites.files.count', set => {
                 key_values => [ { name => 'file_count' }, { name => 'url' }, { name => 'owner' } ],
                 output_template => 'File Count: %d',
                 perfdatas => [
@@ -230,7 +230,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'active-file-count', set => {
+        { label => 'active-file-count', nlabel => 'onedrive.sites.files.active.count', set => {
                 key_values => [ { name => 'active_file_count' }, { name => 'url' }, { name => 'owner' } ],
                 output_template => 'Active File Count: %d',
                 perfdatas => [
@@ -268,6 +268,9 @@ sub manage_selection {
     my $results = $options{custom}->office_get_onedrive_usage();
 
     foreach my $site (@{$results}) {
+        # As it's used as the instance label, let's keep the URL as short as possible, removing its domain name...
+        $site->{'Site URL'} =~ s/^[^\/]*\/\/[^\/]*//;
+
         if (defined($self->{option_results}->{filter_url}) && $self->{option_results}->{filter_url} ne '' &&
             $site->{'Site URL'} !~ /$self->{option_results}->{filter_url}/) {
             $self->{output}->output_add(long_msg => "skipping  '" . $site->{'Site URL'} . "': no matching filter name.", debug => 1);

--- a/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
@@ -204,9 +204,8 @@ sub manage_selection {
     my ($self, %options) = @_;
     
     $self->{active} = { active => 0, total => 0, report_date => '' };
-    $self->{global} = { storage_used_active => 0, storage_used_inactive => 0, synced_file_count => 0,
-                        viewed_edited_file_count => 0, shared_int_file_count => 0, shared_ext_file_count => 0,
-                        visited_page_count => 0 };
+    $self->{global} = { viewed_edited_file_count => 0, synced_file_count => 0,
+                        shared_int_file_count => 0, shared_ext_file_count => 0 };
     $self->{users} = {};
 
     my $results = $options{custom}->office_get_onedrive_activity();

--- a/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'onedrive.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
@@ -220,9 +220,6 @@ sub manage_selection {
     }
 
     foreach my $user (@{$results}, @{$results_daily}) {
-        # Let's lc the instance label to make metrics "clean"...
-        $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
-
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);

--- a/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
@@ -1,0 +1,296 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::microsoft::office365::onedrive::mode::usersactivity;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+
+sub custom_active_perfdata {
+    my ($self, %options) = @_;
+
+    my %total_options = ();
+    if ($self->{instance_mode}->{option_results}->{units} eq '%') {
+        $total_options{total} = $self->{result_values}->{total};
+        $total_options{cast_int} = 1;
+    }
+
+    $self->{output}->perfdata_add(label => 'active_users', nlabel => 'onedrive.users.active.count',
+                                  value => $self->{result_values}->{active},
+                                  warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{label}, %total_options),
+                                  critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{label}, %total_options),
+                                  unit => 'users', min => 0, max => $self->{result_values}->{total});
+}
+
+sub custom_active_threshold {
+    my ($self, %options) = @_;
+
+    my $threshold_value = $self->{result_values}->{active};
+    if ($self->{instance_mode}->{option_results}->{units} eq '%') {
+        $threshold_value = $self->{result_values}->{prct_active};
+    }
+    my $exit = $self->{perfdata}->threshold_check(value => $threshold_value,
+                                               threshold => [ { label => 'critical-' . $self->{label}, exit_litteral => 'critical' },
+                                                              { label => 'warning-' . $self->{label}, exit_litteral => 'warning' } ]);
+    return $exit;
+
+}
+
+sub custom_active_output {
+    my ($self, %options) = @_;
+
+    my $msg = sprintf("Active users on %s : %d/%d (%.2f%%)",
+                        $self->{result_values}->{report_date},
+                        $self->{result_values}->{active},
+                        $self->{result_values}->{total},
+                        $self->{result_values}->{prct_active});
+    return $msg;
+}
+
+sub custom_active_calc {
+    my ($self, %options) = @_;
+
+    $self->{result_values}->{active} = $options{new_datas}->{$self->{instance} . '_active'};
+    $self->{result_values}->{total} = $options{new_datas}->{$self->{instance} . '_total'};
+    $self->{result_values}->{report_date} = $options{new_datas}->{$self->{instance} . '_report_date'};
+    $self->{result_values}->{prct_active} = ($self->{result_values}->{total} != 0) ? $self->{result_values}->{active} * 100 / $self->{result_values}->{total} : 0;
+
+    return 0;
+}
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+    
+    return "Total (active sites) ";
+}
+
+sub prefix_user_output {
+    my ($self, %options) = @_;
+    
+    return "User '" . $options{instance_value}->{name} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'active', type => 0 },
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
+        { name => 'users', type => 1, cb_prefix_output => 'prefix_user_output', message_multiple => 'All users activity are ok' },
+    ];
+    
+    $self->{maps_counters}->{active} = [
+        { label => 'active-users', set => {
+                key_values => [ { name => 'active' }, { name => 'total' }, { name => 'report_date' } ],
+                closure_custom_calc => $self->can('custom_active_calc'),
+                closure_custom_output => $self->can('custom_active_output'),
+                closure_custom_threshold_check => $self->can('custom_active_threshold'),
+                closure_custom_perfdata => $self->can('custom_active_perfdata')
+            }
+        },
+    ];
+    $self->{maps_counters}->{global} = [
+        { label => 'total-viewed-edited-file-count', nlabel => 'onedrive.users.files.viewed.total.count', set => {
+                key_values => [ { name => 'viewed_edited_file_count' } ],
+                output_template => 'Viewed or Edited File Count: %d',
+                perfdatas => [
+                    { label => 'total_viewed_edited_file_count', value => 'viewed_edited_file_count', template => '%d',
+                      min => 0 },
+                ],
+            }
+        },
+        { label => 'total-synced-file-count', nlabel => 'onedrive.users.files.synced.total.count', set => {
+                key_values => [ { name => 'synced_file_count' } ],
+                output_template => 'Synced File Count: %d',
+                perfdatas => [
+                    { label => 'total_synced_file_count', value => 'synced_file_count', template => '%d',
+                      min => 0 },
+                ],
+            }
+        },
+        { label => 'total-shared-int-file-count', nlabel => 'onedrive.users.files.shared.internally.total.count', set => {
+                key_values => [ { name => 'shared_int_file_count' } ],
+                output_template => 'Shared Internally File Count: %d',
+                perfdatas => [
+                    { label => 'total_shared_int_file_count', value => 'shared_int_file_count', template => '%d',
+                      min => 0 },
+                ],
+            }
+        },
+        { label => 'total-shared-ext-file-count', nlabel => 'onedrive.users.files.shared.externally.total.count', set => {
+                key_values => [ { name => 'shared_ext_file_count' } ],
+                output_template => 'Shared Externally File Count: %d',
+                perfdatas => [
+                    { label => 'total_shared_ext_file_count', value => 'shared_ext_file_count', template => '%d',
+                      min => 0 },
+                ],
+            }
+        },
+    ];
+    $self->{maps_counters}->{users} = [
+        { label => 'viewed-edited-file-count', nlabel => 'onedrive.users.files.viewed.count', set => {
+                key_values => [ { name => 'viewed_edited_file_count' }, { name => 'name' } ],
+                output_template => 'Viewed or Edited File Count: %d',
+                perfdatas => [
+                    { label => 'viewed_edited_file_count', value => 'viewed_edited_file_count', template => '%d',
+                      min => 0, label_extra_instance => 1, instance_use => 'name' },
+                ],
+            }
+        },
+        { label => 'synced-file-count', nlabel => 'onedrive.users.files.synced.count', set => {
+                key_values => [ { name => 'synced_file_count' }, { name => 'name' } ],
+                output_template => 'Synced File Count: %d',
+                perfdatas => [
+                    { label => 'synced_file_count', value => 'synced_file_count', template => '%d',
+                      min => 0, label_extra_instance => 1, instance_use => 'name' },
+                ],
+            }
+        },
+        { label => 'shared-int-file-count', nlabel => 'onedrive.users.files.shared.internally.count', set => {
+                key_values => [ { name => 'shared_int_file_count' }, { name => 'name' } ],
+                output_template => 'Shared Internally File Count: %d',
+                perfdatas => [
+                    { label => 'shared_int_file_count', value => 'shared_int_file_count', template => '%d',
+                      min => 0, label_extra_instance => 1, instance_use => 'name' },
+                ],
+            }
+        },
+        { label => 'shared-ext-file-count', nlabel => 'onedrive.users.files.shared.externally.count', set => {
+                key_values => [ { name => 'shared_ext_file_count' }, { name => 'name' } ],
+                output_template => 'Shared Externally File Count: %d',
+                perfdatas => [
+                    { label => 'shared_ext_file_count', value => 'shared_ext_file_count', template => '%d',
+                      min => 0, label_extra_instance => 1, instance_use => 'name' },
+                ],
+            }
+        },
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+    
+    $options{options}->add_options(arguments => {
+        "filter-user:s"         => { name => 'filter_user' },
+        "units:s"               => { name => 'units', default => '%' },
+        "filter-counters:s"     => { name => 'filter_counters', default => 'active|total' }, 
+    });
+
+    return $self;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+    
+    $self->{active} = { active => 0, total => 0, report_date => '' };
+    $self->{global} = { storage_used_active => 0, storage_used_inactive => 0, synced_file_count => 0,
+                        viewed_edited_file_count => 0, shared_int_file_count => 0, shared_ext_file_count => 0,
+                        visited_page_count => 0 };
+    $self->{users} = {};
+
+    my $results = $options{custom}->office_get_onedrive_activity();
+
+    foreach my $user (@{$results}) {
+        # Let's lc the instance label to make metrics "clean"...
+        $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
+
+        $self->{active}->{report_date} = $user->{'Report Refresh Date'} if ($self->{active}->{report_date} eq '');
+
+        if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
+            $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
+            $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);
+            next;
+        }
+    
+        $self->{active}->{total}++;
+
+        if (!defined($user->{'Last Activity Date'}) || $user->{'Last Activity Date'} eq '' ||
+            ($user->{'Last Activity Date'} ne $user->{'Report Refresh Date'})) {
+            $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no activity.", debug => 1);
+            next;
+        }
+    
+        $self->{active}->{active}++;
+
+        $self->{global}->{viewed_edited_file_count} += ($user->{'Viewed Or Edited File Count'} ne '') ? $user->{'Viewed Or Edited File Count'} : 0;
+        $self->{global}->{synced_file_count} += ($user->{'Synced File Count'} ne '') ? $user->{'Synced File Count'} : 0;
+        $self->{global}->{shared_int_file_count} += ($user->{'Shared Internally File Count'} ne '') ? $user->{'Shared Internally File Count'} : 0;
+        $self->{global}->{shared_ext_file_count} += ($user->{'Shared Externally File Count'} ne '') ? $user->{'Shared Externally File Count'} : 0;
+
+        $self->{users}->{$user->{'User Principal Name'}}->{name} = $user->{'User Principal Name'};
+        $self->{users}->{$user->{'User Principal Name'}}->{viewed_edited_file_count} = $user->{'Viewed Or Edited File Count'};
+        $self->{users}->{$user->{'User Principal Name'}}->{synced_file_count} = $user->{'Synced File Count'};
+        $self->{users}->{$user->{'User Principal Name'}}->{shared_int_file_count} = $user->{'Shared Internally File Count'};
+        $self->{users}->{$user->{'User Principal Name'}}->{shared_ext_file_count} = $user->{'Shared Externally File Count'};
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check users activity (reporting period over the last 7 days).
+
+(See link for details about metrics :
+https://docs.microsoft.com/en-us/office365/admin/activity-reports/onedrive-activity?view=o365-worldwide)
+
+=over 8
+
+=item B<--filter-user>
+
+Filter users.
+
+=item B<--warning-*>
+
+Threshold warning.
+Can be: 'active-users', 'total-viewed-edited-file-count' (count),
+'total-synced-file-count' (count), 'total-shared-int-file-count' (count),
+'total-shared-ext-file-count' (count), 'total-visited-page-count' (count),
+'viewed-edited-file-count' (count), 'synced-file-count' (count), 'shared-int-file-count' (count),
+'shared-ext-file-count' (count).
+
+=item B<--critical-*>
+
+Threshold critical.
+Can be: 'active-users', 'total-viewed-edited-file-count' (count),
+'total-synced-file-count' (count), 'total-shared-int-file-count' (count),
+'total-shared-ext-file-count' (count), 'total-visited-page-count' (count),
+'viewed-edited-file-count' (count), 'synced-file-count' (count), 'shared-int-file-count' (count),
+'shared-ext-file-count' (count).
+
+=item B<--filter-counters>
+
+Only display some counters (regexp can be used).
+Example to hide per user counters: --filter-counters='active|total'
+(Default: 'active|total')
+
+=item B<--units>
+
+Unit of thresholds (Default: '%') ('%', 'count').
+
+=back
+
+=cut

--- a/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
@@ -24,6 +24,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use Time::Local;
 
 sub custom_active_perfdata {
     my ($self, %options) = @_;
@@ -33,6 +34,9 @@ sub custom_active_perfdata {
         $total_options{total} = $self->{result_values}->{total};
         $total_options{cast_int} = 1;
     }
+
+    $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
+    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'onedrive.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
@@ -208,28 +208,31 @@ sub manage_selection {
                         shared_int_file_count => 0, shared_ext_file_count => 0 };
     $self->{users} = {};
 
-    my $results = $options{custom}->office_get_onedrive_activity();
+    my $results = $options{custom}->office_get_onedrive_activity(param => "period='D7'");
+    my $results_daily = [];
+    if (scalar(@{$results})) {
+       $self->{active}->{report_date} = @{$results}[0]->{'Report Refresh Date'};
+       $results_daily = $options{custom}->office_get_onedrive_activity(param => "date=" . $self->{active}->{report_date});
+    }
 
-    foreach my $user (@{$results}) {
+    foreach my $user (@{$results}, @{$results_daily}) {
         # Let's lc the instance label to make metrics "clean"...
         $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
-
-        $self->{active}->{report_date} = $user->{'Report Refresh Date'} if ($self->{active}->{report_date} eq '');
 
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);
             next;
         }
-    
-        $self->{active}->{total}++;
 
-        if (!defined($user->{'Last Activity Date'}) || $user->{'Last Activity Date'} eq '' ||
-            ($user->{'Last Activity Date'} ne $user->{'Report Refresh Date'})) {
-            $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no activity.", debug => 1);
+        if ($user->{'Report Period'} != 1) {
+            if (!defined($user->{'Last Activity Date'}) || ($user->{'Last Activity Date'} ne $self->{active}->{report_date})) {
+                $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no activity.", debug => 1);
+            }
+            $self->{active}->{total}++;
             next;
         }
-    
+
         $self->{active}->{active}++;
 
         $self->{global}->{viewed_edited_file_count} += ($user->{'Viewed Or Edited File Count'} ne '') ? $user->{'Viewed Or Edited File Count'} : 0;
@@ -251,10 +254,10 @@ __END__
 
 =head1 MODE
 
-Check users activity (reporting period over the last 7 days).
+Check users activity (reporting period over the last refreshed day).
 
 (See link for details about metrics :
-https://docs.microsoft.com/en-us/office365/admin/activity-reports/onedrive-activity?view=o365-worldwide)
+https://docs.microsoft.com/en-us/microsoft-365/admin/activity-reports/onedrive-for-business-activity?view=o365-worldwide)
 
 =over 8
 
@@ -265,20 +268,20 @@ Filter users.
 =item B<--warning-*>
 
 Threshold warning.
-Can be: 'active-users', 'total-viewed-edited-file-count' (count),
-'total-synced-file-count' (count), 'total-shared-int-file-count' (count),
-'total-shared-ext-file-count' (count), 'total-visited-page-count' (count),
-'viewed-edited-file-count' (count), 'synced-file-count' (count), 'shared-int-file-count' (count),
-'shared-ext-file-count' (count).
+Can be: 'active-users',
+'total-viewed-edited-file-count' (count), 'total-synced-file-count' (count),
+'total-shared-int-file-count' (count), 'total-shared-ext-file-count' (count),
+'viewed-edited-file-count' (count), 'synced-file-count' (count),
+'shared-int-file-count' (count), 'shared-ext-file-count' (count).
 
 =item B<--critical-*>
 
 Threshold critical.
-Can be: 'active-users', 'total-viewed-edited-file-count' (count),
-'total-synced-file-count' (count), 'total-shared-int-file-count' (count),
-'total-shared-ext-file-count' (count), 'total-visited-page-count' (count),
-'viewed-edited-file-count' (count), 'synced-file-count' (count), 'shared-int-file-count' (count),
-'shared-ext-file-count' (count).
+Can be: 'active-users',
+'total-viewed-edited-file-count' (count), 'total-synced-file-count' (count),
+'total-shared-int-file-count' (count), 'total-shared-ext-file-count' (count),
+'viewed-edited-file-count' (count), 'synced-file-count' (count),
+'shared-int-file-count' (count), 'shared-ext-file-count' (count).
 
 =item B<--filter-counters>
 

--- a/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/onedrive/mode/usersactivity.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,12,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'onedrive.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/onedrive/plugin.pm
+++ b/cloud/microsoft/office365/onedrive/plugin.pm
@@ -32,7 +32,7 @@ sub new {
     $self->{version} = '0.1';
     %{ $self->{modes} } = (
         'list-sites'            => 'cloud::microsoft::office365::onedrive::mode::listsites',
-        'usage'                 => 'cloud::microsoft::office365::onedrive::mode::usage',
+        'site-usage'            => 'cloud::microsoft::office365::onedrive::mode::siteusage',
     );
 
     $self->{custom_modes}{graphapi} = 'cloud::microsoft::office365::custom::graphapi';

--- a/cloud/microsoft/office365/onedrive/plugin.pm
+++ b/cloud/microsoft/office365/onedrive/plugin.pm
@@ -33,6 +33,7 @@ sub new {
     %{ $self->{modes} } = (
         'list-sites'            => 'cloud::microsoft::office365::onedrive::mode::listsites',
         'site-usage'            => 'cloud::microsoft::office365::onedrive::mode::siteusage',
+        'users-activity'        => 'cloud::microsoft::office365::onedrive::mode::usersactivity',
     );
 
     $self->{custom_modes}{graphapi} = 'cloud::microsoft::office365::custom::graphapi';

--- a/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
@@ -24,6 +24,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use Time::Local;
 
 sub custom_active_perfdata {
     my ($self, %options) = @_;
@@ -33,6 +34,9 @@ sub custom_active_perfdata {
         $total_options{total} = $self->{result_values}->{total};
         $total_options{cast_int} = 1;
     }
+
+    $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
+    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_sites', nlabel => 'sharepoint.sites.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
@@ -382,17 +382,20 @@ Can be: 'url', 'id' (can be a regexp).
 
 Threshold warning.
 Can be: 'active-sites', 'total-usage-active' (count),
-'total-usage-inactive' (count), 'total-file-count' (count),
-'total-active-file-count' (count), 'total-visited-page-count' (count),
-'total-page-view-count' (count), 'usage' (count), 'file-count' (count), 'active-file-count' (count),
+'total-usage-inactive' (count), 'total-file-count-active' (count),
+'total-file-count-inactive' (count), 'total-active-file-count' (count),
+'total-visited-page-count' (count), 'total-page-view-count' (count),
+'usage' (count), 'file-count' (count), 'active-file-count' (count),
 'visited-page-count' (count), 'page-view-count' (count).
 
 =item B<--critical-*>
 
 Threshold critical.
-Can be: 'active-sites', 'total-usage' (count), 'total-file-count' (count),
-'total-active-file-count' (count), 'total-visited-page-count' (count),
-'total-page-view-count' (count), 'usage' (count), 'file-count' (count), 'active-file-count' (count),
+Can be: 'active-sites', 'total-usage-active' (count),
+'total-usage-inactive' (count), 'total-file-count-active' (count),
+'total-file-count-inactive' (count), 'total-active-file-count' (count),
+'total-visited-page-count' (count), 'total-page-view-count' (count),
+'usage' (count), 'file-count' (count), 'active-file-count' (count),
 'visited-page-count' (count), 'page-view-count' (count).
 
 =item B<--filter-counters>

--- a/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
@@ -317,6 +317,8 @@ sub manage_selection {
         # As it's used as the instance label, let's keep the URL as short as possible, removing its domain name...
         $site->{'Site URL'} =~ s/^[^\/]*\/\/[^\/]*//;
 
+        $self->{active}->{report_date} = $site->{'Report Refresh Date'} if ($self->{active}->{report_date} eq '');
+
         if (defined($self->{option_results}->{filter_url}) && $self->{option_results}->{filter_url} ne '' &&
             $site->{'Site URL'} !~ /$self->{option_results}->{filter_url}/) {
             $self->{output}->output_add(long_msg => "skipping  '" . $site->{'Site URL'} . "': no matching filter name.", debug => 1);
@@ -338,7 +340,6 @@ sub manage_selection {
             next;
         }
     
-        $self->{active}->{report_date} = $site->{'Report Refresh Date'};
         $self->{active}->{active}++;
 
         $self->{global}->{storage_used_active} += ($site->{'Storage Used (Byte)'} ne '') ? $site->{'Storage Used (Byte)'} : 0;

--- a/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,12,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_sites', nlabel => 'sharepoint.sites.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
@@ -34,7 +34,7 @@ sub custom_active_perfdata {
         $total_options{cast_int} = 1;
     }
 
-    $self->{output}->perfdata_add(label => 'active_sites',
+    $self->{output}->perfdata_add(label => 'active_sites', nlabel => 'sharepoint.sites.active.count',
                                   value => $self->{result_values}->{active},
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{label}, %total_options),
                                   critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{label}, %total_options),
@@ -83,7 +83,7 @@ sub custom_usage_perfdata {
     my $extra_label = '';
     $extra_label = '_' . $self->{result_values}->{display} if (!defined($options{extra_instance}) || $options{extra_instance} != 0);
     
-    $self->{output}->perfdata_add(label => 'used' . $extra_label,
+    $self->{output}->perfdata_add(label => 'used' . $extra_label, nlabel => $self->{result_values}->{display} . '#sharepoint.sites.usage.bytes', 
                                   unit => 'B',
                                   value => $self->{result_values}->{used},
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{label}, total => $self->{result_values}->{total}, cast_int => 1),
@@ -124,7 +124,7 @@ sub custom_usage_output {
 sub custom_usage_calc {
     my ($self, %options) = @_;
 
-    $self->{result_values}->{display} = $options{new_datas}->{$self->{instance} . '_id'};
+    $self->{result_values}->{display} = $options{new_datas}->{$self->{instance} . '_url'};
     $self->{result_values}->{total} = $options{new_datas}->{$self->{instance} . '_storage_allocated'};
     $self->{result_values}->{used} = $options{new_datas}->{$self->{instance} . '_storage_used'};
 
@@ -173,7 +173,7 @@ sub set_counters {
         },
     ];
     $self->{maps_counters}->{global} = [
-        { label => 'total-usage-active', set => {
+        { label => 'total-usage-active', nlabel => 'sharepoint.sites.active.usage.total.bytes', set => {
                 key_values => [ { name => 'storage_used_active' } ],
                 output_template => 'Usage (active sites): %s %s',
                 output_change_bytes => 1,
@@ -183,7 +183,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-usage-inactive', set => {
+        { label => 'total-usage-inactive', nlabel => 'sharepoint.sites.inactive.usage.total.bytes', set => {
                 key_values => [ { name => 'storage_used_inactive' } ],
                 output_template => 'Usage (inactive sites): %s %s',
                 output_change_bytes => 1,
@@ -193,16 +193,25 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-file-count', set => {
-                key_values => [ { name => 'file_count' } ],
+        { label => 'total-file-count-active', nlabel => 'sharepoint.sites.active.files.total.count', set => {
+                key_values => [ { name => 'file_count_active' } ],
                 output_template => 'File Count (active sites): %d',
                 perfdatas => [
-                    { label => 'total_file_count', value => 'file_count', template => '%d',
+                    { label => 'total_file_count_active', value => 'file_count_active', template => '%d',
                       min => 0 },
                 ],
             }
         },
-        { label => 'total-active-file-count', set => {
+        { label => 'total-file-count-inactive', nlabel => 'sharepoint.sites.inactive.files.total.count', set => {
+                key_values => [ { name => 'file_count_inactive' } ],
+                output_template => 'File Count (inactive sites): %d',
+                perfdatas => [
+                    { label => 'total_file_count_inactive', value => 'file_count_inactive', template => '%d',
+                      min => 0 },
+                ],
+            }
+        },
+        { label => 'total-active-file-count', nlabel => 'sharepoint.sites.files.active.total.count', set => {
                 key_values => [ { name => 'active_file_count' } ],
                 output_template => 'Active File Count (active sites): %d',
                 perfdatas => [
@@ -211,7 +220,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-visited-page-count', set => {
+        { label => 'total-visited-page-count', nlabel => 'sharepoint.sites.pages.visited.total.count', set => {
                 key_values => [ { name => 'visited_page_count' } ],
                 output_template => 'Visited Page Count (active sites): %d',
                 perfdatas => [
@@ -220,7 +229,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-page-view-count', set => {
+        { label => 'total-page-view-count', nlabel => 'sharepoint.sites.pages.viewed.total.count', set => {
                 key_values => [ { name => 'page_view_count' } ],
                 output_template => 'Page View Count (active sites): %d',
                 perfdatas => [
@@ -239,39 +248,39 @@ sub set_counters {
                 closure_custom_threshold_check => $self->can('custom_usage_threshold'),
             }
         },
-        { label => 'file-count', set => {
+        { label => 'file-count', nlabel => 'sharepoint.sites.files.count', set => {
                 key_values => [ { name => 'file_count' }, { name => 'url' }, { name => 'id' } ],
                 output_template => 'File Count: %d',
                 perfdatas => [
                     { label => 'file_count', value => 'file_count', template => '%d',
-                      min => 0, label_extra_instance => 1, instance_use => 'id' },
+                      min => 0, label_extra_instance => 1, instance_use => 'url' },
                 ],
             }
         },
-        { label => 'active-file-count', set => {
+        { label => 'active-file-count', nlabel => 'sharepoint.sites.files.active.count', set => {
                 key_values => [ { name => 'active_file_count' }, { name => 'url' }, { name => 'id' } ],
                 output_template => 'Active File Count: %d',
                 perfdatas => [
                     { label => 'active_file_count', value => 'active_file_count', template => '%d',
-                      min => 0, label_extra_instance => 1, instance_use => 'id' },
+                      min => 0, label_extra_instance => 1, instance_use => 'url' },
                 ],
             }
         },
-        { label => 'visited-page-count', set => {
+        { label => 'visited-page-count', nlabel => 'sharepoint.sites.pages.visited.count', set => {
                 key_values => [ { name => 'visited_page_count' }, { name => 'url' }, { name => 'id' } ],
                 output_template => 'Visited Page Count: %d',
                 perfdatas => [
                     { label => 'visited_page_count', value => 'visited_page_count', template => '%d',
-                      min => 0, label_extra_instance => 1, instance_use => 'id' },
+                      min => 0, label_extra_instance => 1, instance_use => 'url' },
                 ],
             }
         },
-        { label => 'page-view-count', set => {
+        { label => 'page-view-count', nlabel => 'sharepoint.sites.pages.viewed.count', set => {
                 key_values => [ { name => 'page_view_count' }, { name => 'url' }, { name => 'id' } ],
                 output_template => 'Page View Count: %d',
                 perfdatas => [
                     { label => 'page_view_count', value => 'page_view_count', template => '%d',
-                      min => 0, label_extra_instance => 1, instance_use => 'id' },
+                      min => 0, label_extra_instance => 1, instance_use => 'url' },
                 ],
             }
         },
@@ -305,6 +314,9 @@ sub manage_selection {
     my $results = $options{custom}->office_get_sharepoint_site_usage();
 
     foreach my $site (@{$results}) {
+        # As it's used as the instance label, let's keep the URL as short as possible, removing its domain name...
+        $site->{'Site URL'} =~ s/^[^\/]*\/\/[^\/]*//;
+
         if (defined($self->{option_results}->{filter_url}) && $self->{option_results}->{filter_url} ne '' &&
             $site->{'Site URL'} !~ /$self->{option_results}->{filter_url}/) {
             $self->{output}->output_add(long_msg => "skipping  '" . $site->{'Site URL'} . "': no matching filter name.", debug => 1);
@@ -321,6 +333,7 @@ sub manage_selection {
         if (!defined($site->{'Last Activity Date'}) || $site->{'Last Activity Date'} eq '' ||
             ($site->{'Last Activity Date'} ne $site->{'Report Refresh Date'})) {
             $self->{global}->{storage_used_inactive} += ($site->{'Storage Used (Byte)'} ne '') ? $site->{'Storage Used (Byte)'} : 0;
+            $self->{global}->{file_count_inactive} += ($site->{'File Count'} ne '') ? $site->{'File Count'} : 0;
             $self->{output}->output_add(long_msg => "skipping '" . $site->{'Site URL'} . "': no activity.", debug => 1);
             next;
         }
@@ -329,20 +342,20 @@ sub manage_selection {
         $self->{active}->{active}++;
 
         $self->{global}->{storage_used_active} += ($site->{'Storage Used (Byte)'} ne '') ? $site->{'Storage Used (Byte)'} : 0;
-        $self->{global}->{file_count} += ($site->{'File Count'} ne '') ? $site->{'File Count'} : 0;
+        $self->{global}->{file_count_active} += ($site->{'File Count'} ne '') ? $site->{'File Count'} : 0;
         $self->{global}->{active_file_count} += ($site->{'Active File Count'} ne '') ? $site->{'Active File Count'} : 0;
         $self->{global}->{visited_page_count} += ($site->{'Visited Page Count'} ne '') ? $site->{'Visited Page Count'} : 0;
         $self->{global}->{page_view_count} += ($site->{'Page View Count'} ne '') ? $site->{'Page View Count'} : 0;
         
-        $self->{sites}->{$site->{'Site Id'}}->{id} = $site->{'Site Id'};
-        $self->{sites}->{$site->{'Site Id'}}->{url} = $site->{'Site URL'};
-        $self->{sites}->{$site->{'Site Id'}}->{file_count} = $site->{'File Count'};
-        $self->{sites}->{$site->{'Site Id'}}->{active_file_count} = $site->{'Active File Count'};
-        $self->{sites}->{$site->{'Site Id'}}->{visited_page_count} = $site->{'Visited Page Count'};
-        $self->{sites}->{$site->{'Site Id'}}->{page_view_count} = $site->{'Page View Count'};
-        $self->{sites}->{$site->{'Site Id'}}->{storage_used} = $site->{'Storage Used (Byte)'};
-        $self->{sites}->{$site->{'Site Id'}}->{storage_allocated} = $site->{'Storage Allocated (Byte)'};
-        $self->{sites}->{$site->{'Site Id'}}->{last_activity_date} = $site->{'Last Activity Date'};
+        $self->{sites}->{$site->{'Site URL'}}->{url} = $site->{'Site URL'};
+        $self->{sites}->{$site->{'Site URL'}}->{id} = $site->{'Site Id'};
+        $self->{sites}->{$site->{'Site URL'}}->{file_count} = $site->{'File Count'};
+        $self->{sites}->{$site->{'Site URL'}}->{active_file_count} = $site->{'Active File Count'};
+        $self->{sites}->{$site->{'Site URL'}}->{visited_page_count} = $site->{'Visited Page Count'};
+        $self->{sites}->{$site->{'Site URL'}}->{page_view_count} = $site->{'Page View Count'};
+        $self->{sites}->{$site->{'Site URL'}}->{storage_used} = $site->{'Storage Used (Byte)'};
+        $self->{sites}->{$site->{'Site URL'}}->{storage_allocated} = $site->{'Storage Allocated (Byte)'};
+        $self->{sites}->{$site->{'Site URL'}}->{last_activity_date} = $site->{'Last Activity Date'};
     }
 }
 

--- a/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
@@ -307,8 +307,9 @@ sub manage_selection {
     my ($self, %options) = @_;
     
     $self->{active} = { active => 0, total => 0, report_date => '' };
-    $self->{global} = { storage_used_active => 0, storage_used_inactive => 0, file_count => 0,
-                        active_file_count => 0 , visited_file_count => 0 , page_view_count => 0 };
+    $self->{global} = { storage_used_active => 0, storage_used_inactive => 0,
+                        file_count_active => 0, file_count_inactive => 0,
+                        active_file_count => 0 , visited_page_count => 0 , page_view_count => 0 };
     $self->{sites} = {};
 
     my $results = $options{custom}->office_get_sharepoint_site_usage();

--- a/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_sites', nlabel => 'sharepoint.sites.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/siteusage.pm
@@ -324,9 +324,6 @@ sub manage_selection {
     }
 
     foreach my $site (@{$results}, @{$results_daily}) {
-        # As it's used as the instance label, let's keep the URL as short as possible, removing its domain name...
-        $site->{'Site URL'} =~ s/^[^\/]*\/\/[^\/]*//;
-
         if (defined($self->{option_results}->{filter_url}) && $self->{option_results}->{filter_url} ne '' &&
             $site->{'Site URL'} !~ /$self->{option_results}->{filter_url}/) {
             $self->{output}->output_add(long_msg => "skipping  '" . $site->{'Site URL'} . "': no matching filter name.", debug => 1);

--- a/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
@@ -34,7 +34,7 @@ sub custom_active_perfdata {
         $total_options{cast_int} = 1;
     }
 
-    $self->{output}->perfdata_add(label => 'active_users',
+    $self->{output}->perfdata_add(label => 'active_users', nlabel => 'sharepoint.users.active.count',
                                   value => $self->{result_values}->{active},
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{label}, %total_options),
                                   critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{label}, %total_options),
@@ -109,7 +109,7 @@ sub set_counters {
         },
     ];
     $self->{maps_counters}->{global} = [
-        { label => 'total-viewed-edited-file-count', set => {
+        { label => 'total-viewed-edited-file-count', nlabel => 'sharepoint.users.files.viewed.total.count', set => {
                 key_values => [ { name => 'viewed_edited_file_count' } ],
                 output_template => 'Viewed or Edited File Count: %d',
                 perfdatas => [
@@ -118,7 +118,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-synced-file-count', set => {
+        { label => 'total-synced-file-count', nlabel => 'sharepoint.users.files.synced.total.count', set => {
                 key_values => [ { name => 'synced_file_count' } ],
                 output_template => 'Synced File Count: %d',
                 perfdatas => [
@@ -127,7 +127,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-shared-int-file-count', set => {
+        { label => 'total-shared-int-file-count', nlabel => 'sharepoint.users.files.shared.internally.total.count', set => {
                 key_values => [ { name => 'shared_int_file_count' } ],
                 output_template => 'Shared Internally File Count: %d',
                 perfdatas => [
@@ -136,7 +136,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-shared-ext-file-count', set => {
+        { label => 'total-shared-ext-file-count', nlabel => 'sharepoint.users.files.shared.externally.total.count', set => {
                 key_values => [ { name => 'shared_ext_file_count' } ],
                 output_template => 'Shared Externally File Count: %d',
                 perfdatas => [
@@ -145,7 +145,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-visited-page-count', set => {
+        { label => 'total-visited-page-count', nlabel => 'sharepoint.users.pages.visited.total.count', set => {
                 key_values => [ { name => 'visited_page_count' } ],
                 output_template => 'Visited Page Count (active sites): %d',
                 perfdatas => [
@@ -156,7 +156,7 @@ sub set_counters {
         },
     ];
     $self->{maps_counters}->{users} = [
-        { label => 'viewed-edited-file-count', set => {
+        { label => 'viewed-edited-file-count', nlabel => 'sharepoint.users.files.viewed.count', set => {
                 key_values => [ { name => 'viewed_edited_file_count' }, { name => 'name' } ],
                 output_template => 'Viewed or Edited File Count: %d',
                 perfdatas => [
@@ -165,7 +165,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'synced-file-count', set => {
+        { label => 'synced-file-count', nlabel => 'sharepoint.users.files.synced.count', set => {
                 key_values => [ { name => 'synced_file_count' }, { name => 'name' } ],
                 output_template => 'Synced File Count: %d',
                 perfdatas => [
@@ -174,7 +174,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'shared-int-file-count', set => {
+        { label => 'shared-int-file-count', nlabel => 'sharepoint.users.files.shared.internally.count', set => {
                 key_values => [ { name => 'shared_int_file_count' }, { name => 'name' } ],
                 output_template => 'Shared Internally File Count: %d',
                 perfdatas => [
@@ -183,7 +183,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'shared-ext-file-count', set => {
+        { label => 'shared-ext-file-count', nlabel => 'sharepoint.users.files.shared.externally.count', set => {
                 key_values => [ { name => 'shared_ext_file_count' }, { name => 'name' } ],
                 output_template => 'Shared Externally File Count: %d',
                 perfdatas => [
@@ -192,7 +192,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'visited-page-count', set => {
+        { label => 'visited-page-count', nlabel => 'sharepoint.users.pages.visited.count', set => {
                 key_values => [ { name => 'visited_page_count' }, { name => 'name' } ],
                 output_template => 'Visited Page Count: %d',
                 perfdatas => [
@@ -230,6 +230,9 @@ sub manage_selection {
     my $results = $options{custom}->office_get_sharepoint_activity();
 
     foreach my $user (@{$results}) {
+        # Let's lc the instance label to make metrics "clean"...
+        $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
+
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);

--- a/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
@@ -227,28 +227,31 @@ sub manage_selection {
                         visited_page_count => 0 };
     $self->{users} = {};
 
-    my $results = $options{custom}->office_get_sharepoint_activity();
+    my $results = $options{custom}->office_get_sharepoint_activity(param => "period='D7'");
+    my $results_daily = [];
+    if (scalar(@{$results})) {
+       $self->{active}->{report_date} = @{$results}[0]->{'Report Refresh Date'};
+       $results_daily = $options{custom}->office_get_sharepoint_activity(param => "date=" . $self->{active}->{report_date});
+    }
 
-    foreach my $user (@{$results}) {
+    foreach my $user (@{$results}, @{$results_daily}) {
         # Let's lc the instance label to make metrics "clean"...
         $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
-
-        $self->{active}->{report_date} = $user->{'Report Refresh Date'} if ($self->{active}->{report_date} eq '');
 
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);
             next;
         }
-    
-        $self->{active}->{total}++;
 
-        if (!defined($user->{'Last Activity Date'}) || $user->{'Last Activity Date'} eq '' ||
-            ($user->{'Last Activity Date'} ne $user->{'Report Refresh Date'})) {
-            $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no activity.", debug => 1);
+        if ($user->{'Report Period'} != 1) {
+            if (!defined($user->{'Last Activity Date'}) || ($user->{'Last Activity Date'} ne $self->{active}->{report_date})) {
+                $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no activity.", debug => 1);
+            }
+            $self->{active}->{total}++;
             next;
         }
-    
+
         $self->{active}->{active}++;
 
         $self->{global}->{viewed_edited_file_count} += ($user->{'Viewed Or Edited File Count'} ne '') ? $user->{'Viewed Or Edited File Count'} : 0;
@@ -272,10 +275,10 @@ __END__
 
 =head1 MODE
 
-Check users activity (reporting period over the last 7 days).
+Check users activity (reporting period over the last refreshed day).
 
 (See link for details about metrics :
-https://docs.microsoft.com/en-us/office365/admin/activity-reports/sharepoint-activity?view=o365-worldwide)
+https://docs.microsoft.com/en-us/microsoft-365/admin/activity-reports/sharepoint-activity?view=o365-worldwide)
 
 =over 8
 
@@ -286,20 +289,24 @@ Filter users.
 =item B<--warning-*>
 
 Threshold warning.
-Can be: 'active-users', 'total-viewed-edited-file-count' (count),
-'total-synced-file-count' (count), 'total-shared-int-file-count' (count),
-'total-shared-ext-file-count' (count), 'total-visited-page-count' (count),
-'viewed-edited-file-count' (count), 'synced-file-count' (count), 'shared-int-file-count' (count),
-'shared-ext-file-count' (count), 'visited-page-count' (count).
+Can be: 'active-users',
+'total-viewed-edited-file-count' (count), 'total-synced-file-count' (count),
+'total-shared-int-file-count' (count), 'total-shared-ext-file-count' (count),
+'total-visited-page-count' (count),
+'viewed-edited-file-count' (count), 'synced-file-count' (count),
+'shared-int-file-count' (count), 'shared-ext-file-count' (count),
+'visited-page-count' (count).
 
 =item B<--critical-*>
 
 Threshold critical.
-Can be: 'active-users', 'total-viewed-edited-file-count' (count),
-'total-synced-file-count' (count), 'total-shared-int-file-count' (count),
-'total-shared-ext-file-count' (count), 'total-visited-page-count' (count),
-'viewed-edited-file-count' (count), 'synced-file-count' (count), 'shared-int-file-count' (count),
-'shared-ext-file-count' (count), 'visited-page-count' (count).
+Can be: 'active-users',
+'total-viewed-edited-file-count' (count), 'total-synced-file-count' (count),
+'total-shared-int-file-count' (count), 'total-shared-ext-file-count' (count),
+'total-visited-page-count' (count),
+'viewed-edited-file-count' (count), 'synced-file-count' (count),
+'shared-int-file-count' (count), 'shared-ext-file-count' (count),
+'visited-page-count' (count).
 
 =item B<--filter-counters>
 

--- a/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
@@ -24,6 +24,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use Time::Local;
 
 sub custom_active_perfdata {
     my ($self, %options) = @_;
@@ -33,6 +34,9 @@ sub custom_active_perfdata {
         $total_options{total} = $self->{result_values}->{total};
         $total_options{cast_int} = 1;
     }
+
+    $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
+    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'sharepoint.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
@@ -222,8 +222,8 @@ sub manage_selection {
     my ($self, %options) = @_;
     
     $self->{active} = { active => 0, total => 0, report_date => '' };
-    $self->{global} = { storage_used_active => 0, storage_used_inactive => 0, synced_file_count => 0,
-                        viewed_edited_file_count => 0, shared_int_file_count => 0, shared_ext_file_count => 0,
+    $self->{global} = { viewed_edited_file_count => 0, synced_file_count => 0,
+                        shared_int_file_count => 0, shared_ext_file_count => 0,
                         visited_page_count => 0 };
     $self->{users} = {};
 

--- a/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
@@ -233,6 +233,8 @@ sub manage_selection {
         # Let's lc the instance label to make metrics "clean"...
         $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
 
+        $self->{active}->{report_date} = $user->{'Report Refresh Date'} if ($self->{active}->{report_date} eq '');
+
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);
@@ -247,7 +249,6 @@ sub manage_selection {
             next;
         }
     
-        $self->{active}->{report_date} = $user->{'Report Refresh Date'};
         $self->{active}->{active}++;
 
         $self->{global}->{viewed_edited_file_count} += ($user->{'Viewed Or Edited File Count'} ne '') ? $user->{'Viewed Or Edited File Count'} : 0;

--- a/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,12,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'sharepoint.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'sharepoint.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/sharepoint/mode/usersactivity.pm
@@ -239,9 +239,6 @@ sub manage_selection {
     }
 
     foreach my $user (@{$results}, @{$results_daily}) {
-        # Let's lc the instance label to make metrics "clean"...
-        $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
-
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);

--- a/cloud/microsoft/office365/skype/mode/devicesusage.pm
+++ b/cloud/microsoft/office365/skype/mode/devicesusage.pm
@@ -24,6 +24,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use Time::Local;
 
 sub custom_active_perfdata {
     my ($self, %options) = @_;
@@ -33,6 +34,9 @@ sub custom_active_perfdata {
         $total_options{total} = $self->{result_values}->{total};
         $total_options{cast_int} = 1;
     }
+
+    $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
+    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_devices', nlabel => 'skype.devices.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/skype/mode/devicesusage.pm
+++ b/cloud/microsoft/office365/skype/mode/devicesusage.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_devices', nlabel => 'skype.devices.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/skype/mode/devicesusage.pm
+++ b/cloud/microsoft/office365/skype/mode/devicesusage.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,12,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_devices', nlabel => 'skype.devices.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/skype/mode/devicesusage.pm
+++ b/cloud/microsoft/office365/skype/mode/devicesusage.pm
@@ -169,11 +169,14 @@ sub manage_selection {
     $self->{active} = { active => 0, total => 0, report_date => '' };
     $self->{global} = { windows => 0, ipad => 0, iphone => 0, android_phone => 0, windows_phone => 0 };
 
-    my $results = $options{custom}->office_get_skype_device_usage();
+    my $results = $options{custom}->office_get_skype_device_usage(param => "period='D7'");
+    my $results_daily = [];
+    if (scalar(@{$results})) {
+       $self->{active}->{report_date} = @{$results}[0]->{'Report Refresh Date'};
+       $results_daily = $options{custom}->office_get_skype_device_usage(param => "date=" . $self->{active}->{report_date});
+    }
 
-    foreach my $user (@{$results}) {
-        $self->{active}->{report_date} = $user->{'Report Refresh Date'} if ($self->{active}->{report_date} eq '');
-
+    foreach my $user (@{$results}, @{$results_daily}) {
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);
@@ -187,11 +190,11 @@ sub manage_selection {
         $used_devices++ if ($user->{'Used Android Phone'} =~ /Yes/);
         $used_devices++ if ($user->{'Used Windows Phone'} =~ /Yes/);
 
-        $self->{active}->{total} += $used_devices;
-
-        if (!defined($user->{'Last Activity Date'}) || $user->{'Last Activity Date'} eq '' ||
-            ($user->{'Last Activity Date'} ne $user->{'Report Refresh Date'})) {
-            $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no activity.", debug => 1);
+        if ($user->{'Report Period'} != 1) {
+            if (!defined($user->{'Last Activity Date'}) || ($user->{'Last Activity Date'} ne $self->{active}->{report_date})) {
+                $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no activity.", debug => 1);
+            }
+            $self->{active}->{total} += $used_devices;
             next;
         }
 
@@ -211,10 +214,10 @@ __END__
 
 =head1 MODE
 
-Check devices usage (reporting period over the last 7 days).
+Check devices usage (reporting period over the last refreshed day).
 
 (See link for details about metrics :
-https://docs.microsoft.com/en-us/office365/admin/activity-reports/microsoft-teams-device-usage?view=o365-worldwide)
+https://docs.microsoft.com/en-us/SkypeForBusiness/skype-for-business-online-reporting/device-usage-report)
 
 =over 8
 

--- a/cloud/microsoft/office365/skype/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/skype/mode/usersactivity.pm
@@ -34,7 +34,7 @@ sub custom_active_perfdata {
         $total_options{cast_int} = 1;
     }
 
-    $self->{output}->perfdata_add(label => 'active_users',
+    $self->{output}->perfdata_add(label => 'active_users', nlabel => 'skype.users.active.count',
                                   value => $self->{result_values}->{active},
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{label}, %total_options),
                                   critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{label}, %total_options),
@@ -109,7 +109,7 @@ sub set_counters {
         },
     ];
     $self->{maps_counters}->{global} = [
-        { label => 'total-peer-to-peer-sessions', set => {
+        { label => 'total-peer-to-peer-sessions', nlabel => 'skype.users.sessions.p2p.total.count', set => {
                 key_values => [ { name => 'peer_to_peer_sessions' } ],
                 output_template => 'Peer-to-peer Sessions Count: %d',
                 perfdatas => [
@@ -118,7 +118,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-organized-conference', set => {
+        { label => 'total-organized-conference', nlabel => 'skype.users.conferences.organized.total.count', set => {
                 key_values => [ { name => 'organized_conference' } ],
                 output_template => 'Organized Conference Count: %d',
                 perfdatas => [
@@ -127,7 +127,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-participated-conference', set => {
+        { label => 'total-participated-conference', nlabel => 'skype.users.conferences.participated.total.count', set => {
                 key_values => [ { name => 'participated_conference' } ],
                 output_template => 'Participated Conference Count: %d',
                 perfdatas => [
@@ -138,7 +138,7 @@ sub set_counters {
         },
     ];
     $self->{maps_counters}->{users} = [
-        { label => 'peer-to-peer-sessions', set => {
+        { label => 'peer-to-peer-sessions', nlabel => 'skype.users.sessions.p2p.count', set => {
                 key_values => [ { name => 'peer_to_peer_sessions' }, { name => 'name' } ],
                 output_template => 'Peer-to-peer Sessions Count: %d',
                 perfdatas => [
@@ -147,7 +147,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'organized-conference', set => {
+        { label => 'organized-conference', nlabel => 'skype.users.conferences.organized.count', set => {
                 key_values => [ { name => 'organized_conference' }, { name => 'name' } ],
                 output_template => 'Organized Conference Count: %d',
                 perfdatas => [
@@ -156,7 +156,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'participated-conference', set => {
+        { label => 'participated-conference', nlabel => 'skype.users.conferences.participated.count', set => {
                 key_values => [ { name => 'participated_conference' }, { name => 'name' } ],
                 output_template => 'Participated Conference Count: %d',
                 perfdatas => [
@@ -192,6 +192,9 @@ sub manage_selection {
     my $results = $options{custom}->office_get_skype_activity();
 
     foreach my $user (@{$results}) {
+        # Let's lc the instance label to make metrics "clean"...
+        $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
+
         $self->{active}->{report_date} = $user->{'Report Refresh Date'} if ($self->{active}->{report_date} eq '');
 
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&

--- a/cloud/microsoft/office365/skype/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/skype/mode/usersactivity.pm
@@ -201,9 +201,6 @@ sub manage_selection {
     }
 
     foreach my $user (@{$results}, @{$results_daily}) {
-        # Let's lc the instance label to make metrics "clean"...
-        $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
-
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);

--- a/cloud/microsoft/office365/skype/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/skype/mode/usersactivity.pm
@@ -24,6 +24,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use Time::Local;
 
 sub custom_active_perfdata {
     my ($self, %options) = @_;
@@ -33,6 +34,9 @@ sub custom_active_perfdata {
         $total_options{total} = $self->{result_values}->{total};
         $total_options{cast_int} = 1;
     }
+
+    $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
+    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'skype.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/skype/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/skype/mode/usersactivity.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,12,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'skype.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/skype/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/skype/mode/usersactivity.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'skype.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/teams/mode/devicesusage.pm
+++ b/cloud/microsoft/office365/teams/mode/devicesusage.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,12,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_devices', nlabel => 'teams.devices.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/teams/mode/devicesusage.pm
+++ b/cloud/microsoft/office365/teams/mode/devicesusage.pm
@@ -24,6 +24,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use Time::Local;
 
 sub custom_active_perfdata {
     my ($self, %options) = @_;
@@ -33,6 +34,9 @@ sub custom_active_perfdata {
         $total_options{total} = $self->{result_values}->{total};
         $total_options{cast_int} = 1;
     }
+
+    $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
+    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_devices', nlabel => 'teams.devices.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/teams/mode/devicesusage.pm
+++ b/cloud/microsoft/office365/teams/mode/devicesusage.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_devices', nlabel => 'teams.devices.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/teams/mode/devicesusage.pm
+++ b/cloud/microsoft/office365/teams/mode/devicesusage.pm
@@ -236,14 +236,14 @@ Filter users.
 =item B<--warning-*>
 
 Threshold warning.
-Can be: 'active-users', 'windows' (count), 'mac' (count),
+Can be: 'active-devices', 'windows' (count), 'mac' (count),
 'web' (count), 'ios' (count), 'android-phone' (count),
 'windows-phone' (count).
 
 =item B<--critical-*>
 
 Threshold critical.
-Can be: 'active-users', 'windows' (count), 'mac' (count),
+Can be: 'active-devices', 'windows' (count), 'mac' (count),
 'web' (count), 'ios' (count), 'android-phone' (count),
 'windows-phone' (count).
 

--- a/cloud/microsoft/office365/teams/mode/devicesusage.pm
+++ b/cloud/microsoft/office365/teams/mode/devicesusage.pm
@@ -181,6 +181,8 @@ sub manage_selection {
     my $results = $options{custom}->office_get_teams_device_usage();
 
     foreach my $user (@{$results}) {
+        $self->{active}->{report_date} = $user->{'Report Refresh Date'} if ($self->{active}->{report_date} eq '');
+
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);
@@ -203,7 +205,6 @@ sub manage_selection {
             next;
         }
 
-        $self->{active}->{report_date} = $user->{'Report Refresh Date'};
         $self->{active}->{active} += $used_devices;
 
         $self->{global}->{windows}++ if ($user->{'Used Windows'} =~ /Yes/);

--- a/cloud/microsoft/office365/teams/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/teams/mode/usersactivity.pm
@@ -24,6 +24,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use Time::Local;
 
 sub custom_active_perfdata {
     my ($self, %options) = @_;
@@ -33,6 +34,9 @@ sub custom_active_perfdata {
         $total_options{total} = $self->{result_values}->{total};
         $total_options{cast_int} = 1;
     }
+
+    $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
+    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'teams.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/teams/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/teams/mode/usersactivity.pm
@@ -34,7 +34,7 @@ sub custom_active_perfdata {
         $total_options{cast_int} = 1;
     }
 
-    $self->{output}->perfdata_add(label => 'active_users',
+    $self->{output}->perfdata_add(label => 'active_users', nlabel => 'teams.users.active.count',
                                   value => $self->{result_values}->{active},
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{label}, %total_options),
                                   critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{label}, %total_options),
@@ -109,7 +109,7 @@ sub set_counters {
         },
     ];
     $self->{maps_counters}->{global} = [
-        { label => 'total-team-chat', set => {
+        { label => 'total-team-chat', nlabel => 'teams.users.messages.team.total.count', set => {
                 key_values => [ { name => 'team_chat' } ],
                 output_template => 'Team Chat Message Count: %d',
                 perfdatas => [
@@ -118,7 +118,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-private-chat', set => {
+        { label => 'total-private-chat', nlabel => 'teams.users.messages.private.total.count', set => {
                 key_values => [ { name => 'private_chat' } ],
                 output_template => 'Private Chat Message Count: %d',
                 perfdatas => [
@@ -127,7 +127,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-call', set => {
+        { label => 'total-call', nlabel => 'teams.users.call.total.count', set => {
                 key_values => [ { name => 'call' } ],
                 output_template => 'Call Count: %d',
                 perfdatas => [
@@ -136,7 +136,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'total-meeting', set => {
+        { label => 'total-meeting', nlabel => 'teams.users.meeting.total.count', set => {
                 key_values => [ { name => 'meeting' } ],
                 output_template => 'Meeting Count: %d',
                 perfdatas => [
@@ -147,7 +147,7 @@ sub set_counters {
         },
     ];
     $self->{maps_counters}->{users} = [
-        { label => 'team-chat', set => {
+        { label => 'team-chat', nlabel => 'teams.users.messages.team.count', set => {
                 key_values => [ { name => 'team_chat' }, { name => 'name' } ],
                 output_template => 'Team Chat Message Count: %d',
                 perfdatas => [
@@ -156,7 +156,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'private-chat', set => {
+        { label => 'private-chat', nlabel => 'teams.users.messages.private.count', set => {
                 key_values => [ { name => 'private_chat' }, { name => 'name' } ],
                 output_template => 'Private Chat Message Count: %d',
                 perfdatas => [
@@ -165,7 +165,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'call', set => {
+        { label => 'call', nlabel => 'teams.users.call.count', set => {
                 key_values => [ { name => 'call' }, { name => 'name' } ],
                 output_template => 'Call Count: %d',
                 perfdatas => [
@@ -174,7 +174,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => 'meeting', set => {
+        { label => 'meeting', nlabel => 'teams.users.meeting.count', set => {
                 key_values => [ { name => 'meeting' }, { name => 'name' } ],
                 output_template => 'Meeting Count: %d',
                 perfdatas => [
@@ -210,6 +210,9 @@ sub manage_selection {
     my $results = $options{custom}->office_get_teams_activity();
 
     foreach my $user (@{$results}) {
+        # Let's lc the instance label to make metrics "clean"...
+        $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
+
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);

--- a/cloud/microsoft/office365/teams/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/teams/mode/usersactivity.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,12,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'teams.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/teams/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/teams/mode/usersactivity.pm
@@ -219,9 +219,6 @@ sub manage_selection {
     }
 
     foreach my $user (@{$results}, @{$results_daily}) {
-        # Let's lc the instance label to make metrics "clean"...
-        $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
-
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);

--- a/cloud/microsoft/office365/teams/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/teams/mode/usersactivity.pm
@@ -36,7 +36,7 @@ sub custom_active_perfdata {
     }
 
     $self->{result_values}->{report_date} =~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/;
-    $self->{output}->perfdata_add(label => 'perfdate', value => timegm(0,0,0,$3,$2-1,$1-1900));
+    $self->{output}->perfdata_add(label => 'perfdate', value => timelocal(0,0,0,$3,$2-1,$1-1900));
 
     $self->{output}->perfdata_add(label => 'active_users', nlabel => 'teams.users.active.count',
                                   value => $self->{result_values}->{active},

--- a/cloud/microsoft/office365/teams/mode/usersactivity.pm
+++ b/cloud/microsoft/office365/teams/mode/usersactivity.pm
@@ -213,6 +213,8 @@ sub manage_selection {
         # Let's lc the instance label to make metrics "clean"...
         $user->{'User Principal Name'} = lc($user->{'User Principal Name'});
 
+        $self->{active}->{report_date} = $user->{'Report Refresh Date'} if ($self->{active}->{report_date} eq '');
+
         if (defined($self->{option_results}->{filter_user}) && $self->{option_results}->{filter_user} ne '' &&
             $user->{'User Principal Name'} !~ /$self->{option_results}->{filter_user}/) {
             $self->{output}->output_add(long_msg => "skipping '" . $user->{'User Principal Name'} . "': no matching filter name.", debug => 1);
@@ -227,7 +229,6 @@ sub manage_selection {
             next;
         }
 
-        $self->{active}->{report_date} = $user->{'Report Refresh Date'};
         $self->{active}->{active}++;
 
         $self->{global}->{team_chat} += $user->{'Team Chat Message Count'};


### PR DESCRIPTION
Hi,

Here's a rework of Office365 plugins.

- I add some new labels (this helps #1989).
- I rename some counters to better correspond to what the API calls return, and to avoid having identical counters over different modes.
- I add a few new counters.
- I update some instance labels to make things proper / easier.
- I rename `onedrive` `usage` mode to `site-usage` (as it is with `sharepoint`).
- I add the `onedrive` `users-activity` mode (as we have with `sharepoint`).
- I now use daily data to compute the active counters, to have more relevant numbers than the 7-days aggregated ones.
- I add a `perfdate` perfdata counter set to the _Report Refresh Date_, so that it can be used by Stream Connector Scripts to properly set the data timestamp (see https://github.com/centreon/centreon-stream-connector-scripts/pull/23).

Thank you 👍