### PR TITLE
fix(windows-wsman): list-storages backslash issue for GUI

### DIFF
--- a/os/windows/wsman/mode/liststorages.pm
+++ b/os/windows/wsman/mode/liststorages.pm
@@ -62,6 +62,7 @@ sub manage_selection {
 
     my $results = {};
     foreach my $entry (@$entries) {
+	$entry->{Name} =~ s/\\//g;
         $results->{ $entry->{DeviceID} } = {
             size => $entry->{Capacity},
             name => $entry->{Name},


### PR DESCRIPTION
Substitute "\" for service discovery rules