### PR TITLE
(plugin) cloud::aws::backup - fix mode name for compliance

### DIFF
--- a/cloud/aws/backup/plugin.pm
+++ b/cloud/aws/backup/plugin.pm
@@ -32,7 +32,7 @@ sub new {
     $self->{version} = '0.1';
     %{ $self->{modes} } = (
         'discovery'     => 'cloud::aws::backup::mode::discovery',
-        'jobstatus'     => 'cloud::aws::backup::mode::jobstatus'
+        'job-status'    => 'cloud::aws::backup::mode::jobstatus'
     );
 
     $self->{custom_modes}{paws} = 'cloud::aws::custom::paws';


### PR DESCRIPTION
Fix AWS backup mode job-status name for compliance.
Adding a '-'.  