### PR TITLE
Add new Loggly plugin

### DIFF
--- a/apps/monitoring/loggly/restapi/custom/api.pm
+++ b/apps/monitoring/loggly/restapi/custom/api.pm
@@ -1,0 +1,246 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::monitoring::loggly::restapi::custom::api;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use JSON::XS;
+use URI::Encode;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    if (!defined($options{output})) {
+        print "Class Custom: Need to specify 'output' argument.\n";
+        exit 3;
+    }
+    if (!defined($options{options})) {
+        $options{output}->add_option_msg(short_msg => "Class Custom: Need to specify 'options' argument.");
+        $options{output}->option_exit();
+    }
+
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments =>  {
+            'hostname:s'       => { name => 'hostname' },
+            'port:s'           => { name => 'port'},
+            'proto:s'          => { name => 'proto' },
+            'api-password:s'   => { name => 'api_password' },
+            'timeout:s'        => { name => 'timeout', default => 30 }
+        });
+    }
+    
+    $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
+
+    $self->{output} = $options{output};
+    $self->{http} = centreon::plugins::http->new(%options);
+
+    return $self;
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+
+    $self->{option_results} = $options{option_results};
+}
+
+sub set_defaults {}
+
+sub check_options {
+    my ($self, %options) = @_;
+
+    $self->{hostname} = (defined($self->{option_results}->{hostname})) ? $self->{option_results}->{hostname} : undef;
+    $self->{port} = (defined($self->{option_results}->{port})) ? $self->{option_results}->{port} : 443;
+    $self->{proto} = (defined($self->{option_results}->{proto})) ? $self->{option_results}->{proto} : 'https';
+    $self->{timeout} = (defined($self->{option_results}->{timeout})) ? $self->{option_results}->{timeout} : 30;
+    $self->{ssl_opt} = (defined($self->{option_results}->{ssl_opt})) ? $self->{option_results}->{ssl_opt} : undef;
+    $self->{api_password} = (defined($self->{option_results}->{api_password})) ? $self->{option_results}->{api_password} : undef;
+
+    if (!defined($self->{hostname}) || $self->{hostname} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --hostname option.");
+        $self->{output}->option_exit();
+    }
+    if (!defined($self->{api_password}) || $self->{api_password} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --api-password option.");
+        $self->{output}->option_exit();
+    }
+
+    return 0;
+}
+
+sub build_options_for_httplib {
+    my ($self, %options) = @_;
+
+    $self->{option_results}->{hostname} = $self->{hostname};
+    $self->{option_results}->{port} = $self->{port};
+    $self->{option_results}->{proto} = $self->{proto};
+    $self->{option_results}->{ssl_opt} = $self->{ssl_opt};
+    $self->{option_results}->{timeout} = $self->{timeout};
+}
+
+sub settings {
+    my ($self, %options) = @_;
+
+    $self->build_options_for_httplib();
+    $self->{http}->add_header(key => 'Content-Type', value => 'application/json;charset=UTF-8');
+    $self->{http}->add_header(key => 'Authorization', value => 'bearer ' . $self->{option_results}->{api_password});
+    $self->{http}->set_options(%{$self->{option_results}});
+}
+
+sub request_api {
+    my ($self, %options) = @_;
+
+    $self->settings();
+    my $content = $self->{http}->request(%options, 
+        warning_status => '', unknown_status => '%{http_code} < 200 or %{http_code} >= 300', critical_status => ''
+    );
+
+    my $decoded;
+    eval {
+        $decoded = JSON::XS->new->decode($content);
+    };
+    if ($@) {
+        $self->{output}->output_add(long_msg => $content, debug => 1);
+        $self->{output}->add_option_msg(short_msg => "Cannot decode json response: $@");
+        $self->{output}->option_exit();
+    }
+    if (!defined($decoded)) {
+        $self->{output}->output_add(long_msg => $decoded, debug => 1);
+        $self->{output}->add_option_msg(short_msg => "Error while retrieving data (add --debug option for detailed message)");
+        $self->{output}->option_exit();
+    }
+
+    return $decoded;
+}
+
+sub internal_search {
+    my ($self, %options) = @_;
+
+    my $uri = URI::Encode->new({encode_reserved => 1});
+    my $status = $self->request_api(method => 'GET', url_path => '/apiv2/search?size=1&from=-' . $self->{option_results}->{time_period} . 'm&q=' . $uri->encode($self->{option_results}->{query}));
+    return $status->{rsid}->{id};
+}
+
+sub internal_events {
+    my ($self, %options) = @_;
+
+    my $status = $self->request_api(method => 'GET', url_path => '/apiv2/events?rsid=' . $options{id});
+    return $status;
+}
+
+sub api_events {
+    my ($self, %options) = @_;
+
+    my $id = $self->internal_search();
+    my $status = $self->internal_events(id => $id);
+
+    # Get a proper output message
+    my $message = '';
+    if(length($self->{option_results}->{output_field}) && scalar($status->{events}) && defined($status->{events}[0]->{event})) {
+        $message = $status->{events}[0]->{event};
+        for (split /\./, $self->{option_results}->{output_field}) {
+            if (defined($message->{$_})) {
+                $message = $message->{$_};
+            } else {
+                $message = '';
+                last;
+            }
+        }
+    }
+
+    # Message may be messed-up with wrongly encoded characters, let's force some cleanup
+    utf8::decode($message);
+    utf8::encode($message);
+    $message =~ s/[\r\n]//g;
+    $message =~ s/^\s+|\s+$//g;
+
+    # Clean returned hash
+    $status->{message} = $message;
+    delete $status->{events};
+    delete $status->{page};
+
+    return $status;
+}
+
+sub internal_fields {
+    my ($self, %options) = @_;
+
+    my $uri = URI::Encode->new({encode_reserved => 1});
+    # 300 limitation comes from the API : https://documentation.solarwinds.com/en/Success_Center/loggly/Content/admin/api-retrieving-data.htm
+    my $status = $self->request_api(method => 'GET', url_path => '/apiv2/fields/' . $self->{option_results}->{field} .'/?facet_size=300&from=-' . $self->{option_results}->{time_period} . 'm&q=' . $uri->encode($self->{option_results}->{query}));
+    return $status;
+}
+
+sub api_fields {
+    my ($self, %options) = @_;
+
+    my $status = $self->internal_fields();
+
+    # Fields may be messed-up with wrongly encoded characters, let's force some cleanup
+    foreach (@{$status->{$self->{option_results}->{field}}}) {
+        utf8::decode($_->{term});
+        utf8::encode($_->{term});
+        $_->{term} =~ s/[\r\n]//g;
+        $_->{term} =~ s/^\s+|\s+$//g;
+    }
+
+    return $status;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Loggly Rest API
+
+=head1 REST API OPTIONS
+
+=over 8
+
+=item B<--hostname>
+
+Set hostname of the Loggly server (<subdomain>.loggly.com).
+
+=item B<--port>
+
+Set Loggly Port (Default: '443').
+
+=item B<--proto>
+
+Specify http if needed (Default: 'https').
+
+=item B<--api-password>
+
+Set Loggly API token.
+
+=item B<--timeout>
+
+Threshold for HTTP timeout (Default: '30').
+
+=back
+
+=cut

--- a/apps/monitoring/loggly/restapi/mode/events.pm
+++ b/apps/monitoring/loggly/restapi/mode/events.pm
@@ -1,0 +1,115 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::monitoring::loggly::restapi::mode::events;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0 }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'events', nlabel => 'events.count', display_ok => 1, set => {
+                key_values => [ { name => 'events' } ],
+                output_template => 'Matching events: %s',
+                perfdatas => [
+                    { template => '%s', value => 'events', min => 0 },
+                ],
+            }
+        },
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $self->{version} = '1.0';
+    $options{options}->add_options(arguments => {
+        'time-period:s'  => { name => 'time_period' },
+        'query:s'        => { name => 'query' },
+        'output-field:s' => { name => 'output_field' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{time_period}) || $self->{option_results}->{time_period} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --time-period option.");
+        $self->{output}->option_exit();
+    }
+    if (!defined($self->{option_results}->{query}) || $self->{option_results}->{query} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --query option.");
+        $self->{output}->option_exit();
+    }
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $results = $options{custom}->api_events();
+    $self->{global} = { events => $results->{total_events} };
+    if (length($results->{message})) {
+        $self->{output}->output_add(long_msg => 'Last ' . $self->{option_results}->{output_field} . ': ' . $results->{message});
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Count events matching the query.
+
+=over 8
+
+=item B<--time-period>
+
+Set request period, in minutes.
+
+=item B<--query>
+
+Set the query.
+
+=item B<--output-field>
+
+Set the field to verbose-output from the last matching event (ex: json.message).
+
+=item B<--warning-*> B<--critical-*>
+
+Thresholds.
+Can be: 'events'.
+
+=back
+
+=cut

--- a/apps/monitoring/loggly/restapi/mode/fields.pm
+++ b/apps/monitoring/loggly/restapi/mode/fields.pm
@@ -1,0 +1,172 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::monitoring::loggly::restapi::mode::fields;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0 },
+        { name => 'field', type => 1, cb_prefix_output => 'prefix_field_output' }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'events', nlabel => 'events.count', display_ok => 1, set => {
+                key_values => [ { name => 'events' } ],
+                output_template => 'Matching events: %s',
+                perfdatas => [
+                    { template => '%s', value => 'events', min => 0 },
+                ],
+            }
+        },
+        { label => 'fields', nlabel => 'fields.count', display_ok => 1, set => {
+                key_values => [ { name => 'fields' } ],
+                output_template => 'Matching fields: %s',
+                perfdatas => [
+                    { template => '%s', value => 'fields', min => 0 },
+                ],
+            }
+        },
+    ];
+
+    $self->{maps_counters}->{field} = [
+        { label => 'field-events', nlabel => 'field.events.count', set => {
+                key_values => [ { name => 'count' }, { name => 'display' } ],
+                output_template => 'matching events: %s',
+                perfdatas => [
+                    { template => '%s', value => 'count', min => 0, label_extra_instance => 1, instance_use => 'display' },
+                ],
+            }
+        },
+    ];
+}
+
+sub prefix_field_output {
+    my ($self, %options) = @_;
+
+    return "Field '" . $options{instance_value}->{display} . "' ";
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $self->{version} = '1.0';
+    $options{options}->add_options(arguments => {
+        'time-period:s'  => { name => 'time_period' },
+        'query:s'        => { name => 'query' },
+        'field:s'        => { name => 'field' },
+        'filter-field:s' => { name => 'filter_field' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{time_period}) || $self->{option_results}->{time_period} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --time-period option.");
+        $self->{output}->option_exit();
+    }
+    if (!defined($self->{option_results}->{query}) || $self->{option_results}->{query} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --query option.");
+        $self->{output}->option_exit();
+    }
+    if (!defined($self->{option_results}->{field}) || $self->{option_results}->{field} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --field option.");
+        $self->{output}->option_exit();
+    }
+    # 300 limitation comes from the API : https://documentation.solarwinds.com/en/Success_Center/loggly/Content/admin/api-retrieving-data.htm
+    if (defined($self->{option_results}->{'warning-fields-count'}) && $self->{option_results}->{'warning-fields-count'} >= 300) {
+        $self->{output}->add_option_msg(short_msg => "Threshold --warning-fields must be lower than 300.");
+        $self->{output}->option_exit();
+    }
+    if (defined($self->{option_results}->{'critical-fields-count'}) && $self->{option_results}->{'critical-fields-count'} >= 300) {
+        $self->{output}->add_option_msg(short_msg => "Threshold --critical-fields must be lower than 300.");
+        $self->{output}->option_exit();
+    }
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $results = $options{custom}->api_fields();
+
+    my $events = 0;
+    my $fields = 0;
+
+    $self->{field} = {};
+    foreach (@{$results->{$self->{option_results}->{field}}}) {
+        if (!defined($self->{option_results}->{filter_field}) || ($_->{term} =~ /$self->{option_results}->{filter_field}/i)) {
+            $fields++;
+            $events += $_->{count};
+            $self->{field}->{$fields} = {
+                display => $_->{term},
+                count => $_->{count}
+            };
+        }
+    }
+
+    $self->{global} = { events => $events, fields => $fields };
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Count unique field-values from events matching the query.
+
+=over 8
+
+=item B<--time-period>
+
+Set request period, in minutes.
+
+=item B<--query>
+
+Set the query.
+
+=item B<--field>
+
+Set the field to count unique values for (ex: json.host).
+
+=item B<--filter-field>
+
+Set the a field filter.
+
+=item B<--warning-*> B<--critical-*>
+
+Thresholds.
+Can be: 'events', 'fields', field-events'.
+
+=back
+
+=cut

--- a/apps/monitoring/loggly/restapi/plugin.pm
+++ b/apps/monitoring/loggly/restapi/plugin.pm
@@ -1,0 +1,54 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::monitoring::loggly::restapi::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_custom);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{version} = '1.0';
+    %{$self->{modes}} = (
+        'events' => 'apps::monitoring::loggly::restapi::mode::events',
+        'fields' => 'apps::monitoring::loggly::restapi::mode::fields',
+    );
+
+    $self->{custom_modes}{api} = 'apps::monitoring::loggly::restapi::custom::api';
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 PLUGIN DESCRIPTION
+
+Check Loggly through its HTTPS remote API.
+
+=over 8
+
+=back
+
+=cut


### PR DESCRIPTION
Hi,

Here's a new plugin, for Loggly.
Based on their API :
https://documentation.solarwinds.com/en/Success_Center/loggly/Content/admin/api-retrieving-data.htm

One `events` mode, to count the number of events matching the given query.
One `fields` mode, which allows to count the number of unique fields (for example a number of hosts) matching the query.

Thx 👍 