### PR TITLE
enh(imm) Add some standard modes

### DIFF
--- a/hardware/server/ibm/mgmt_cards/imm/snmp/plugin.pm
+++ b/hardware/server/ibm/mgmt_cards/imm/snmp/plugin.pm
@@ -32,7 +32,8 @@ sub new {
     $self->{version} = '1.0';
     %{$self->{modes}} = (
         'environment' => 'hardware::server::ibm::mgmt_cards::imm::snmp::mode::environment',
-        'eventlog' => 'hardware::server::ibm::mgmt_cards::imm::snmp::mode::eventlog',
+        'eventlog'    => 'hardware::server::ibm::mgmt_cards::imm::snmp::mode::eventlog',
+        'time'        => 'snmp_standard::mode::ntp'
     );
 
     return $self;


### PR DESCRIPTION
Hi,

Let's add `time` standard mode to IMM, so that we can check they are time-synchronised, which is helpful when handling logs etc...

Thx 👍