### PR TITLE
Convert queue_file_enabled it to yes/no on brokerstats output

### DIFF
--- a/apps/centreon/local/mode/brokerstats.pm
+++ b/apps/centreon/local/mode/brokerstats.pm
@@ -182,7 +182,7 @@ sub manage_selection {
                 speed_events => $json->{$entry}->{event_processing_speed},
                 queued_events => $json->{$entry}->{queued_events},
                 unacknowledged_events => $json->{$entry}->{bbdo_unacknowledged_events},
-                queue_file_enabled => defined($json->{$entry}->{queue_file_enabled}) ? $json->{$entry}->{queue_file_enabled} : '-',
+                queue_file_enabled => defined($json->{$entry}->{queue_file_enabled}) ? $json->{$entry}->{queue_file_enabled} ? 'yes' : 'no' : '-',
             };
         }
     }


### PR DESCRIPTION
Hello,

When using this plugin the output is something like the following:

Endpoint output 'central-broker-master-sql' state : connected [status : reading event from multiplexing engine] [queue file enabled : JSON::PP::Boolean=SCALAR(0x558e45644110)]

This is incompatible with the default critical-status both on the plugin and on the plugin pack definition:

%{type} eq "output" and %{queue_file_enabled} =~ /yes/i

This is a possible solution, I believe this is only happens after this change on centreon-broker so it should be present in versions 19.10 and up:

https://github.com/centreon/centreon-broker/commit/55428949aae4ff078390f82416d98f9f0ec6a5da#diff-1bc589d6a5fb10d15ac56c499d547daf42803b988d3dfd8ae62f70f5458466b2