### PR TITLE
(custom) cloud::aws::custom::awscli - adding AssumeRole auth for awscli

### DIFF
--- a/cloud/aws/custom/awscli.pm
+++ b/cloud/aws/custom/awscli.pm
@@ -869,6 +869,10 @@ Set AWS access key.
 
 Set AWS session token.
 
+=item B<--aws-role-arn>
+
+Set arn of the role to be assumed.
+
 =item B<--aws-profile>
 
 Set AWS profile.


### PR DESCRIPTION
User can now use authentication through AssumeRole with awscli custom mode. 

Fixes plugin part of https://github.com/centreon/centreon-plugin-packs/issues/964. 