### PR TITLE
enh(statefile) Use a windir on Windows

### DIFF
--- a/centreon/plugins/statefile.pm
+++ b/centreon/plugins/statefile.pm
@@ -27,6 +27,9 @@ use vars qw($datas);
 use centreon::plugins::misc;
 
 my $default_dir = '/var/lib/centreon/centplugins';
+if ($^O eq 'MSWin32') {
+    $default_dir = 'C:/Windows/Temp';
+}
 
 sub new {
     my ($class, %options) = @_;


### PR DESCRIPTION
Hi,

This defaults `statefile-dir` to a Windows directory on Windows systems.

Thx 👍