### PR TITLE
(plugin) apps::monitoring::linux::nodeexporter - correct paths and disco keys name

### DIFF
--- a/apps/monitoring/nodeexporter/linux/mode/cpu.pm
+++ b/apps/monitoring/nodeexporter/linux/mode/cpu.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package apps::monitoring::nodeexporter::mode::cpu;
+package apps::monitoring::nodeexporter::linux::mode::cpu;
 
 use base qw(centreon::plugins::templates::counter);
 

--- a/apps/monitoring/nodeexporter/linux/mode/listinterfaces.pm
+++ b/apps/monitoring/nodeexporter/linux/mode/listinterfaces.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package apps::monitoring::nodeexporter::mode::listinterfaces;
+package apps::monitoring::nodeexporter::linux::mode::listinterfaces;
 
 use base qw(centreon::plugins::templates::counter);
 
@@ -52,7 +52,7 @@ sub manage_selection {
 
         foreach my $data (@{$raw_metrics->{$metric}->{data}}) {
             $self->{interfaces}->{$data->{dimensions}->{device}}->{name} = $data->{dimensions}->{device};
-            $self->{interfaces}->{$data->{dimensions}->{device}}->{state} = ($data->{value} == 1) ? "up" : "down" ;
+            $self->{interfaces}->{$data->{dimensions}->{device}}->{status} = ($data->{value} == 1) ? "up" : "down" ;
         }
     }
 }
@@ -62,8 +62,8 @@ sub run {
 
     $self->manage_selection(%options);
     foreach my $interface (sort keys %{$self->{interfaces}}) {
-        $self->{output}->output_add(long_msg => '[interface = ' . $interface . "]" .
-            "[state = '" . $self->{interfaces}->{$interface}->{state} . "']"
+        $self->{output}->output_add(long_msg => '[name = ' . $interface . "]" .
+            "[status = '" . $self->{interfaces}->{$interface}->{status} . "']"
         );
     }
 
@@ -76,7 +76,7 @@ sub run {
 sub disco_format {
     my ($self, %options) = @_;
 
-    $self->{output}->add_disco_format(elements => ['interface', 'state']);
+    $self->{output}->add_disco_format(elements => ['name', 'status']);
 }
 
 sub disco_show {
@@ -85,8 +85,8 @@ sub disco_show {
     $self->manage_selection(%options);
     foreach my $interface (sort keys %{$self->{interfaces}}) {
         $self->{output}->add_disco_entry(
-            interface => $self->{interfaces}->{$interface}->{name},
-            state => $self->{interfaces}->{$interface}->{state},
+            name => $self->{interfaces}->{$interface}->{name},
+            status => $self->{interfaces}->{$interface}->{status},
         );
     }
 }

--- a/apps/monitoring/nodeexporter/linux/mode/liststorages.pm
+++ b/apps/monitoring/nodeexporter/linux/mode/liststorages.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package apps::monitoring::nodeexporter::mode::liststorages;
+package apps::monitoring::nodeexporter::linux::mode::liststorages;
 
 use base qw(centreon::plugins::templates::counter);
 

--- a/apps/monitoring/nodeexporter/linux/mode/load.pm
+++ b/apps/monitoring/nodeexporter/linux/mode/load.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package apps::monitoring::nodeexporter::mode::load;
+package apps::monitoring::nodeexporter::linux::mode::load;
 
 use base qw(centreon::plugins::templates::counter);
 

--- a/apps/monitoring/nodeexporter/linux/mode/memory.pm
+++ b/apps/monitoring/nodeexporter/linux/mode/memory.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package apps::monitoring::nodeexporter::mode::memory;
+package apps::monitoring::nodeexporter::linux::mode::memory;
 
 use base qw(centreon::plugins::templates::counter);
 

--- a/apps/monitoring/nodeexporter/linux/mode/storage.pm
+++ b/apps/monitoring/nodeexporter/linux/mode/storage.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package apps::monitoring::nodeexporter::mode::storage;
+package apps::monitoring::nodeexporter::linux::mode::storage;
 
 use base qw(centreon::plugins::templates::counter);
 

--- a/apps/monitoring/nodeexporter/linux/mode/traffic.pm
+++ b/apps/monitoring/nodeexporter/linux/mode/traffic.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package apps::monitoring::nodeexporter::mode::traffic;
+package apps::monitoring::nodeexporter::linux::mode::traffic;
 
 use base qw(centreon::plugins::templates::counter);
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);

--- a/apps/monitoring/nodeexporter/linux/plugin.pm
+++ b/apps/monitoring/nodeexporter/linux/plugin.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package apps::monitoring::nodeexporter::plugin;
+package apps::monitoring::nodeexporter::linux::plugin;
 
 use strict;
 use warnings;
@@ -31,13 +31,13 @@ sub new {
 
     $self->{version} = '0.1';
     %{$self->{modes}} = (
-        'cpu'             => 'apps::monitoring::nodeexporter::mode::cpu',
-        'list-interfaces' => 'apps::monitoring::nodeexporter::mode::listinterfaces',
-        'list-storages'   => 'apps::monitoring::nodeexporter::mode::liststorages',
-        'load'            => 'apps::monitoring::nodeexporter::mode::load',
-        'memory'          => 'apps::monitoring::nodeexporter::mode::memory',
-        'storage'         => 'apps::monitoring::nodeexporter::mode::storage',
-        'traffic'         => 'apps::monitoring::nodeexporter::mode::traffic'
+        'cpu'             => 'apps::monitoring::nodeexporter::linux::mode::cpu',
+        'list-interfaces' => 'apps::monitoring::nodeexporter::linux::mode::listinterfaces',
+        'list-storages'   => 'apps::monitoring::nodeexporter::linux::mode::liststorages',
+        'load'            => 'apps::monitoring::nodeexporter::linux::mode::load',
+        'memory'          => 'apps::monitoring::nodeexporter::linux::mode::memory',
+        'storage'         => 'apps::monitoring::nodeexporter::linux::mode::storage',
+        'traffic'         => 'apps::monitoring::nodeexporter::linux::mode::traffic'
     );
 
     $self->{custom_modes}{web} = 'centreon::common::monitoring::openmetrics::custom::web';
@@ -50,6 +50,6 @@ __END__
 
 =head1 PLUGIN DESCRIPTION
 
-Check host metrics based on node exporter's metrics.
+Check Linux OS-based host metrics based on node exporter's metrics.
 
 =cut


### PR DESCRIPTION
Modifying plugin paths and correcting interface discovery keys names