### PR TITLE
fix(mode): Azure CDN requests deprecated metrics

### DIFF
--- a/cloud/azure/network/cdn/mode/requests.pm
+++ b/cloud/azure/network/cdn/mode/requests.pm
@@ -36,22 +36,6 @@ sub get_metrics_mapping {
             'unit'   => '',
             'min'    => '0',
             'max'    => ''
-        },
-        'percentage4xx' => {
-            'output' => 'Percentage of 4XX',
-            'label'  => '4xx-requests-percentage',
-            'nlabel' => 'cdn.requests.4xx.percentage',
-            'unit'   => '%',
-            'min'    => '0',
-            'max'    => '100'
-        },
-        'percentage5xx' => {
-            'output' => 'Percentage of 5XX',
-            'label'  => '5xx-requests-percentage',
-            'nlabel' => 'cdn.requests.5xx.percentage',
-            'unit'   => '%',
-            'min'    => '0',
-            'max'    => '100'
         }
     };
 


### PR DESCRIPTION
azure-cdn-fix

{"code":"BadRequest","message":"Failed to find metric configuration for provider: Microsoft.Cdn, resource Type: profiles, metric: percentage4xx, Valid metrics: RequestCount,ResponseSize,TotalLatency,ByteHitRatio"}

{"code":"BadRequest","message":"Failed to find metric configuration for provider: Microsoft.Cdn, resource Type: profiles, metric: percentage5xx, Valid metrics: RequestCount,ResponseSize,TotalLatency,ByteHitRatio"}