### PR TITLE
new plugin for SmarterMail API

### DIFF
--- a/apps/smartermail/restapi/custom/api.pm
+++ b/apps/smartermail/restapi/custom/api.pm
@@ -1,0 +1,302 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Authors : Roman Morandell - ivertix
+#
+
+package apps::smartermail::restapi::custom::api;
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use centreon::plugins::statefile;
+use JSON::XS;
+use Digest::MD5 qw(md5_hex);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = {};
+    bless $self, $class;
+    # $options{options} = options object
+    # $options{output} = output object
+    # $options{exit_value} = integer
+    # $options{noptions} = integer
+
+    if (!defined($options{output})) {
+        print "Class Custom: Need to specify 'output' argument.\n";
+        exit 3;
+    }
+    if (!defined($options{options})) {
+        $options{output}->add_option_msg(short_msg => "Class Custom: Need to specify 'options' argument.");
+        $options{output}->option_exit();
+    }
+
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            "hostname:s" => { name => 'hostname' },
+            "port:s"     => { name => 'port' },
+            "proto:s"    => { name => 'proto' },
+            "url_path:s" => { name => 'url_path' },
+            "username:s" => { name => 'username' },
+            "password:s" => { name => 'password' },
+            "timeout:s"  => { name => 'timeout' },
+        });
+    }
+    $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
+
+    $self->{output} = $options{output};
+    $self->{mode} = $options{mode};
+    $self->{http} = centreon::plugins::http->new(%options);
+    $self->{cache} = centreon::plugins::statefile->new(%options);
+
+    return $self;
+}
+
+# Method to manage multiples
+sub set_options {
+    my ($self, %options) = @_;
+    # options{options_result}
+
+    $self->{option_results} = $options{option_results};
+}
+
+# Method to manage multiples
+sub set_defaults {
+    my ($self, %options) = @_;
+    # options{default}
+
+    # Manage default value
+    foreach (keys %{$options{default}}) {
+        if ($_ eq $self->{mode}) {
+            for (my $i = 0; $i < scalar(@{$options{default}->{$_}}); $i++) {
+                foreach my $opt (keys %{$options{default}->{$_}[$i]}) {
+                    if (!defined($self->{option_results}->{$opt}[$i])) {
+                        $self->{option_results}->{$opt}[$i] = $options{default}->{$_}[$i]->{$opt};
+                    }
+                }
+            }
+        }
+    }
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    # return 1 = ok still customarg
+    # return 0 = no customarg left
+
+    $self->{hostname} = $self->{option_results}->{hostname};
+    $self->{proto} = (defined($self->{option_results}->{proto})) ? $self->{option_results}->{proto} : 'https';
+    $self->{port} = (defined($self->{option_results}->{port})) ? $self->{option_results}->{port} : 443;
+    $self->{url_path} = (defined($self->{option_results}->{url_path})) ? $self->{option_results}->{url_path} : '/api/v1';
+    $self->{username} = (defined($self->{option_results}->{username})) ? $self->{option_results}->{username} : undef;
+    $self->{password} = (defined($self->{option_results}->{password})) ? $self->{option_results}->{password} : undef;
+    $self->{timeout} = (defined($self->{option_results}->{timeout})) ? $self->{option_results}->{timeout} : 10;
+
+    if (!defined($self->{hostname})) {
+        $self->{output}->add_option_msg(short_msg => "Need to specify hostname option.");
+        $self->{output}->option_exit();
+    }
+
+    $self->{cache}->check_options(option_results => $self->{option_results});
+
+    return 0;
+}
+
+sub get_connection_infos {
+    my ($self, %options) = @_;
+
+    return $self->{hostname} . '_' . $self->{http}->get_port();
+}
+
+sub get_hostname {
+    my ($self, %options) = @_;
+
+    return $self->{hostname};
+}
+
+sub get_port {
+    my ($self, %options) = @_;
+
+    return $self->{port};
+}
+
+sub get_endpoint {
+    my ($self, %options) = @_;
+
+    my $result = $self->request_api(%options);
+
+    return $result;
+}
+
+sub json_decode {
+    my ($self, $content) = @_;
+
+    my $decoded;
+    eval {
+        $decoded = JSON::XS->new->utf8->decode($content);
+    };
+    if ($@) {
+        $self->{output}->output_add(long_msg => $content, debug => 1);
+        $self->{output}->add_option_msg(short_msg => "Cannot decode json response: $@");
+        $self->{output}->option_exit();
+    }
+
+    return $decoded;
+}
+
+sub build_options_for_httplib {
+    my ($self, %options) = @_;
+
+    $self->{option_results}->{hostname} = $self->{hostname};
+    $self->{option_results}->{port} = $self->{port};
+    $self->{option_results}->{proto} = $self->{proto};
+    $self->{option_results}->{url_path} = $self->{url_path};
+    $self->{option_results}->{username} = $self->{username};
+    $self->{option_results}->{password} = $self->{password};
+    $self->{option_results}->{warning_status} = '';
+    $self->{option_results}->{critical_status} = '';
+}
+
+sub settings {
+    my ($self, %options) = @_;
+
+    $self->build_options_for_httplib();
+
+    $self->{http}->add_header(key => 'Accept', value => 'application/json');
+    if (defined($self->{api_token})) {
+        $self->{http}->add_header(key => 'Authorization', value => 'Bearer ' . $self->{api_token});
+        $self->{http}->add_header(key => 'Content-Type', value => 'application/json');
+    }
+    $self->{http}->set_options(%{$self->{option_results}});
+}
+
+sub get_auth_token {
+    my ($self, %options) = @_;
+
+    my $has_cache_file = $options{statefile}->read(statefile => 'smatermail_api_' . md5_hex($self->{option_results}->{hostname}) .
+        '_' . md5_hex($self->{option_results}->{username}));
+    my $expires_on = $options{statefile}->get(name => 'expires_on');
+    my $accessToken = $options{statefile}->get(name => 'accessToken');
+
+    if ($has_cache_file == 0 || !defined($accessToken) || (($expires_on - time()) < 60)) {
+        my $post_param = [ 'username=' . $self->{username}, 'password=' . $self->{password} ];
+
+        $self->settings();
+        my $url = $self->{url_path} . '/auth/authenticate-user';
+
+        my $content = $self->{http}->request(method => 'POST', url_path => $url, post_param => $post_param);
+
+        if ($self->{http}->get_code() != 200) {
+            $self->{output}->add_option_msg(short_msg => "Authentication error [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']");
+            $self->{output}->option_exit();
+        }
+
+        my $jsonResponse = $self->json_decode($content);
+
+        if (!defined($jsonResponse->{"resultCode"}) || $jsonResponse->{"resultCode"} ne "200" || !defined($jsonResponse->{accessToken})) {
+            $self->{output}->output_add(long_msg => $content, debug => 1);
+            $self->{output}->add_option_msg(short_msg => "Cannot get token");
+            $self->{output}->option_exit();
+        }
+
+        $accessToken = $jsonResponse->{accessToken};
+        my $datas = { last_timestamp => time(), accessToken => $jsonResponse->{accessToken}, expires_on => time() + 900 };
+        $options{statefile}->write(data => $datas);
+    }
+
+    return $accessToken;
+}
+
+sub request_api {
+    my ($self, %options) = @_;
+
+    if (!defined($self->{api_token})) {
+        $self->{api_token} = $self->get_auth_token(statefile => $self->{cache});
+    }
+
+    $self->settings();
+
+    my $content = $self->{http}->request(
+        method          => $options{method},
+        url_path        => $self->{url_path} . $options{api_path},
+        query_form_post => $options{query_form_post},
+        critical_status => '', warning_status => '', unknown_status => '');
+
+
+    my $jsonResponse = $self->json_decode($content);
+
+    if (!$jsonResponse->{success}) {
+        $self->{output}->output_add(long_msg => $content, debug => 1);
+        $self->{output}->add_option_msg(short_msg => "Request could not be processed: $jsonResponse->{message}");
+        $self->{output}->option_exit();
+    }
+
+    return ($jsonResponse, JSON::XS->new->utf8->pretty->encode($jsonResponse));
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+SmarterMail API
+
+=head1 SYNOPSIS
+
+smartermail api
+
+=head1 API OPTIONS
+
+=over 8
+
+=item B<--hostname>
+
+API hostname.
+
+=item B<--url-path>
+
+API url path (Default: '/api/v1')
+
+=item B<--port>
+
+API port (Default: 443)
+
+=item B<--proto>
+
+Specify https if needed (Default: 'https')
+
+=item B<--username>
+
+Set API username
+
+=item B<--password>
+
+Set API password
+
+=item B<--timeout>
+
+Set HTTP timeout
+
+=back
+
+=head1 DESCRIPTION
+
+B<custom>.
+
+=cut

--- a/apps/smartermail/restapi/mode/licensenotifications.pm
+++ b/apps/smartermail/restapi/mode/licensenotifications.pm
@@ -1,0 +1,140 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Authors : Roman Morandell - ivertix
+#
+
+package apps::smartermail::restapi::mode::licensenotifications;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use JSON::XS;
+
+sub custom_threshold_output {
+    my ($self, %options) = @_;
+    my $status = 'ok';
+
+    if ($self->{result_values}->{isUpgradeProtectionExpired_absolute} =~ /Expired/) {
+        $status = 'critical';
+    }
+    return $status;
+}
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    my $msg = sprintf("Upgrade protection status is '%s'", $self->{result_values}->{isUpgradeProtectionExpired_absolute});
+    return $msg;
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'protectionStatus', type => 0, message_separator => ' - ' },
+        { name => 'counters', type => 0, message_separator => ' - ' },
+    ];
+    $self->{maps_counters}->{counters} = [
+        { label => 'daysUntilUpgradeProtectionExpires', set => {
+            key_values      => [ { name => 'daysUntilUpgradeProtectionExpires' } ],
+            output_template => 'expires in %d days',
+            perfdatas       => [
+                { label => 'daysUntilUpgradeProtectionExpires', value => 'daysUntilUpgradeProtectionExpires_absolute', template => '%d', min => 0 },
+            ],
+        }
+        }
+    ];
+
+    $self->{maps_counters}->{protectionStatus} = [
+        { label => 'isUpgradeProtectionExpired', threshold => 0, set => {
+            key_values => [ { name => 'isUpgradeProtectionExpired' } ],
+            closure_custom_output => $self->can('custom_status_output'),
+            closure_custom_perfdata => sub { return 0; },
+            closure_custom_threshold_check => $self->can('custom_threshold_output')
+        }
+        },
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $jsonResponse = $options{custom}->get_endpoint(api_path => '/settings/sysadmin/license-notifications');
+
+    my $response;
+    eval {
+        $response = decode_json($jsonResponse);
+    };
+    # the response was checked on "get_endpoint" if contains 'success=true'
+    if ($@) {
+        $self->{output}->output_add(long_msg => $jsonResponse, debug => 1);
+        $self->{output}->add_option_msg(short_msg => "Cannot decode json response");
+        $self->{output}->option_exit();
+    }
+
+    $self->{counters} = '';
+    $self->{counters} = {
+        daysUntilUpgradeProtectionExpires => $response->{daysUntilUpgradeProtectionExpires},
+    };
+
+    $self->{protectionStatus} = '';
+    $self->{protectionStatus} = {
+        isUpgradeProtectionExpired => $response->{isUpgradeProtectionExpired} ? "Expired" : "Licensed"
+    };
+}
+
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check upgrade protection expire
+
+=over 8
+
+=item B<--warning-*>
+
+Threshold warning.
+Can be: 'daysUntilUpgradeProtectionExpires'.
+
+=item B<--critical-*>
+
+Threshold critical.
+Can be: 'daysUntilUpgradeProtectionExpires'.
+
+=back
+
+=cut

