### PR TITLE
(plugin) hardware::server::hp::proliant::snmp mode hardware - force new perfdata

### DIFF
--- a/hardware/server/hp/proliant/snmp/mode/components/fan.pm
+++ b/hardware/server/hp/proliant/snmp/mode/components/fan.pm
@@ -115,7 +115,7 @@ sub check {
 
         if (defined($result->{cpqHeFltTolFanCurrentSpeed})) {
             $self->{output}->perfdata_add(
-                label => 'fan_speed', unit => 'rpm',
+                unit => 'rpm',
                 nlabel => 'hardware.fan.speed.rpm',
                 instances => $instance,
                 value => $result->{cpqHeFltTolFanCurrentSpeed}

--- a/hardware/server/hp/proliant/snmp/mode/components/psu.pm
+++ b/hardware/server/hp/proliant/snmp/mode/components/psu.pm
@@ -116,14 +116,14 @@ sub check {
         }
         
         $self->{output}->perfdata_add(
-            label => 'psu_power', unit => 'W',
+            unit => 'W',
             nlabel => 'hardware.powersupply.power.watt',
             instances => $instance,
             value => $result->{cpqHeFltTolPowerSupplyCapacityUsed},
             critical => $result->{cpqHeFltTolPowerSupplyCapacityMaximum}
         );
         $self->{output}->perfdata_add(
-            label => 'psu_voltage', unit => 'V',
+            unit => 'V',
             nlabel => 'hardware.powersupply.voltage.volt',
             instances => $instance,
             value => $result->{cpqHeFltTolPowerSupplyMainVoltage}

--- a/hardware/server/hp/proliant/snmp/mode/components/temperature.pm
+++ b/hardware/server/hp/proliant/snmp/mode/components/temperature.pm
@@ -106,7 +106,7 @@ sub check {
                                             short_msg => sprintf("Temperature '%s' %s is %s degree centigrade", $instance, $result->{cpqHeTemperatureLocale}, $result->{cpqHeTemperatureCelsius}));
             }
             $self->{output}->perfdata_add(
-                label => "temp", unit => 'C',
+                unit => 'C',
                 nlabel => 'hardware.temperature.celsius',
                 instances => [$instance, $result->{cpqHeTemperatureLocale}],
                 value => $result->{cpqHeTemperatureCelsius},

--- a/hardware/server/hp/proliant/snmp/mode/hardware.pm
+++ b/hardware/server/hp/proliant/snmp/mode/hardware.pm
@@ -176,7 +176,7 @@ sub snmp_execute {
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
 
     $options{options}->add_options(arguments => {});


### PR DESCRIPTION
Forcing use of new perfdata.