### PR TITLE
new raisecom pon series support

### DIFF
--- a/network/raisecom/pon/snmp/mode/components/fan.pm
+++ b/network/raisecom/pon/snmp/mode/components/fan.pm
@@ -1,0 +1,87 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Authors : Roman Morandell - i-Vertix
+#
+
+package network::raisecom::pon::snmp::mode::components::fan;
+
+use strict;
+use warnings;
+
+my %map_fan_state = (
+    1 => 'normal',
+    2 => 'abnormal',
+    3 => 'null',
+    4 => 'unknown',
+);
+
+my $mapping = {
+    raisecomFanSpeedValue   => { oid => '.1.3.6.1.4.1.8886.1.27.5.1.1.4' },
+    raisecomFanWorkState    => { oid => '.1.3.6.1.4.1.8886.1.27.5.1.1.3.6', map => \%map_fan_state },
+};
+my $oid_raisecomFanMonitorStateEntry = '.1.3.6.1.4.1.8886.1.27.5.1.1';
+
+sub load {
+    my ($self) = @_;
+
+    push @{$self->{request}}, { oid => $oid_raisecomFanMonitorStateEntry };
+}
+
+sub check {
+    my ($self) = @_;
+
+    $self->{output}->output_add(long_msg => "Checking fans");
+    $self->{components}->{fan} = {name => 'fan', total => 0, skip => 0};
+    return if ($self->check_filter(section => 'fan'));
+
+    foreach my $oid ($self->{snmp}->oid_lex_sort(keys %{$self->{results}->{$oid_raisecomFanMonitorStateEntry}})) {
+        next if ($oid !~ /^$mapping->{raisecomFanWorkState}->{oid}\.(.*)$/);
+        my $instance = $1;
+        my $result = $self->{snmp}->map_instance(mapping => $mapping, results => $self->{results}->{$oid_raisecomFanMonitorStateEntry}, instance => $instance);
+
+        next if ($self->check_filter(section => 'fan', instance => $instance));
+
+        $self->{components}->{fan}->{total}++;
+        $self->{output}->output_add(long_msg => sprintf("Fan '%s' status is '%s' [instance = %s]",
+                                                        $instance, $result->{raisecomFanWorkState}, $instance));
+        my $exit = $self->get_severity(section => 'fan', value => $result->{raisecomFanWorkState});
+        if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
+            $self->{output}->output_add(severity => $exit,
+                                       short_msg => sprintf("Fan '%s' status is '%s'", $instance, $result->{raisecomFanWorkState}));
+        }
+        
+        my ($exit2, $warn, $crit) = $self->get_severity_numeric(section => 'fan.speed', instance => $instance, value => $result->{raisecomFanSpeedValue});
+        if (!$self->{output}->is_status(value => $exit2, compare => 'ok', litteral => 1)) {
+            $self->{output}->output_add(severity => $exit2,
+                                        short_msg => sprintf("Fan speed '%s' is %s rpm", $instance, $result->{raisecomFanSpeedValue}));
+        }
+        
+        $self->{output}->perfdata_add(
+            label => 'fan', unit => 'rpm',
+            nlabel => 'hardware.fan.speed.rpm',
+            instances => $instance,
+            value => $result->{raisecomFanSpeedValue},
+            warning => $warn,
+            critical => $crit,
+            min => 0
+        );
+    }
+}
+
+1;

--- a/network/raisecom/pon/snmp/mode/components/temperature.pm
+++ b/network/raisecom/pon/snmp/mode/components/temperature.pm
@@ -1,0 +1,81 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Authors : Roman Morandell - i-Vertix
+#
+
+package network::raisecom::pon::snmp::mode::components::temperature;
+
+use strict;
+use warnings;
+
+my $mapping = {
+    tempValue => { oid => '.1.3.6.1.4.1.8886.1.27.2.1.1.10' }
+};
+
+sub load {
+    my ($self) = @_;
+
+    push @{$self->{request}}, {
+        oid => $mapping->{tempValue}->{oid}
+    };
+}
+
+sub check {
+    my ($self) = @_;
+
+    $self->{output}->output_add(long_msg => 'checking temperatures');
+    $self->{components}->{temperature} = { name => 'temperatures', total => 0, skip => 0 };
+    return if ($self->check_filter(section => 'temperature'));
+
+    foreach my $oid ($self->{snmp}->oid_lex_sort(keys %{$self->{results}->{ $mapping->{tempValue}->{oid} }})) {
+        next if ($oid !~ /^$mapping->{tempValue}->{oid}\.(.*)$/);
+        my $instance = $1;
+
+        my $result = $self->{snmp}->map_instance(mapping => $mapping, results => $self->{results}->{ $mapping->{tempValue}->{oid} }, instance => $instance);
+        next if ($self->check_filter(section => 'temperature', instance => $instance));
+
+        $self->{components}->{temperature}->{total}++;
+        $self->{output}->output_add(
+            long_msg => sprintf(
+                "System temperature is %s celsius",
+                 $result->{tempValue}
+            )
+        );
+
+        my ($exit, $warn, $crit) = $self->get_severity_numeric(section => 'temperature', instance => $instance, value => $result->{tempValue});
+        if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
+            $self->{output}->output_add(
+                severity => $exit,
+                short_msg => sprintf(
+                    "System temperature is %s celsius", $result->{tempValue}
+                )
+            );
+        }
+        $self->{output}->perfdata_add(
+            nlabel => 'hardware.temperature.celsius',
+            unit => 'C',
+            instances => 'system',
+            value => $result->{tempValue},
+            warning => $warn,
+            critical => $crit, min => 0
+        );
+    }
+}
+
+1;