--- a/apps/smartermail/restapi/mode/services.pm
+++ b/apps/smartermail/restapi/mode/services.pm
@@ -1,0 +1,156 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Authors : Roman Morandell - ivertix
+#
+
+package apps::smartermail::restapi::mode::services;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use JSON::XS;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold catalog_status_calc);
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'service', type => 1, cb_prefix_output => 'prefix_service_output',
+            message_multiple => 'All services are ok' },
+    ];
+
+    $self->{maps_counters}->{service} = [
+        { label => 'status', threshold => 0, set => {
+            key_values      => [ { name => 'state' }, { name => 'display' }],
+            closure_custom_perfdata => sub { return 0; },
+            closure_custom_output => $self->can('custom_status_output'),
+            closure_custom_threshold_check => \&catalog_status_threshold,
+        }
+        },
+    ];
+}
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    my $msg .= 'state is ' . $self->{result_values}->{state_absolute};
+    return $msg;
+}
+
+sub prefix_service_output {
+    my ($self, %options) = @_;
+
+    return "Service '" . $options{instance_value}->{display} ."' ";
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments =>
+        {
+            "filter-service:s" => { name => 'filter_service' },
+            'unknown-status:s'  => { name => 'unknown_status', default => '' },
+            'warning-status:s'  => { name => 'warning_status', default => '' },
+            'critical-status:s' => { name => 'critical_status', default => '%{state_absolute} !~ /running/' },
+        });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    $self->change_macros(macros => [
+        'warning_status', 'critical_status', 'unknown_status',
+    ]);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $jsonResponse = $options{custom}->get_endpoint(api_path => '/settings/sysadmin/services');
+    # my $jsonResponse = '{"services":{"spool":true,"smtp":true,"pop":true,"xmpp":true,"imap":true,"ldap":true,"popretrieval":true,"imapretrieval":true,"indexing":true},"success":true,"message":""}';
+
+    my $response;
+    eval {
+        $response = decode_json($jsonResponse);
+    };
+    # the response was checked on "get_endpoint" if contains 'success=true'
+    if ($@) {
+        $self->{output}->output_add(long_msg => $jsonResponse, debug => 1);
+        $self->{output}->add_option_msg(short_msg => "Cannot decode json response");
+        $self->{output}->option_exit();
+    }
+
+    my $jsonServiceStates = $response->{services};
+    my @services = ('spool', 'smtp', 'pop', 'xmpp', 'imap', 'ldap', 'popretrieval', 'imapretrieval', 'indexing');
+
+    $self->{service} = {};
+    foreach (@services) {
+        if (defined($self->{option_results}->{filter_service}) && $self->{option_results}->{filter_service} ne '' &&
+            $_ !~ /$self->{option_results}->{filter_service}/) {
+            $self->{output}->output_add(long_msg => "skipping  '" . $_  . "': no matching filter.", debug => 1);
+            next;
+        }
+
+        $self->{service}->{$_} = {
+            display => $_,
+            state => $jsonServiceStates->{$_} ? "running" : "inactive",
+        };
+    }
+}
+
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check service states
+
+=over 8
+
+=item B<--filter-service>
+
+Only display some counters (regexp can be used).
+(Example: --filter-service='spool|smtp|pop')
+
+=item B<--unknown-status>
+
+unknown status.
+default: ''.
+
+=item B<--warning-status>
+
+warning status.
+default: ''.
+
+=item B<--critical-status>
+
+critical status.
+default: '%{state_absolute} !~ /running/'.
+
+=back
+
+=cut

