### PR TITLE
cloud::microsoft::office365::azuread - add Directory Size usage check (AD Quota)

### DIFF
--- a/cloud/microsoft/office365/azuread/mode/directorysizeusage.pm
+++ b/cloud/microsoft/office365/azuread/mode/directorysizeusage.pm
@@ -102,7 +102,7 @@ sub set_counters {
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
     
     $options{options}->add_options(arguments => {

--- a/cloud/microsoft/office365/azuread/mode/directorysizeusage.pm
+++ b/cloud/microsoft/office365/azuread/mode/directorysizeusage.pm
@@ -119,7 +119,7 @@ sub manage_selection {
     
     $self->{directory} = {
         used => @{$results}[0]->{'directorySizeQuota'}->{'used'},
-        total => @{$results}[1]->{'directorySizeQuota'}->{'total'}
+        total => @{$results}[0]->{'directorySizeQuota'}->{'total'}
     }
 }
 

--- a/cloud/microsoft/office365/azuread/mode/directorysizeusage.pm
+++ b/cloud/microsoft/office365/azuread/mode/directorysizeusage.pm
@@ -35,7 +35,7 @@ sub custom_used_perfdata {
     }
 
     $self->{output}->perfdata_add(
-        nlabel => 'azure.ad.directory.usage.percent',
+        nlabel => 'azure.ad.directory.usage.count',
         value => $self->{result_values}->{used},
         warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{thlabel}, %total_options),
         critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{thlabel}, %total_options),
@@ -107,8 +107,8 @@ sub new {
     
     $options{options}->add_options(arguments => {
         "units:s"           => { name => 'units', default => '%' },
-        "warning-used:s"    => { name => 'warning-used', default => 80 },
-        "critical-used:s"   => { name => 'critical-used', default => 90 }
+        "warning-used:s"    => { name => 'warning-used' },
+        "critical-used:s"   => { name => 'critical-used }
     });
 
     return $self;

--- a/cloud/microsoft/office365/azuread/mode/directorysizeusage.pm
+++ b/cloud/microsoft/office365/azuread/mode/directorysizeusage.pm
@@ -1,0 +1,166 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::microsoft::office365::azuread::mode::directorysizeusage;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use Time::Local;
+
+sub custom_used_perfdata {
+    my ($self, %options) = @_;
+
+    my %total_options = ();
+    if ($self->{instance_mode}->{option_results}->{units} eq '%') {
+        $total_options{total} = $self->{result_values}->{total};
+        $total_options{cast_int} = 1;
+    }
+
+    $self->{output}->perfdata_add(
+        label => 'directorysizeusage',
+        nlabel => 'directorysizeusage.used',
+        value => $self->{result_values}->{used},
+        warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{thlabel}, %total_options),
+        critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{thlabel}, %total_options),
+        min => 0, max => $self->{result_values}->{total}
+    );
+}
+
+sub custom_used_threshold {
+    my ($self, %options) = @_;
+
+    my $threshold_value = $self->{result_values}->{used};
+    if ($self->{instance_mode}->{option_results}->{units} eq '%') {
+        $threshold_value = $self->{result_values}->{prct_used};
+    }
+    my $exit = $self->{perfdata}->threshold_check(
+        value => $threshold_value,
+        threshold => [
+            { label => 'critical-' . $self->{thlabel}, exit_litteral => 'critical' },
+            { label => 'warning-' . $self->{thlabel}, exit_litteral => 'warning' }
+        ]
+    );
+    return $exit;
+
+}
+
+sub custom_used_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "Directory size usage : %d/%d (%.2f%%)",
+        $self->{result_values}->{used},
+        $self->{result_values}->{total},
+        $self->{result_values}->{prct_used}
+    );
+}
+
+sub custom_used_calc {
+    my ($self, %options) = @_;
+
+    $self->{result_values}->{used} = $options{new_datas}->{$self->{instance} . '_used'};
+    $self->{result_values}->{total} = $options{new_datas}->{$self->{instance} . '_total'};
+    $self->{result_values}->{prct_used} = ($self->{result_values}->{total} != 0) ? $self->{result_values}->{used} * 100 / $self->{result_values}->{total} : 0;
+    return 0;
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'used', type => 0 }
+	];
+
+    $self->{maps_counters}->{used} = [
+        { label => 'used', set => {
+	    key_values => [ { name => 'used' }, { name => 'total' } ],
+                closure_custom_calc => $self->can('custom_used_calc'),
+                closure_custom_output => $self->can('custom_used_output'),
+                closure_custom_threshold_check => $self->can('custom_used_threshold'),
+                closure_custom_perfdata => $self->can('custom_used_perfdata')
+	  }
+        },
+	];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+    
+    $options{options}->add_options(arguments => {
+        "units:s"               => { name => 'units', default => '%' },
+	"filter-counters:s"     => { name => 'filter_counters', default => 'used|total' },
+        "warning-used:s"             => { name => 'warning-used', default => 80 },
+        "critical-used:s"            => { name => 'critical-used', default => 90 }
+    });
+
+    return $self;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+    
+    $self->{used} = { used => 0, total => 0 };
+
+    my $results = $options{custom}->azuread_get_organization();
+    $self->{used}->{used} = @{$results}[0]->{'directorySizeQuota'}->{'used'};
+    $self->{used}->{total} = @{$results}[0]->{'directorySizeQuota'}->{'total'};
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Azure AD directory size usage/quota.
+
+=over 8
+
+=item B<--filter-user>
+
+Filter users.
+
+=item B<--warning-*>
+
+Threshold warning.
+Can be: 'used'.
+
+=item B<--critical-*>
+
+Threshold critical.
+Can be: 'used'.
+
+=item B<--filter-counters>
+
+Only display some counters (regexp can be used).
+Example to hide per user counters: --filter-counters='active|total'
+(Default: 'active|total')
+
+=item B<--units>
+
+Unit of thresholds (Default: '%') ('%', 'count').
+
+=back
+
+=cut

