### PR TITLE
enh(idrac) add enclosure hw component

### DIFF
--- a/hardware/server/dell/idrac/snmp/mode/components/enclosure.pm
+++ b/hardware/server/dell/idrac/snmp/mode/components/enclosure.pm
@@ -1,0 +1,78 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package hardware::server::dell::idrac::snmp::mode::components::enclosure;
+
+use strict;
+use warnings;
+use hardware::server::dell::idrac::snmp::mode::components::resources qw(%map_status %map_enclosure_state);
+
+my $mapping = {
+    enclosureState           => { oid => '.1.3.6.1.4.1.674.10892.5.5.1.20.130.3.1.4', map => \%map_enclosure_state },
+    enclosureName            => { oid => '.1.3.6.1.4.1.674.10892.5.5.1.20.130.3.1.2' },
+    enclosureRollUpStatus    => { oid => '.1.3.6.1.4.1.674.10892.5.5.1.20.130.3.1.23', map => \%map_status },
+};
+my $oid_enclosureTableEntry = '.1.3.6.1.4.1.674.10892.5.5.1.20.130.3';
+
+sub load {
+    my ($self) = @_;
+    
+    push @{$self->{request}}, {
+        oid => $oid_enclosureTableEntry,
+        start => $mapping->{enclosureName}->{oid},
+        end => $mapping->{enclosureRollUpStatus}->{oid}
+    };
+}
+
+sub check {
+    my ($self) = @_;
+
+    $self->{output}->output_add(long_msg => "Checking enclosures");
+    $self->{components}->{enclosure} = {name => 'enclosures', total => 0, skip => 0};
+    return if ($self->check_filter(section => 'enclosure'));
+
+    foreach my $oid ($self->{snmp}->oid_lex_sort(keys %{$self->{results}->{$oid_enclosureTableEntry}})) {
+        next if ($oid !~ /^$mapping->{enclosureRollUpStatus}->{oid}\.(.*)$/);
+        my $instance = $1;
+        my $result = $self->{snmp}->map_instance(mapping => $mapping, results => $self->{results}->{$oid_enclosureTableEntry}, instance => $instance);
+        
+        next if ($self->check_filter(section => 'enclosure', instance => $instance));
+        $self->{components}->{enclosure}->{total}++;
+
+        $self->{output}->output_add(long_msg => sprintf("enclosure '%s' status is '%s' [instance = %s] [state = %s]",
+                                    $result->{enclosureName}, $result->{enclosureRollUpStatus}, $instance, 
+                                    $result->{enclosureState}));
+        
+        my $exit = $self->get_severity(section => 'enclosure.state', value => $result->{enclosureState});
+        if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
+            $self->{output}->output_add(severity => $exit,
+                                        short_msg => sprintf("Enclosure '%s' state is '%s'", $result->{enclosureName}, $result->{enclosureState}));
+            next;
+        }
+
+        $exit = $self->get_severity(label => 'default.status', section => 'enclosure.status', value => $result->{enclosureRollUpStatus});
+        if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
+            $self->{output}->output_add(severity => $exit,
+                                        short_msg => sprintf("Enclosure '%s' status is '%s'", $result->{enclosureName}, $result->{enclosureRollUpStatus}));
+        }
+    }
+}
+
+1;

--- a/hardware/server/dell/idrac/snmp/mode/components/resources.pm
+++ b/hardware/server/dell/idrac/snmp/mode/components/resources.pm
@@ -27,13 +27,14 @@ use Exporter;
 our %map_state;
 our %map_status;
 our %map_probe_status;
+our %map_enclosure_state;
 our %map_amperage_type;
 our %map_pdisk_state;
 our %map_pdisk_smartstate;
 our %map_vdisk_state;
 
 our @ISA = qw(Exporter);
-our @EXPORT_OK = qw(%map_probe_status %map_state %map_status %map_amperage_type %map_pdisk_state %map_pdisk_smartstate %map_vdisk_state);
+our @EXPORT_OK = qw(%map_probe_status %map_state %map_status %map_enclosure_state %map_amperage_type %map_pdisk_state %map_pdisk_smartstate %map_vdisk_state);
 
 %map_pdisk_smartstate = (
     0 => 'off',
@@ -67,6 +68,14 @@ our @EXPORT_OK = qw(%map_probe_status %map_state %map_status %map_amperage_type 
     2 => 'enabled', 
     4 => 'notReady', 
     6 => 'enabledAndNotReady',
+);
+
+%map_enclosure_state = (
+    1 => 'unknown',
+    2 => 'ready',
+    3 => 'failed',
+    4 => 'missing',
+    5 => 'degraded',
 );
 
 %map_pdisk_state = (

--- a/hardware/server/dell/idrac/snmp/mode/hardware.pm
+++ b/hardware/server/dell/idrac/snmp/mode/hardware.pm
@@ -59,6 +59,13 @@ sub set_system {
             ['nonRecoverableLower', 'CRITICAL'],
             ['failed', 'CRITICAL']
         ],
+        'enclosure.state' => [
+            ['unknown', 'UNKNOWN'],
+            ['ready', 'OK'],
+            ['failed', 'CRITICAL'],
+            ['missing', 'WARNING'],
+            ['degraded', 'WARNING']
+        ],
         'pdisk.state' => [
             ['unknown', 'UNKNOWN'],
             ['readySpareDedicated', 'OK'],
@@ -89,7 +96,7 @@ sub set_system {
     $self->{components_module} = [
         'psu', 'punit', 'temperature', 'voltage', 'amperage', 
         'systembattery', 'coolingunit', 'coolingdevice', 'processor', 'memory', 'pci', 'network', 
-        'slot', 'fru', 'storagectrl', 'storagebattery', 'pdisk', 'vdisk'
+        'slot', 'fru', 'storagectrl', 'storagebattery', 'pdisk', 'vdisk', 'enclosure'
     ];
 }
 
@@ -125,7 +132,7 @@ Check hardware components.
 Which component to check (Default: '.*').
 Can be: 'psu', 'punit', 'temperature', 'voltage', 'amperage', 
 'systembattery', 'coolingunit', 'coolingdevice', 'processor', 'memory', 'pci', 'network', 
-'slot', 'fru', 'storagectrl', 'storagebattery', 'pdisk', 'vdisk'.
+'slot', 'fru', 'storagectrl', 'storagebattery', 'pdisk', 'vdisk', 'enclosure'.
 
 =item B<--filter>
 


### PR DESCRIPTION
Hi,

This PR improves `idrac` plugin adding the enclosure hardware component.
I took the RollUpStatus : _this is the combined status of the enclosure and its sub-components_.
Instead of the ComponentStatus : _the status of the enclosure/backplane itself without the
propagation of any contained component status_.

So that we get the whole enclosure status.

```
OK: All 1 components are ok [1/1 enclosures]. | 'count_enclosure'=1;;;;
Checking enclosures
enclosure 'BP14G+ 0:1' status is 'ok' [instance = 1] [state = ready]
```

Thank you 👍