### PR TITLE
(plugin) apps::backup::rubrik::restapi - enhance compliance mode, use public api instead internal one

### DIFF
--- a/apps/backup/rubrik/restapi/custom/api.pm
+++ b/apps/backup/rubrik/restapi/custom/api.pm
@@ -207,8 +207,9 @@ sub request_api {
 
     $self->settings();
     my $creds = $self->credentials();
+    my $api_version = defined($options{api_version}) ? $options{api_version} : 'internal';
     my ($content) = $self->{http}->request(
-        url_path => '/api/internal' . $options{endpoint},
+        url_path => '/api/' . $api_version . $options{endpoint},
         get_param => $options{get_param},
         %$creds
     );
@@ -218,7 +219,7 @@ sub request_api {
         $self->clean_token();
         $creds = $self->credentials();
         $content = $self->{http}->request(
-            url_path => '/api/internal' . $options{endpoint},
+            url_path => '/api/' . $api_version . $options{endpoint},
             get_param => $options{get_param},
             %$creds,
             unknown_status => $self->{unknown_http_status},

--- a/apps/backup/rubrik/restapi/mode/compliance.pm
+++ b/apps/backup/rubrik/restapi/mode/compliance.pm
@@ -30,8 +30,17 @@ sub prefix_global_output {
     
     my $prefix_output;
     
+    if ($self->{option_results}->{snapshot_range} eq 'LastSnapshot') {
+        $prefix_output = 'last snapshot';
+    } elsif ($self->{option_results}->{snapshot_range} eq 'Last2Snapshot') {
+        $prefix_output = 'last 2 snapshots';
+    } elsif ($self->{option_results}->{snapshot_range} eq 'Last3Snapshot') {
+        $prefix_output = 'last 3 snapshots';
+    } else {
+        $prefix_output = 'all snapshots';
+    }
     
-    return 'Backup objects ' . $prefix_output . ') ';
+    return 'Backup objects (based on ' . $prefix_output . ') ';
 }
 
 sub set_counters {


### PR DESCRIPTION
Use of api/v1/report/compliance_summary_sla instead of api/internal/report/{id}/chart 

Rubrik APIv1 doc:
"
api/v1/report/complaince_summary_sla
Returns the compliance summary information for all protected objects based on whether the last expected snapshot was successful. This requirement is based on the SLA Domain assigned to the objects.
With
snapshot-range : 
An SLA Domain-based range of snapshots. Compliance is calculated for snapshots in the range.
"

api/v1/report/compliance_summary_sla can give us 4 ranges of snapshots:
Last snapshot
Last 2 snapshots
Last 3 snapshots
All snapshots

Add percent value

