### PR TITLE
new mode: --mode='backend-health'

### DIFF
--- a/cloud/azure/network/appgateway/mode/backendhealth.pm
+++ b/cloud/azure/network/appgateway/mode/backendhealth.pm
@@ -43,7 +43,6 @@ sub get_metrics_mapping {
             'unit'   => '',
             'min'    => '0'
         }
-
     };
 
     return $metrics_mapping;
@@ -135,13 +134,15 @@ Set resource name or id (Required).
 
 Set resource group (Required if resource's name is used).
 
-=item B<--warning-current-connections>
+=item B<--warning-*>
 
-Warning threshold.
+Warning threshold where '*' can be:
+'healthyhostcount', 'unhealthyhostcount'.
 
-=item B<--critical-current-connections>
+=item B<--critical-*>
 
-Critical threshold.
+Critical threshold where '*' can be:
+'healthyhostcount', 'unhealthyhostcount'.
 
 =back
 

--- a/cloud/azure/network/appgateway/mode/backendhealth.pm
+++ b/cloud/azure/network/appgateway/mode/backendhealth.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package cloud::azure::network::appgateway::mode::backendunhealthyhost;
+package cloud::azure::network::appgateway::mode::backendhealth;
 
 use base qw(cloud::azure::custom::mode);
 

--- a/cloud/azure/network/appgateway/mode/backendhealth.pm
+++ b/cloud/azure/network/appgateway/mode/backendhealth.pm
@@ -113,13 +113,13 @@ Example:
 
 Using resource name :
 
-perl centreon_plugins.pl --plugin=cloud::azure::network::appgateway::plugin --mode=backend-unhealthy-host --custommode=api
+perl centreon_plugins.pl --plugin=cloud::azure::network::appgateway::plugin --mode=backend-health --custommode=api
 --resource=<appgateway_id> --resource-group=<resourcegroup_id> --aggregation='average'
 --warning-unhealthy-host-count=':0' --critical-unhealthy-host-count=':1'
 
 Using resource id :
 
-perl centreon_plugins.pl --plugin=cloud::azure::network::appgateway::plugin --mode=backend-unhealthy-host --custommode=api
+perl centreon_plugins.pl --plugin=cloud::azure::network::appgateway::plugin --mode=backend-health --custommode=api
 --resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.Network/applicationGateways/<appgateway_id>'
 --aggregation='average' --warning-unhealthy-host-count='1' --critical-unhealthy-host-count='2'
 

--- a/cloud/azure/network/appgateway/mode/backendhealth.pm
+++ b/cloud/azure/network/appgateway/mode/backendhealth.pm
@@ -115,7 +115,7 @@ Using resource name :
 
 perl centreon_plugins.pl --plugin=cloud::azure::network::appgateway::plugin --mode=backend-health --custommode=api
 --resource=<appgateway_id> --resource-group=<resourcegroup_id> --aggregation='average'
---warning-unhealthy-host-count=':0' --critical-unhealthy-host-count=':1'
+--warning-unhealthy-host-count='1' --critical-unhealthy-host-count='2'
 
 Using resource id :
 

--- a/cloud/azure/network/appgateway/mode/backendunhealthyhost.pm
+++ b/cloud/azure/network/appgateway/mode/backendunhealthyhost.pm
@@ -1,0 +1,140 @@
+#
+# Copyright 2021 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::network::appgateway::mode::backendunhealthyhost;
+
+use base qw(cloud::azure::custom::mode);
+
+use strict;
+use warnings;
+
+sub get_metrics_mapping {
+    my ($self, %options) = @_;
+
+    my $metrics_mapping = {
+        'unhealthyhostcount' => {
+            'output' => 'Unhealthy Host Count',
+            'label'  => 'unhealthy-host-count',
+            'nlabel' => 'appgateway.backend.unhealthy.host.count',
+            'unit'   => '',
+            'min'    => '0'
+        }
+    };
+
+    return $metrics_mapping;
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-metric:s'  => { name => 'filter_metric' },
+        'resource:s'       => { name => 'resource' },
+        'resource-group:s' => { name => 'resource_group' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{resource}) || $self->{option_results}->{resource} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify either --resource <name> with --resource-group option or --resource <id>.');
+        $self->{output}->option_exit();
+    }
+    my $resource = $self->{option_results}->{resource};
+    my $resource_group = defined($self->{option_results}->{resource_group}) ? $self->{option_results}->{resource_group} : '';
+    if ($resource =~ /^\/subscriptions\/.*\/resourceGroups\/(.*)\/providers\/Microsoft\.Network\/applicationGateways\/(.*)$/) {
+        $resource_group = $1;
+        $resource = $2;
+    }
+
+    $self->{az_resource} = $resource;
+    $self->{az_resource_group} = $resource_group;
+    $self->{az_resource_type} = 'applicationGateways';
+    $self->{az_resource_namespace} = 'Microsoft.Network';
+    $self->{az_timeframe} = defined($self->{option_results}->{timeframe}) ? $self->{option_results}->{timeframe} : 900;
+    $self->{az_interval} = defined($self->{option_results}->{interval}) ? $self->{option_results}->{interval} : 'PT5M';
+    $self->{az_aggregations} = ['Average'];
+    if (defined($self->{option_results}->{aggregation})) {
+        $self->{az_aggregations} = [];
+        foreach my $stat (@{$self->{option_results}->{aggregation}}) {
+            if ($stat ne '') {
+                push @{$self->{az_aggregations}}, ucfirst(lc($stat));
+            }
+        }
+    }
+
+    foreach my $metric (keys %{$self->{metrics_mapping}}) { 
+       next if (defined($self->{option_results}->{filter_metric}) && $self->{option_results}->{filter_metric} ne ''
+            && $metric !~ /$self->{option_results}->{filter_metric}/);
+        push @{$self->{az_metrics}}, $metric;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Azure Application Gateway backend hosts health statistics.
+
+Example:
+
+Using resource name :
+
+perl centreon_plugins.pl --plugin=cloud::azure::network::appgateway::plugin --mode=backend-unhealthyhost --custommode=api
+--resource=<appgateway_id> --resource-group=<resourcegroup_id> --aggregation='average'
+--warning-unhealthy-host-count=':0' --critical-unhealthy-host-count=':1'
+
+Using resource id :
+
+perl centreon_plugins.pl --plugin=cloud::azure::integration::servicebus::plugin --mode=backend-unhealthyhost --custommode=api
+--resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.Network/applicationGateways/<appgateway_id>'
+--aggregation='average' --warning-unhealthy-host-count=':0' --critical-unhealthy-host-count=':1'
+
+Default aggregation: 'average' / 'total', 'minimum' and 'maximum' are valid.
+
+=over 8
+
+=item B<--resource>
+
+Set resource name or id (Required).
+
+=item B<--resource-group>
+
+Set resource group (Required if resource's name is used).
+
+=item B<--warning-current-connections>
+
+Warning threshold.
+
+=item B<--critical-current-connections>
+
+Critical threshold.
+
+=back
+
+=cut

--- a/cloud/azure/network/appgateway/mode/backendunhealthyhost.pm
+++ b/cloud/azure/network/appgateway/mode/backendunhealthyhost.pm
@@ -35,7 +35,15 @@ sub get_metrics_mapping {
             'nlabel' => 'appgateway.backend.unhealthy.host.count',
             'unit'   => '',
             'min'    => '0'
+        },
+        'healthyhostcount' => {
+            'output' => 'Healthy Host Count',
+            'label'  => 'healthy-host-count',
+            'nlabel' => 'appgateway.backend.healthy.host.count',
+            'unit'   => '',
+            'min'    => '0'
         }
+
     };
 
     return $metrics_mapping;

--- a/cloud/azure/network/appgateway/mode/backendunhealthyhost.pm
+++ b/cloud/azure/network/appgateway/mode/backendunhealthyhost.pm
@@ -105,15 +105,15 @@ Example:
 
 Using resource name :
 
-perl centreon_plugins.pl --plugin=cloud::azure::network::appgateway::plugin --mode=backend-unhealthyhost --custommode=api
+perl centreon_plugins.pl --plugin=cloud::azure::network::appgateway::plugin --mode=backend-unhealthy-host --custommode=api
 --resource=<appgateway_id> --resource-group=<resourcegroup_id> --aggregation='average'
 --warning-unhealthy-host-count=':0' --critical-unhealthy-host-count=':1'
 
 Using resource id :
 
-perl centreon_plugins.pl --plugin=cloud::azure::integration::servicebus::plugin --mode=backend-unhealthyhost --custommode=api
+perl centreon_plugins.pl --plugin=cloud::azure::network::appgateway::plugin --mode=backend-unhealthy-host --custommode=api
 --resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.Network/applicationGateways/<appgateway_id>'
---aggregation='average' --warning-unhealthy-host-count=':0' --critical-unhealthy-host-count=':1'
+--aggregation='average' --warning-unhealthy-host-count='1' --critical-unhealthy-host-count='2'
 
 Default aggregation: 'average' / 'total', 'minimum' and 'maximum' are valid.
 

--- a/cloud/azure/network/appgateway/plugin.pm
+++ b/cloud/azure/network/appgateway/plugin.pm
@@ -32,6 +32,7 @@ sub new {
     $self->{version} = '0.1';
     $self->{modes} = {
         'backend-status'  => 'cloud::azure::network::appgateway::mode::backendstatus',
+        'backend-unhealthy-host'  => 'cloud::azure::network::appgateway::mode::backendunhealthyhost',
         'backend-time'    => 'cloud::azure::network::appgateway::mode::backendtime',
         'clients-traffic' => 'cloud::azure::network::appgateway::mode::clientstraffic',
         'connections'     => 'cloud::azure::network::appgateway::mode::connections',

--- a/cloud/azure/network/appgateway/plugin.pm
+++ b/cloud/azure/network/appgateway/plugin.pm
@@ -31,8 +31,8 @@ sub new {
 
     $self->{version} = '0.1';
     $self->{modes} = {
-        'backend-status'  => 'cloud::azure::network::appgateway::mode::backendstatus',
         'backend-health'  => 'cloud::azure::network::appgateway::mode::backendhealth',
+        'backend-status'  => 'cloud::azure::network::appgateway::mode::backendstatus',
         'backend-time'    => 'cloud::azure::network::appgateway::mode::backendtime',
         'clients-traffic' => 'cloud::azure::network::appgateway::mode::clientstraffic',
         'connections'     => 'cloud::azure::network::appgateway::mode::connections',

--- a/cloud/azure/network/appgateway/plugin.pm
+++ b/cloud/azure/network/appgateway/plugin.pm
@@ -32,7 +32,7 @@ sub new {
     $self->{version} = '0.1';
     $self->{modes} = {
         'backend-status'  => 'cloud::azure::network::appgateway::mode::backendstatus',
-        'backend-unhealthy-host'  => 'cloud::azure::network::appgateway::mode::backendunhealthyhost',
+        'backend-health'  => 'cloud::azure::network::appgateway::mode::backendhealth',
         'backend-time'    => 'cloud::azure::network::appgateway::mode::backendtime',
         'clients-traffic' => 'cloud::azure::network::appgateway::mode::clientstraffic',
         'connections'     => 'cloud::azure::network::appgateway::mode::connections',


### PR DESCRIPTION
adds a mode to get backends unhealthy host count (FYI: existing mode backend-status does ONLY work on App Gateway **v2**, not on v1 which are the most deployed globally on Azure; app gateway v2 is quite new)