### PR TITLE
fix(plugin) imm mgmt_cards environment with version < 2.0

### DIFF
--- a/hardware/server/ibm/mgmt_cards/imm/snmp/mode/components/fan.pm
+++ b/hardware/server/ibm/mgmt_cards/imm/snmp/mode/components/fan.pm
@@ -60,13 +60,6 @@ sub check {
                 $result->{fanDescr}, $result->{fanSpeed}, $instance
             )
         );
-        my $exit = $self->get_severity(label => 'health', section => 'fan', value => $result->{fanHealthStatus});
-        if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
-            $self->{output}->output_add(
-                severity => $exit,
-                short_msg => sprintf("Fan '%s' is '%s'", $result->{fanDescr}, $result->{fanHealthStatus})
-            );
-        }
         
         next if ($result->{fanSpeed} !~ /(\d+)/);
         
@@ -87,6 +80,15 @@ sub check {
             unit => '%',
             min => 0, max => 100
         );
+        # HealthStatus OIDs are only available with IMM v2
+        next if !defined($result->{fanHealthStatus});
+        my $exit = $self->get_severity(label => 'health', section => 'fan', value => $result->{fanHealthStatus});
+        if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
+            $self->{output}->output_add(
+                severity => $exit,
+                short_msg => sprintf("Fan '%s' is '%s'", $result->{fanDescr}, $result->{fanHealthStatus})
+            );
+        }
     }
 }
 

--- a/hardware/server/ibm/mgmt_cards/imm/snmp/mode/components/memory.pm
+++ b/hardware/server/ibm/mgmt_cards/imm/snmp/mode/components/memory.pm
@@ -51,6 +51,8 @@ sub check {
         next if ($self->check_filter(section => 'memory', instance => $instance));
 
         $self->{components}->{memory}->{total}++;
+        # HealthStatus OIDs are only available with IMM v2
+        next if !defined($result->{memoryHealthStatus});
         $self->{output}->output_add(
             long_msg => sprintf(
                 "memory '%s' is '%s' [instance = %s]",


### PR DESCRIPTION
Fix #2891 

Some of the HealthStatus OIDs are only available with v2. 
