### PR TITLE
(plugin) cloud::azure::compute::disk - fixing missing unit causing error in output

### DIFF
--- a/cloud/azure/compute/disk/mode/diskio.pm
+++ b/cloud/azure/compute/disk/mode/diskio.pm
@@ -49,6 +49,7 @@ sub get_metrics_mapping {
             'output' => 'Disk Read Operationss/sec',
             'label'  => 'disk-read-ops-persec',
             'nlabel' => 'disk.write.ops.persec',
+            'unit'   => 'B/s',
             'min'    => '0',
             'max'    => ''
         },
@@ -56,6 +57,7 @@ sub get_metrics_mapping {
             'output' => 'Disk Write Operations/sec',
             'label'  => 'disk-write-ops-persec',
             'nlabel' => 'disk.write.ops.persec',
+            'unit'   => 'B/s',
             'min'    => '0',
             'max'    => ''
         }       


### PR DESCRIPTION
Adding unit in metrics_mapping to prevent such errors in output : 

```Use of uninitialized value in string eq at /home/centos/centreon-plugins/cloud/azure/custom/mode.pm line 92.
Use of uninitialized value $unit in sprintf at /home/centos/centreon-plugins/cloud/azure/custom/mode.pm line 102.
Use of uninitialized value in string eq at /home/centos/centreon-plugins/cloud/azure/custom/mode.pm line 92.
Use of uninitialized value $unit in sprintf at /home/centos/centreon-plugins/cloud/azure/custom/mode.pm line 102
