### PR TITLE
fix for 3 modes of this plugin

### DIFF
--- a/cloud/azure/database/mysql/mode/connections.pm
+++ b/cloud/azure/database/mysql/mode/connections.pm
@@ -123,7 +123,7 @@ sub check_options {
 
     my $metrics_mapping_transformed;
     foreach my $metric_type (@{$resource_mapping->{$resource_type}}) {
-        $metrics_mapping_transformed->{$metric_type} = $self->{resource_mapping}->{$metric_type};
+        $self->{metrics_mapping_transformed}->{$metric_type} = $self->{metrics_mapping}->{$metric_type};
     }
 
     foreach my $metric (keys %{$self->{metrics_mapping_transformed}}) {

--- a/cloud/azure/database/mysql/mode/connections.pm
+++ b/cloud/azure/database/mysql/mode/connections.pm
@@ -123,7 +123,7 @@ sub check_options {
 
     my $metrics_mapping_transformed;
     foreach my $metric_type (@{$resource_mapping->{$resource_type}}) {
-        $metrics_mapping_transformed->{$metric_type} = $self->{metrics_mapping}->{$metric_type};
+        $metrics_mapping_transformed->{$metric_type} = $self->{resource_mapping}->{$metric_type};
     }
 
     foreach my $metric (keys %{$self->{metrics_mapping_transformed}}) {

--- a/cloud/azure/database/mysql/mode/replication.pm
+++ b/cloud/azure/database/mysql/mode/replication.pm
@@ -109,7 +109,7 @@ sub check_options {
 
     my $metrics_mapping_transformed;
     foreach my $metric_type (@{$resource_mapping->{$resource_type}}) {
-        $metrics_mapping_transformed->{$metric_type} = $self->{metrics_mapping}->{$metric_type};
+        $metrics_mapping_transformed->{$metric_type} = $self->{resource_mapping}->{$metric_type};
     }
 
     foreach my $metric (keys %{$self->{metrics_mapping_transformed}}) {

--- a/cloud/azure/database/mysql/mode/replication.pm
+++ b/cloud/azure/database/mysql/mode/replication.pm
@@ -109,7 +109,7 @@ sub check_options {
 
     my $metrics_mapping_transformed;
     foreach my $metric_type (@{$resource_mapping->{$resource_type}}) {
-        $metrics_mapping_transformed->{$metric_type} = $self->{resource_mapping}->{$metric_type};
+        $self->{metrics_mapping_transformed}->{$metric_type} = $self->{metrics_mapping}->{$metric_type};
     }
 
     foreach my $metric (keys %{$self->{metrics_mapping_transformed}}) {

--- a/cloud/azure/database/mysql/mode/storage.pm
+++ b/cloud/azure/database/mysql/mode/storage.pm
@@ -126,7 +126,7 @@ sub check_options {
     $self->{az_resource_type} = $resource_type;
     $self->{az_resource_namespace} = 'Microsoft.DBforMySQL';
     $self->{az_timeframe} = defined($self->{option_results}->{timeframe}) ? $self->{option_results}->{timeframe} : 900;
-    $self->{az_interval} = defined($self->{option_results}->{interval}) ? $self->{option_results}->{interval} : 'PT5M';
+    $self->{az_interval} = defined($self->{option_results}->{interval}) ? $self->{option_results}->{interval} : 'PT15M';
     $self->{az_aggregations} = ['Maximum'];
     if (defined($self->{option_results}->{aggregation})) {
         $self->{az_aggregations} = [];
@@ -146,7 +146,7 @@ sub check_options {
 
     my $metrics_mapping_transformed;
     foreach my $metric_type (@{$resource_mapping->{$resource_type}}) {
-        $metrics_mapping_transformed->{$metric_type} = $self->{resource_mapping}->{$metric_type};
+        $self->{metrics_mapping_transformed}->{$metric_type} = $self->{metrics_mapping}->{$metric_type};
     }
 
     foreach my $metric (keys %{$self->{metrics_mapping_transformed}}) {

--- a/cloud/azure/database/mysql/mode/storage.pm
+++ b/cloud/azure/database/mysql/mode/storage.pm
@@ -146,7 +146,7 @@ sub check_options {
 
     my $metrics_mapping_transformed;
     foreach my $metric_type (@{$resource_mapping->{$resource_type}}) {
-        $metrics_mapping_transformed->{$metric_type} = $self->{metrics_mapping}->{$metric_type};
+        $metrics_mapping_transformed->{$metric_type} = $self->{resource_mapping}->{$metric_type};
     }
 
     foreach my $metric (keys %{$self->{metrics_mapping_transformed}}) {


### PR DESCRIPTION
there is a wrong hash assignment causing the metric hash to be empty.

 $metrics_mapping_transformed->{$metric_type}= $self->{metrics_mapping}->{$metric_type};
->**$self->{metrics_mapping_transformed}->{$metric_type}** = $self->{metrics_mapping}->{$metric_type};

+ on storage mode, 5 minutes interval is refused by Azure API, 15 is the minimum:
Message : Commonly allowed time grains: 00:15:00,00:30:00,01:00:00,06:00:00,12:00:00,1.00:00:00 between metrics: serverlog_storage_percent,storage_percent,backup_storage_used,storage_used,storage_limit,serverlog_storage_usage,serverlog_storage_limit, can not support requsted time grain: 00:05:00, TraceId: {58880017-a5b4-4cdd-84a3-7172c0dc0eec}
