### PR TITLE
ansible tower restapi

### DIFF
--- a/apps/automation/ansible/tower/restapi/custom/api.pm
+++ b/apps/automation/ansible/tower/restapi/custom/api.pm
@@ -211,17 +211,15 @@ sub settings {
     $self->build_options_for_httplib();
 
     # When using session authentication, we must set www-form-urlencoded as content-type
-    # if (defined($self->{session_id}) || defined($self->{api_token}) || defined($self->{api_username})) {
     $self->{http}->add_header(key => 'Content-Type', value => 'application/json;charset=UTF-8');
     $self->{http}->add_header(key => 'Accept', value => 'application/json;charset=UTF-8');
-    # }
     if (defined $self->{api_token}) {
         $self->{http}->add_header(key => 'Authorization', value => 'Bearer ' . $self->{api_token});
     } elsif (defined($self->{api_username}) && defined($self->{api_password})) {
-        # XXX store base64 encoded info as self property ?
+        # XXX store base64 encoded info as an object property ?
         $self->{http}->add_header(key => 'Authorization', value => 'Basic ' . encode_base64($self->{api_username} . ':' . $self->{api_password}, ''));  
     } else {
-        # XXX Do we really want this ?
+        # XXX Do we really want session authentication wwith cookies ?
         $self->session_authentication();
     }
     $self->{http}->set_options(%{$self->{option_results}});
@@ -363,8 +361,6 @@ sub plugin_exit() {
     my $force_ignore_perfdata = defined($options{force_ignore_perfdata}) ? $options{force_ignore_perfdata} : 1;
     my $force_long_output = defined($options{force_long_output}) ? $options{force_long_output} : 1;
 
-    # $self->{output}->output_add(severity => $options{severity},
-    #     short_msg => $options{short_message});
     $self->{output}->output_add(severity => $self->{status},
         short_msg => $options{short_message});
     $self->{output}->display(force_ignore_perfdata => $force_ignore_perfdata, force_long_output => $force_long_output);

--- a/apps/automation/ansible/tower/restapi/custom/api.pm
+++ b/apps/automation/ansible/tower/restapi/custom/api.pm
@@ -1,0 +1,413 @@
+#...
+# Authors: Guillaume Carpentier <guillaume.carpentier@externes.justice.gouv.fr>
+
+package apps::automation::ansible::tower::restapi::custom::api;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use centreon::plugins::statefile;
+use JSON::XS;
+use Digest::MD5 qw(md5_hex);
+use MIME::Base64 qw(encode_base64);
+
+my %job_status_mapping = (
+    'running' => 'UNKNOWN', # Running, should not be stuck too long in this state
+    'successful' => 'OK', # This should be the only state we consider as OK
+    'failed' => 'CRITICAL', # Something bad happened
+    'canceled' => 'WARNING', # Not really critical because it was deliberate
+    'pending' => 'UNKNOWN', # Just like running state
+    'default' => 'UNKNOWN', # should not happen
+);
+
+my $exit_status = {
+    'OK' => 0,
+    'WARNING' => 1,
+    'CRITICAL' => 2,
+    'UNKNOWN' => 3
+};
+
+# From centreon/plugins/backend/http/curl.pm
+# No info in lwp.pm which is the default backend and curl.pm needs Curl::Easy installation
+# XXX Should be set in centreon/plugins/http.pm ???
+my $http_code_explained = {
+    100 => 'Continue',
+    101 => 'Switching Protocols',
+    200 => 'OK',
+    201 => 'Created',
+    202 => 'Accepted',
+    203 => 'Non-Authoritative Information',
+    204 => 'No Content',
+    205 => 'Reset Content',
+    206 => 'Partial Content',
+    300 => 'Multiple Choices',
+    301 => 'Moved Permanently',
+    302 => 'Found',
+    303 => 'See Other',
+    304 => 'Not Modified',
+    305 => 'Use Proxy',
+    306 => '(Unused)',
+    307 => 'Temporary Redirect',
+    400 => 'Bad Request',
+    401 => 'Unauthorized',
+    402 => 'Payment Required',
+    403 => 'Forbidden',
+    404 => 'Not Found',
+    405 => 'Method Not Allowed',
+    406 => 'Not Acceptable',
+    407 => 'Proxy Authentication Required',
+    408 => 'Request Timeout',
+    409 => 'Conflict',
+    410 => 'Gone',
+    411 => 'Length Required',
+    412 => 'Precondition Failed',
+    413 => 'Request Entity Too Large',
+    414 => 'Request-URI Too Long',
+    415 => 'Unsupported Media Type',
+    416 => 'Requested Range Not Satisfiable',
+    417 => 'Expectation Failed',
+    500 => 'Internal Server Error',
+    501 => 'Not Implemented',
+    502 => 'Bad Gateway',
+    503 => 'Service Unavailable',
+    504 => 'Gateway Timeout',
+    505 => 'HTTP Version Not Supported',
+};
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    if (!defined($options{output})) {
+        print "Class Custom: Need to specify 'output' argument.\n";
+        exit 3;
+    }
+    if (!defined($options{options})) {
+        $options{output}->add_option_msg(short_msg => "Class Custom: Need to specify 'options' argument.");
+        $options{output}->option_exit();
+    }
+    
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            'hostname:s'        => { name => 'hostname' },
+            'port:s'            => { name => 'port'},
+            'proto:s'           => { name => 'proto' },
+            'api-username:s'    => { name => 'api_username' },
+            'api-password:s'    => { name => 'api_password' },
+            'api-token:s'       => { name => 'api_token' },
+            'timeout:s'         => { name => 'timeout', default => 30 },
+        });
+    }
+    
+    $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
+
+    $self->{output} = $options{output};
+    $self->{mode} = $options{mode};
+    $self->{http} = centreon::plugins::http->new(%options);
+    $self->{cache} = centreon::plugins::statefile->new(%options);
+    $self->{status} = 'OK';
+
+    return $self;
+}
+
+sub get_job_status_severity {
+    my ($self, %options) = @_;
+
+    if (defined($options{status}) &&
+        defined($job_status_mapping{$options{status}}) ) {
+        return $job_status_mapping{$options{status}};
+    } else {
+        return $job_status_mapping{'default'};
+    }
+}
+
+sub escalate_status {
+    my ($self, %options) = @_;
+
+    if (exists $exit_status->{$options{'status'}}) {
+        if ($exit_status->{$options{'status'}} > $exit_status->{$self->{status}}) {
+            $self->{status} = $options{'status'};
+        }
+    }
+}
+
+sub get_status {
+    my ($self, %options) = @_;
+
+    return $self->{status};
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+
+    $self->{option_results} = $options{option_results};
+}
+
+sub set_defaults {
+    my ($self, %options) = @_;
+
+    foreach (keys %{$options{default}}) {
+        if ($_ eq $self->{mode}) {
+            for (my $i = 0; $i < scalar(@{$options{default}->{$_}}); $i++) {
+                foreach my $opt (keys %{$options{default}->{$_}[$i]}) {
+                    if (!defined($self->{option_results}->{$opt}[$i])) {
+                        $self->{option_results}->{$opt}[$i] = $options{default}->{$_}[$i]->{$opt};
+                    }
+                }
+            }
+        }
+    }
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+
+    $self->{hostname} = (defined($self->{option_results}->{hostname})) ? $self->{option_results}->{hostname} : undef;
+    $self->{port} = (defined($self->{option_results}->{port})) ? $self->{option_results}->{port} : 443;
+    $self->{proto} = (defined($self->{option_results}->{proto})) ? $self->{option_results}->{proto} : 'https';
+    $self->{timeout} = (defined($self->{option_results}->{timeout})) ? $self->{option_results}->{timeout} : 30;
+    $self->{api_username} = (defined($self->{option_results}->{api_username})) ? $self->{option_results}->{api_username} : undef;
+    $self->{api_password} = (defined($self->{option_results}->{api_password})) ? $self->{option_results}->{api_password} : undef;
+    $self->{api_token} = (defined($self->{option_results}->{api_token})) ? $self->{option_results}->{api_token} : undef;
+
+    if (!defined($self->{hostname}) || $self->{hostname} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --hostname option.");
+        $self->{output}->option_exit();
+    }
+
+    if (!defined($self->{api_token})) {
+        if (!defined($self->{api_username}) || $self->{api_username} eq '') {
+            $self->{output}->add_option_msg(short_msg => "Need to specify --api-username option.");
+            $self->{output}->option_exit();
+        }
+        if (!defined($self->{api_password}) || $self->{api_password} eq '') {
+            $self->{output}->add_option_msg(short_msg => "Need to specify --api-password option.");
+            $self->{output}->option_exit();
+        }
+    } elsif ($self->{api_token} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --api-token option.");
+        $self->{output}->option_exit();
+    }
+    $self->{cache}->check_options(option_results => $self->{option_results});
+
+    return 0;
+}
+
+sub build_options_for_httplib {
+    my ($self, %options) = @_;
+
+    $self->{option_results}->{hostname} = $self->{hostname};
+    $self->{option_results}->{port} = $self->{port};
+    $self->{option_results}->{proto} = $self->{proto};
+    $self->{option_results}->{timeout} = $self->{timeout};
+}
+
+sub settings {
+    my ($self, %options) = @_;
+
+    $self->build_options_for_httplib();
+
+    # When using session authentication, we must set www-form-urlencoded as content-type
+    # if (defined($self->{session_id}) || defined($self->{api_token}) || defined($self->{api_username})) {
+    $self->{http}->add_header(key => 'Content-Type', value => 'application/json;charset=UTF-8');
+    $self->{http}->add_header(key => 'Accept', value => 'application/json;charset=UTF-8');
+    # }
+    if (defined $self->{api_token}) {
+        $self->{http}->add_header(key => 'Authorization', value => 'Bearer ' . $self->{api_token});
+    } elsif (defined($self->{api_username}) && defined($self->{api_password})) {
+        # XXX store base64 encoded info as self property ?
+        $self->{http}->add_header(key => 'Authorization', value => 'Basic ' . encode_base64($self->{api_username} . ':' . $self->{api_password}, ''));  
+    } else {
+        # XXX Do we really want this ?
+        $self->session_authentication();
+    }
+    $self->{http}->set_options(%{$self->{option_results}});
+}
+
+sub json_decode {
+    my ($self, %options) = @_;
+
+    my $decoded;
+    eval {
+        $decoded = JSON::XS->new->utf8->decode($options{content});
+    };
+    if ($@) {
+        $self->{output}->add_option_msg(short_msg => "Cannot decode json response: $@");
+        $self->{output}->option_exit();
+    }
+
+    return $decoded;
+}
+
+# XXX regex pattern could be an arg
+sub str_to_hash {
+    my ($self, %options) = @_;
+
+    my $hash = {};
+    my ($value, $key);
+    if (defined($options{str}) && length $options{str} > 0) {
+        for my $elt (split(/,/, $options{str})) {
+            if ($elt =~ /(?<key>[\w_\.]+)=(?<value>[\w_\.]+)/) {
+                $key = $+{key};
+                $value = $+{value};
+                # Fix JSON encode with numerics and ints
+                if ($value =~ /^[\d]+(?:\.[\d]+)?$/) {
+                    $hash->{$key} = $value + 0;
+                } else {
+                    $hash->{$key} = $value;
+                }
+            }
+        }
+    }
+
+    return $hash;
+}
+
+# XXX Unused ! Works only with GET requests
+# XXX manage cookies file in a better way
+sub session_authentication() {
+    my ($self, %options) = @_;
+
+    my $state_file = 'automation_ansible_tower_api_' . md5_hex($self->{option_results}->{hostname}) . '_' . md5_hex($self->{option_results}->{api_username});
+    my $cookies_file = 'automation_ansible_tower_api_cookie_' . md5_hex($self->{option_results}->{hostname}) . '_' . md5_hex($self->{option_results}->{api_username});
+
+    # my $has_cache_file = $options{statefile}->read(statefile => $state_file);
+    # my $session_id = $options{statefile}->get(name => 'session_id');
+
+    # cookies file is managed by lwp backend when defined and != '' otherwise does not work well
+    if (! -e $cookies_file && 0) { # || !defined($session_id) ) {
+        my $content = $self->{http}->request(method => 'GET',
+            url_path => '/api/login/',
+            cookies_file => $cookies_file,
+            warning_status => '', unknown_status => '', critical_status => '');
+        my $csrf_cookie = $self->{http}->get_header(name => 'Set-Cookie');
+        if ($csrf_cookie !~ /^csrftoken=(?<csrftoken>[a-zA-Z0-9]+);/) {
+            $self->{output}->add_option_msg(short_msg => "No valid csrf token found.");
+            $self->{output}->option_exit();
+        }
+        $self->{csrftoken} = $+{csrftoken};
+
+        # Must not set content type otherwise post_params is not interpreted (seriously ?)
+        # $self->{http}->add_header(key => 'Content-Type', value => 'application/x-www-form-urlencoded');
+        $self->{http}->add_header(key => 'X-CSRFToken', value => $self->{csrftoken});
+
+        my $response = $self->{http}->request(
+                                method => 'POST',
+                                url_path => '/api/login/',
+                                cookies_file => $cookies_file,
+                                post_params => { 'username' => $self->{api_username}, 'password' => $self->{api_password}},
+                                warning_status => '', unknown_status => '', critical_status => '',
+                                );
+        if ($self->{http}->get_code() != 302 && $self->{http}->get_code() != 404) {
+            $self->{output}->add_option_msg(short_msg => "Login error [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']");
+            $self->{output}->option_exit();
+        }
+
+        my $session_id_cookie = $self->{http}->get_header(name => 'Set-Cookie');
+        if ($session_id_cookie !~ /^sessionid=(?<session_id>[a-zA-Z0-9]+);/) {
+            $self->{output}->add_option_msg(short_msg => "No session id found.");
+            $self->{output}->option_exit();
+        }
+        my $session_id = $+{session_id};
+        my $datas = { last_timestamp => time(), session_id => $session_id };
+        # $options{statefile}->write(data => $datas);
+        $self->{session_id} = $session_id;
+    }
+    # $self->{http}->add_header(key => 'sessionid', value => $self->{session_id});
+    $self->{cookies_file} = $cookies_file;
+}
+
+sub request_api() {
+    my ($self, %options) = @_;
+
+    $self->settings();
+
+    # XXX Set default request options with HASH struct ?
+    my $response = $self->{http}->request(
+            method => (defined($options{method})?$options{method}:'GET'),
+            url_path => (defined($options{url_path})?$options{url_path}:'/'),
+            query_form_post => (defined($options{query_form_post})?$options{query_form_post}:undef),
+            critical_status => (defined($options{critical_status})?$options{critical_status}:''),
+            warning_status => (defined($options{warning_status})?$options{warning_status}:''),
+            unknown_status => (defined($options{unknown_status})?$options{unknown_status}:'')
+            );
+    
+    # Set 200 as default status code if not provided
+    my $status_code = defined($options{status_code}) ? $options{status_code} : 200;
+    my $decoded = $self->json_decode(content => $response);
+    if (!defined($decoded)) {
+        $self->{output}->add_option_msg(short_msg => "Error while retrieving data (add --debug option for detailed message)");
+        $self->{output}->option_exit();
+    }
+
+    if ($self->{http}->get_code() != $status_code) {
+        if (defined($decoded) && !defined($decoded->{type})) {
+            $self->{output}->add_option_msg(short_msg => '[' . $self->{http}->get_code() . '] - ' .
+                            $http_code_explained->{$self->{http}->get_code()} . ' for url_path:' .
+                            $options{url_path} . ' message:'.$response);
+        } else {
+            $self->{output}->add_option_msg(short_msg => 'Api request error: ' . (defined($decoded->{type}) ? $decoded->{type} : 'unknown'));
+        }
+        $self->{output}->option_exit();
+    }
+    
+    return $decoded;
+}
+
+# XXX add long_message ?
+sub plugin_exit() {
+    my ($self, %options) = @_;
+    my $force_ignore_perfdata = defined($options{force_ignore_perfdata}) ? $options{force_ignore_perfdata} : 1;
+    my $force_long_output = defined($options{force_long_output}) ? $options{force_long_output} : 1;
+
+    # $self->{output}->output_add(severity => $options{severity},
+    #     short_msg => $options{short_message});
+    $self->{output}->output_add(severity => $self->{status},
+        short_msg => $options{short_message});
+    $self->{output}->display(force_ignore_perfdata => $force_ignore_perfdata, force_long_output => $force_long_output);
+    $self->{output}->exit();
+}
+
+1;
+
+
+__END__
+
+=head1 NAME
+
+AWX Rest API
+
+=head1 REST API OPTIONS
+
+=over 8
+
+=item B<--hostname>
+
+Set hostname or IP of vsca.
+
+=item B<--port>
+
+Set port (Default: '443').
+
+=item B<--proto>
+
+Specify https if needed (Default: 'https').
+
+=item B<--api-username>
+
+Set username.
+
+=item B<--api-password>
+
+Set password.
+
+=item B<--timeout>
+
+Threshold for HTTP timeout (Default: '30').
+
+=back
+
+=cut