--- a/cloud/microsoft/office365/azuread/mode/directorysizeusage.pm
+++ b/cloud/microsoft/office365/azuread/mode/directorysizeusage.pm
@@ -108,7 +108,7 @@ sub new {
     $options{options}->add_options(arguments => {
         "units:s"           => { name => 'units', default => '%' },
         "warning-used:s"    => { name => 'warning-used' },
-        "critical-used:s"   => { name => 'critical-used }
+        "critical-used:s"   => { name => 'critical-used' }
     });
 
     return $self;

--- a/cloud/microsoft/office365/azuread/mode/directorysizeusage.pm
+++ b/cloud/microsoft/office365/azuread/mode/directorysizeusage.pm
@@ -106,9 +106,7 @@ sub new {
     bless $self, $class;
     
     $options{options}->add_options(arguments => {
-        "units:s"           => { name => 'units', default => '%' },
-        "warning-used:s"    => { name => 'warning-used' },
-        "critical-used:s"   => { name => 'critical-used' }
+        "units:s"           => { name => 'units', default => '%' }
     });
 
     return $self;

--- a/cloud/microsoft/office365/azuread/plugin.pm
+++ b/cloud/microsoft/office365/azuread/plugin.pm
@@ -1,0 +1,49 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::microsoft::office365::azuread::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_custom);
+
+sub new {
+    my ( $class, %options ) = @_;
+    my $self = $class->SUPER::new( package => __PACKAGE__, %options );
+    bless $self, $class;
+
+    $self->{version} = '0.1';
+    %{ $self->{modes} } = (
+        'directory-size-usage'            => 'cloud::microsoft::office365::azuread::mode::directorysizeusage',
+    );
+
+    $self->{custom_modes}{graphapi} = 'cloud::microsoft::office365::custom::graphapi';
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 PLUGIN DESCRIPTION
+
+Check Microsoft Azure AD.
+
+=cut

--- a/cloud/microsoft/office365/azuread/plugin.pm
+++ b/cloud/microsoft/office365/azuread/plugin.pm
@@ -31,7 +31,7 @@ sub new {
 
     $self->{version} = '0.1';
     %{ $self->{modes} } = (
-        'directory-size-usage'            => 'cloud::microsoft::office365::azuread::mode::directorysizeusage',
+        'directory-size-usage' => 'cloud::microsoft::office365::azuread::mode::directorysizeusage',
     );
 
     $self->{custom_modes}{graphapi} = 'cloud::microsoft::office365::custom::graphapi';
@@ -44,6 +44,6 @@ __END__
 
 =head1 PLUGIN DESCRIPTION
 
-Check Microsoft Azure AD.
+Check Microsoft Azure AD using GraphAPI
 
 =cut

--- a/cloud/microsoft/office365/custom/graphapi.pm
+++ b/cloud/microsoft/office365/custom/graphapi.pm
@@ -451,20 +451,28 @@ sub teams_post_notification {
     return $response;
 }
 
+sub azuread_get_organization_set_url {
+    my ($self, %options) = @_;
+
+    my $url = $self->{graph_endpoint} . "/beta/organization"; #/v1.0/reports/getEmailActivityUserDetail(" . $options{param} . ")";
+
+    return $url;
+}
+
+sub azuread_get_organization {
+    my ($self, %options) = @_;
+
+    my $full_url = $self->azuread_get_organization_set_url(%options);
+    my $response = $self->request_api_json(method => 'GET', full_url => $full_url, hostname => '');
+
+    return $response;
+}
+
 sub get_services_health {
     my ($self, %options) = @_;
 
     my $full_url = $self->{graph_endpoint} . '/v1.0/admin/serviceAnnouncement/healthOverviews';
     my $response = $self->request_api_json(method => 'GET', full_url => $full_url, hostname => '', get_param => ['$expand=issues']);
-
-    return $response;
-}
-
-sub get_applications {
-    my ($self, %options) = @_;
-
-    my $full_url = $self->{graph_endpoint} . '/v1.0/applications';
-    my $response = $self->request_api_json(method => 'GET', full_url => $full_url, hostname => '');
 
     return $response;
 }

--- a/cloud/microsoft/office365/custom/graphapi.pm
+++ b/cloud/microsoft/office365/custom/graphapi.pm
@@ -477,6 +477,15 @@ sub get_services_health {
     return $response;
 }
 
+sub get_applications {
+    my ($self, %options) = @_;
+
+    my $full_url = $self->{graph_endpoint} . '/v1.0/applications';
+    my $response = $self->request_api_json(method => 'GET', full_url => $full_url, hostname => '');
+
+    return $response;
+}
+
 1;
 
 __END__

--- a/cloud/microsoft/office365/custom/graphapi.pm
+++ b/cloud/microsoft/office365/custom/graphapi.pm
@@ -454,7 +454,7 @@ sub teams_post_notification {
 sub azuread_get_organization_set_url {
     my ($self, %options) = @_;
 
-    my $url = $self->{graph_endpoint} . "/beta/organization"; #/v1.0/reports/getEmailActivityUserDetail(" . $options{param} . ")";
+    my $url = $self->{graph_endpoint} . "/beta/organization";
 
     return $url;
 }


### PR DESCRIPTION
## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [X] 21.04.x
- [X] 21.10.x
- [X] 22.04.x
- [X] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

New plugin to check Azure AD stuff.
1 mode in included for now but some others may follow in the future

/usr/lib/centreon/plugins//centreon-plugins/centreon_plugins.pl --plugin=cloud::microsoft::office365::azuread::plugin --custommode='graphapi' --mode='directory-size-usage' --tenant='xxx' --client-id='xxx' --client-secret='xxx'
WARNING: Directory size usage : 264943/309000 (85.74%) | 'directorysizeusage'=264943;0:247200;0:278100;0;309000


## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
