### PR TITLE
enh(fortigate) Add Standard modes

### DIFF
--- a/network/fortinet/fortigate/snmp/plugin.pm
+++ b/network/fortinet/fortigate/snmp/plugin.pm
@@ -43,9 +43,10 @@ sub new {
         'memory'              => 'centreon::common::fortinet::fortigate::snmp::mode::memory',
         'sessions'            => 'centreon::common::fortinet::fortigate::snmp::mode::sessions',
         'signatures'          => 'centreon::common::fortinet::fortigate::snmp::mode::signatures',
+        'uptime'              => 'snmp_standard::mode::uptime',
         'vdom-usage'          => 'centreon::common::fortinet::fortigate::snmp::mode::vdomusage',
         'virus'               => 'centreon::common::fortinet::fortigate::snmp::mode::virus',
-        'vpn'                 => 'centreon::common::fortinet::fortigate::snmp::mode::vpn',
+        'vpn'                 => 'centreon::common::fortinet::fortigate::snmp::mode::vpn'
     );
 
     return $self;


### PR DESCRIPTION
Hi,
Let's add some standard modes to Fortigate.
Strangely enough it does not support `time` mode (`.1.3.6.1.2.1.25.1.2` is not available there).
Thx 👍