--- a/apps/automation/ansible/tower/restapi/mode/jobs.pm
+++ b/apps/automation/ansible/tower/restapi/mode/jobs.pm
@@ -1,0 +1,108 @@
+#...
+# Authors: Guillaume Carpentier <guillaume.carpentier@externes.justice.gouv.fr>
+
+package apps::automation::ansible::tower::restapi::mode::jobs;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use centreon::plugins::statefile;
+use JSON::XS;
+
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{version} = '0.1';
+    $self->{object_type} = 'job';
+
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            "job:s" => { name => 'job'},
+        });
+    }
+
+    $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
+    # $self->{http} = centreon::plugins::http->new(%options);
+    $self->{mode} = $options{mode};
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+    if (!defined($self->{option_results}->{job}) || $self->{option_results}->{job} !~ /^[0-9]+$/ ) {
+        $self->{output}->add_option_msg(short_msg => "Need to specify job id (numeric value) option.");
+        $self->{output}->option_exit();
+    }
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    my %status;
+    my @short_messages;
+    my $path = '/api/v2/jobs/' . $self->{option_results}->{job};
+    my $result = $options{custom}->request_api(
+                    url_path => $path,
+                    method => 'GET',
+                    status_code => 200);
+    my $job_name = $result->{name};
+
+    # An other approach to find play logs with no match
+    # $path = '/api/v2/jobs/' . $self->{option_results}->{job} . '/job_events/';
+    # my $event = $options{custom}->request_api(
+    #                 url_path => $path,
+    #                 method => 'GET',
+    #                 status_code => 200);
+
+    # Contains events hash or 0 if none found.
+    # my @filtered_events = grep { $_->{event} =~ /^playbook_on_no_hosts_matched$/ } @{$event->{results}};
+
+    # Compute exit code
+    $options{custom}->escalate_status(status => $options{custom}->get_job_status_severity(status => $result->{status}));
+    push @short_messages, 'Job \'' . $job_name . '\' was ' . $result->{status};
+
+    # Handle the OK state when no hosts matched.
+    if ($options{custom}->get_status() =~ /^OK$/ ) {
+        # Simpler job_host_summaries contains the hosts that ran the play.
+        $path = '/api/v2/jobs/' . $self->{option_results}->{job} . '/job_host_summaries/';
+        my $summary_event = $options{custom}->request_api(
+                        url_path => $path,
+                        method => 'GET',
+                        status_code => 200);
+
+        # No hosts match is relevant only when result is false-positive
+        if ($summary_event->{count} == 0) {
+            $options{custom}->escalate_status(status => 'CRITICAL');
+            push @short_messages, 'But no hosts matched !'
+        }
+    }
+    # Add job uri detail
+    push @short_messages, '(' . $self->{option_results}->{proto} . '://' . $self->{option_results}->{hostname} . $result->{url} . ')';
+
+    $options{custom}->plugin_exit(short_message => join('. ', @short_messages));
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Lauch a Job template and check its result.
+
+=over 8
+
+=item B<--job-template>
+
+Id of the job template.
+
+=back
+
+=cut

