### PR TITLE
add perfdate to x509 validity mode

### DIFF
--- a/apps/protocols/x509/mode/validity.pm
+++ b/apps/protocols/x509/mode/validity.pm
@@ -100,7 +100,7 @@ sub run {
         $self->{output}->exit()
     }
 
-    #Retrieve Certificat
+    #Retrieve Certificate
     my $cert;
     eval { $cert = $client->peer_certificate() };
     if ($@) {
@@ -124,6 +124,12 @@ sub run {
                                                       threshold => [ { label => 'critical', exit_litteral => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
         $self->{output}->output_add(severity => $exit,
                                     short_msg => sprintf("Certificate expiration for '%s' in days: %s - Validity Date: %s", $subject, $daysbefore, $notafterdate));
+    
+		$self->{output}->perfdata_add(label => 'days', unit => undef,
+	                                value => $daysbefore,
+	                                warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning'),
+	                                critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical'),
+	                                min => undef, max => undef);    
     #Subject Name
     } elsif ($self->{option_results}->{validity_mode} eq 'subject') {
         my @subject_matched = ();


### PR DESCRIPTION
Hi, I need to add perfdata to the validity mode on the  apps::protocols::x509::plugin.

This pull request adds the missing perf data to the validity.pm file

```
"perl" "/sites/icinga2/resources/scripts/centreon-latest/centreon_plugins.pl" "--plugin" "apps::protocols::x509::plugin" "--mode" "validity" "--hostname" "monitoring-icinga.dev.internal" "--port" "443" "--validity-mode" "expiration" "--ssl-opt" "SSL_verify_mode=SSL_VERIFY_NONE" "--warning-date" "45:" --critical-date "35:"
OK: Certificate expiration for '*.dev.internal' in days: 76 - Validity Date: Nov 26 14:22:20 2020 | 'days'=76;45:;35:;;
```