### PR TITLE
Added missing job-status options

### DIFF
--- a/apps/automation/ansible/tower/mode/hosts.pm
+++ b/apps/automation/ansible/tower/mode/hosts.pm
@@ -68,8 +68,8 @@ sub set_counters {
     $self->{maps_counters}->{hosts} = [
         {
             label => 'job-status', type => 2,
-            unknown_default => '%{last_job_status} =~ /default/',
-            critical_default => '%{last_job_status} =~ /failed/',
+            unknown_default => $self->{option_results}->{unknown_job_status},
+            critical_default => $self->{option_results}->{critical_job_status},
             set => {
                 key_values => [ { name => 'last_job_status' }, { name => 'display' } ],
                 output_template => "last job status is '%s'",
@@ -87,7 +87,10 @@ sub new {
 
     $options{options}->add_options(arguments => {
         'filter-name:s'        => { name => 'filter_name' },
-        'display-failed-hosts' => { name => 'display_failed_hosts' }
+        'display-failed-hosts' => { name => 'display_failed_hosts' },
+        'unknown-job-status:s' => { name => 'unknown_job_status', default => '%{last_job_status} =~ /default/' },
+        'warning-job-status:s' => { name => 'warning_job_status', default => '' },
+        'critical-job-status:s' => { name => 'critical_job_status', default => '%{last_job_status} =~ /failed/' }
     });
 
     return $self;

--- a/apps/automation/ansible/tower/mode/jobtemplates.pm
+++ b/apps/automation/ansible/tower/mode/jobtemplates.pm
@@ -72,8 +72,8 @@ sub set_counters {
     $self->{maps_counters}->{jobtpl} = [
         {
             label => 'job-status', type => 2,
-            unknown_default => '%{last_job_status} =~ /default/',
-            critical_default => '%{last_job_status} =~ /failed/',
+            unknown_default => $self->{option_results}->{unknown_job_status},
+            critical_default => $self->{option_results}->{critical_job_status},
             set => {
                 key_values => [ { name => 'last_job_status' }, { name => 'display' } ],
                 output_template => "last job status is '%s'",
@@ -98,7 +98,10 @@ sub new {
         'launch-inventory:s'       => { name => 'launch_inventory' },
         'launch-credential:s'      => { name => 'launch_credential' },
         'launch-max-retries:s'     => { name => 'launch_max_retries', default => 5 },
-        'launch-retry-interval:s'  => { name => 'launch_retry_interval', default => 10 }
+        'launch-retry-interval:s'  => { name => 'launch_retry_interval', default => 10 },
+        'unknown-job-status:s' => { name => 'unknown_job_status', default => '%{last_job_status} =~ /default/' },
+        'warning-job-status:s' => { name => 'warning_job_status', default => '' },
+        'critical-job-status:s' => { name => 'critical_job_status', default => '%{last_job_status} =~ /failed/' }
     });
 
     return $self;

--- a/apps/automation/ansible/tower/mode/schedules.pm
+++ b/apps/automation/ansible/tower/mode/schedules.pm
@@ -83,8 +83,8 @@ sub set_counters {
     $self->{maps_counters}->{schedules} = [
         {
             label => 'job-status', type => 2,
-            unknown_default => '%{last_job_status} =~ /default/',
-            critical_default => '%{last_job_status} =~ /failed/',
+            unknown_default => $self->{option_results}->{unknown_job_status},
+            critical_default => $self->{option_results}->{critical_job_status},
             set => {
                 key_values => [ { name => 'last_job_status' }, { name => 'display' } ],
                 output_template => "last job status is '%s'",
@@ -109,7 +109,10 @@ sub new {
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
-        'filter-name:s' => { name => 'filter_name' }
+        'filter-name:s' => { name => 'filter_name' },
+        'unknown-job-status:s' => { name => 'unknown_job_status', default => '%{last_job_status} =~ /default/' },
+        'warning-job-status:s' => { name => 'warning_job_status', default => '' },
+        'critical-job-status:s' => { name => 'critical_job_status', default => '%{last_job_status} =~ /failed/' }
     });
 
     return $self;


### PR DESCRIPTION
Hello,

While trying to execute the commands I noticed that the job-status options were missing even though they were in the documentation.

This will add the options on the plugin and use them in the appropriate place.

Thank you for your time.