### PR TITLE
fix(idrac) "other" status is WARNING

### DIFF
--- a/hardware/server/dell/idrac/snmp/mode/globalstatus.pm
+++ b/hardware/server/dell/idrac/snmp/mode/globalstatus.pm
@@ -173,12 +173,12 @@ Can used special variables like: %{status}
 
 =item B<--warning-status>
 
-Set warning threshold for status (Default: '%{status} =~ /nonRecoverable|non critical|other/i').
+Set warning threshold for status (Default: '%{status} =~ /non critical|other/i').
 Can used special variables like: %{status}
 
 =item B<--critical-status>
 
-Set critical threshold for status (Default: '%{status} =~ /^critical/i').
+Set critical threshold for status (Default: '%{status} =~ /^critical|nonRecoverable/i').
 Can used special variables like: %{status}
 
 =item B<--unknown-storage-status>
@@ -188,12 +188,12 @@ Can used special variables like: %{status}
 
 =item B<--warning-storage-status>
 
-Set warning threshold for status (Default: '%{status} =~ /nonRecoverable|non critical|other/i').
+Set warning threshold for status (Default: '%{status} =~ /non critical|other/i').
 Can used special variables like: %{status}
 
 =item B<--critical-storage-status>
 
-Set critical threshold for status (Default: '%{status} =~ /^critical/i').
+Set critical threshold for status (Default: '%{status} =~ /^critical|nonRecoverable/i').
 Can used special variables like: %{status}
 
 =back

--- a/hardware/server/dell/idrac/snmp/mode/globalstatus.pm
+++ b/hardware/server/dell/idrac/snmp/mode/globalstatus.pm
@@ -88,11 +88,11 @@ sub new {
     
     $options{options}->add_options(arguments => {
         "unknown-status:s"          => { name => 'unknown_status', default => '%{status} =~ /^unknown/i' },
-        "warning-status:s"          => { name => 'warning_status', default => '%{status} =~ /nonRecoverable|non critical|other/i' },
-        "critical-status:s"         => { name => 'critical_status', default => '%{status} =~ /^critical/i' },
+        "warning-status:s"          => { name => 'warning_status', default => '%{status} =~ /non critical|other/i' },
+        "critical-status:s"         => { name => 'critical_status', default => '%{status} =~ /^critical|nonRecoverable/i' },
         "unknown-storage-status:s"  => { name => 'unknown_storage_status', default => '%{status} =~ /^unknown/i' },
-        "warning-storage-status:s"  => { name => 'warning_storage_status', default => '%{status} =~ /nonRecoverable|non critical|other/i' },
-        "critical-storage-status:s" => { name => 'critical_storage_status', default => '%{status} =~ /^critical/i' },
+        "warning-storage-status:s"  => { name => 'warning_storage_status', default => '%{status} =~ /non critical|other/i' },
+        "critical-storage-status:s" => { name => 'critical_storage_status', default => '%{status} =~ /^critical|nonRecoverable/i' },
     });
 
     return $self;

--- a/hardware/server/dell/idrac/snmp/mode/hardware.pm
+++ b/hardware/server/dell/idrac/snmp/mode/hardware.pm
@@ -40,7 +40,7 @@ sub set_system {
             ['enabledAndNotReady', 'WARNING'],
         ],
         'default.status' => [
-            ['other', 'UNKNOWN'],
+            ['other', 'WARNING'],
             ['unknown', 'UNKNOWN'],
             ['ok', 'OK'],
             ['nonCritical', 'WARNING'],
@@ -48,7 +48,7 @@ sub set_system {
             ['nonRecoverable', 'CRITICAL'],
         ],
         'probe.status' => [
-            ['other', 'UNKNOWN'],
+            ['other', 'WARNING'],
             ['unknown', 'UNKNOWN'],
             ['ok', 'OK'],
             ['nonCriticalUpper', 'WARNING'],


### PR DESCRIPTION
Hi,

As it is already in `globalstatus` mode, let's make the `other` status return `WARNING` (instead of `UNKNOWN` currently).
It's then more consistent.

Same thing with `nonRecoverable` status, let's make it consistent over the different modes...

Some thoughts regarding `unknown` status set to an `UNKNOWN` alert level.
It's true that `unknown` = `UNKNOWN` :)
But here, the device properly responded, with an `unknown` status, shouldn't we consider this as a `WARNING` level ? Could be a proper issue.
I thought that `UNKNOWN` was rather meant for communication errors or inconsistent results / things.

Feel free if I'm wrong, and thank you for your feedback 👍