### PR TITLE
(plugin) apps::monitoring::ntopng::restapi - Fix interface option not…

### DIFF
--- a/apps/monitoring/ntopng/restapi/mode/alerts.pm
+++ b/apps/monitoring/ntopng/restapi/mode/alerts.pm
@@ -120,7 +120,7 @@ sub new {
     $options{options}->add_options(arguments => {
         'filter-type:s'     => { name => 'filter_type' },
         'filter-severity:s' => { name => 'filter_severity' },
-        'interface:i'       => { name => 'interface', default => 0 },
+        'interface:s'       => { name => 'interface', default => 0 },
         'period:s'          => { name => 'period', default => 'last-5mns' }
     });
 

--- a/apps/monitoring/ntopng/restapi/mode/hostflows.pm
+++ b/apps/monitoring/ntopng/restapi/mode/hostflows.pm
@@ -97,7 +97,7 @@ sub new {
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
-        'interface:i' => { name => 'interface', default => 0 },
+        'interface:s' => { name => 'interface', default => 0 },
         'ip:s'        => { name => 'ip' }
     });
 

--- a/apps/monitoring/ntopng/restapi/mode/netflowhealth.pm
+++ b/apps/monitoring/ntopng/restapi/mode/netflowhealth.pm
@@ -120,7 +120,7 @@ sub new {
     bless $self, $class;
     
     $options{options}->add_options(arguments => {
-        'interface:i' => { name => 'interface', default => 0 }
+        'interface:s' => { name => 'interface', default => 0 }
     });
 
     return $self;

--- a/apps/monitoring/ntopng/restapi/mode/probehealth.pm
+++ b/apps/monitoring/ntopng/restapi/mode/probehealth.pm
@@ -75,7 +75,7 @@ sub new {
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
-        'interface:i' => { name => 'interface', default => 0 }
+        'interface:s' => { name => 'interface', default => 0 }
     });
 
     return $self;


### PR DESCRIPTION
… consider if the value is quoted in the command line

## Description

The interface stays to the default value 0 if the option value is quoted in the check command line

Current result:
![image](https://user-images.githubusercontent.com/11980015/176749623-c21aa741-c5de-404c-81cd-da268c4ff54b.png)

Expected result:
![image](https://user-images.githubusercontent.com/11980015/176750168-4c6fb857-6ad1-408e-9108-7d3c09ee1b5c.png)




## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
