### PR TITLE
fix(idrac) Hardware thresholds

### DIFF
--- a/hardware/server/dell/idrac/snmp/mode/components/resources.pm
+++ b/hardware/server/dell/idrac/snmp/mode/components/resources.pm
@@ -79,6 +79,7 @@ our @EXPORT_OK = qw(%map_probe_status %map_state %map_status %map_amperage_type 
     7 => 'failed',
     8 => 'non-raid',
     9 => 'removed',
+    10 => 'readonly',
 );
 
 %map_vdisk_state = (

--- a/hardware/server/dell/idrac/snmp/mode/hardware.pm
+++ b/hardware/server/dell/idrac/snmp/mode/hardware.pm
@@ -69,6 +69,7 @@ sub set_system {
             ['failed', 'CRITICAL'],
             ['non-raid', 'OK'],
             ['removed', 'OK'],
+            ['readonly', 'WARNING'],
         ],
         'pdisk.smartalert' => [
             ['off', 'OK'],
@@ -88,7 +89,11 @@ sub set_system {
         'slot', 'fru', 'storagectrl', 'storagebattery', 'pdisk', 'vdisk'];
 
     $self->{regexp_threshold_overload_check_section_option} = 
-        '^(?:' . join('|', @{$self->{components_module}}). ')\.(?:status|state)$';
+        '^(' .
+        '(psu|punit|temperature|voltage|amperage|systembattery|coolingunit|coolingdevice|processor|memory|pci|network|slot|fru|storagectrl|storagebattery|pdisk)\.status' .
+        '|(punit|temperature|voltage|amperage|systembattery|coolingunit|coolingdevice|processor|memory|pci|pdisk|vdisk)\.state' .
+        '|(pdisk)\.smartalert' .
+        ')$';
 }
 
 sub snmp_execute {


### PR DESCRIPTION
Hi,

This PR fixes idrac hardware thresholds :
- it adds a missing `pdisk` state value ;
- it sets `regexp_threshold_overload_check_section_option` to possible values only ;
- it allows to set  `--threshold-overload` on `pdisk.smartalert`.

Thx 👍