### PR TITLE
(plugin) network::stormshield::snmp::mode::vpnstatus - enhance thresholds triggers on vpn states

### DIFF
--- a/network/stormshield/snmp/mode/vpnstatus.pm
+++ b/network/stormshield/snmp/mode/vpnstatus.pm
@@ -76,10 +76,10 @@ sub prefix_vpn_output {
 
 my $thresholds = {
     vpn => [
-        ['larval', 'WARNING'],
+        ['larval', 'OK'],
         ['mature', 'OK'],
-        ['dying', 'CRITICAL'],
-        ['dead', 'CRITICAL']
+        ['dying', 'OK'],
+        ['dead', 'WARNING']
     ]
 };
 


### PR DESCRIPTION
We have a lot of Stormshield appliance to check, a lot of warning/critical alert are issued frequently on VPN which are just renegociating (larval), or waiting for activity before renegotiating (dying).

I suggest to move the critical state for these result, to OK state.

the dead state is not really a critical state too, as a VPN tunnel can be offline if no trafic is detected, but I suggest to change to "WARNING" (considering the tunnel business critical and keepalive activated, dead is not a normal state).

We should add some argument to be able to change this behaviour, in function of the keepalive/DPD tunnel option.
(if DPD/keepalive is ON, dying & dead are CRITICAL)

https://documentation.stormshield.eu/SNS/v4/fr/Content/HowTo_-_IPSec_VPN_-_Hub_and_Spoke_Configuration/Checking_the_tunnel_setup.htm
https://documentation.stormshield.eu/SNS-RELATED-TOOLS/fr/Content/Real-Time_Monitor_User_Guide_v3/5-Network-Activity/51-VPN-Tunnels.htm