### PR TITLE
enh(qnap) add a --force-counters-legacy

### DIFF
--- a/storage/qnap/snmp/mode/memory.pm
+++ b/storage/qnap/snmp/mode/memory.pm
@@ -77,7 +77,11 @@ sub new {
     my ($class, %options) = @_;
     my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
-    
+
+    $options{options}->add_options(arguments => {
+        'force-counters-legacy' => { name => 'force_counters_legacy' }
+    });
+
     return $self;
 }
 
@@ -149,8 +153,10 @@ sub manage_selection {
         oids => [ map($_->{oid} . '.0', values(%{$mapping->{legacy}}), values(%{$mapping->{ex}}), values(%{$mapping->{es}})) ],
         nothing_quit => 1
     );
-    $self->check_memory(snmp => $options{snmp}, type => 'ex', snmp_result => $snmp_result);
-    $self->check_memory(snmp => $options{snmp}, type => 'es', snmp_result => $snmp_result, convert => 1);
+    if (!defined($self->{option_results}->{force_counters_legacy})) {
+        $self->check_memory(snmp => $options{snmp}, type => 'ex', snmp_result => $snmp_result);
+        $self->check_memory(snmp => $options{snmp}, type => 'es', snmp_result => $snmp_result, convert => 1);
+    }
     $self->check_memory(snmp => $options{snmp}, type => 'legacy', snmp_result => $snmp_result, convert => 1);
 }
 
@@ -163,6 +169,10 @@ __END__
 Check memory.
 
 =over 8
+
+=item B<--force-counters-legacy>
+
+Force to use legacy counters. Should be used when EX/ES counters are buggy.
 
 =item B<--warning-*> B<--critical-*>
 


### PR DESCRIPTION
Hi,

This PR fixes #2860, adding a `--force-counters-legacy` to Qnap `memory` mode, to workaround EX/ES buggy counters.
We'll be able to get rid of it once Qnap will have solved this SNMP counters bug.

Thx 👍