### PR TITLE
Fix(plugin)loganalytics enhancement

### DIFF
--- a/cloud/azure/custom/api.pm
+++ b/cloud/azure/custom/api.pm
@@ -625,8 +625,9 @@ sub azure_get_log_analytics_set_url {
 
     my $uri = URI::Encode->new({encode_reserved => 1});
     my $encoded_query = $uri->encode($options{query});
-    my $encoded_interval = $uri->encode($options{interval});
-    my $url = $self->{management_endpoint} . '/v1/workspaces/' . $options{workspace_id} . '/query?query=' . $encoded_query . '&timespan=' . $encoded_interval;
+    my $encoded_timespan = $uri->encode($options{timespan});
+    my $url = $self->{management_endpoint} . '/v1/workspaces/' . $options{workspace_id} . '/query?query=' . $encoded_query;
+    $url .= '&timespan=' . $encoded_timespan if (defined($encoded_timespan));
 
     return $url;
 }

--- a/cloud/azure/custom/azcli.pm
+++ b/cloud/azure/custom/azcli.pm
@@ -526,7 +526,8 @@ sub azure_get_log_analytics_set_cmd {
 
     return if (defined($self->{option_results}->{command_options}) && $self->{option_results}->{command_options} ne '');
 
-    my $cmd_options = "monitor log-analytics query --workspace '$options{workspace_id}' --analytics-query \"$options{query}\" --timespan '$options{interval}' --only-show-errors";
+    my $cmd_options = "monitor log-analytics query --workspace '$options{workspace_id}' --analytics-query \"$options{query}\" --only-show-errors";
+    $cmd_options .= " --timespan '$options{timespan}'" if (defined($options{timespan}));
     return $cmd_options; 
 }
 

--- a/cloud/azure/management/loganalytics/mode/kustoquery.pm
+++ b/cloud/azure/management/loganalytics/mode/kustoquery.pm
@@ -73,9 +73,10 @@ sub new {
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
-        'workspace-id:s'    => { name => 'workspace_id' },
+        'custom-output:s'   => { name => 'custom_output'},
         'query:s'           => { name => 'query'},
-        'custom-output:s'   => { name => 'custom_output'}
+        'timespan:s'        => { name => 'timespan' },
+        'workspace-id:s'    => { name => 'workspace_id' }
     });
 
     return $self;
@@ -95,7 +96,6 @@ sub check_options {
         $self->{output}->option_exit();
     }
 
-    $self->{az_interval} = defined($self->{option_results}->{interval}) ? $self->{option_results}->{interval} : 'PT5M';
 }
 
 sub manage_selection {
@@ -104,7 +104,7 @@ sub manage_selection {
     my ($log_results) = $options{custom}->azure_get_log_analytics(
         workspace_id => $self->{option_results}->{workspace_id},
         query => $self->{option_results}->{query},
-        interval => $self->{az_interval}
+        timespan => $self->{option_results}->{timespan}
     );
 
     $self->{global} = { match => 0 };
@@ -134,19 +134,24 @@ OK: Number of Syslog '2' | 'match.count'=2;;;0;
 
 =over 8
 
-=item B<--workspace-id>
+=item B<--custom-output>
 
-Set workspace id (Required).
+Set a custom message to output in printf format.
+Exemple: 'Number of Syslog message collected %d'
 
 =item B<--query>
 
 Set query (Required).
 Syntax: https://docs.microsoft.com/en-us/azure/kusto/query/
 
-=item B<--custom-output>
+=item B<--workspace-id>
 
-Set a custom message to output in printf format.
-Exemple: 'Number of Syslog message collected %d'
+Set workspace id (Required).
+
+=item B<--timespan>
+
+Set Timespan of the query (Do not use it if time filters is included in the 
+query)
 
 =item B<--warning-match> B<--critical-match>
 

--- a/cloud/azure/management/loganalytics/mode/kustoquery.pm
+++ b/cloud/azure/management/loganalytics/mode/kustoquery.pm
@@ -152,6 +152,7 @@ Set workspace id (Required).
 
 Set Timespan of the query (Do not use it if time filters is included in the 
 query)
+(Can be : PT1M, PT5M, PT15M, PT30M, PT1H, PT6H, PT12H, PT24H).
 
 =item B<--warning-match> B<--critical-match>
 


### PR DESCRIPTION
- Stick to MS documentation on the option name (timespan instead of interval)
- Timespan should not be mandatory because users can filter on time through the query