### PR TITLE
(plugin): apps::ipfabric - add platform in host discovery output

### DIFF
--- a/apps/ipfabric/mode/discovery.pm
+++ b/apps/ipfabric/mode/discovery.pm
@@ -83,6 +83,7 @@ sub manage_selection {
         $device{siteName} = $host->{siteName};
         $device{vendor} = $host->{vendor};
         $device{family} = $host->{family};
+        $device{platform} = $host->{platform};
         $device{snmp_community} = undef;
         push @disco_data, \%device;
     }


### PR DESCRIPTION
Adding platform property in host discovery output.