### PR TITLE
enh(cloud/kubernetes): add metrics to node-usage mode

### DIFF
--- a/cloud/kubernetes/mode/nodeusage.pm
+++ b/cloud/kubernetes/mode/nodeusage.pm
@@ -24,65 +24,76 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
-use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold);
 
-sub custom_usage_perfdata {
+sub custom_cpu_output {
     my ($self, %options) = @_;
 
-    my $label = 'allocated_pods';
-    my $value_perf = $self->{result_values}->{allocated};
-    
-    my %total_options = ();
-    if ($self->{instance_mode}->{option_results}->{units} eq '%') {
-        $total_options{total} = $self->{result_values}->{allocatable};
-        $total_options{cast_int} = 1;
-    }
-
-    $self->{output}->perfdata_add(
-        label => $label,
-        nlabel => 'pods.allocated.count',
-        value => $value_perf,
-        warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{thlabel}, %total_options),
-        critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{thlabel}, %total_options),
-        min => 0, max => $self->{result_values}->{allocatable},
-        instances => $self->use_instances(extra_instance => $options{extra_instance}) ? $self->{result_values}->{display} : undef,
+    return sprintf(
+        'CPU %s: %.2f%% (%s/%s)',
+        $self->{result_values}->{flavor},
+        $self->{result_values}->{'cpu_' . $self->{result_values}->{flavor} . '_prct'},
+        $self->{result_values}->{'cpu_' . $self->{result_values}->{flavor}},
+        $self->{result_values}->{cpu_allocatable}
     );
 }
 
-sub custom_usage_threshold {
-    my ($self, %options) = @_;
-
-    my ($exit, $threshold_value);
-    $threshold_value = $self->{result_values}->{allocated};
-    if ($self->{instance_mode}->{option_results}->{units} eq '%') {
-        $threshold_value = $self->{result_values}->{prct_allocated};
-    }
-    $exit = $self->{perfdata}->threshold_check(
-        value => $threshold_value, threshold => [ { label => 'critical-' . $self->{thlabel}, exit_litteral => 'critical' },
-                                                  { label => 'warning-'. $self->{thlabel}, exit_litteral => 'warning' } ]
-    );
-    return $exit;
-}
-
-sub custom_usage_output {
-    my ($self, %options) = @_;
-
-    my $msg = sprintf("Pods Capacity: %s, Allocatable: %s, Allocated: %s (%.2f%%)",
-        $self->{result_values}->{capacity},
-        $self->{result_values}->{allocatable},
-        $self->{result_values}->{allocated},
-        $self->{result_values}->{prct_allocated});
-    return $msg;
-}
-
-sub custom_usage_calc {
+sub custom_cpu_calc {
     my ($self, %options) = @_;
 
     $self->{result_values}->{display} = $options{new_datas}->{$self->{instance} . '_display'};
-    $self->{result_values}->{capacity} = $options{new_datas}->{$self->{instance} . '_capacity'};    
-    $self->{result_values}->{allocatable} = $options{new_datas}->{$self->{instance} . '_allocatable'};
-    $self->{result_values}->{allocated} = $options{new_datas}->{$self->{instance} . '_allocated'};
-    $self->{result_values}->{prct_allocated} = ($self->{result_values}->{allocatable} > 0) ? $self->{result_values}->{allocated} * 100 / $self->{result_values}->{allocatable} : 0;
+    $self->{result_values}->{flavor} = $options{extra_options}->{flavor};
+    $self->{result_values}->{cpu_allocatable} = $options{new_datas}->{$self->{instance} . '_cpu_allocatable'};    
+    $self->{result_values}->{'cpu_' . $self->{result_values}->{flavor}} = $options{new_datas}->{$self->{instance} . '_cpu_' . $self->{result_values}->{flavor}};
+    $self->{result_values}->{'cpu_' . $self->{result_values}->{flavor} . '_prct'} = ($self->{result_values}->{cpu_allocatable} > 0) ?
+        $self->{result_values}->{'cpu_' . $self->{result_values}->{flavor}} * 100 / $self->{result_values}->{cpu_allocatable} : 0;
+
+    return 0;
+}
+
+sub custom_memory_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        'Memory %s: %.2f%% (%s%s/%s%s)',
+        $self->{result_values}->{flavor},
+        $self->{result_values}->{'memory_' . $self->{result_values}->{flavor} . '_prct'},
+        $self->{perfdata}->change_bytes(value => $self->{result_values}->{'memory_' . $self->{result_values}->{flavor}}),
+        $self->{perfdata}->change_bytes(value => $self->{result_values}->{memory_allocatable})
+    );
+}
+
+sub custom_memory_calc {
+    my ($self, %options) = @_;
+
+    $self->{result_values}->{display} = $options{new_datas}->{$self->{instance} . '_display'};
+    $self->{result_values}->{flavor} = $options{extra_options}->{flavor};
+    $self->{result_values}->{memory_allocatable} = $options{new_datas}->{$self->{instance} . '_memory_allocatable'};    
+    $self->{result_values}->{'memory_' . $self->{result_values}->{flavor}} = $options{new_datas}->{$self->{instance} . '_memory_' . $self->{result_values}->{flavor}};
+    $self->{result_values}->{'memory_' . $self->{result_values}->{flavor} . '_prct'} = ($self->{result_values}->{memory_allocatable} > 0) ?
+        $self->{result_values}->{'memory_' . $self->{result_values}->{flavor}} * 100 / $self->{result_values}->{memory_allocatable} : 0;
+
+    return 0;
+}
+
+sub custom_pods_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        'Pods allocation: %.2f%% (%s/%s)',
+        $self->{result_values}->{pods_allocated_prct},
+        $self->{result_values}->{pods_allocated},
+        $self->{result_values}->{pods_allocatable}
+    );
+}
+
+sub custom_pods_calc {
+    my ($self, %options) = @_;
+
+    $self->{result_values}->{display} = $options{new_datas}->{$self->{instance} . '_display'};
+    $self->{result_values}->{pods_allocatable} = $options{new_datas}->{$self->{instance} . '_pods_allocatable'};
+    $self->{result_values}->{pods_allocated} = $options{new_datas}->{$self->{instance} . '_pods_allocated'};
+    $self->{result_values}->{pods_allocated_prct} = ($self->{result_values}->{pods_allocatable} > 0) ?
+        $self->{result_values}->{pods_allocated} * 100 / $self->{result_values}->{pods_allocatable} : 0;
     
     return 0;
 }