--- a/apps/smartermail/restapi/mode/services.pm
+++ b/apps/smartermail/restapi/mode/services.pm
@@ -89,8 +89,7 @@ sub manage_selection {
     my ($self, %options) = @_;
 
     my $jsonResponse = $options{custom}->get_endpoint(api_path => '/settings/sysadmin/services');
-    # my $jsonResponse = '{"services":{"spool":true,"smtp":true,"pop":true,"xmpp":true,"imap":true,"ldap":true,"popretrieval":true,"imapretrieval":true,"indexing":true},"success":true,"message":""}';
-
+   
     my $response;
     eval {
         $response = decode_json($jsonResponse);

--- a/apps/smartermail/restapi/mode/services.pm
+++ b/apps/smartermail/restapi/mode/services.pm
@@ -50,7 +50,7 @@ sub set_counters {
 sub custom_status_output {
     my ($self, %options) = @_;
 
-    my $msg .= 'state is ' . $self->{result_values}->{state_absolute};
+    my $msg .= 'state is ' . $self->{result_values}->{state};
     return $msg;
 }
 
@@ -70,7 +70,7 @@ sub new {
             "filter-service:s" => { name => 'filter_service' },
             'unknown-status:s'  => { name => 'unknown_status', default => '' },
             'warning-status:s'  => { name => 'warning_status', default => '' },
-            'critical-status:s' => { name => 'critical_status', default => '%{state_absolute} !~ /running/' },
+            'critical-status:s' => { name => 'critical_status', default => '%{state} !~ /running/' },
         });
 
     return $self;
@@ -148,7 +148,7 @@ default: ''.
 =item B<--critical-status>
 
 critical status.
-default: '%{state_absolute} !~ /running/'.
+default: '%{state} !~ /running/'.
 
 =back
 

--- a/apps/smartermail/restapi/mode/spoolmessagecount.pm
+++ b/apps/smartermail/restapi/mode/spoolmessagecount.pm
@@ -131,8 +131,7 @@ sub manage_selection {
     my ($self, %options) = @_;
 
     my $jsonResponse = $options{custom}->get_endpoint(api_path => '/settings/sysadmin/spool-message-counts');
-    # my $jsonResponse = '{"counts":{"default":6,"waiting":31,"virus":0,"spam":0,"throttledUsers":1,"throttledMailingLists":0,"throttledDomains":0,"spool_limit":50000,"quarantine_limit":5000},"success":true,"message":""}';
-
+    
     my $response;
     eval {
         $response = decode_json($jsonResponse);

--- a/apps/smartermail/restapi/mode/spoolmessagecount.pm
+++ b/apps/smartermail/restapi/mode/spoolmessagecount.pm
@@ -1,0 +1,191 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Authors : Roman Morandell - ivertix
+#
+
+package apps::smartermail::restapi::mode::spoolmessagecount;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use JSON::XS;
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, message_separator => ' - ' },
+    ];
+    $self->{maps_counters}->{global} = [
+        { label => 'default', set => {
+            key_values      => [ { name => 'default' } ],
+            output_template => 'Default count: %d',
+            perfdatas       => [
+                { label => 'default', value => 'default_absolute', template => '%d', min => 0 },
+            ],
+        }
+        },
+        { label => 'waiting', set => {
+            key_values      => [ { name => 'waiting' } ],
+            output_template => 'Waiting : %d',
+            perfdatas       => [
+                { label => 'waiting', value => 'waiting_absolute', template => '%d', min => 0 },
+            ],
+            }
+        },
+        { label => 'spam', set => {
+            key_values      => [ { name => 'spam' } ],
+            output_template => 'Spam : %d',
+            perfdatas       => [
+                { label => 'spam', value => 'spam_absolute', template => '%d', min => 0 },
+            ],
+        }
+        },
+        { label => 'virus', set => {
+            key_values      => [ { name => 'virus' } ],
+            output_template => 'Virus : %d',
+            perfdatas       => [
+                { label => 'virus', value => 'virus_absolute', template => '%d', min => 0 },
+            ],
+        }
+        },
+        { label => 'throttledUsers', set => {
+            key_values      => [ { name => 'throttledUsers' } ],
+            output_template => 'ThrottledUsers : %d',
+            perfdatas       => [
+                { label => 'throttledUsers', value => 'throttledUsers_absolute', template => '%d', min => 0 },
+            ],
+        }
+        },
+        { label => 'throttledMailingLists', set => {
+            key_values      => [ { name => 'throttledMailingLists' } ],
+            output_template => 'ThrottledMailingLists : %d',
+            perfdatas       => [
+                { label => 'throttledMailingLists', value => 'throttledMailingLists_absolute', template => '%d', min => 0 },
+            ],
+        }
+        },
+        { label => 'throttledDomains', set => {
+            key_values      => [ { name => 'throttledDomains' } ],
+            output_template => 'ThrottledDomains : %d',
+            perfdatas       => [
+                { label => 'throttledDomains', value => 'throttledDomains_absolute', template => '%d', min => 0 },
+            ],
+        }
+        },
+        { label => 'spool_limit', set => {
+            key_values      => [ { name => 'spool_limit' } ],
+            output_template => 'Spool_limit : %d',
+            perfdatas       => [
+                { label => 'spool_limit', value => 'spool_limit_absolute', template => '%d', min => 0 },
+            ],
+        }
+        },
+        { label => 'quarantine_limit', set => {
+            key_values      => [ { name => 'quarantine_limit' } ],
+            output_template => 'Quarantine_limit : %d',
+            perfdatas       => [
+                { label => 'quarantine_limit', value => 'quarantine_limit_absolute', template => '%d', min => 0 },
+            ],
+        }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments =>
+        {
+            "filter-counter:s" => { name => 'filter_counters' },
+        });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $jsonResponse = $options{custom}->get_endpoint(api_path => '/settings/sysadmin/spool-message-counts');
+    # my $jsonResponse = '{"counts":{"default":6,"waiting":31,"virus":0,"spam":0,"throttledUsers":1,"throttledMailingLists":0,"throttledDomains":0,"spool_limit":50000,"quarantine_limit":5000},"success":true,"message":""}';
+
+    my $response;
+    eval {
+        $response = decode_json($jsonResponse);
+    };
+    # the response was checked on "get_endpoint" if contains 'success=true'
+    if ($@) {
+        $self->{output}->output_add(long_msg => $jsonResponse, debug => 1);
+        $self->{output}->add_option_msg(short_msg => "Cannot decode json response");
+        $self->{output}->option_exit();
+    }
+
+    my $counts = $response->{counts};
+
+    $self->{global} = '';
+    $self->{global} = {
+        default => $counts->{default},
+        waiting               => $counts->{waiting},
+        spam                  => $counts->{spam},
+        virus                 => $counts->{virus},
+        throttledUsers        => $counts->{throttledUsers},
+        throttledMailingLists => $counts->{throttledMailingLists},
+        throttledDomains      => $counts->{throttledDomains},
+        spool_limit           => $counts->{spool_limit},
+        quarantine_limit      => $counts->{quarantine_limit},
+    };
+}
+
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check spool message counters.
+
+=over 8
+
+=item B<--filter>
+
+Only display some counters (regexp can be used).
+(Example: --filter-counter='active')
+
+=item B<--warning-*>
+
+Threshold warning.
+Can be: 'default', 'waiting', 'spam', 'virus', 'throttledUsers', 'throttledMailingLists', 'throttledDomains'.
+
+=item B<--critical-*>
+
+Threshold critical.
+Can be: 'default', 'waiting', 'spam', 'virus', 'throttledUsers', 'throttledMailingLists', 'throttledDomains'.
+
+=back
+
+=cut

--- a/apps/smartermail/restapi/plugin.pm
+++ b/apps/smartermail/restapi/plugin.pm
@@ -1,0 +1,57 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Authors : Roman Morandell - ivertix
+#
+
+package apps::smartermail::restapi::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_custom);
+
+sub new {
+    my ($class, %options) = @_;
+
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{version} = '1.0';
+    %{$self->{modes}} = (
+        'spoolmessagecount' => 'apps::smartermail::restapi::mode::spoolmessagecount',
+        'licensenotifications' => 'apps::smartermail::restapi::mode::licensenotifications',
+        'services' => 'apps::smartermail::restapi::mode::services',
+    );
+    $self->{custom_modes}{api} = 'apps::smartermail::restapi::custom::api';
+
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 PLUGIN DESCRIPTION
+
+Check Custom mode (an example for creating test with a same line argument).
+
+=over 8
+
+=back
+
+=cut


### PR DESCRIPTION
**Plugin to get information from SmarterMail API**

https://mail.smartertools.com/Documentation/api#/topics/overview

Authentication via username and password to get the JWT. Writes the JWT in a cache file in order to reuse it for later queries up to its expiration date

### **** Modes: services, spoolmessagecount, licensenotifications

**mode=services**

https://mail.smartertools.com/Documentation/api#/reference/SmarterMail.Web.Controllers.Api.SystemAdminSettingsController/GetServices

checks if services are in running state

services: 'spool', 'smtp', 'pop', 'xmpp', 'imap', 'ldap', 'popretrieval', 'imapretrieval', 'indexing'

perl /usr/lib/centreon/plugins/centreon_plugins.pl --plugin=apps::smartermail::restapi::plugin --mode=services --hostname='webmail.example.com' --username=username --password='***password***' 

**filter option**

perl /usr/lib/centreon/plugins/centreon_plugins.pl --plugin=apps::smartermail::restapi::plugin --mode=services --hostname='webmail.example.com' --username=username --password='***password***' --filter-service='spool|smtp|pop|imap'

**critical-status**

perl /usr/lib/centreon/plugins/centreon_plugins.pl --plugin=apps::smartermail::restapi::plugin --mode=services --hostname='webmail.example.com' --username=username --password='***password***' --filter-service='spool|smtp|pop|imap' --critical-status='%{state_absolute} !~ /running/'

*********************

**mode=spoolmessagecount**

https://mail.smartertools.com/Documentation/api#/reference/SmarterMail.Web.Controllers.Api.SystemAdminSettingsController/GetSpoolMessageCounts

perl /usr/lib/centreon/plugins/centreon_plugins.pl --plugin=apps::smartermail::restapi::plugin --mode=spoolmessagecount --hostname=webmail.example.com --username=username --password='***password***' --warning-default= --warning-waiting= --warning-spam= --warning-virus= --critical-default= --critical-waiting= --critical-spam= --critical-virus=

**filter option**

perl /usr/lib/centreon/plugins/centreon_plugins.pl --plugin=apps::smartermail::restapi::plugin --mode=spoolmessagecount --hostname=webmail.example.com --username=username --password='***password***' --warning-default= --warning-waiting= --warning-spam= --warning-virus= --critical-default= --critical-waiting= --critical-spam= --critical-virus= --filter-counter='waiting|spam|virus'

*********************

**mode=licensenotifications**

gets information about the license state. 

https://mail.smartertools.com/Documentation/api#/reference/SmarterMail.Web.Controllers.Api.SystemAdminSettingsController/GetLicenseNotifications

perl /usr/lib/centreon/plugins/centreon_plugins.pl --plugin=apps::smartermail::restapi::plugin --mode=licensenotifications --hostname='webmail.example.com' --username=username --password='***password***' --warning-daysUntilUpgradeProtectionExpires=50: --critical-daysUntilUpgradeProtectionExpires=30: