### PR TITLE
enh(plugin): Appserviceplan new mode "queue"

### DIFF
--- a/cloud/azure/web/appserviceplan/mode/queue.pm
+++ b/cloud/azure/web/appserviceplan/mode/queue.pm
@@ -108,7 +108,7 @@ __END__
 
 =head1 MODE
 
-Check Azure App Service Plan socket statistics.
+Check Azure App Service Plan queue statistics.
 
 Example:
 

--- a/cloud/azure/web/appserviceplan/mode/queue.pm
+++ b/cloud/azure/web/appserviceplan/mode/queue.pm
@@ -1,0 +1,151 @@
+#
+# Copyright 2021 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::web::appserviceplan::mode::queue;
+
+use base qw(cloud::azure::custom::mode);
+
+use strict;
+use warnings;
+
+sub get_metrics_mapping {
+    my ($self, %options) = @_;
+
+    my $metrics_mapping = {
+        'diskqueuelength' => {
+            'output'   => 'Disk Queue Length',
+            'label'    => 'disk-queue-length',
+            'nlabel'   => 'appserviceplan.disk.queue.length',
+            'unit'     => '',
+            'min'      => '0',
+            'template' => '%d'
+        },
+        'httpqueuelength' => {
+            'output'   => 'Http Queue Length',
+            'label'    => 'http-queue-length',
+            'nlabel'   => 'appserviceplan.http.queue.length',
+            'unit'     => '',
+            'min'      => '0',
+            'template' => '%d'
+        }
+    };
+
+    return $metrics_mapping;
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-metric:s'  => { name => 'filter_metric' },
+        'resource:s'       => { name => 'resource' },
+        'resource-group:s' => { name => 'resource_group' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{resource}) || $self->{option_results}->{resource} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify either --resource <name> with --resource-group option or --resource <id>.');
+        $self->{output}->option_exit();
+    }
+    my $resource = $self->{option_results}->{resource};
+    my $resource_group = defined($self->{option_results}->{resource_group}) ? $self->{option_results}->{resource_group} : '';
+    if ($resource =~ /^\/subscriptions\/.*\/resourceGroups\/(.*)\/providers\/Microsoft\.Web\/serverFarms\/(.*)$/) {
+        $resource_group = $1;
+        $resource = $2;
+    }
+
+    $self->{az_resource} = $resource;
+    $self->{az_resource_group} = $resource_group;
+    $self->{az_resource_type} = 'serverFarms';
+    $self->{az_resource_namespace} = 'Microsoft.Web';
+    $self->{az_timeframe} = defined($self->{option_results}->{timeframe}) ? $self->{option_results}->{timeframe} : 900;
+    $self->{az_interval} = defined($self->{option_results}->{interval}) ? $self->{option_results}->{interval} : 'PT5M';
+    $self->{az_aggregations} = ['Average'];
+    if (defined($self->{option_results}->{aggregation})) {
+        $self->{az_aggregations} = [];
+        foreach my $stat (@{$self->{option_results}->{aggregation}}) {
+            if ($stat ne '') {
+                push @{$self->{az_aggregations}}, ucfirst(lc($stat));
+            }
+        }
+    }
+
+    foreach my $metric (keys %{$self->{metrics_mapping}}) {
+        next if (defined($self->{option_results}->{filter_metric}) && $self->{option_results}->{filter_metric} ne ''
+            && $metric !~ /$self->{option_results}->{filter_metric}/);
+        push @{$self->{az_metrics}}, $metric;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Azure App Service Plan socket statistics.
+
+Example:
+
+Using resource name :
+
+perl centreon_plugins.pl --plugin=cloud::azure::web::appserviceplan::plugin --mode=queue --custommode=api
+--resource=<appsvcplan_id> --resource-group=<resourcegroup_id> --aggregation='average'
+--warning-disk-queue-length='8' --critical-disk-queue-length='9'
+
+Using resource id :
+
+perl centreon_plugins.pl --plugin=cloud::azure::web::appserviceplan::plugin --mode=queue --custommode=api
+--resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.Web/serverFarms/<appsvcplan_id>'
+--aggregation='average' --warning-disk-queue-length='8' --critical-disk-queue-length='9'
+
+Default aggregation: 'average' / 'total', 'minimum' and 'maximum' are valid.
+
+=over 8
+
+=item B<--resource>
+
+Set resource name or id (Required).
+
+=item B<--resource-group>
+
+Set resource group (Required if resource's name is used).
+
+=item B<--warning-*>
+
+Warning threshold where '*' can be:
+'disk-queue-length', 'http-queue-length'.
+
+=item B<--critical-*>
+
+Critical threshold where '*' can be:
+'disk-queue-length', 'http-queue-length'.
+
+=back
+
+=cut

--- a/cloud/azure/web/appserviceplan/mode/queue.pm
+++ b/cloud/azure/web/appserviceplan/mode/queue.pm
@@ -32,7 +32,7 @@ sub get_metrics_mapping {
         'diskqueuelength' => {
             'output'   => 'Disk Queue Length',
             'label'    => 'disk-queue-length',
-            'nlabel'   => 'appserviceplan.disk.queue.length',
+            'nlabel'   => 'appserviceplan.disk.queue.length.count',
             'unit'     => '',
             'min'      => '0',
             'template' => '%d'
@@ -40,7 +40,7 @@ sub get_metrics_mapping {
         'httpqueuelength' => {
             'output'   => 'Http Queue Length',
             'label'    => 'http-queue-length',
-            'nlabel'   => 'appserviceplan.http.queue.length',
+            'nlabel'   => 'appserviceplan.http.queue.length.count',
             'unit'     => '',
             'min'      => '0',
             'template' => '%d'

--- a/cloud/azure/web/appserviceplan/plugin.pm
+++ b/cloud/azure/web/appserviceplan/plugin.pm
@@ -36,9 +36,9 @@ sub new {
         'discovery'       => 'cloud::azure::web::appserviceplan::mode::discovery',
         'health'          => 'cloud::azure::web::appserviceplan::mode::health',
         'memory'          => 'cloud::azure::web::appserviceplan::mode::memory',
+        'queue'           => 'cloud::azure::web::appserviceplan::mode::queue',
         'socket'          => 'cloud::azure::web::appserviceplan::mode::socket',
-        'tcp-connections' => 'cloud::azure::web::appserviceplan::mode::tcpconnections',
-        'queue'           => 'cloud::azure::web::appserviceplan::mode::queue'
+        'tcp-connections' => 'cloud::azure::web::appserviceplan::mode::tcpconnections'
     };
 
     $self->{custom_modes}->{azcli} = 'cloud::azure::custom::azcli';

--- a/cloud/azure/web/appserviceplan/plugin.pm
+++ b/cloud/azure/web/appserviceplan/plugin.pm
@@ -37,7 +37,8 @@ sub new {
         'health'          => 'cloud::azure::web::appserviceplan::mode::health',
         'memory'          => 'cloud::azure::web::appserviceplan::mode::memory',
         'socket'          => 'cloud::azure::web::appserviceplan::mode::socket',
-        'tcp-connections' => 'cloud::azure::web::appserviceplan::mode::tcpconnections'
+        'tcp-connections' => 'cloud::azure::web::appserviceplan::mode::tcpconnections',
+        'queue'           => 'cloud::azure::web::appserviceplan::mode::queue'
     };
 
     $self->{custom_modes}->{azcli} = 'cloud::azure::custom::azcli';


### PR DESCRIPTION
Azure Appserviceplan new mode:

[ appserviceplan]# /usr/lib/centreon/plugins//centreon-plugins/centreon_plugins.pl --plugin=cloud::azure::web::appserviceplan::plugin --custommode='api' --mode='queue' --subscription='xxx' --tenant='xxx' --client-id='xxx' --client-secret='***' --resource-group='xxx' --resource='xxx' --warning-disk-queue-length='8' --critical-disk-queue-length='9'
OK: Instance 'xxx' Statistic 'average' Metrics Http Queue Length: 0, Disk Queue Length: 0 | 'AEUW-Diorpress-prd-ServicePlan~average#appserviceplan.http.queue.length'=0;;;0; 'AEUW-Diorpress-prd-ServicePlan~average#appserviceplan.disk.queue.length'=0;0:8;0:9;0;