### PR TITLE
Adds 'other' and 'total' metrics for netapp plugin

### DIFF
--- a/storage/netapp/ontap/restapi/mode/cluster.pm
+++ b/storage/netapp/ontap/restapi/mode/cluster.pm
@@ -86,6 +86,24 @@ sub set_counters {
                 ]
             }
         },
+        { label => 'other', nlabel => 'cluster.io.other.usage.bytespersecond', display_ok => 0, set => {
+                key_values => [ { name => 'other', per_second => 1 }, { name => 'display' } ],
+                output_template => 'other: %s %s/s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    { template => '%d', unit => 'B/s', label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'total', nlabel => 'cluster.io.total.usage.bytespersecond', display_ok => 0, set => {
+                key_values => [ { name => 'total', per_second => 1 }, { name => 'display' } ],
+                output_template => 'total: %s %s/s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    { template => '%d', unit => 'B/s', min => 0, label_extra_instance => 1 }
+                ]
+            }
+        },
         { label => 'read-iops', nlabel => 'cluster.io.read.usage.iops', set => {
                 key_values => [ { name => 'read_iops' }, { name => 'display' } ],
                 output_template => 'read iops: %s',
@@ -102,6 +120,22 @@ sub set_counters {
                 ]
             }
         },
+        { label => 'other-iops', nlabel => 'cluster.io.other.usage.iops', set => {
+                key_values => [ { name => 'other_iops' }, { name => 'display' } ],
+                output_template => 'other iops: %s',
+                perfdatas => [
+                    { template => '%s', unit => 'iops', min => 0, label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'total-iops', nlabel => 'cluster.io.total.usage.iops', set => {
+                key_values => [ { name => 'total_iops' }, { name => 'display' } ],
+                output_template => 'total iops: %s',
+                perfdatas => [
+                    { template => '%s', unit => 'iops', min => 0, label_extra_instance => 1 }
+                ]
+            }
+        },
         { label => 'read-latency', nlabel => 'cluster.io.read.latency.milliseconds', set => {
                 key_values => [ { name => 'read_latency' }, { name => 'display' } ],
                 output_template => 'read latency: %s ms',
@@ -113,6 +147,22 @@ sub set_counters {
         { label => 'write-latency', nlabel => 'cluster.io.write.latency.milliseconds', set => {
                 key_values => [ { name => 'write_latency' }, { name => 'display' } ],
                 output_template => 'write latency: %s ms',
+                perfdatas => [
+                    { template => '%s', unit => 'ms', min => 0, label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'other-latency', nlabel => 'cluster.io.other.latency.milliseconds', set => {
+                key_values => [ { name => 'other_latency' }, { name => 'display' } ],
+                output_template => 'other latency: %s ms',
+                perfdatas => [
+                    { template => '%s', unit => 'ms', min => 0 }
+                ]
+            }
+        },
+        { label => 'total-latency', nlabel => 'cluster.io.total.latency.milliseconds', set => {
+                key_values => [ { name => 'total_latency' }, { name => 'display' } ],
+                output_template => 'total latency: %s ms',
                 perfdatas => [
                     { template => '%s', unit => 'ms', min => 0, label_extra_instance => 1 }
                 ]
@@ -154,10 +204,16 @@ sub manage_selection {
                 display       => $cluster->{name},
                 read          => $cluster->{statistics}->{throughput_raw}->{read},
                 write         => $cluster->{statistics}->{throughput_raw}->{write},
+                other         => $cluster->{statistics}->{throughput_raw}->{other},
+                total         => $cluster->{statistics}->{throughput_raw}->{total},
                 read_iops     => $cluster->{metric}->{iops}->{read},
                 write_iops    => $cluster->{metric}->{iops}->{write},
+                other_iops     => $cluster->{metric}->{iops}->{other},
+                total_iops    => $cluster->{metric}->{iops}->{total},
                 read_latency  => $cluster->{metric}->{latency}->{read},
-                write_latency => $cluster->{metric}->{latency}->{write}
+                write_latency => $cluster->{metric}->{latency}->{write},
+                other_latency  => $cluster->{metric}->{latency}->{other},
+                total_latency => $cluster->{metric}->{latency}->{total}
             },
             nodes => {}
         }
@@ -209,7 +265,9 @@ Can used special variables like: %{state}, %{link_status}, %{display}
 =item B<--warning-*> B<--critical-*>
 
 Thresholds.
-Can be: 'cpu-utilization' (%), 'read' (B/s), 'write' (B/s), 'read-iops', 'write-iops'.
+Can be: 'cpu-utilization' (%), 'read' (B/s), 'write' (B/s), 'read-iops', 'write-iops',
+'read-latency' (ms), 'write-lantency' (ms), 'other-latency' (ms), 'total-latency' (ms),
+'other' (B/s), 'total' (B/s), 'other-iops', 'total-iops'.
 
 =back
 

--- a/storage/netapp/ontap/restapi/mode/volumes.pm
+++ b/storage/netapp/ontap/restapi/mode/volumes.pm
@@ -112,6 +112,24 @@ sub set_counters {
                 ]
             }
         },
+        { label => 'other', nlabel => 'volume.io.other.usage.bytespersecond', display_ok => 0, set => {
+                key_values => [ { name => 'other' } ],
+                output_template => 'other: %s %s/s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    { template => '%d', unit => 'B/s', min => 0, label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'total', nlabel => 'volume.io.total.usage.bytespersecond', display_ok => 0, set => {
+                key_values => [ { name => 'total' } ],
+                output_template => 'total: %s %s/s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    { template => '%d', unit => 'B/s', min => 0, label_extra_instance => 1 }
+                ]
+            }
+        },
         { label => 'read-iops', nlabel => 'volume.io.read.usage.iops', set => {
                 key_values => [ { name => 'read_iops' } ],
                 output_template => 'read iops: %s',
@@ -128,6 +146,22 @@ sub set_counters {
                 ]
             }
         },
+        { label => 'other-iops', nlabel => 'volume.io.other.usage.iops', set => {
+                key_values => [ { name => 'other_iops' } ],
+                output_template => 'other iops: %s',
+                perfdatas => [
+                    { template => '%s', unit => 'iops', min => 0, label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'total-iops', nlabel => 'volume.io.total.usage.iops', set => {
+                key_values => [ { name => 'total_iops' } ],
+                output_template => 'total iops: %s',
+                perfdatas => [
+                    { template => '%s', unit => 'iops', min => 0, label_extra_instance => 1 }
+                ]
+            }
+        },
         { label => 'read-latency', nlabel => 'volume.io.read.latency.milliseconds', set => {
                 key_values => [ { name => 'read_latency' } ],
                 output_template => 'read latency: %s ms',
@@ -139,6 +173,22 @@ sub set_counters {
         { label => 'write-latency', nlabel => 'volume.io.write.latency.milliseconds', set => {
                 key_values => [ { name => 'write_latency' } ],
                 output_template => 'write latency: %s ms',
+                perfdatas => [
+                    { template => '%s', unit => 'ms', min => 0, label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'other-latency', nlabel => 'volume.io.other.latency.milliseconds', set => {
+                key_values => [ { name => 'other_latency' } ],
+                output_template => 'other latency: %s ms',
+                perfdatas => [
+                    { template => '%s', unit => 'ms', min => 0, label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'total-latency', nlabel => 'volume.io.total.latency.milliseconds', set => {
+                key_values => [ { name => 'total_latency' } ],
+                output_template => 'total latency: %s ms',
                 perfdatas => [
                     { template => '%s', unit => 'ms', min => 0, label_extra_instance => 1 }
                 ]
@@ -193,10 +243,16 @@ sub manage_selection {
 
             read          => $_->{metric}->{throughput}->{read},
             write         => $_->{metric}->{throughput}->{write},
+            other         => $_->{metric}->{throughput}->{other},
+            total         => $_->{metric}->{throughput}->{total},
             read_iops     => $_->{metric}->{iops}->{read},
             write_iops    => $_->{metric}->{iops}->{write},
+            other_iops    => $_->{metric}->{iops}->{other},
+            total_iops    => $_->{metric}->{iops}->{total},
             read_latency  => $_->{metric}->{latency}->{read},
-            write_latency => $_->{metric}->{latency}->{write}
+            write_latency => $_->{metric}->{latency}->{write},
+            other_latency => $_->{metric}->{latency}->{other},
+            total_latency => $_->{metric}->{latency}->{total}
         };
     }
 
@@ -249,7 +305,9 @@ Can used special variables like: %{state}, %{display}
 Thresholds.
 Can be: 'usage' (B), 'usage-free' (B), 'usage-prct' (%),
 'read' (B/s), 'read-iops', 'write' (B/s), 'write-iops',
-'read-latency' (ms), 'write-latency' (ms).
+'read-latency' (ms), 'write-latency' (ms), 'total-latency' (ms),
+'other-latency' (ms), 'other' (B/s), 'total' (B/s),
+'other-iops', 'total-iops'.
 
 =back
 


### PR DESCRIPTION
Enhancement for netapp plugin in order to add 'other' and 'total' metrics for 'volume' and 'cluster' modes.