### PR TITLE
enh(whatchguard) Properly report 0 tunnel

### DIFF
--- a/network/watchguard/snmp/mode/ipsectunnel.pm
+++ b/network/watchguard/snmp/mode/ipsectunnel.pm
@@ -105,7 +105,7 @@ sub manage_selection {
         oid => $oid_wgIpsecTunnelEntry,
         start => $mapping->{wgIpsecTunnelLocalAddr}->{oid},
         end => $mapping->{wgIpsecTunnelPeerAddr}->{oid},
-        nothing_quit => 1
+        nothing_quit => 0
     );
     foreach (keys %$snmp_result) {
         next if (!/$mapping->{wgIpsecTunnelLocalAddr}->{oid}\.(.*)/);


### PR DESCRIPTION
Hi,

It's a normal situation, from time to time, to have 0 VPN / IPsec tunnel, depending whether or not there are connected users.
In this case, let's then properly report `OK: Total Tunnels: 0`, instead of returning an `UNKNOWN` status, which is not really expected here.

Thx 👍