### PR TITLE
enh(netscaler) Add standard modes

### DIFF
--- a/network/citrix/netscaler/snmp/plugin.pm
+++ b/network/citrix/netscaler/snmp/plugin.pm
@@ -42,6 +42,7 @@ sub new {
             'vserver-status'        => 'network::citrix::netscaler::snmp::mode::vserverstatus',
             'memory'                => 'network::citrix::netscaler::snmp::mode::memory',
             'connections'           => 'network::citrix::netscaler::snmp::mode::connections',
+            'uptime'                => 'snmp_standard::mode::uptime'
     );
 
     return $self;


### PR DESCRIPTION
Hi,
Let's add some standard modes to Netscaler.
Strangely enough it does not support `time` mode (`.1.3.6.1.2.1.25.1.2` is not available there).
Thx 👍 