### PR TITLE
enh(netscaler) Add CPU newlabel

### DIFF
--- a/network/citrix/netscaler/snmp/mode/cpu.pm
+++ b/network/citrix/netscaler/snmp/mode/cpu.pm
@@ -71,7 +71,7 @@ sub run {
         
         $self->{output}->output_add(severity => $exit,
                                     short_msg => sprintf("CPU '%s' Usage: %.2f%%", $name, $value));
-        $self->{output}->perfdata_add(label => "cpu_" . $name, unit => '%',
+        $self->{output}->perfdata_add(label => "cpu_" . $name, unit => '%', nlabel => $name . "#cpu.utilization.percentage",
                                       value => $value,
                                       warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                       critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical'),


### PR DESCRIPTION
Hi,

This PR adds a missing newlabel in Netscaler CPU mode.
It works, but up to you whether or not you prefer to fully refactor this mode.

Thx 👍