### PR TITLE
Add eval on curl backend to accept any type of variable in curl-opt

### DIFF
--- a/centreon/plugins/backend/http/curl.pm
+++ b/centreon/plugins/backend/http/curl.pm
@@ -240,7 +240,7 @@ sub set_extra_curl_opt {
             }
         }
 
-        $self->curl_setopt(option => $fields->{key}, parameter => $fields->{value});
+        $self->curl_setopt(option => $fields->{key}, parameter => eval $fields->{value});
     }
 }
 


### PR DESCRIPTION
Hello,

While testing Kerberos proxy authentication, I noticed that the "curl-opt" does not accept an array as an argument in the hash, only strings are translated since the argument is a string array.

This makes it that you can't use the [CURLOPT_RESOLVE](https://curl.haxx.se/libcurl/c/CURLOPT_RESOLVE.html) option to set an alternative name resolution.

I see that this option is used in line 297 to set the "http_peer_addr", however it does not work for the proxy name resolution, only for the host.

The need for this option is due to the Kerberos authentication process needing to have the SPN (proxyserver.mynetwork) in the --proxyurl option.

So if the proxy SPN is a VIP, we can't test the individual proxy servers with Kerberos by passing the server's IP, the SPN needs to be used and the resolve option as well so we can change the IP.

An example call in this case is the following:

`centreon_plugins.pl --plugin=apps::protocols::http::plugin --mode=response --hostname=www.google.com --port=80 --http-backend=curl --proxyurl=http://proxyserver.mynetwork:8080 --curl-opt="CURLOPT_PROXYAUTH => CURLAUTH_GSSNEGOTIATE" --curl-opt="CURLOPT_PROXYUSERPWD => ':'" --curl-opt="CURLOPT_USERAGENT => 'MyBrowser v0.1'" --curl-opt="CURLOPT_RESOLVE => ['proxyserver.mynetwork:8080:192.168.2.2']" --curl-opt="CURLOPT_SSL_VERIFYPEER => 0"`

Another option to solve this issue would be to add a new argument like the "http_peer_addr", for example "proxy_peer_addr" so we can set an alternative name resolution for the proxy.