### PR TITLE
enh(os10) temperature new label

### DIFF
--- a/network/dell/os10/snmp/mode/components/temperature.pm
+++ b/network/dell/os10/snmp/mode/components/temperature.pm
@@ -72,7 +72,7 @@ sub check {
         }
         $self->{output}->perfdata_add(
             unit => 'C',
-            nlabel => 'hardware.chassis.temperature.celsius',
+            nlabel => 'hardware.temperature.celsius',
             instances => $name,
             value => $result->{os10ChassisTemp},
             warning => $warn,


### PR DESCRIPTION
Hi,

For same reasons as given in #2905, let's "properly" rename Dell OS10 temperature newlabel.

Thx 👍