--- a/apps/automation/ansible/tower/restapi/mode/jobs.pm
+++ b/apps/automation/ansible/tower/restapi/mode/jobs.pm
@@ -27,7 +27,6 @@ sub new {
     }
 
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
-    # $self->{http} = centreon::plugins::http->new(%options);
     $self->{mode} = $options{mode};
 
     return $self;
@@ -55,14 +54,13 @@ sub run {
     my $job_name = $result->{name};
 
     # An other approach to find play logs with no match
-    # $path = '/api/v2/jobs/' . $self->{option_results}->{job} . '/job_events/';
-    # my $event = $options{custom}->request_api(
+    #$path = '/api/v2/jobs/' . $self->{option_results}->{job} . '/job_events/';
+    #my $event = $options{custom}->request_api(
     #                 url_path => $path,
     #                 method => 'GET',
     #                 status_code => 200);
-
     # Contains events hash or 0 if none found.
-    # my @filtered_events = grep { $_->{event} =~ /^playbook_on_no_hosts_matched$/ } @{$event->{results}};
+    #my @filtered_events = grep { $_->{event} =~ /^playbook_on_no_hosts_matched$/ } @{$event->{results}};
 
     # Compute exit code
     $options{custom}->escalate_status(status => $options{custom}->get_job_status_severity(status => $result->{status}));

--- a/apps/automation/ansible/tower/restapi/mode/jobtemplate.pm
+++ b/apps/automation/ansible/tower/restapi/mode/jobtemplate.pm
@@ -1,0 +1,195 @@
+#...
+# Authors: Guillaume Carpentier <guillaume.carpentier@externes.justice.gouv.fr>
+
+package apps::automation::ansible::tower::restapi::mode::jobtemplate;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use JSON::XS;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{version} = '0.1';
+    $self->{object_type} = 'job-template';
+
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            "job-template:s" => { name => 'job_template'},
+            "extra-vars:s" => { name => 'extra_vars', default => undef},
+            "job-tags:s" => { name => 'job_tags'},
+            "limit:s" => { name => 'limit'},
+            "inventory:s" => { name => 'inventory'},
+            "credential:s" => { name => 'credential'},
+            "max-retries:s" => { name => 'max_retries', default => 20},
+            "retry-interval:s" => { name => 'retry_interval', default => 10},
+        });
+    }            
+    $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
+    $self->{mode} = $options{mode};
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+    if (!defined($self->{option_results}->{job_template}) || $self->{option_results}->{job_template} !~ /^[0-9]+$/ ) {
+        $self->{output}->add_option_msg(short_msg => "Need to specify job_template id (numeric value) option.");
+        $self->{output}->option_exit();
+    }
+    if ($self->{option_results}->{retry_interval} !~ /^[0-9]+$/ &&
+        int($self->{option_results}->{retry_interval}) == 0) {
+        $self->{output}->add_option_msg(short_msg => "Need to specify retry_interval (numeric value > 0) option.");
+        $self->{output}->option_exit();
+    }
+    if ($self->{option_results}->{max_retries} !~ /^[0-9]+$/ &&
+        int($self->{option_results}->{max_retries}) == 0) {
+        $self->{output}->add_option_msg(short_msg => "Need to specify max_retries (numeric value > 0) option.");
+        $self->{output}->option_exit();
+    }
+    if (defined($self->{option_results}->{extra_vars}) &&
+        $self->{option_results}->{extra_vars} !~ /^[\w_\.]+=[\w_\.]+(?:,[\w_\.]+=[\w_\.]+)*$/) {
+        $self->{output}->add_option_msg(short_msg => "Extra vars should be written like this 'k1=v1,k2=v2...'");
+        $self->{output}->option_exit();
+    }
+    if (defined($self->{option_results}->{credential}) &&
+        $self->{option_results}->{credential} !~ /^[0-9]+$/) {
+        $self->{output}->add_option_msg(short_msg => "Option 'credential' must be an integer");
+        $self->{output}->option_exit();
+    }
+    if (defined($self->{option_results}->{inventory}) &&
+        $self->{option_results}->{inventory} !~ /^[0-9]+$/) {
+        $self->{output}->add_option_msg(short_msg => "Option 'inventory' must be an integer");
+        $self->{output}->option_exit();
+    }
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    my %status;
+    my $path = '/api/v2/job_templates/' . $self->{option_results}->{job_template} . '/launch/';
+
+    # Extra vars, inventories,...
+    my $json_request = {};
+
+    # https://docs.ansible.com/ansible-tower/3.2.6/html/towerapi/launch_jobtemplate.html
+    # Add 0 to lure Perl for a number, ahahah !
+    $json_request->{inventory} = ($self->{option_results}->{inventory} + 0) if defined($self->{option_results}->{inventory});
+    $json_request->{credential} = ($self->{option_results}->{credential} + 0) if defined($self->{option_results}->{credential});
+    $json_request->{limit} = $self->{option_results}->{limit} if defined($self->{option_results}->{limit});
+    $json_request->{job_tags} = $self->{option_results}->{job_tags} if defined($self->{option_results}->{job_tags});
+    $json_request->{extra_vars} = $options{custom}->str_to_hash(str => $self->{option_results}->{extra_vars});
+
+    my @short_messages;
+    my $encoded = {};
+    eval {
+        $encoded = encode_json($json_request);
+    };
+    if ($@) {
+        $self->{output}->add_option_msg(short_msg => "Cannot encode json request");
+        $self->{output}->option_exit();
+    }
+
+    my $result = $options{custom}->request_api(
+                                    method => 'POST',
+                                    url_path => $path,
+                                    query_form_post => $encoded,
+                                    status_code => 201);
+    my $job_template_name = $result->{name};
+
+    my ($job_completed, $retry_idx, $job_result);
+    $retry_idx = 0;
+    while ( !defined($job_completed) &&
+            $retry_idx < $self->{option_results}->{max_retries}) {
+        sleep ($self->{option_results}->{retry_interval}) if ($retry_idx > 0);
+        $job_result = $options{custom}->request_api(
+                        url_path => $result->{url});
+        # Will be defined when finished
+        $job_completed = $job_result->{finished};
+        $retry_idx++;
+    }
+
+    $options{custom}->escalate_status(status => $options{custom}->get_job_status_severity(status => $job_result->{status}));
+    push @short_messages, 'Job \'' . $job_template_name . '\' was ' . $job_result->{status};
+
+    # Handle the OK state when no hosts matched.
+    if ($options{custom}->get_status() =~ /^OK$/ ) {
+        # Get job_host_summaries containing the hosts that ran the play.
+        # $path = '/api/v2/jobs/' . $self->{option_results}->{job} . '/job_host_summaries/';
+        my $summary_event = $options{custom}->request_api(
+                        url_path => $result->{url} . 'job_host_summaries/',
+                        method => 'GET',
+                        status_code => 200);
+
+        # 'No hosts match' is kind of false-positive
+        if ($summary_event->{count} == 0) {
+            $options{custom}->escalate_status(status => 'CRITICAL');
+            push @short_messages, ' But no hosts matched !'
+        }
+    }
+    # Add job uri
+    push @short_messages, '(' . $self->{option_results}->{proto} . '://' . $self->{option_results}->{hostname} . $result->{url} . ')';
+
+    $options{custom}->plugin_exit(short_message => join('. ', @short_messages));
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Lauch a Job template and check its result.
+
+=over 8
+
+=item B<--job-template>
+
+Id of the job template.
+
+=item B<--max-retries>
+
+Number of retries to get job result once launched.
+Default : 20
+
+=item B<--retry-interval>
+
+Number of seconds between retries.
+Default : 10 seconds
+
+=item B<--extra-vars>
+
+Extra vars passed to job template with k1=v1,k2=v2.
+Keys and values must match [\w_\.]+
+Only works for job templates with extra-vars enabled (prompt on launch checked).
+
+=item B<--job-tags>
+
+A string that represents a comma-separated list of tags in the playbook to run.
+Only works for job templates with job tags enabled (prompt on launch checked).
+
+=item B<--limit>
+
+A string that represents a comma-separated list of hosts or groups to operate on.
+Only works for job templates with limit enabled (prompt on launch checked).
+
+=item B<--inventory>
+
+A integer value for the foreign key of an inventory to use in this job run.
+Only works for job templates with inventory enabled (prompt on launch checked).
+
+=item B<--credential>
+
+A integer value for the foreign key of a credential to use in this job run.
+Only works for job templates with credential enabled (prompt on launch checked).
+
+=back
+
+=cut

