### PR TITLE
(plugin) cloud::azure:database::mariadb - fix typo in label

### DIFF
--- a/cloud/azure/database/mariadb/mode/replication.pm
+++ b/cloud/azure/database/mariadb/mode/replication.pm
@@ -119,13 +119,13 @@ Using resource name :
 
 perl centreon_plugins.pl --plugin=cloud::azure::database::mariadb::plugin --mode=connections --custommode=api
 --resource=<db_id> --resource-group=<resourcegroup_id> --aggregation='maximum'
---warning-replication-lag='1000' --critical-replication-lag='2000'
+--warning-slave-latency-seconds='1000' --critical-slave-latency-seconds='2000'
 
 Using resource id :
 
 perl centreon_plugins.pl --plugin=cloud::azure::database::mariadb::plugin --mode=connections --custommode=api
 --resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.DBforMariaDB/servers/<db_id>'
---aggregation='maximum' --warning-replication-lag='1000' --critical-replication-lag='2000'
+--aggregation='maximum' --warning-slave-latency-seconds='1000' --critical-slave-latency-seconds='2000'
 
 Default aggregation: 'maximum' / 'average', 'minimum' and 'total' are valid.
 
@@ -142,12 +142,12 @@ Set resource group (Required if resource's name is used).
 =item B<--warning-*>
 
 Warning threshold where '*' can be:
-'replication-lag-count'.
+'slave-latency-seconds'.
 
 =item B<--critical-*>
 
 Critical threshold where '*' can be:
-'replication-lag-count'.
+'slave-latency-seconds'.
 
 =back
 

--- a/cloud/azure/database/mariadb/mode/storage.pm
+++ b/cloud/azure/database/mariadb/mode/storage.pm
@@ -52,7 +52,7 @@ sub get_metrics_mapping {
         },
         'serverlog_storage_usage' => {
             'output' => 'Server Log storage used',
-            'label'  => 'servelog-usage',
+            'label'  => 'serverlog-usage',
             'nlabel' => 'azmariadb.storage.serverlog.usage.bytes',
             'unit'   => 'B',
             'min'    => '0'
@@ -186,13 +186,13 @@ Set resource group (Required if resource's name is used).
 =item B<--warning-*>
 
 Warning threshold where '*' can be:
-'storage-backup', 'serverlog-limit', 'serverlog-percent', 'servelog-usage', 
+'storage-backup', 'serverlog-limit', 'serverlog-percent', 'serverlog-usage', 
 'storage-limit', 'storage-percent', 'storage-used'.
 
 =item B<--critical-*>
 
 Critical threshold where '*' can be:
-'storage-backup', 'serverlog-limit', 'serverlog-percent', 'servelog-usage', 
+'storage-backup', 'serverlog-limit', 'serverlog-percent', 'serverlog-usage', 
 'storage-limit', 'storage-percent', 'storage-used'.
 
 =back


### PR DESCRIPTION
* Fix little typo in counter label resulting in wrong threshold name for storage serverlog. 

May break output if users used --warning-servelog-usage or --critical-servelog-usage.

* Fixing help for replication mode.