--- a/network/raisecom/pon/snmp/mode/components/voltage.pm
+++ b/network/raisecom/pon/snmp/mode/components/voltage.pm
@@ -1,0 +1,162 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Authors : Roman Morandell - i-Vertix
+#
+
+package network::raisecom::pon::snmp::mode::components::voltage;
+
+use strict;
+use warnings;
+
+my %map_output_status = (
+    1 => 'normal', 2 => 'abnormal', 3 => 'null',
+    4 => 'highAlarm', 5 => 'lowAlarm'
+);
+
+my $mapping_output = {
+    raisecomPowerStatus    => { oid => '.1.3.6.1.4.1.8886.1.27.4.2.1.2', map => \%map_output_status },
+    raisecomPowerOutputvol => { oid => '.1.3.6.1.4.1.8886.1.27.4.2.1.3' }
+};
+
+my $oid_raisecomOutputEntry = '.1.3.6.1.4.1.8886.1.27.4.2.1';
+
+my %map_input_status = (
+    1 => 'normal', 2 => 'lowMin', 3 => 'lowMaj',
+    4 => 'lowCri', 5 => 'uppMin', 6 => 'uppMaj', 7 => 'uppCri'
+);
+
+my $mapping_input = {
+    raisecomPowerStatus    => { oid => '.1.3.6.1.4.1.8886.1.27.4.1.1.10', map => \%map_input_status },
+    raisecomPowerInputvol => { oid => '.1.3.6.1.4.1.8886.1.27.4.1.1.9' }
+};
+
+my $oid_raisecomInputEntry = '.1.3.6.1.4.1.8886.1.27.4.1.1';
+
+sub load {
+    my ($self) = @_;
+
+    push @{$self->{request}}, { oid => $oid_raisecomOutputEntry };
+    push @{$self->{request}}, { oid => $oid_raisecomInputEntry };
+}
+
+sub check {
+    my ($self) = @_;
+
+    $self->{output}->output_add(long_msg => "Checking output voltages");
+    $self->{components}->{voltage} = { name => 'voltages', total => 0, skip => 0 };
+    return if ($self->check_filter(section => 'voltage_output'));
+
+    my ($exit, $warn, $crit, $checked);
+
+    # check output
+    foreach my $oid ($self->{snmp}->oid_lex_sort(keys %{$self->{results}->{$oid_raisecomOutputEntry}})) {
+        next if ($oid !~ /^$mapping_output->{raisecomPowerStatus}->{oid}\.(.*)$/);
+        my $instance = $1;
+        my $instance_id =  substr($instance, 0, index($instance, "."));
+
+        my $result = $self->{snmp}->map_instance(mapping => $mapping_output, results => $self->{results}->{$oid_raisecomOutputEntry}, instance => $instance);
+
+        next if ($self->check_filter(section => 'voltage_output', instance => $instance_id));
+        $self->{components}->{voltage}->{total}++;
+
+        $self->{output}->output_add(
+            long_msg => sprintf(
+                "Power Output '%s' status is '%s' [instance: %s, voltage is %.2f mV]",
+                $instance_id,
+                $result->{raisecomPowerStatus},
+                $instance_id,
+                defined($result->{raisecomPowerOutputvol}) ? $result->{raisecomPowerOutputvol} : 'unknown'
+            )
+        );
+        $exit = $self->get_severity(section => 'voltage_output', value => $result->{raisecomPowerStatus});
+        if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
+            $self->{output}->output_add(
+                severity  => $exit,
+                short_msg => sprintf("Power Output '%s' status is '%s'", $instance_id, $result->{raisecomPowerStatus})
+            );
+        }
+
+        next if (!defined($result->{raisecomPowerOutputvol}) || $result->{raisecomPowerOutputvol} !~ /[0-9]+/);
+
+        ($exit, $warn, $crit, $checked) = $self->get_severity_numeric(section => 'voltage_output', instance => $instance_id, value => $result->{raisecomPowerOutputvol});
+
+        if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
+            $self->{output}->output_add(severity => $exit,
+                short_msg                        => sprintf("Voltage '%s' is %.2f mV", "Power Output $instance_id", $result->{raisecomPowerOutputvol}));
+        }
+        $self->{output}->perfdata_add(
+            label     => 'volt_output', unit => 'mV',
+            nlabel    => 'hardware.voltage.volt',
+            instances => $instance_id,
+            value     => $result->{raisecomPowerOutputvol},
+            warning   => $warn,
+            critical  => $crit,
+        );
+    }
+
+    $self->{output}->output_add(long_msg => "Checking input voltages");
+    $self->{components}->{voltage} = { name => 'voltages', total => 0, skip => 0 };
+    return if ($self->check_filter(section => 'voltage_input'));
+
+    # check input
+    foreach my $oid ($self->{snmp}->oid_lex_sort(keys %{$self->{results}->{$oid_raisecomInputEntry}})) {
+        next if ($oid !~ /^$mapping_input->{raisecomPowerStatus}->{oid}\.(.*)$/);
+        my $instance = $1;
+        my $result = $self->{snmp}->map_instance(mapping => $mapping_input, results => $self->{results}->{$oid_raisecomInputEntry}, instance => $instance);
+
+        next if ($self->check_filter(section => 'voltage_input', instance => $instance));
+        $self->{components}->{voltage}->{total}++;
+
+        $self->{output}->output_add(
+            long_msg => sprintf(
+                "Power Input '%s' status is '%s' [instance: %s, voltage is %.2f mV]",
+                $instance,
+                $result->{raisecomPowerStatus},
+                $instance,
+                defined($result->{raisecomPowerInputvol}) ? $result->{raisecomPowerInputvol} : 'unknown'
+            )
+        );
+        $exit = $self->get_severity(section => 'voltage_input', value => $result->{raisecomPowerStatus});
+        if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
+            $self->{output}->output_add(
+                severity  => $exit,
+                short_msg => sprintf("Power Input '%s' status is '%s'", $instance, $result->{raisecomPowerStatus})
+            );
+        }
+
+        next if (!defined($result->{raisecomPowerInputvol}) || $result->{raisecomPowerInputvol} !~ /[0-9]+/);
+
+        ($exit, $warn, $crit, $checked) = $self->get_severity_numeric(section => 'voltage_input', instance => $instance, value => $result->{raisecomPowerInputvol});
+
+        if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
+            $self->{output}->output_add(severity => $exit,
+                short_msg                        => sprintf("Voltage '%s' is %.2f mV", "Power Input $instance", $result->{raisecomPowerInputvol}));
+        }
+        $self->{output}->perfdata_add(
+            label     => 'volt_input', unit => 'mV',
+            nlabel    => 'hardware.voltage.volt',
+            instances => $instance,
+            value     => $result->{raisecomPowerInputvol},
+            warning   => $warn,
+            critical  => $crit,
+        );
+    }
+}
+
+1;

