### PR TITLE
(plugin) apps::monitoring::kadiska - apply suggestions 

### DIFF
--- a/apps/monitoring/kadiska/mode/listtargets.pm
+++ b/apps/monitoring/kadiska/mode/listtargets.pm
@@ -58,11 +58,11 @@ sub manage_selection {
 
     my $raw_form_post = {
         "select" => [
-            "tracer_id"
+            "target_name"
         ],
         "from" => "traceroute",
         "groupby" => [
-            "tracer_id"
+            "target_name"
         ],
         "offset" => 0,
         "options" => {"sampling" => \1 }
@@ -86,7 +86,7 @@ sub run {
     foreach my $target (@{$self->{targets}->{data}}){
         $self->{output}->output_add(
             long_msg => sprintf("[target = %s][station = %s]", 
-                $target->{tracer_id},
+                $target->{target_name},
                 $self->{option_results}->{station_name}
             )
         );
@@ -113,7 +113,7 @@ sub disco_show {
 
     foreach my $target (@{$self->{targets}->{data}}){
         $self->{output}->add_disco_entry( 
-                target => $target->{tracer_id},
+                target => $target->{target_name},
                 station => $self->{option_results}->{station_name}
         );
     }

--- a/apps/monitoring/kadiska/mode/nettracerstatistics.pm
+++ b/apps/monitoring/kadiska/mode/nettracerstatistics.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package apps::monitoring::kadiska::mode::tracerstatistics;
+package apps::monitoring::kadiska::mode::nettracerstatistics;
 
 use base qw(centreon::plugins::templates::counter);
 
@@ -125,16 +125,16 @@ sub manage_selection {
     );
 
     $self->{targets} = {};
-    foreach my $watcher (@{$results->{data}}) {
+    foreach my $station (@{$results->{data}}) {
         next if (defined($self->{option_results}->{filter_target_name}) && $self->{option_results}->{filter_target_name} ne ''
-            && $watcher->{'target:group'} !~ /^$self->{option_results}->{filter_target_name}$/);
+            && $station->{'target:group'} !~ /^$self->{option_results}->{filter_target_name}$/);
 
-        my $instance = $watcher->{"target:group"};
+        my $instance = $station->{"target:group"};
 
         $self->{targets}->{$instance} = {
-            round_trip => ($watcher->{'rtt_furthest:avg'} / 1000),
-            packets_loss_prct => $watcher->{'loss_furthest:avg'},
-            path_length => $watcher->{'length_furthest:avg'},
+            round_trip => ($station->{'rtt_furthest:avg'} / 1000),
+            packets_loss_prct => $station->{'loss_furthest:avg'},
+            path_length => $station->{'length_furthest:avg'},
         };
     };
 
@@ -151,17 +151,17 @@ __END__
 
 =head1 MODE
 
-Check Kadiska tracer targets' statistics during the period specified.
+Check Kadiska net tracer targets' statistics during the period specified.
 
 =over 8
 
 =item B<--filter-station-name>
 
-Filter on station name to display tracer targets' statistics linked to a particular station. 
+Filter on station name to display net tracer targets' statistics linked to a particular station. 
 
 =item B<--filter-target-name>
 
-Filter to display statistics for particular tracer targets. Can be a regex or a single tracer target.
+Filter to display statistics for particular net tracer targets. Can be a regex or a single tracer target.
 A target name must be given. 
 
 Regex example: 

--- a/apps/monitoring/kadiska/mode/tracerstatistics.pm
+++ b/apps/monitoring/kadiska/mode/tracerstatistics.pm
@@ -78,8 +78,8 @@ sub new {
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
-        'filter-station-name:s' => { name => 'filter_station_name' },
-        'filter-tracer:s'       => { name => 'filter_tracer' }
+        'filter-station-name:s'      => { name => 'filter_station_name' },
+        'filter-target-name:s'       => { name => 'filter_target_name' }
     });
 
     return $self;
@@ -91,7 +91,7 @@ sub manage_selection {
     my $raw_form_post = {
         "select" => [
             {
-                "tracer:group" => "tracer_id"
+                "target:group" => "target_name"
             },
             {
                 "length_furthest:avg" => ["avg","length_furthest"]
@@ -105,7 +105,7 @@ sub manage_selection {
         ],
         "from" => "traceroute",
         "groupby" => [
-            "tracer:group"
+            "target:group"
         ],
         "orderby" => [
             ["rtt_furthest:avg","desc"]
@@ -126,10 +126,10 @@ sub manage_selection {
 
     $self->{targets} = {};
     foreach my $watcher (@{$results->{data}}) {
-        next if (defined($self->{option_results}->{filter_tracer}) && $self->{option_results}->{filter_tracer} ne ''
-            && $watcher->{'tracer:group'} !~ /$self->{option_results}->{filter_tracer}/);
+        next if (defined($self->{option_results}->{filter_target_name}) && $self->{option_results}->{filter_target_name} ne ''
+            && $watcher->{'target:group'} !~ /^$self->{option_results}->{filter_target_name}$/);
 
-        my $instance = $watcher->{"tracer:group"};
+        my $instance = $watcher->{"target:group"};
 
         $self->{targets}->{$instance} = {
             round_trip => ($watcher->{'rtt_furthest:avg'} / 1000),
@@ -159,13 +159,13 @@ Check Kadiska tracer targets' statistics during the period specified.
 
 Filter on station name to display tracer targets' statistics linked to a particular station. 
 
-=item B<--filter-tracer>
+=item B<--filter-target-name>
 
 Filter to display statistics for particular tracer targets. Can be a regex or a single tracer target.
-A tracer_id must be given. 
+A target name must be given. 
 
 Regex example: 
---filter-tracer="(tracer:myid|tracer:anotherid)"
+--filter-target-name="(mylab.com|shop.mylab.com)"
 
 =item B<--warning-round-trip>
 

--- a/apps/monitoring/kadiska/mode/watcherstatistics.pm
+++ b/apps/monitoring/kadiska/mode/watcherstatistics.pm
@@ -64,6 +64,14 @@ sub set_counters {
                 ],
             }
         },
+        { label => 'loading-page', nlabel => 'watcher.loading.page.duration.seconds', set => {
+                key_values => [ { name => 'loading_page' } ],
+                output_template => 'Loading page duration: %.2f s',
+                perfdatas => [
+                    { template => '%.2f', unit => 's', min => 0, label_extra_instance => 1 },
+                ],
+            }
+        },   
         { label => 'pages', nlabel => 'watcher.pages.count', set => {
                 key_values => [ { name => 'pages' } ],
                 output_template => 'pages: %d',
@@ -114,6 +122,9 @@ sub manage_selection {
             },
             {
                 "item:count|pages" => ["countFor","pages"]
+            },
+            {
+                "lcp:p75|pages" => ["p75For","pages","lcp"]
             }
         ],
         "from" => "rum",
@@ -141,9 +152,10 @@ sub manage_selection {
 
         $self->{watchers}->{$instance} = {
             errors_prct => $watcher->{'%errors:avg|hits'},
-            sessions => $watcher->{'session:sum|hits'},
+            loading_page => ($watcher->{'lcp:p75|pages'} / 10**6),
+            pages => $watcher->{'item:count|pages'},
             requests => $watcher->{'item:count|requests'},
-            pages => $watcher->{'item:count|pages'} 
+            sessions => $watcher->{'session:sum|hits'}
         };
     };
 

--- a/apps/monitoring/kadiska/plugin.pm
+++ b/apps/monitoring/kadiska/plugin.pm
@@ -31,11 +31,11 @@ sub new {
 
     $self->{version} = '1.0';
     $self->{modes} = {
-        'list-watchers'      => 'apps::monitoring::kadiska::mode::listwatchers',
-        'list-stations'      => 'apps::monitoring::kadiska::mode::liststations',
-        'list-targets'       => 'apps::monitoring::kadiska::mode::listtargets',
-        'watcher-statistics' => 'apps::monitoring::kadiska::mode::watcherstatistics',
-        'tracer-statistics'  => 'apps::monitoring::kadiska::mode::tracerstatistics'
+        'list-watchers'         => 'apps::monitoring::kadiska::mode::listwatchers',
+        'list-stations'         => 'apps::monitoring::kadiska::mode::liststations',
+        'list-targets'          => 'apps::monitoring::kadiska::mode::listtargets',
+        'watcher-statistics'    => 'apps::monitoring::kadiska::mode::watcherstatistics',
+        'nettracer-statistics'  => 'apps::monitoring::kadiska::mode::nettracerstatistics'
     };
 
     $self->{custom_modes}->{api} = 'apps::monitoring::kadiska::custom::api';


### PR DESCRIPTION
Apply enhancement suggestions :

- use target_name instead of tracer_id for listtargets.pm and nettracerstatistics.pm
- rename tracer-statistics in favor of nettracer-statistics
- add loading page duration for watchers 