--- a/apps/automation/ansible/tower/restapi/mode/jobtemplate.pm
+++ b/apps/automation/ansible/tower/restapi/mode/jobtemplate.pm
@@ -76,11 +76,9 @@ sub run {
     my %status;
     my $path = '/api/v2/job_templates/' . $self->{option_results}->{job_template} . '/launch/';
 
-    # Extra vars, inventories,...
     my $json_request = {};
 
     # https://docs.ansible.com/ansible-tower/3.2.6/html/towerapi/launch_jobtemplate.html
-    # Add 0 to lure Perl for a number, ahahah !
     $json_request->{inventory} = ($self->{option_results}->{inventory} + 0) if defined($self->{option_results}->{inventory});
     $json_request->{credential} = ($self->{option_results}->{credential} + 0) if defined($self->{option_results}->{credential});
     $json_request->{limit} = $self->{option_results}->{limit} if defined($self->{option_results}->{limit});
@@ -122,7 +120,6 @@ sub run {
     # Handle the OK state when no hosts matched.
     if ($options{custom}->get_status() =~ /^OK$/ ) {
         # Get job_host_summaries containing the hosts that ran the play.
-        # $path = '/api/v2/jobs/' . $self->{option_results}->{job} . '/job_host_summaries/';
         my $summary_event = $options{custom}->request_api(
                         url_path => $result->{url} . 'job_host_summaries/',
                         method => 'GET',
@@ -134,7 +131,8 @@ sub run {
             push @short_messages, ' But no hosts matched !'
         }
     }
-    # Add job uri
+
+    # Add job uri detail
     push @short_messages, '(' . $self->{option_results}->{proto} . '://' . $self->{option_results}->{hostname} . $result->{url} . ')';
 
     $options{custom}->plugin_exit(short_message => join('. ', @short_messages));

--- a/apps/automation/ansible/tower/restapi/mode/schedule.pm
+++ b/apps/automation/ansible/tower/restapi/mode/schedule.pm
@@ -64,8 +64,8 @@ sub run {
         $options{custom}->plugin_exit(short_message => $schedule_name . ' is disabled.');
     }
 
-    # Get all jobs starting with the latest for the schedule. If we checked first the job-template/ or jobs/
-    # we could have some jobs launched manually
+    # Get all jobs starting with the latest for the schedule. If we checked only the job-template/ or jobs/
+    # endpoint we could have some jobs launched manually and not by the scheduler
     $path = '/api/v2/schedules/' . $self->{option_results}->{schedule} . '/jobs/?order_by=-id&page_size=1';
     my $last_jobs = $options{custom}->request_api(
                         url_path => $path,
@@ -78,7 +78,6 @@ sub run {
     my $last_job = $last_jobs->{results}[0];
     my $last_job_uri;
     # Get finished date and compute freshness for ie : 2020-06-11T09:20:41.809341Z
-    # Remove microseconds - not parsed with Time::Piece
     if (defined($last_job->{finished})) {
         my $finished = ParseDate($last_job->{finished});
         my $now = localtime;

--- a/apps/automation/ansible/tower/restapi/mode/schedule.pm
+++ b/apps/automation/ansible/tower/restapi/mode/schedule.pm
@@ -1,0 +1,139 @@
+#...
+# Authors: Guillaume Carpentier <guillaume.carpentier@externes.justice.gouv.fr>
+
+package apps::automation::ansible::tower::restapi::mode::schedule;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use centreon::plugins::statefile;
+use JSON::XS;
+use Date::Parse;
+use Date::Manip;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{version} = '0.1';
+    $self->{object_type} = 'schedule';
+
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            "schedule:s" => { name => 'schedule'},
+            "freshness:s" => { name => 'freshness', default => 2 },
+        });
+    }
+
+    $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
+    $self->{mode} = $options{mode};
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+    if (!defined($self->{option_results}->{schedule}) || $self->{option_results}->{schedule} !~ /^[0-9]+$/ ) {
+        $self->{output}->add_option_msg(short_msg => "Need to specify schedule id (numeric value) option.");
+        $self->{output}->option_exit();
+    }
+    if ($self->{option_results}->{freshness} !~ /^[0-9]+$/ || $self->{option_results}->{freshness} == 0) {
+        $self->{output}->add_option_msg(short_msg => "Need to specify freshness (>0) option.");
+        $self->{output}->option_exit();
+    }
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    my %status;
+    my $path = '/api/v2/schedules/' . $self->{option_results}->{schedule};
+    my $result = $options{custom}->request_api(
+                    url_path => $path,
+                    method => 'GET',
+                    status_code => 200);
+    my $schedule_name = $result->{name};
+    my @short_messages;
+
+    if (! $result->{enabled}) {
+        $options{custom}->escalate_status(status => 'CRITICAL');
+        $options{custom}->plugin_exit(short_message => $schedule_name . ' is disabled.');
+    }
+
+    # Get all jobs starting with the latest for the schedule. If we checked first the job-template/ or jobs/
+    # we could have some jobs launched manually
+    $path = '/api/v2/schedules/' . $self->{option_results}->{schedule} . '/jobs/?order_by=-id&page_size=1';
+    my $last_jobs = $options{custom}->request_api(
+                        url_path => $path,
+                        method => 'GET');
+    if (scalar $last_jobs->{results} == 0) {
+        $options{custom}->escalate_status(status => 'CRITICAL');
+        $options{custom}->plugin_exit(short_message => 'No job found for ' . $schedule_name);
+    }
+
+    my $last_job = $last_jobs->{results}[0];
+    my $last_job_uri;
+    # Get finished date and compute freshness for ie : 2020-06-11T09:20:41.809341Z
+    # Remove microseconds - not parsed with Time::Piece
+    if (defined($last_job->{finished})) {
+        my $finished = ParseDate($last_job->{finished});
+        my $now = localtime;
+        my $err;
+        my $diff = DateCalc($finished, $now, \$err);
+        if (Delta_Format($diff, 0, '%st')/3600 > $self->{option_results}->{freshness} ) {
+            $options{custom}->escalate_status(status => 'CRITICAL');
+            push @short_messages, 'Last job is too old, finished : ' . UnixDate($finished,  '%d/%m/%Y %H:%M');
+        }
+        $last_job_uri = $self->{option_results}->{proto} . '://' . $self->{option_results}->{hostname} . $last_job->{url};
+    }
+    
+    # Get exit code from status
+    $options{custom}->escalate_status(status => $options{custom}->get_job_status_severity(status => $last_job->{status}));
+    push @short_messages, 'Job \'' . $last_job->{name} . '\' was ' . $last_job->{status};
+
+    # Handle the OK state when no hosts matched.
+    if ($options{custom}->get_status() =~ /^OK$/ ) {
+        $path = '/api/v2/jobs/' . $last_job->{id} . '/job_host_summaries/';
+        my $summary_event = $options{custom}->request_api(
+                        url_path => $path,
+                        method => 'GET',
+                        status_code => 200);
+
+        # No hosts matched. Only when result is false-positive
+        if ($summary_event->{count} == 0) {
+            $options{custom}->escalate_status(status => 'CRITICAL');
+            push @short_messages, 'But no hosts matched !'
+        }
+    }
+
+    # Add url detail at the end
+    push @short_messages, '(' . $last_job_uri . ')' if ($last_job_uri !~ /^$/);
+    $options{custom}->plugin_exit(short_message => join('. ', @short_messages));
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check last job from given scheduled job template.
+
+=over 8
+
+=item B<--schedule>
+
+Id of scheduled job-template
+
+=item B<--freshness>
+
+Max age of the latest job (in hours)
+Default: 2
+
+=back
+
+=cut

--- a/apps/automation/ansible/tower/restapi/plugin.pm
+++ b/apps/automation/ansible/tower/restapi/plugin.pm
@@ -1,0 +1,42 @@
+#...
+# Authors: Guillaume Carpentier <guillaume.carpentier@externes.justice.gouv.fr>
+
+package apps::automation::ansible::tower::restapi::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_custom);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{version} = '1.0';
+    %{$self->{modes}} = (
+        'job-template'   => 'apps::automation::ansible::tower::restapi::mode::jobtemplate',
+        'jobs'           => 'apps::automation::ansible::tower::restapi::mode::jobs',
+        'schedule'       => 'apps::automation::ansible::tower::restapi::mode::schedule',
+    );
+    $self->{custom_modes}{api} = 'apps::automation::ansible::tower::restapi::custom::api';
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 PLUGIN DESCRIPTION
+
+Checks various elements of Tower/AWX through its REST API.
+Currently supports :
+    check job result
+    check scheduled job-template result
+    launch job template and checks its result
+
+
+=over 8
+
+=back
+
+=cut


### PR DESCRIPTION
Bonjour,

Seul les status de job, schedule (latest job) et lancement de job-template sont supportés.

Les status code http du backend ont été mis dans dans `custom/api.pm` afin de ne pas modifier le backend global (`http.pm`) car je ne les ai vus que dans le backend `curl` et pas `lwp` (utilisé par défaut).

J'ai laissé l'authentification par session bien que cela ne soit pas vraiment fonctionnel. Si vous le souhaitez vous pouvez essayez de le faire fonctionner sinon on peut s'en passer.