### PR TITLE
bug fix when queue has no message

### DIFF
--- a/apps/mulesoft/restapi/mode/messages.pm
+++ b/apps/mulesoft/restapi/mode/messages.pm
@@ -147,9 +147,11 @@ sub manage_selection {
                 push @{$self->{raw_results}->{$queue->{queueId}}->{$message_type}}, $values->{value};
                 $total_value += $values->{value};
             }
-            my $points = scalar(@{$self->{raw_results}->{$queue->{queueId}}->{$message_type}});
+            if ($self->{raw_results}->{$queue->{queueId}}->{$message_type}) {
+                my $points = scalar(@{$self->{raw_results}->{$queue->{queueId}}->{$message_type}});
 
-            $self->{raw_results}->{$queue->{queueId}}{$message_type} =  $total_value / $points;
+                $self->{raw_results}->{$queue->{queueId}}{$message_type} =  $total_value / $points;
+            }
         }
 
         $self->{queues}->{$queue->{queueId}} = {


### PR DESCRIPTION
just add a check when object is undefined.
this is to avoid error message: UNKNOWN: Can't use an undefined value as an ARRAY reference at /usr/lib/centreon/plugins/centreon-plugins/apps/mulesoft/restapi/mode/messages.pm line 150
and the current check to fail.