### PR TITLE
Update vplexapi.pm error line 137

### DIFF
--- a/storage/emc/vplex/restapi/custom/vplexapi.pm
+++ b/storage/emc/vplex/restapi/custom/vplexapi.pm
@@ -133,8 +133,8 @@ sub get_items {
         my $engine_name;
         
         if (defined($options{parent})) {
-            $context->{parent} =~ /\/$options{parent}-(.*?)\//;
-            $engine_name = $options{parent} . '-' . $1;
+            $context->{parent} =~ /\/.*?\/(.*?)\//;
+            $engine_name = $1;
             $items->{$engine_name} = {} if (!defined($items->{$engine_name}));
         }
         


### PR DESCRIPTION
Correct an error:
/storage/emc/vplex/restapi/custom/vplexapi.pm line 137
when clusters as been renamed (not named by default cluster-1 & cluster-2)
Bug exist on VS2 & VS6 patch tried on both and works greats
All mode commandes on both VS2 & VS6 in debug mode:
VS2 -> http://dl.free.fr/fXGIMpctN
VG6 -> http://dl.free.fr/sWvDo8tYA