### PR TITLE
Fix UNKNOWN: Illegal division by zero problem

### DIFF
--- a/cloud/docker/restapi/mode/containerusage.pm
+++ b/cloud/docker/restapi/mode/containerusage.pm
@@ -39,6 +39,9 @@ sub custom_cpu_calc {
 
     my $delta_cpu_total = $options{new_datas}->{$self->{instance} . '_cpu_total_usage'} - $options{old_datas}->{$self->{instance} . '_cpu_total_usage'};
     my $delta_cpu_system = $options{new_datas}->{$self->{instance} . '_cpu_system_usage'} - $options{old_datas}->{$self->{instance} . '_cpu_system_usage'};
+    if($delta_cpu_system == 0){
+       $delta_cpu_system = 1;
+    }
     $self->{result_values}->{prct_cpu} = (($delta_cpu_total / $delta_cpu_system) * $options{new_datas}->{$self->{instance} . '_cpu_number'}) * 100;
     $self->{result_values}->{display} = $options{new_datas}->{$self->{instance} . '_display'};
 
@@ -94,6 +97,9 @@ sub custom_memory_calc {
     $self->{result_values}->{display} = $options{new_datas}->{$self->{instance} . '_display'};
     $self->{result_values}->{total} = $options{new_datas}->{$self->{instance} . '_memory_total'};
     $self->{result_values}->{used} = $options{new_datas}->{$self->{instance} . '_memory_usage'};
+    if($self->{result_values}->{total} == 0){
+       $self->{result_values}->{total} = 1;
+    }    
     $self->{result_values}->{free} = $self->{result_values}->{total} - $self->{result_values}->{used};
     $self->{result_values}->{prct_free} = $self->{result_values}->{free} * 100 / $self->{result_values}->{total};
     $self->{result_values}->{prct_used} = $self->{result_values}->{used} * 100 / $self->{result_values}->{total};


### PR DESCRIPTION
i wanted use the Docker plugin for check container status (running = OK, other status = Critical), while keeping the other metrics (CPU, RAM.. etc).

Here my request :
`/centreon_plugins.pl --plugin cloud::docker::restapi::plugin --mode container-usage --hostname 'IP' --port PORT--use-name --filter-name 'REGEX' --critical-container-status '%{state} !~ /running/'`

When the container is Running, no problem. However, if the container is not Running i have error :
UNKNOWN: Illegal division by zero at /usr/lib/centreon/plugins/centreon-plugins/cloud/docker/restapi/mode/containerusage.pm line 42.

This is because in containerusage.pm, there are few lines where there are a division by a value who doesn't exist like the container is off :

```
my $delta_cpu_system = $options{new_datas}->{$self->{instance} . '_cpu_system_usage'} - $options{old_datas}->{$self->{instance} . '_cpu_system_usage'};

$self->{result_values}->{prct_free} = $self->{result_values}->{free} * 100 / $self->{result_values}->{total};

$self->{result_values}->{prct_used} = $self->{result_values}->{used} * 100 / $self->{result_values}->{total};

```
For fix the problem, i have surcharged variable with add an "if value = 0" like that

```
sub custom_cpu_calc {
    my ($self, %options) = @_;

    my $delta_cpu_total = $options{new_datas}->{$self->{instance} . '_cpu_total_usage'} - $options{old_datas}->{$self->{instance} . '_cpu_total_usage'};
    my $delta_cpu_system = $options{new_datas}->{$self->{instance} . '_cpu_system_usage'} - $options{old_datas}->{$self->{instance} . '_cpu_system_usage'};
    if($delta_cpu_system == 0){
       $delta_cpu_system = 1;
    }
    $self->{result_values}->{prct_cpu} = (($delta_cpu_total / $delta_cpu_system) * $options{new_datas}->{$self->{instance} . '_cpu_number'}) * 100;
    $self->{result_values}->{display} = $options{new_datas}->{$self->{instance} . '_display'};

    return 0;
}

sub custom_memory_calc {
    my ($self, %options) = @_;

    $self->{result_values}->{display} = $options{new_datas}->{$self->{instance} . '_display'};
    $self->{result_values}->{total} = $options{new_datas}->{$self->{instance} . '_memory_total'};
    $self->{result_values}->{used} = $options{new_datas}->{$self->{instance} . '_memory_usage'};
    $self->{result_values}->{free} = $self->{result_values}->{total} - $self->{result_values}->{used};
    if($self->{result_values}->{total} == 0){
       $self->{result_values}->{total} = 1;
       }
    $self->{result_values}->{prct_free} = $self->{result_values}->{free} * 100 / $self->{result_values}->{total};
    $self->{result_values}->{prct_used} = $self->{result_values}->{used} * 100 / $self->{result_values}->{total};
    return 0;
}
```

Cordialy
Maxime