### PR TITLE
fix(plugin):avoid perl error when checking Elastic basic instances

### DIFF
--- a/database/elasticsearch/restapi/mode/license.pm
+++ b/database/elasticsearch/restapi/mode/license.pm
@@ -80,7 +80,7 @@ sub manage_selection {
         status => $result->{license}->{status},
         issued_to => $result->{license}->{issued_to},
         issue_date => $result->{license}->{issue_date},
-        expiry_date_in_seconds => int($result->{license}->{expiry_date_in_millis} / 1000)
+        expiry_date_in_seconds => defined($result->{license}->{expiry_date_in_millis}) ? int($result->{license}->{expiry_date_in_millis} / 1000) : "n/a"
     };
 }
 


### PR DESCRIPTION
Closes https://github.com/centreon/centreon-plugins/issues/2986 