### PR TITLE
enh(idrac) Spare state for ready pdisks

### DIFF
--- a/hardware/server/dell/idrac/snmp/mode/hardware.pm
+++ b/hardware/server/dell/idrac/snmp/mode/hardware.pm
@@ -61,7 +61,9 @@ sub set_system {
         ],
         'pdisk.state' => [
             ['unknown', 'UNKNOWN'],
-            ['ready', 'OK'],
+            ['readySpareDedicated', 'OK'],
+            ['readySpareGlobal', 'OK'],
+            ['ready', 'WARNING'],
             ['online', 'OK'],
             ['foreign', 'OK'],
             ['offline', 'WARNING'],


### PR DESCRIPTION
Hi,

In iDRAC plugin, a `ready` pdisk might not be OK, whether or not it has been declared as a hotspare.
Let's then verify the spare status of such `ready` disks, and introduce 2 new pdisk states :
- readySpareDedicated
- readySpareGlobal

Thank you 👍