@@ -96,15 +107,65 @@ sub set_counters {
     ];
 
     $self->{maps_counters}->{nodes} = [
-        { label => 'allocated-pods', set => {
-                key_values => [ { name => 'capacity' }, { name => 'allocatable' }, { name => 'allocated' },
-                    { name => 'display' } ],
-                closure_custom_calc => $self->can('custom_usage_calc'),
-                closure_custom_output => $self->can('custom_usage_output'),
-                closure_custom_perfdata => $self->can('custom_usage_perfdata'),
-                closure_custom_threshold_check => $self->can('custom_usage_threshold'),
+        { label => 'cpu-requests', nlabel => 'cpu.requests.percentage', set => {
+                key_values => [ { name => 'cpu_allocatable' }, { name => 'cpu_requests' }, { name => 'display' } ],
+                closure_custom_calc => $self->can('custom_cpu_calc'),
+                closure_custom_calc_extra_options => { flavor => 'requests' },
+                closure_custom_output => $self->can('custom_cpu_output'),
+                perfdatas => [
+                    { label => 'cpu_requests', value => 'cpu_requests_prct',
+                      template => '%.2f', min => 0, max => '100', unit => '%',
+                      label_extra_instance => 1, instance_use => 'display' }
+                ]
             }
         },
+        { label => 'cpu-limits', nlabel => 'cpu.limits.percentage', set => {
+                key_values => [ { name => 'cpu_allocatable' }, { name => 'cpu_limits' }, { name => 'display' } ],
+                closure_custom_calc => $self->can('custom_cpu_calc'),
+                closure_custom_calc_extra_options => { flavor => 'limits' },
+                closure_custom_output => $self->can('custom_cpu_output'),
+                perfdatas => [
+                    { label => 'cpu_limits', value => 'cpu_limits_prct',
+                      template => '%.2f', min => 0, max => '100', unit => '%',
+                      label_extra_instance => 1, instance_use => 'display' }
+                ]
+            }
+        },
+        { label => 'memory-requests', nlabel => 'memory.requests.percentage', set => {
+                key_values => [ { name => 'memory_allocatable' }, { name => 'memory_requests' }, { name => 'display' } ],
+                closure_custom_calc => $self->can('custom_memory_calc'),
+                closure_custom_calc_extra_options => { flavor => 'requests' },
+                closure_custom_output => $self->can('custom_memory_output'),
+                perfdatas => [
+                    { label => 'memory_requests', value => 'memory_requests_prct',
+                      template => '%.2f', min => 0, max => '100', unit => '%',
+                      label_extra_instance => 1, instance_use => 'display' }
+                ]
+            }
+        },
+        { label => 'memory-limits', nlabel => 'memory.limits.percentage', set => {
+                key_values => [ { name => 'memory_allocatable' }, { name => 'memory_limits' }, { name => 'display' } ],
+                closure_custom_calc => $self->can('custom_memory_calc'),
+                closure_custom_calc_extra_options => { flavor => 'limits' },
+                closure_custom_output => $self->can('custom_memory_output'),
+                perfdatas => [
+                    { label => 'memory_limits', value => 'memory_limits_prct',
+                      template => '%.2f', min => 0, max => '100', unit => '%',
+                      label_extra_instance => 1, instance_use => 'display' }
+                ]
+            }
+        },
+        { label => 'allocated-pods', nlabel => 'pods.allocation.percentage', set => {
+                key_values => [ { name => 'pods_allocatable' }, { name => 'pods_allocated' }, { name => 'display' } ],
+                closure_custom_calc => $self->can('custom_pods_calc'),
+                closure_custom_output => $self->can('custom_pods_output'),
+                perfdatas => [
+                    { label => 'allocated_pods', value => 'pods_allocated_prct',
+                      template => '%.2f', min => 0, max => '100', unit => '%',
+                      label_extra_instance => 1, instance_use => 'display' }
+                ]
+            }
+        }
     ];
 }
 
@@ -121,7 +182,7 @@ sub new {
     
     $options{options}->add_options(arguments => {
         "filter-name:s" => { name => 'filter_name' },
-        "units:s"       => { name => 'units', default => '%' },        
+        "units:s"       => { name => 'units', default => '%' }, # Keep compat
     });
    
     return $self;
@@ -130,8 +191,6 @@ sub new {
 sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::check_options(%options);
-
-    $self->change_macros(macros => ['warning_status', 'critical_status']);
 }
 
 sub manage_selection {
@@ -150,8 +209,9 @@ sub manage_selection {
 
         $self->{nodes}->{$node->{metadata}->{name}} = {
             display => $node->{metadata}->{name},
-            capacity => $node->{status}->{capacity}->{pods},
-            allocatable => $node->{status}->{allocatable}->{pods},
+            pods_allocatable => $node->{status}->{allocatable}->{pods},
+            cpu_allocatable => $self->to_bytes(value => $node->{status}->{allocatable}->{cpu}),
+            memory_allocatable => $self->to_bytes(value => $node->{status}->{capacity}->{memory}),
         }            
     }
     
@@ -164,8 +224,44 @@ sub manage_selection {
 
     foreach my $pod (@{$pods}) {
         next if (defined($pod->{spec}->{nodeName}) && !defined($self->{nodes}->{$pod->{spec}->{nodeName}}));
-        $self->{nodes}->{$pod->{spec}->{nodeName}}->{allocated}++;
+        $self->{nodes}->{$pod->{spec}->{nodeName}}->{pods_allocated}++;
+        foreach my $container (@{$pod->{spec}->{containers}}) {
+            $self->{nodes}->{$pod->{spec}->{nodeName}}->{cpu_requests} += $self->to_core(value => $container->{resources}->{requests}->{cpu}) if (defined($container->{resources}->{requests}->{cpu}));
+            $self->{nodes}->{$pod->{spec}->{nodeName}}->{cpu_limits} += $self->to_core(value => $container->{resources}->{limits}->{cpu}) if (defined($container->{resources}->{limits}->{cpu}));            
+            $self->{nodes}->{$pod->{spec}->{nodeName}}->{memory_requests} += $self->to_bytes(value => $container->{resources}->{requests}->{memory}) if (defined($container->{resources}->{requests}->{memory}));
+            $self->{nodes}->{$pod->{spec}->{nodeName}}->{memory_limits} += $self->to_bytes(value => $container->{resources}->{limits}->{memory}) if (defined($container->{resources}->{limits}->{memory}));
+        }
     }
+}
+
+sub to_bytes {
+    my ($self, %options) = @_;
+
+    my $value = $options{value};
+    
+    if ($value =~ /(\d+)Ki$/) {
+        $value = $1 * 1024;
+    } elsif ($value =~ /(\d+)Mi$/) {
+        $value = $1 * 1024 * 1024;
+    } elsif ($value =~ /(\d+)Gi$/) {
+        $value = $1 * 1024 * 1024 * 1024;
+    } elsif ($value =~ /(\d+)Ti$/) {
+        $value = $1 * 1024 * 1024 * 1024 * 1024;
+    }
+
+    return $value;
+}
+
+sub to_core {
+    my ($self, %options) = @_;
+
+    my $value = $options{value};
+    
+    if ($value =~ /(\d+)m$/) {
+        $value = $1 / 1000;
+    }
+
+    return $value;
 }
 
 1;
@@ -182,17 +278,11 @@ Check node usage.
 
 Filter node name (can be a regexp).
 
-=item B<--warning-allocated-pods>
+=item B<--warning-*> B<--critical-*> 
 
-Threshold warning for pods allocation.
-
-=item B<--critical-allocated-pods>
-
-Threshold critical for pods allocation.
-
-=item B<--units>
-
-Units of thresholds (Default: '%') (Can be '%' or absolute).
+Thresholds (in percentage).
+Can be: 'cpu-requests', 'cpu-limits', 'memory-requests', 'memory-limits',
+'allocated-pods'.
 
 =back
 


### PR DESCRIPTION
Keep --units option for compat, but turn all thresholds to percentages.

Get closer to Kubernetes dashboard metrics:

```
perl centreon_plugins.pl --plugin=cloud::kubernetes::plugin --mode=node-usage --custommode='api' --hostname=amzkubernetesapi.int.centreon.com --port='443' --proto='https' --token='abcd' --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE" --verbose --use-new-perfdata
OK: All nodes usage are ok | 'amzkubemaster.int.centreon.com#cpu.requests.percentage'=37.50%;;;0;100 'amzkubemaster.int.centreon.com#cpu.limits.percentage'=5.00%;;;0;100 'amzkubemaster.int.centreon.com#memory.requests.percentage'=3.96%;;;0;100 'amzkubemaster.int.centreon.com#memory.limits.percentage'=1.32%;;;0;100 'amzkubemaster.int.centreon.com#pods.allocation.percentage'=7.27%;;;0;100 'amzkubenode1.int.centreon.com#cpu.requests.percentage'=35.00%;;;0;100 'amzkubenode1.int.centreon.com#cpu.limits.percentage'=115.00%;;;0;100 'amzkubenode1.int.centreon.com#memory.requests.percentage'=31.51%;;;0;100 'amzkubenode1.int.centreon.com#memory.limits.percentage'=115.21%;;;0;100 'amzkubenode1.int.centreon.com#pods.allocation.percentage'=9.09%;;;0;100 'amzkubenode2.int.centreon.com#cpu.requests.percentage'=30.00%;;;0;100 'amzkubenode2.int.centreon.com#cpu.limits.percentage'=555.00%;;;0;100 'amzkubenode2.int.centreon.com#memory.requests.percentage'=30.19%;;;0;100 'amzkubenode2.int.centreon.com#memory.limits.percentage'=546.23%;;;0;100 'amzkubenode2.int.centreon.com#pods.allocation.percentage'=10.91%;;;0;100
Node 'amzkubemaster.int.centreon.com' CPU requests: 37.50% (0.75/2), CPU limits: 5.00% (0.1/2), Memory requests: 3.96% (150.00MB/3.70GB), Memory limits: 1.32% (50.00MB/3.70GB), Pods allocation: 7.27% (8/110)
Node 'amzkubenode1.int.centreon.com' CPU requests: 35.00% (0.7/2), CPU limits: 115.00% (2.3/2), Memory requests: 31.51% (1.17GB/3.70GB), Memory limits: 115.21% (4.26GB/3.70GB), Pods allocation: 9.09% (10/110)
Node 'amzkubenode2.int.centreon.com' CPU requests: 30.00% (0.6/2), CPU limits: 555.00% (11.1/2), Memory requests: 30.19% (1.12GB/3.70GB), Memory limits: 546.23% (20.21GB/3.70GB), Pods allocation: 10.91% (12/110)
```
![image](https://user-images.githubusercontent.com/23257354/109479395-a2271080-7a7a-11eb-9c7f-3721bf9f7b37.png)

