### PR TITLE
(plugins) apps::ipfabric - adding missing var for discovery

### DIFF
--- a/apps/ipfabric/mode/discovery.pm
+++ b/apps/ipfabric/mode/discovery.pm
@@ -79,6 +79,7 @@ sub manage_selection {
         $disco_data->{$device->{id}} = {
             id => $device->{id},
             hostname => $device->{hostname},
+	    loginIp => $device->{loginIp},
             siteName => $device->{siteName},
             vendor => $device->{vendor},
             family => $device->{family},


### PR DESCRIPTION
Adding loginIp variable missing from disco output