### PR TITLE
fix(loggly) various fixes

### DIFF
--- a/apps/monitoring/loggly/restapi/custom/api.pm
+++ b/apps/monitoring/loggly/restapi/custom/api.pm
@@ -26,7 +26,6 @@ use strict;
 use warnings;
 use centreon::plugins::http;
 use JSON::XS;
-use Encode;
 
 sub new {
     my ($class, %options) = @_;
@@ -150,7 +149,7 @@ sub internal_search {
         url_path => '/apiv2/search',
         get_param => [
             'size=1',
-            'from=' . $options{time_period} . 'm',
+            'from=-' . $options{time_period} . 'm',
             'q=' . $options{query}
         ]
     );
@@ -192,7 +191,8 @@ sub api_events {
     }
 
     # Message may be messed-up with wrongly encoded characters, let's force some cleanup
-    $message = Encode::encode('UTF-8', $message);
+    utf8::decode($message);
+    utf8::encode($message);
     $message =~ s/[\r\n]//g;
     $message =~ s/^\s+|\s+$//g;
 
@@ -210,10 +210,10 @@ sub internal_fields {
     # 300 limitation comes from the API : https://documentation.solarwinds.com/en/Success_Center/loggly/Content/admin/api-retrieving-data.htm
     my $status = $self->request_api(
         method => 'GET',
-        url_path => '/apiv2/fields/'
+        url_path => '/apiv2/fields/' . $options{field} . '/',
         get_param => [
             'facet_size=300',
-            'from=' . $options{time_period} . 'm',
+            'from=-' . $options{time_period} . 'm',
             'q=' . $options{query}
         ]
     );
@@ -225,12 +225,14 @@ sub api_fields {
 
     my $status = $self->internal_fields(
         time_period => $options{time_period},
+        field => $options{field},
         query => $options{query}
     );
 
     # Fields may be messed-up with wrongly encoded characters, let's force some cleanup
     for (my $i = 0; $i < scalar(@{$status->{ $options{field} }}); $i++) {
-        $status->{ $options{field} }->[$i]->{term} = Encode::encode('UTF-8', $status->{ $options{field} }->[$i]->{term});
+        utf8::decode($status->{ $options{field} }->[$i]->{term});
+        utf8::encode($status->{ $options{field} }->[$i]->{term});
         $status->{ $options{field} }->[$i]->{term} =~ s/[\r\n]//g;
         $status->{ $options{field} }->[$i]->{term} =~ s/^\s+|\s+$//g;
     }


### PR DESCRIPTION
Hi,

This follows https://github.com/centreon/centreon-plugins/commit/88c67fed712da2ae3ff0f5b18fbf406364debe6c, with various fixes.

I also reverted back to :
```
utf8::decode($message);
utf8::encode($message);
```

Look at the source message :
`appel \x{c3}\x{a0} la rescousse du mod\x{c3}\x{a8}le 43`

With `Encode::encode('UTF-8', $message)` :
`appel Ã  la rescousse du modÃ¨le 43`
(as it is exactly in Loggly web UI itself)

With above original method :
`appel à la rescousse du modèle 43`

Thx 👍