### PR TITLE
enh(pacemaker/local): mode crm - modify nodes online/offline regexp

### DIFF
--- a/apps/pacemaker/local/mode/crm.pm
+++ b/apps/pacemaker/local/mode/crm.pm
@@ -332,10 +332,10 @@ sub parse_crm {
             if ($lines[$i] !~ /partition with quorum$/) {
                 $self->{cluster}->{global}->{quorum}->{quorum_status} = 'noQuorum';
             }
-        } elsif ($lines[$i] =~ /^(offline|online):\s*\[\s*(.*?)\s*\]/i) {
+        } elsif ($lines[$i] =~ /^(?:(?:\s*\*\s*)?(offline|online)):\s*\[\s*(.*?)\s*\]/i) {
             my @nodes = split(/\s+/, $2);
             $self->{cluster}->{global}->{nodes}->{lc($1)} = scalar(@nodes);
-            $self->{cluster}->{global}->{nodes}->{lc($1) . '_names'} = ' ' . join(' ',  @nodes);
+            $self->{cluster}->{global}->{nodes}->{lc($1) . '_names'} = join(' ',  @nodes);
         } elsif ($lines[$i] =~ /^node\s+(\S+?):\s*standby/i) {
             $self->{cluster}->{global}->{nodes}->{standby}++;
             $self->{cluster}->{global}->{nodes}->{standby_names} .= ' ' . $1;


### PR DESCRIPTION
New format:
```
Cluster Summary:
  * Stack: corosync
  * Current DC: server2 (version 2.0.5-ba59be7122) - partition with quorum
  * Last updated: Mon Dec 27 16:10:53 2021
  * Last change:  Sun Dec 26 15:20:00 2021 by root via cibadmin on server1
  * 2 nodes configured
  * 2 resource instances configured

Node List:
  * Online: [ server1 server2 ]

Full List of Resources:
  * Resource Group: core_cluster:
    * floating_ip       (ocf:heartbeatI.IPaddr2):        Started server1
    * http_server       (ocf:heartbeatI.nginx):  Started server1

Migration Summary:

command response: Cluster Summary:
  * Stack: corosync
  * Current DC: server2 (version 2.0.5-ba59be7122) - partition with quorum
  * Last updated: Mon Dec 27 16:10:53 2021
  * Last change:  Sun Dec 26 15:20:00 2021 by root via cibadmin on server1
  * 2 nodes configured
  * 2 resource instances configured

Node List:
  * Online: [ server1 server2 ]

Full List of Resources:
  * Resource Group: core_cluster:
    * floating_ip       (ocf:heartbeatI.Paddr2):        Started server1
    * http_server       (ocf:heartbeatI.nginx):  Started server1

Migration Summary:
checking cluster
    connection status: ok [error: -]
    quorum status: ok
    nodes online: 0 [], offline: 0 [], standby: 0 []
    actions failed: 0
resource 'floating_ip' status: started [node: server1] [unmanaged: no], actions failed: 0, migration failed: 0
resource 'http_server' status: started [node: server1] [unmanaged: no], actions failed: 0, migration failed: 0
```