### PR TITLE
fix(synology) properly rename temperature metric

### DIFF
--- a/storage/synology/snmp/mode/temperature.pm
+++ b/storage/synology/snmp/mode/temperature.pm
@@ -33,7 +33,7 @@ sub set_counters {
     ];
 
     $self->{maps_counters}->{global} = [
-        { label => 'temperature', nlabel => 'system.temperature.celsius', set => {
+        { label => 'temperature', nlabel => 'system#hardware.temperature.celsius', set => {
                 key_values => [ { name => 'temperature' } ],
                 output_template => 'system temperature: %s C',
                 perfdatas => [


### PR DESCRIPTION
Hi,

Let's properly rename Synology temperature metric as in other hardware modes.

Thx 👍