--- a/network/raisecom/pon/snmp/mode/cpu.pm
+++ b/network/raisecom/pon/snmp/mode/cpu.pm
@@ -1,0 +1,147 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Authors : Roman Morandell - i-Vertix
+#
+
+package network::raisecom::pon::snmp::mode::cpu;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'cpu', type => 0, cb_prefix_output => 'prefix_cpu_output' }
+    ];
+
+    $self->{maps_counters}->{cpu} = [
+        { label => '1s', set => {
+            key_values      => [ { name => 'oneSec' } ],
+            output_template => '%.2f%% (1sec)',
+            perfdatas       => [
+                { label => 'cpu_1s', value => 'oneSec', template => '%.2f',
+                    min => 0, max => 100, unit => '%' },
+            ],
+        }
+        },
+        { label => '10m', set => {
+            key_values      => [ { name => 'tenMin' } ],
+            output_template => '%.2f%% (10min)',
+            perfdatas       => [
+                { label => 'cpu_10m', value => 'tenMin', template => '%.2f',
+                    min => 0, max => 100, unit => '%' },
+            ],
+        }
+        },
+        { label => '2h', set => {
+            key_values      => [ { name => 'twoHour' } ],
+            output_template => '%.2f%% (2h)',
+            perfdatas       => [
+                { label => 'cpu_2h', value => 'twoHour', template => '%.2f',
+                    min => 0, max => 100, unit => '%' },
+            ],
+        }
+        }
+    ];
+}
+
+sub prefix_cpu_output {
+    my ($self, %options) = @_;
+
+    return "CPU Usage ";
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments =>
+        {
+        });
+
+    return $self;
+}
+
+my $mapping = {
+    oneSec  => { oid => '.1.3.6.1.4.1.8886.18.1.7.1.1.1.3' },
+    tenMin  => { oid => '.1.3.6.1.4.1.8886.18.1.7.1.1.1.4' },
+    twoHour => { oid => '.1.3.6.1.4.1.8886.18.1.7.1.1.1.5' }
+};
+
+my $oid_raisecomCPUUtilizationEntry = '.1.3.6.1.4.1.8886.18.1.7.1.1.1';
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    $self->{cpu} = {};
+
+    my $snmp_result = $options{snmp}->get_table(
+        oid          => $oid_raisecomCPUUtilizationEntry,
+        start        => $mapping->{oneSec}->{oid},
+        end        => $mapping->{twoHour}->{oid},
+        nothing_quit => 1
+    );
+
+    use Data::Dumper;
+    print Dumper($snmp_result);
+
+    foreach my $oid (keys %{$snmp_result}) {
+        next if ($oid !~ /^$mapping->{oneSec}->{oid}\.(.*)$/);
+        my $instance = $1;
+
+        my $result = $options{snmp}->map_instance(mapping => $mapping, results => $snmp_result, instance => $instance);
+
+        foreach my $period (keys $mapping) {
+            $self->{cpu}->{$period} = $result->{$period};
+        }
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check CPU usage.
+
+=over 8
+
+=item B<--filter-counters>
+
+Only display some counters (regexp can be used).
+Example: --filter-counters='^(1s|10m|2h)$'
+
+=item B<--warning-*>
+
+Threshold warning.
+Can be: '1s', '10m', '2h'.
+
+=item B<--critical-*>
+
+Threshold critical.
+Can be: '1s', '10m', '2h'.
+
+=back
+
+=cut

--- a/network/raisecom/pon/snmp/mode/hardware.pm
+++ b/network/raisecom/pon/snmp/mode/hardware.pm
@@ -1,0 +1,125 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Authors : Roman Morandell - i-Vertix
+#
+
+package network::raisecom::pon::snmp::mode::hardware;
+
+use base qw(centreon::plugins::templates::hardware);
+
+use strict;
+use warnings;
+
+sub set_system {
+    my ($self, %options) = @_;
+
+    $self->{regexp_threshold_numeric_check_section_option} = '^(temperature|fan.speed|voltage_output|voltage_input)$';
+
+    $self->{cb_hook2} = 'snmp_execute';
+
+    $self->{thresholds} = {
+        fan => [
+            ['abnormal', 'CRITICAL'],
+            ['unknown', 'UNKNOWN'],
+            ['null', 'UNKNOWN'],
+            ['normal', 'OK']
+        ],
+        voltage_input => [
+            ['abnormal', 'CRITICAL'],
+            ['unknown', 'UNKNOWN'],
+            ['null', 'UNKNOWN'],
+            ['normal', 'OK']
+        ],
+        voltage_output => [
+            ['highAlarm', 'CRITICAL'],
+            ['uppCri', 'CRITICAL'],
+            ['lowCri', 'CRITICAL'],
+            ['lowAlarm', 'WARNING'],
+            ['lowMin', 'WARNING'],
+            ['lowMaj', 'WARNING'],
+            ['normal', 'OK']
+        ]
+    };
+
+    $self->{components_path} = 'network::raisecom::pon::snmp::mode::components';
+    $self->{components_module} = ['fan', 'temperature', 'voltage'];
+}
+
+sub snmp_execute {
+    my ($self, %options) = @_;
+
+    $self->{snmp} = $options{snmp};
+    $self->{results} = $self->{snmp}->get_multiple_table(oids => $self->{request});
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {});
+
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check hardware.
+
+=over 8
+
+=item B<--component>
+
+Which component to check (Default: '.*').
+Can be: 'temperature', 'fan', 'voltage'.
+
+=item B<--filter>
+
+Exclude some parts (comma seperated list) (Example: --filter=fan, --filter=voltage_input,
+ --filter=voltage_output, --filter=temperature
+Can also exclude specific instance: --filter=fan,1
+
+=item B<--no-component>
+
+Return an error if no compenents are checked.
+If total (with skipped) is 0. (Default: 'critical' returns).
+
+=item B<--threshold-overload>
+
+Set to overload default threshold values (syntax: section,[instance,]status,regexp)
+It used before default thresholds (order stays).
+Example: --threshold-overload='fan,CRITICAL,^(?!(normal)$)'
+
+=item B<--warning>
+
+Set warning threshold for temperatures, fan speed (syntax: type,instance,threshold)
+Example: --warning='temperature,.*,30'
+
+=item B<--critical>
+
+Set critical threshold for temperatures, fan speed (syntax: type,instance,threshold)
+Example: --critical='temperature,.*,40'
+
+=back
+
+=cut

--- a/network/raisecom/pon/snmp/mode/listprocesses.pm
+++ b/network/raisecom/pon/snmp/mode/listprocesses.pm
@@ -1,0 +1,152 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Authors : Roman Morandell - i-Vertix
+#
+
+package network::raisecom::pon::snmp::mode::listprocesses;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s' => { name => 'filter_name' },
+        'filter-status:s' => { name => 'filter_status' }
+    });
+
+    $self->{order} = ['name', 'pid', 'status'];
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+}
+
+my %map_status = (
+    0 => 'ready',
+    1 => 'suspend',
+    2 => 'pend',
+    3 => 'pend_s',
+    4 => 'delay',
+    5 => 'delay_s',
+    6 => 'pend_t',
+    7 => 'pend_t_s',
+    8 => 'dead'
+);
+
+my $mapping = {
+    name       => { oid => '.1.3.6.1.4.1.8886.18.1.7.2.2.1.3' }, # rcRunProcessName
+    pid       => { oid => '.1.3.6.1.4.1.8886.18.1.7.2.2.1.2' }, #  rcRunProcessPID
+    status     => { oid => '.1.3.6.1.4.1.8886.18.1.7.2.2.1.9', map => \%map_status }, #  rcRunProcessStatus
+};
+
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $oid_hrSWRunEntry = '.1.3.6.1.4.1.8886.18.1.7.2.2.1';
+    my $snmp_result = $options{snmp}->get_table(
+        oid => $oid_hrSWRunEntry,
+        start => $mapping->{pid}->{oid},
+        end => $mapping->{status}->{oid},
+        nothing_quit => 1
+    );
+    my $results = {};
+    foreach my $oid (keys %$snmp_result) {
+        next if ($oid !~ /^$mapping->{name}->{oid}\.(.*?)$/);
+        my $instance = $1;
+        my $result = $options{snmp}->map_instance(mapping => $mapping, results => $snmp_result, instance => $instance);
+
+        if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
+            $result->{name} !~ /$self->{option_results}->{filter_name}/) {
+            $self->{output}->output_add(long_msg => "skipping '" . $result->{name} . "': no matching name filter.", debug => 1);
+            next;
+        }
+
+        if (defined($self->{option_results}->{filter_status}) && $self->{option_results}->{filter_status} ne '' &&
+            $result->{name} !~ /$self->{option_results}->{filter_status}/) {
+            $self->{output}->output_add(long_msg => "skipping '" . $result->{name} . "': no matching status filter.", debug => 1);
+            next;
+        }
+
+        $results->{$instance} = { %$result };
+    }
+
+    return $results;
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    my $results = $self->manage_selection(%options);
+    foreach (values %$results) {
+        my $entry = '';
+        foreach my $label (@{$self->{order}}) {
+            $entry .= '[' . $label . ' = ' . $_->{$label} . '] ';
+        }
+        $self->{output}->output_add(long_msg => $entry);
+    }
+
+    $self->{output}->output_add(
+        severity => 'OK',
+        short_msg => 'List processes:'
+    );
+    $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+    $self->{output}->exit();
+}
+
+sub disco_format {
+    my ($self, %options) = @_;
+
+    $self->{output}->add_disco_format(elements => $self->{order});
+}
+
+sub disco_show {
+    my ($self, %options) = @_;
+
+    my $results = $self->manage_selection(%options);
+    foreach (values %$results) {
+        $self->{output}->add_disco_entry(%$_);
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+List processes.
+
+=over 8
+
+=item B<--filter-name>
+
+Filter by service name (can be a regexp).
+
+=back
+
+=cut

--- a/network/raisecom/pon/snmp/mode/memory.pm
+++ b/network/raisecom/pon/snmp/mode/memory.pm
@@ -1,0 +1,115 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package network::raisecom::pon::snmp::mode::memory;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments =>
+        {
+            "warning:s"               => { name => 'warning' },
+            "critical:s"              => { name => 'critical' },
+        });
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+
+    if (($self->{perfdata}->threshold_validate(label => 'warning', value => $self->{option_results}->{warning})) == 0) {
+        $self->{output}->add_option_msg(short_msg => "Wrong warning threshold '" . $self->{option_results}->{warning} . "'.");
+        $self->{output}->option_exit();
+    }
+    if (($self->{perfdata}->threshold_validate(label => 'critical', value => $self->{option_results}->{critical})) == 0) {
+        $self->{output}->add_option_msg(short_msg => "Wrong critical threshold '" . $self->{option_results}->{critical} . "'.");
+        $self->{output}->option_exit();
+    }
+}
+
+sub run {
+    my ($self, %options) = @_;
+    $self->{snmp} = $options{snmp};
+
+    my $oid_raisecomAvailableMemory = '.1.3.6.1.4.1.8886.18.1.7.3.1.1.2.1.0';
+    my $oid_raisecomTotalMemory = '.1.3.6.1.4.1.8886.18.1.7.3.1.1.1.1.0';
+
+    my $oids = [$oid_raisecomAvailableMemory, $oid_raisecomTotalMemory];
+
+    my $result = $self->{snmp}->get_leef(oids => $oids,
+        nothing_quit => 1);
+
+    my $free_size = $result->{$oid_raisecomAvailableMemory};
+    my $total_size = $result->{$oid_raisecomTotalMemory};
+    my $used_size = $total_size - $free_size;
+
+    my $prct_used = $used_size * 100 / $total_size;
+    my $prct_free = 100 - $prct_used;
+    my $exit = $self->{perfdata}->threshold_check(value => $prct_used, threshold => [ { label => 'critical', exit_litteral => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
+
+    my ($total_value, $total_unit) = $self->{perfdata}->change_bytes(value => $total_size);
+    my ($used_value, $used_unit) = $self->{perfdata}->change_bytes(value => $used_size);
+    my ($free_value, $free_unit) = $self->{perfdata}->change_bytes(value => $free_size);
+
+    $self->{output}->output_add(severity => $exit,
+        short_msg => sprintf("Memory Total: %s, Used: %s (%.2f%%), Free: %s (%.2f%%)",
+            $total_value . " " . $total_unit,
+            $used_value . " " . $used_unit, $prct_used,
+            $free_value . " " . $free_unit, $prct_free));
+
+    $self->{output}->perfdata_add(label => "used", unit => 'B',
+        value => $used_size,
+        warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning', total => $total_size, cast_int => 1),
+        critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical', total => $total_size, cast_int => 1),
+        min => 0, max => $total_size);
+
+    $self->{output}->display();
+    $self->{output}->exit();
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check memory usage.
+
+=over 8
+
+=item B<--warning>
+
+Threshold warning in percent.
+
+=item B<--critical>
+
+Threshold critical in percent.
+
+=back
+
+=cut

--- a/network/raisecom/pon/snmp/mode/processcount.pm
+++ b/network/raisecom/pon/snmp/mode/processcount.pm
@@ -1,0 +1,168 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Authors : Roman Morandell - i-Vertix
+#
+
+package network::raisecom::pon::snmp::mode::processcount;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+my %map_process_status = (
+    0 => 'ready',
+    1 => 'suspend',
+    2 => 'pend',
+    3 => 'pend_s',
+    4 => 'delay',
+    5 => 'delay_s',
+    6 => 'pend_t',
+    7 => 'pend_t_s',
+    8 => 'dead'
+);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'process-status:s' => { name => 'process_status' },
+        'process-name:s'   => { name => 'process_name' },
+        'regexp-name'      => { name => 'regexp_name' },
+        'process-pid'      => { name => 'process_pid' },
+        'warning:s'        => { name => 'warning' },
+        'critical:s'       => { name => 'critical' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+
+    if (($self->{perfdata}->threshold_validate(label => 'warning', value => $self->{option_results}->{warning})) == 0) {
+        $self->{output}->add_option_msg(short_msg => "Wrong warning threshold '" . $self->{option_results}->{warning} . "'.");
+        $self->{output}->option_exit();
+    }
+    if (($self->{perfdata}->threshold_validate(label => 'critical', value => $self->{option_results}->{critical})) == 0) {
+        $self->{output}->add_option_msg(short_msg => "Wrong critical threshold '" . $self->{option_results}->{critical} . "'.");
+        $self->{output}->option_exit();
+    }
+}
+
+my $filters = {
+    status => { oid => '.1.3.6.1.4.1.8886.18.1.7.2.2.1.9', value => '', regexp => 1 }, # rcRunProcessStatus
+    name   => { oid => '.1.3.6.1.4.1.8886.18.1.7.2.2.1.3', value => '' },              # rcRunProcessName
+    pid    => { oid => '.1.3.6.1.4.1.8886.18.1.7.2.2.1.2', value => '' },              # rcRunProcessPID
+};
+
+my $oid_rcRunProcessName = '.1.3.6.1.4.1.8886.18.1.7.2.2.1.3';
+my $oid_rcRunProcessPID = '.1.3.6.1.4.1.8886.18.1.7.2.2.1.2';
+my $oid_rcRunProcessStatus = '.1.3.6.1.4.1.8886.18.1.7.2.2.1.9';
+
+
+sub run {
+    my ($self, %options) = @_;
+    $self->{snmp} = $options{snmp};
+
+    foreach my $filter (keys %$filters) {
+        if (defined($self->{option_results}->{'process_' . $filter}) && $self->{option_results}->{'process_' . $filter} ne '') {
+            $filters->{$filter}->{value} = $self->{option_results}->{'process_' . $filter};
+        }
+        if (defined($self->{option_results}->{'regexp_' . $filter})) {
+            $filters->{$filter}->{regexp} = 1;
+        }
+    }
+
+    my $oids_multiple_table = [
+        { oid => $oid_rcRunProcessStatus },
+        { oid => $oid_rcRunProcessName },
+        { oid => $oid_rcRunProcessPID }
+    ];
+
+    # First lookup on name and status
+    $self->{snmp_response} = $self->{snmp}->get_multiple_table(oids => $oids_multiple_table);
+    use Data::Dumper;
+    foreach my $key ($self->{snmp}->oid_lex_sort(keys %{$self->{snmp_response}->{$oid_rcRunProcessStatus}})) {
+        next if ($key !~ /^$oid_rcRunProcessStatus\.(.*)$/);
+        my $instance = $1;
+        $self->{results}->{$instance}->{status} = $map_process_status{$self->{snmp_response}->{$oid_rcRunProcessStatus}->{$oid_rcRunProcessStatus . '.' . $instance}};
+        $self->{results}->{$instance}->{name} = $self->{snmp_response}->{$oid_rcRunProcessName}->{$oid_rcRunProcessName . '.' . $instance};
+        $self->{results}->{$instance}->{pid} = $self->{snmp_response}->{$oid_rcRunProcessPID}->{$oid_rcRunProcessPID . '.' . $instance};
+
+        foreach my $filter (keys %$filters) {
+            next if !defined($self->{results}->{$instance}) || $filters->{$filter}->{value} eq '';
+            if ((defined($filters->{$filter}->{regexp}) && $self->{results}->{$instance}->{$filter} !~ /$filters->{$filter}->{value}/)
+                || (!defined($filters->{$filter}->{regexp}) && $self->{results}->{$instance}->{$filter} ne $filters->{$filter}->{value})) {
+                delete $self->{results}->{$instance};
+            }
+        }
+    }
+
+    my $num_processes_match = scalar(keys(%{$self->{results}}));
+    my $exit = $self->{perfdata}->threshold_check(value => $num_processes_match,
+        threshold                                       => [ { label => 'critical', exit_litteral => 'critical' },
+            { label => 'warning', exit_litteral => 'warning' } ]);
+    $self->{output}->output_add(severity => $exit,
+        short_msg                        => "Number of current processes running: $num_processes_match");
+    $self->{output}->perfdata_add(label => 'nbproc',
+        value                           => $num_processes_match,
+        warning                         => $self->{perfdata}->get_perfdata_for_output(label => 'warning'),
+        critical                        => $self->{perfdata}->get_perfdata_for_output(label => 'critical'),
+        min                             => 0);
+
+    foreach my $pid (keys %{$self->{results}}) {
+        my $long_msg = sprintf("Process '%s'", $self->{results}->{$pid}->{name});
+        $long_msg .= sprintf(" [status: %s, pid: %s]", $self->{results}->{$pid}->{status}, $self->{results}->{$pid}->{pid});
+        $self->{output}->output_add(long_msg => $long_msg);
+    }
+
+    $self->{output}->display();
+    $self->{output}->exit();
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check system number of processes.
+
+=over 8
+
+=item B<--process-status>
+
+Filter process status. Can be a regexp.
+
+=item B<--process-name>
+
+Filter process name.
+
+=item B<--regexp-name>
+
+Allows to use regexp to filter process
+name (with option --process-name)
+
+=back
+
+=cut

--- a/network/raisecom/pon/snmp/plugin.pm
+++ b/network/raisecom/pon/snmp/plugin.pm
@@ -1,0 +1,56 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Authors : Roman Morandell - i-Vertix
+#
+
+package network::raisecom::pon::snmp::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_snmp);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{version} = '0.1';
+    %{$self->{modes}} = (
+        'cpu'          => 'network::raisecom::pon::snmp::mode::cpu',
+        'hardware'     => 'network::raisecom::pon::snmp::mode::hardware',
+        'interfaces'   => 'snmp_standard::mode::interfaces',
+        'memory'       => 'network::raisecom::pon::snmp::mode::memory',
+        'processcount' => 'network::raisecom::pon::snmp::mode::processcount',
+        'uptime'       => 'snmp_standard::mode::uptime',
+        'list-interfaces' => 'snmp_standard::mode::listinterfaces',
+        'list-processes' => 'network::raisecom::pon::snmp::mode::listprocesses',
+    );
+
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 PLUGIN DESCRIPTION
+
+Check Raisecom devices through SNMP
+
+=cut


### PR DESCRIPTION
Hi Quentin,

As discussed here is my pull request for raisecom pon series devices. I have already tested it extensively with one device. regarding folder structure I was not sure because there is already a snmp folder directly under raisecom. This would be then maybe the "general" folder ? I have all under /raisecom/pon/snmp/xxx ..

**Modes Available:
   cpu
   hardware
   interfaces
   list-interfaces
   list-processes
   memory
   processcount
   uptime**
   
   **--cpu**

` ./centreon_plugins.pl --plugin=network::raisecom::pon::snmp::plugin --mode=cpu --hostname=xxx --snmp-community=publicc --snmp-version=2c`

`OK: CPU Usage 0.00% (1sec), 1.00% (10min), 1.00% (2h) | 'cpu_1s'=0.00%;;;0;100 'cpu_10m'=1.00%;;;0;100 'cpu_2h'=1.00%;;;0;100`
   
   
**--hardware**

`./centreon_plugins.pl --plugin=network::raisecom::pon::snmp::plugin --mode=hardware --hostname=xxx --snmp-community=publicc --snmp-version=2c --verbose`

```
[OK: All 6 components are ok [3/3 fan, 1/1 temperatures, 2/2 voltages]. | 'fan_1'=rpm;;;0; 'fan_2'=rpm;;;0; 'fan_3'=rpm;;;0; '_system'=33C;;;0; 'volt_output_4'=5000mV;;;; 'volt_output_5'=5000mV;;;; 'volt_input_4'=48000mV;;;; 'volt_input_5'=48000mV;;;; 'count_fan'=3;;;; 'count_temperature'=1;;;; 'count_voltage'=2;;;;
Checking fans
Fan '1' status is 'normal' [instance = 1]
Fan '2' status is 'normal' [instance = 2]
Fan '3' status is 'normal' [instance = 3]
checking temperatures
System temperature is 33 celsius
Checking output voltages
Power Output '4' status is 'normal' [instance: 4, voltage is 5000.00 mV]
Power Output '5' status is 'normal' [instance: 5, voltage is 5000.00 mV]
Checking input voltages
Power Input '4' status is 'normal' [instance: 4, voltage is 48000.00 mV]
Power Input '5' status is 'normal' [instance: 5, voltage is 48000.00 mV]](url)
```

--insterfaces && --list-interfaces && --uptime: standard snmp

**--memory**

```
 ./centreon_plugins.pl --plugin=network::raisecom::pon::snmp::plugin --mode=memory --hostname=xxx --snmp-community=publicc --snmp-version=2c
OK: Memory Total: 460.26 MB, Used: 213.48 MB (46.38%), Free: 246.78 MB (53.62%) | 'used'=223847616B;;;0;482617136
```

**--processcount**

```
 ./centreon_plugins.pl --plugin=network::raisecom::pon::snmp::plugin --mode=processcount --hostname=xxx --snmp-community=publicc --snmp-version=2c --verbose --process-status='pend' --process-name='^tMs.*$' --regexp-name

OK: Number of current processes running: 1 | 'nbproc'=1;;;0;
Process 'tMstp' [status: pend, pid: 231323736]](url)
```



**--list-processes**

`_./centreon_plugins.pl --plugin=network::raisecom::pon::snmp::plugin --mode=list-processes --hostname=xxx --snmp-community=publicc --snmp-version=2c --verbose --filter-name='^tGpon.*$' --disco-show_`

```
<?xml version="1.0" encoding="utf-8"?>
<data>
  <label pid="242767824" status="pend" name="tGponPonSysCfg"/>
  <label pid="242631776" status="pend" name="tGponRmtOnuCfg"/>
  <label pid="192124336" status="pend" name="tGponPasOnuReg"/>
  <label pid="244981544" status="pend" name="tGponRmtOnuAlarm"/>
  <label pid="245286784" status="pend" name="tGponPrtUdpMsgRx"/>
  <label pid="192086472" status="delay" name="tGponPasEnc"/>
  <label pid="245097424" status="pend" name="tGponPrtFtpUpgrade"/>
  <label pid="241342928" status="pend" name="tGponPktTx"/>
  <label pid="242838336" status="delay" name="tGponRmtScan"/>
  <label pid="245357416" status="pend" name="tGponPrtTcpMsgRx"/>
  <label pid="261872504" status="pend" name="tGponPasSpecEvent"/>
  <label pid="241276400" status="pend" name="tGponPktRx"/>
  <label pid="241209904" status="pend" name="tGponOmciCommRx"/>
  <label pid="245248920" status="pend" name="tGponPrtKeepaliveTx"/>
</data>
```