### PR TITLE
Fix Filter AS

### DIFF
--- a/apps/protocols/bgp/4/mode/bgppeerstate.pm
+++ b/apps/protocols/bgp/4/mode/bgppeerstate.pm
@@ -162,7 +162,7 @@ sub manage_selection {
             next;
         }
         if (defined($self->{option_results}->{filter_as}) && $self->{option_results}->{filter_as} ne '' &&
-            $instance !~ /$self->{option_results}->{filter_as}/) {
+            $mapped_value->{bgpPeerRemoteAs} !~ /$self->{option_results}->{filter_as}/) {
             $self->{output}->output_add(
                 long_msg => "skipping AS '" . $mapped_value->{bgpPeerRemoteAs} . "': no matching filter.",
                 debug => 1


### PR DESCRIPTION
The Filter AS option didn't work because the filter was compare to the instance which is equal to the peer and not AS.
Just fixing the correct variable.