### PR TITLE
(plugin) apps::pvx::restapi - add default-value parameter

### DIFF
--- a/apps/pvx/restapi/custom/api.pm
+++ b/apps/pvx/restapi/custom/api.pm
@@ -44,18 +44,19 @@ sub new {
 
     if (!defined($options{noptions})) {
         $options{options}->add_options(arguments => {
-            'api-key:s'   => { name => 'api_key' },
-            'hostname:s'  => { name => 'hostname' },
-            'url-path:s'  => { name => 'url_path' },
-            'port:s'      => { name => 'port' },
-            'proto:s'     => { name => 'proto' },
-            'credentials' => { name => 'credentials' },
-            'basic'       => { name => 'basic' },
-            'username:s'  => { name => 'username' },
-            'password:s'  => { name => 'password' },
-            'timeout:s'   => { name => 'timeout', default => 10 },
-            'timeframe:s' => { name => 'timeframe' },
-            'timezone:s'  => { name => 'timezone', default => 'UTC' }
+            'api-key:s'       => { name => 'api_key' },
+            'default-value:s' => { name => 'default_value' },
+            'hostname:s'      => { name => 'hostname' },
+            'url-path:s'      => { name => 'url_path' },
+            'port:s'          => { name => 'port' },
+            'proto:s'         => { name => 'proto' },
+            'credentials'     => { name => 'credentials' },
+            'basic'           => { name => 'basic' },
+            'username:s'      => { name => 'username' },
+            'password:s'      => { name => 'password' },
+            'timeout:s'       => { name => 'timeout', default => 10 },
+            'timeframe:s'     => { name => 'timeframe' },
+            'timezone:s'      => { name => 'timezone', default => 'UTC' }
         });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -165,6 +166,13 @@ sub query_range {
     $query .= sprintf(' TOP %s', $options{top}) if (defined($options{top}) && $options{top} ne '');
 
     my $result = $self->get_endpoint(url_path => '/query?expr=' . $uri->encode($query));
+
+    if (defined( $self->{option_results}->{default_value} ) && !exists( $result->{data} )) {
+        my $forced_hash;
+        $options{filter} =~ /([^\s\\]+) = \"([^\s\\]+)\"/;
+        push @{ $forced_hash->{key} }, { value => $2 };
+        push @{ $forced_hash->{values} }, { value => $self->{option_results}->{default_value} }; push @{$result->{data}}, $forced_hash;
+    }
 
     return $result->{data};
 }

--- a/apps/pvx/restapi/custom/api.pm
+++ b/apps/pvx/restapi/custom/api.pm
@@ -167,11 +167,10 @@ sub query_range {
 
     my $result = $self->get_endpoint(url_path => '/query?expr=' . $uri->encode($query));
 
-    if (defined( $self->{option_results}->{default_value} ) && !exists( $result->{data} )) {
-        my $forced_hash;
+    if (defined( $self->{option_results}->{default_value} ) && $options{filter} ne '' && !exists( $result->{data} )) {
         $options{filter} =~ /([^\s\\]+) = \"([^\s\\]+)\"/;
-        push @{ $forced_hash->{key} }, { value => $2 };
-        push @{ $forced_hash->{values} }, { value => $self->{option_results}->{default_value} }; push @{$result->{data}}, $forced_hash;
+        push @{$result->{data}->{key}}, { value => $2 };
+        push @{$result->{data}->{values}}, { value => $self->{option_results}->{default_value} };
     }
 
     return $result->{data};
@@ -215,6 +214,10 @@ PVX Rest API custom mode
 =head1 REST API OPTIONS
 
 =over 8
+
+=item B<--default-value>
+
+Set a default value when nothing returned by PVX API
 
 =item B<--timeframe>
 


### PR DESCRIPTION
Sometimes users want to set a default value when no data is returned by PVX (Some kind of --zeroed parameter). 

Here we allow setting any value the user might want to set to identify that PVX didn't return any data back. 