### PR TITLE
Fixed infinite loop on multiple page output

### DIFF
--- a/apps/automation/ansible/tower/custom/api.pm
+++ b/apps/automation/ansible/tower/custom/api.pm
@@ -134,11 +134,10 @@ sub request_api {
     my ($self, %options) = @_;
 
     my $results = [];
-    my $page = 1;
+    my $path = defined($options{force_endpoint}) ? $self->{api_path} . $options{force_endpoint} : $self->{api_path} . $options{endpoint} . '?page_size=100&page=1';
 
     $self->settings();
     while (1) {
-        my $path = defined($options{force_endpoint}) ? $self->{api_path} . $options{force_endpoint} : $self->{api_path} . $options{endpoint} . '?page_size=100&page=' . $page;
         my $content = $self->{http}->request(
             method => defined($options{method}) ? $options{method} : 'GET', 
             url_path => $path,
@@ -167,6 +166,8 @@ sub request_api {
 
         push @$results, @{$decoded->{results}};
         last if (!defined($decoded->{next}));
+
+        $path = $decoded->{next};
     }
 
     return $results;


### PR DESCRIPTION
Hello,

On using this plugin when it returns multiple pages, it will stay in an infinite loop as neither the page nor the path gets changed.

This is one solution, I don't know if it is what you have in mind, we can also extract the page number from the "next" url.