### PR TITLE
(plugin) ceph::restapi -- add 'Accept: application/vnd.ceph.api.v1.0+json' header

### DIFF
--- a/apps/ceph/restapi/custom/api.pm
+++ b/apps/ceph/restapi/custom/api.pm
@@ -191,7 +191,10 @@ sub request_api {
     my ($content) = $self->{http}->request(
         url_path => $options{endpoint},
         get_param => $options{get_param},
-        header => ['Authorization: Bearer ' . $token]
+        header => [
+                'Authorization: Bearer ' . $token,
+                'Accept: application/vnd.ceph.api.v1.0+json',
+        ],
     );
 
     # Maybe token is invalid. so we retry
@@ -201,7 +204,10 @@ sub request_api {
         $content = $self->{http}->request(
             url_path => $options{endpoint},
             get_param => $options{get_param},
-            header => ['Authorization: Bearer ' . $token],
+            header => [
+                'Authorization: Bearer ' . $token,
+                'Accept: application/vnd.ceph.api.v1.0+json',
+            ],
             unknown_status => $self->{unknown_http_status},
             warning_status => $self->{warning_http_status},
             critical_status => $self->{critical_http_status}

--- a/apps/ceph/restapi/custom/api.pm
+++ b/apps/ceph/restapi/custom/api.pm
@@ -192,8 +192,8 @@ sub request_api {
         url_path => $options{endpoint},
         get_param => $options{get_param},
         header => [
-                'Authorization: Bearer ' . $token,
-                'Accept: application/vnd.ceph.api.v1.0+json',
+            'Authorization: Bearer ' . $token,
+            'Accept: application/vnd.ceph.api.v1.0+json',
         ],
     );
 


### PR DESCRIPTION
## Description

Hello this is a quick fix to add header ''Accept: application/vnd.ceph.api.v1.0+json' 

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
