### PR TITLE
Updated storage.pm to work with larger volumes

### DIFF
--- a/snmp_standard/mode/storage.pm
+++ b/snmp_standard/mode/storage.pm
@@ -335,8 +335,18 @@ sub manage_selection {
             next;
         }
         
+        my $size = $result->{$oid_hrStorageSize . "." . $_};
+        my $used = $result->{$oid_hrStorageUsed . "." . $_};
+        
+        if ($size <= 0) {
+            $size += 2**32;
+        }
+        if ($used <= 0) {
+            $used += 2**32;
+        }
+        
         # in bytes hrStorageAllocationUnits
-        my $total_size = $result->{$oid_hrStorageSize . "." . $_} * $result->{$oid_hrStorageAllocationUnits . "." . $_};
+        my $total_size = $size * $result->{$oid_hrStorageAllocationUnits . "." . $_};
         if ($total_size <= 0) {
             $self->{output}->output_add(
                 long_msg => sprintf(
@@ -353,8 +363,8 @@ sub manage_selection {
             my $duplicate = 0;
             foreach my $entry (values %{$self->{storage}}) {
                 if (($entry->{allocation_units} == $result->{$oid_hrStorageAllocationUnits . '.' . $_}) &&
-                    ($entry->{size} == $result->{$oid_hrStorageSize . "." . $_}) &&
-                    ($entry->{used} == $result->{$oid_hrStorageUsed . "." . $_})) {
+                    ($entry->{size} == $size) &&
+                    ($entry->{used} == $used)) {
                     $duplicate = 1;
                     last;
                 }
@@ -365,8 +375,8 @@ sub manage_selection {
         $self->{storage}->{$_} = {
             display => $name_storage,
             allocation_units => $result->{$oid_hrStorageAllocationUnits . '.' . $_},
-            size => $result->{$oid_hrStorageSize . '.' . $_},
-            used => $result->{$oid_hrStorageUsed . '.' . $_},
+            size => $size,
+            used => $used,
             access => defined($access_result->{$_}) ? $access_result->{$_} : undef,
         };
         $self->{global}->{count}++;


### PR DESCRIPTION
Hey, I've been told in Slack to suggest this change over here. So please be gentle as this is my first GitHub post 😬.

In reference to:
https://github.com/centreon/centreon-plugins/issues/1651
https://github.com/centreon/centreon-plugins/issues/983

Since the Windows SNMP agent utilizes signed 32-bit Integer variables (-2.147.483.648 to 2.147.483.647) for storing the size and used amounts in bytes of disks, they are prone to overflow and report negative values when working with large disks of 8TB+. 

This simple workaround checks for a negative return value and adds the 32-bit range (2^32 = 4.294.967.296).
From personal experience, this works with disks of up to 40TB.
I am however not sure of the actual limit this works with.
Furthermore, with a 40TB disk, 4096 Bytes block size (= 10.742.787.580 hrStorageSize), it should wrap around multiple times, however the plugin still manages to report the correct value with this change (As to why... I'd be very interested to hear if you could tell me! 😄 ).