### PR TITLE
fix(plugin)bypass-perl-error-messy-commvault-api

### DIFF
--- a/apps/backup/commvault/commserve/restapi/custom/api.pm
+++ b/apps/backup/commvault/commserve/restapi/custom/api.pm
@@ -361,6 +361,7 @@ sub request_paging {
             header => ['Cache-Control: private']
         );
 
+	last if !defined($results->{feedsList});
         push @$alerts, @{$results->{feedsList}};
         last if ($results->{totalNoOfAlerts} < ($page_num * $page_count));
         $page_num++;

--- a/apps/backup/commvault/commserve/restapi/custom/api.pm
+++ b/apps/backup/commvault/commserve/restapi/custom/api.pm
@@ -361,7 +361,7 @@ sub request_paging {
             header => ['Cache-Control: private']
         );
 
-	last if !defined($results->{feedsList});
+        last if (!defined($results->{feedsList}));
         push @$alerts, @{$results->{feedsList}};
         last if ($results->{totalNoOfAlerts} < ($page_num * $page_count));
         $page_num++;


### PR DESCRIPTION
- One of the user got the following error with the latest version: 
 ```
UNKNOWN: Can't use an undefined value as an ARRAY reference at /usr/lib/centreon/plugins/centreon_commvault_commserve_restapi.pl line 289.
```

- After some troubleshooting, find out that the data was corrupted - $content scalar value was ')' -
- Adding `last if` allow to avoid Perl unclean exit but not sure it's the correct way to fix that. `next if` results in an infinite loop. 

