### PR TITLE
Fix help message

### DIFF
--- a/cloud/prometheus/restapi/mode/expression.pm
+++ b/cloud/prometheus/restapi/mode/expression.pm
@@ -231,12 +231,12 @@ Set the instance label on which the results should be calculate for (Example: --
 
 =item B<--output>
 
-Set the output for each instances (Example: --output='Container %{instance} value is {label}').
+Set the output for each instances (Example: --output='Container %{instance} value is %{label}').
 
 =item B<--multiple-output>
 
 Set the global output in case everything is fine for multiple instances
-(Example: --multiple-output='Container %{instance} value is {label}').
+(Example: --multiple-output='Containers are OK').
 
 =item B<--warning-status>
 


### PR DESCRIPTION
There is no variable substitution for the --multiple-output option according to the answer I’ve been given in ticket #00095776 of the customer portal (centreon.force.com).
I’m fixing the help message accordingly.