### PR TITLE
fix(mode): timeframe value should not be null

### DIFF
--- a/apps/graylog/restapi/mode/query.pm
+++ b/apps/graylog/restapi/mode/query.pm
@@ -65,6 +65,11 @@ sub check_options {
         $self->{output}->add_option_msg(short_msg => 'Please set --query option.');
         $self->{output}->option_exit();
     }
+    
+    if (defined($self->{option_results}->{timeframe}) && $self->{option_results}->{timeframe} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Please set --timeframe value.');
+        $self->{output}->option_exit();
+    }
 }
 
 sub manage_selection {


### PR DESCRIPTION
The graylog API consider requests with undef parameters values as 0. So we'd better ensure that the timeframe value is valid when the option is set