### PR TITLE
(plugin) cloud::azure::compute::disk - fixing wrong type of unit

### DIFF
--- a/cloud/azure/compute/disk/mode/diskio.pm
+++ b/cloud/azure/compute/disk/mode/diskio.pm
@@ -49,7 +49,7 @@ sub get_metrics_mapping {
             'output' => 'Disk Read Operationss/sec',
             'label'  => 'disk-read-ops-persec',
             'nlabel' => 'disk.write.ops.persec',
-            'unit'   => 'B/s',
+            'unit'   => '',
             'min'    => '0',
             'max'    => ''
         },
@@ -57,7 +57,7 @@ sub get_metrics_mapping {
             'output' => 'Disk Write Operations/sec',
             'label'  => 'disk-write-ops-persec',
             'nlabel' => 'disk.write.ops.persec',
-            'unit'   => 'B/s',
+            'unit'   => '',
             'min'    => '0',
             'max'    => ''
         }       

--- a/cloud/azure/compute/disk/mode/diskio.pm
+++ b/cloud/azure/compute/disk/mode/diskio.pm
@@ -46,7 +46,7 @@ sub get_metrics_mapping {
             'max'    => ''
         }, 
         'Composite Disk Read Operations/sec' => {
-            'output' => 'Disk Read Operationss/sec',
+            'output' => 'Disk Read Operations/sec',
             'label'  => 'disk-read-ops-persec',
             'nlabel' => 'disk.write.ops.persec',
             'unit'   => '',


### PR DESCRIPTION
Related to https://github.com/centreon/centreon-plugins/pull/3379
Not B/s but op/s and Output already is 'Disk Read Operations/sec: '