### PR TITLE
fix(mode): Dynatrace fix URI for local hostnames

### DIFF
--- a/apps/monitoring/dynatrace/restapi/custom/api.pm
+++ b/apps/monitoring/dynatrace/restapi/custom/api.pm
@@ -104,6 +104,7 @@ sub build_options_for_httplib {
     } else {
         $self->{option_results}->{hostname} = $self->{hostname};
     }
+    $self->{option_results}->{environment_id} = $self->{environment_id};
     $self->{option_results}->{port} = $self->{port};
     $self->{option_results}->{proto} = $self->{proto};
     $self->{option_results}->{ssl_opt} = $self->{ssl_opt};
@@ -123,7 +124,7 @@ sub request_api {
     my ($self, %options) = @_;
 
     $self->settings();
-    my $content = $self->{http}->request(%options, 
+    my $content = $self->{http}->request(%options,
         warning_status => '', unknown_status => '%{http_code} < 200 or %{http_code} >= 300', critical_status => ''
     );
 
@@ -148,7 +149,10 @@ sub request_api {
 sub internal_problem {
     my ($self, %options) = @_;
 
-    my $status = $self->request_api(method => 'GET', url_path => (($self->{hostname} eq 'live.dynatrace.com') ? '' : '/e') . '/api/v1/problem/feed?relativeTime=' . $self->{option_results}->{relative_time});
+    my $status = $self->request_api(
+        method => 'GET',
+        url_path => (($self->{hostname} eq 'live.dynatrace.com') ? '' : '/e/' . $self->{option_results}->{environment_id}) . '/api/v1/problem/feed?relativeTime=' . $self->{option_results}->{relative_time}
+    );
     return $status;
 }
 


### PR DESCRIPTION
#./centreon_plugins.pl --mode=problems --plugin=apps::monitoring::dynatrace::restapi::plugin --hostname="live.dynatrace.com" --environment-id="1234-abcd-5678" --api-password=**** --debug
UNKNOWN: 404 Not Found |
======> request send
GET https://1234-abcd-5678.live.dynatrace.com:443/api/v1/problem/feed?relativeTime=min

#./centreon_plugins.pl --mode=problems --plugin=apps::monitoring::dynatrace::restapi::plugin --hostname="dynatrace.test.lan" --environment-id="1234-abcd-5678" --api-password=**** --debug
UNKNOWN: 500 Can't connect to dynatrace.test.lan:443 |
======> request send
GET https://dynatrace.test.lan:443/e/1234-abcd-5678/api/v1/problem/feed?relativeTime=min