### PR TITLE
(plugin) cloud::aws::health::mode::events - fix error in output caused by type of returned time

### DIFF
--- a/cloud/aws/health/mode/events.pm
+++ b/cloud/aws/health/mode/events.pm
@@ -150,7 +150,7 @@ sub manage_selection {
                 $events->{$_}->{region},
                 $events->{$_}->{statusCode},
                 $events->{$_}->{eventTypeCode},
-                scalar(localtime($events->{$_}->{startTime})),
+                $events->{$_}->{startTime},
                 $entity
             )
         );


### PR DESCRIPTION
Fix error in output while executing aws health events mode: 
`Argument "2022-02-26T14:00:00+01:00" isn't numeric in localtime`
Causing plugin result to display start time in 1970: 
`[service: RDS][region: eu-west-1][status: closed][type: AWS_RDS_TYPE01][start: Thu Jan  1 00:33:42 1970]`

After fix display is now: 
`[service: RDS][region: eu-west-1][status: closed][type: AWS_RDS_TYPE01][start: 2022-02-26T14:00:00+01:00]`