### PR TITLE
Update getreason.pm

### DIFF
--- a/storage/emc/celerra/local/mode/getreason.pm
+++ b/storage/emc/celerra/local/mode/getreason.pm
@@ -91,9 +91,9 @@ sub new {
         'ssh-command:s'     => { name => 'ssh_command', default => 'ssh' },
         'timeout:s'         => { name => 'timeout', default => 30 },
         'sudo'              => { name => 'sudo' },
-        'command:s'         => { name => 'command', default => 'getreason' },
+        'command:s'         => { name => 'command', default => 'getreason;if [ "$?" -eq "255" ]; then exit 0; else exit 1;fi' },
         'command-path:s'    => { name => 'command_path', default => '/nas/sbin' },
-        'command-options:s' => { name => 'command_options', default => '2>&1' }
+        'command-options:s' => { name => 'command_options', default => '-q' }
     });
 
     return $self;


### PR DESCRIPTION
[nasadmin@celerra ~]$ /nas/sbin/getreason --help ; echo "OUT=$?"
Getreason - Version 5.04.0 - 08/10/04
usage: getreason [-b sib_mask] [-s slot_id]
       Collects Tier2 reason codes from the shoe boxes specified by
                the sib_mask or slot_id.  If no parameters are provided then
                reason codes for all boxes in the Tier2 rack will be returned.

   -b box ID mask in hex (0C = box 2 and box 3)
   -s slot ID of a single shoebox to reset.
Source revision  5.2.0.1 -  06/12/03
OUT=255

As you can see the normal return is 255 so it create errors.

So if cmd return 255 I change to exit 0 else exit 1

OUTPUT OF DEBUG ODE:
./centreon_plugins.pl --plugin storage::emc::celerra::local::plugin --mode getreason --hostname celerra --remote --ssh-option='-lnasadmin' --ssh-option='-q' --command='getreason;if [ "$?" -eq "255" ]; then exit 0; else exit 1;fi' --debug
OK: All 4 components are ok [2/2 control stations, 2/2 data movers]. | 'count_controlstation'=2;;;; 'count_datamover'=2;;;;
Checking control stations
Control station 'slot_0' status is 'Primary Control Station'
Control station 'slot_1' status is 'Secondary Control Station'
Checking data movers
Data mover 'slot_2' status is 'DART is in contact with Control Station box monitor'
Data mover 'slot_3' status is 'DART is in contact with Control Station box monitor'

I have also change the 'command-options' cause getreason always display on >1 ans '-q' permit to hide the MOTD