### PR TITLE
new mode "capacity" for Azure APIM

### DIFF
--- a/cloud/azure/management/apimanagement/mode/capacity.pm
+++ b/cloud/azure/management/apimanagement/mode/capacity.pm
@@ -34,7 +34,8 @@ sub get_metrics_mapping {
             'label'  => 'capacity-percentage',
             'nlabel' => 'apimanagement.capacity.percentage',
             'unit'   => '%',
-            'min'    => '0'
+            'min'    => '0',
+            'max'    => '100',
         },
     };
 

--- a/cloud/azure/management/apimanagement/mode/capacity.pm
+++ b/cloud/azure/management/apimanagement/mode/capacity.pm
@@ -115,7 +115,7 @@ perl centreon_plugins.pl --plugin=cloud::azure::management::apimanagement::plugi
 --resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.ApiManagement/service/<management_id>'
 --aggregation='average' --warning-capacity-percentage='80' --critical-capacity-percentage='90'
 
-Default aggregation: 'total' / 'average', 'minimum' and 'maximum' are valid.
+Default aggregation: 'average' / 'total', 'minimum' and 'maximum' are valid.
 
 =over 8
 

--- a/cloud/azure/management/apimanagement/mode/capacity.pm
+++ b/cloud/azure/management/apimanagement/mode/capacity.pm
@@ -127,10 +127,9 @@ Set resource name or id (Required).
 
 Set resource group (Required if resource's name is used).
 
-=item B<--warning-*>
+=item B<--warning-capacity-percentage>
 
-Warning threshold where '*' can be:
-'capacity-percentage'.
+Set warning threshold for capacity.
 
 =item B<--critical-*>
 

--- a/cloud/azure/management/apimanagement/mode/capacity.pm
+++ b/cloud/azure/management/apimanagement/mode/capacity.pm
@@ -131,10 +131,9 @@ Set resource group (Required if resource's name is used).
 
 Set warning threshold for capacity.
 
-=item B<--critical-*>
+=item B<--critical-capacity-percentage>
 
-Critical threshold where '*' can be:
-'capacity-percentage'.
+Set critical threshold for capacity.
 
 =back
 

--- a/cloud/azure/management/apimanagement/mode/capacity.pm
+++ b/cloud/azure/management/apimanagement/mode/capacity.pm
@@ -1,0 +1,142 @@
+#
+# Copyright 2021 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::management::apimanagement::mode::capacity;
+
+use base qw(cloud::azure::custom::mode);
+
+use strict;
+use warnings;
+
+sub get_metrics_mapping {
+    my ($self, %options) = @_;
+
+    my $metrics_mapping = {
+        'capacity' => {
+            'output' => 'Capacity',
+            'label'  => 'capacity-percentage',
+            'nlabel' => 'apimanagement.capacity.percentage',
+            'unit'   => '%',
+            'min'    => '0'
+        },
+    };
+
+    return $metrics_mapping;
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-metric:s'  => { name => 'filter_metric' },
+        'resource:s'       => { name => 'resource' },
+        'resource-group:s' => { name => 'resource_group' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{resource}) || $self->{option_results}->{resource} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify either --resource <name> with --resource-group option or --resource <id>.');
+        $self->{output}->option_exit();
+    }
+    my $resource = $self->{option_results}->{resource};
+    my $resource_group = defined($self->{option_results}->{resource_group}) ? $self->{option_results}->{resource_group} : '';
+    if ($resource =~ /^\/subscriptions\/.*\/resourceGroups\/(.*)\/providers\/Microsoft\.ApiManagement\/service\/(.*)$/) {
+        $resource_group = $1;
+        $resource = $2;
+    }
+
+    $self->{az_resource} = $resource;
+    $self->{az_resource_group} = $resource_group;
+    $self->{az_resource_type} = 'service';
+    $self->{az_resource_namespace} = 'Microsoft.ApiManagement';
+    $self->{az_timeframe} = defined($self->{option_results}->{timeframe}) ? $self->{option_results}->{timeframe} : 900;
+    $self->{az_interval} = defined($self->{option_results}->{interval}) ? $self->{option_results}->{interval} : 'PT5M';
+    $self->{az_aggregations} = ['Average'];
+    if (defined($self->{option_results}->{aggregation})) {
+        $self->{az_aggregations} = [];
+        foreach my $stat (@{$self->{option_results}->{aggregation}}) {
+            if ($stat ne '') {
+                push @{$self->{az_aggregations}}, ucfirst(lc($stat));
+            }
+        }
+    }
+
+    foreach my $metric (keys %{$self->{metrics_mapping}}) {
+        next if (defined($self->{option_results}->{filter_metric}) && $self->{option_results}->{filter_metric} ne ''
+            && $metric !~ /$self->{option_results}->{filter_metric}/);
+        push @{$self->{az_metrics}}, $metric;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Azure API Management capacity statistics.
+
+Example:
+
+Using resource name :
+
+perl centreon_plugins.pl --plugin=cloud::azure::management::apimanagement::plugin --mode=capacity --custommode=api
+--resource=<management_id> --resource-group=<resourcegroup_id> --aggregation='average'
+--warning-capacity-percentage='80' --critical-capacity-percentage='90'
+
+Using resource id :
+
+perl centreon_plugins.pl --plugin=cloud::azure::management::apimanagement::plugin --mode=capacity --custommode=api
+--resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.ApiManagement/service/<management_id>'
+--aggregation='average' --warning-capacity-percentage='80' --critical-capacity-percentage='90'
+
+Default aggregation: 'total' / 'average', 'minimum' and 'maximum' are valid.
+
+=over 8
+
+=item B<--resource>
+
+Set resource name or id (Required).
+
+=item B<--resource-group>
+
+Set resource group (Required if resource's name is used).
+
+=item B<--warning-*>
+
+Warning threshold where '*' can be:
+'capacity-percentage'.
+
+=item B<--critical-*>
+
+Critical threshold where '*' can be:
+'capacity-percentage'.
+
+=back
+
+=cut

--- a/cloud/azure/management/apimanagement/plugin.pm
+++ b/cloud/azure/management/apimanagement/plugin.pm
@@ -32,7 +32,9 @@ sub new {
     $self->{version} = '0.1';
     $self->{modes} = {
         'events'    => 'cloud::azure::management::apimanagement::mode::events',
+        'capacity'    => 'cloud::azure::management::apimanagement::mode::capacity',
         'discovery' => 'cloud::azure::management::apimanagement::mode::discovery',
+        'health'    => 'cloud::azure::management::apimanagement::mode::health',
         'requests'  => 'cloud::azure::management::apimanagement::mode::requests',
         'duration'  => 'cloud::azure::management::apimanagement::mode::duration'
     };

--- a/cloud/azure/management/apimanagement/plugin.pm
+++ b/cloud/azure/management/apimanagement/plugin.pm
@@ -34,7 +34,6 @@ sub new {
         'events'    => 'cloud::azure::management::apimanagement::mode::events',
         'capacity'    => 'cloud::azure::management::apimanagement::mode::capacity',
         'discovery' => 'cloud::azure::management::apimanagement::mode::discovery',
-        'health'    => 'cloud::azure::management::apimanagement::mode::health',
         'requests'  => 'cloud::azure::management::apimanagement::mode::requests',
         'duration'  => 'cloud::azure::management::apimanagement::mode::duration'
     };


### PR DESCRIPTION
gives the percentage of used capacity of the APIM

[root@svzam-cenpol001 apimanagement]# /usr/lib/centreon/plugins//centreon-plugins/centreon_plugins.pl --plugin=cloud::azure::management::apimanagement::plugin --custommode='api' --mode='capacity' --subscription='xxx' --tenant='xxx' --client-id='xxx' --client-secret='***' --resource-group='xxx' --resource='xxx' --warning-capacity-percentage='80' --critical-capacity-percentage='90'
OK: Instance 'xxx' Statistic 'average' Metrics Capacity: 2.46% | 'xxx#apimanagement.capacity.percentage'=2.46%;0:80;0:90;0;