### PR TITLE
(plugin) apps::monitoring::nodeexporter::windows - adding list services mode

### DIFF
--- a/apps/monitoring/nodeexporter/windows/mode/listinterfaces.pm
+++ b/apps/monitoring/nodeexporter/windows/mode/listinterfaces.pm
@@ -20,7 +20,7 @@
 
 package apps::monitoring::nodeexporter::windows::mode::listinterfaces;
 
-use base qw(centreon::plugins::templates::counter);
+use base qw(centreon::plugins::mode);
 
 use strict;
 use warnings;

--- a/apps/monitoring/nodeexporter/windows/mode/listservices.pm
+++ b/apps/monitoring/nodeexporter/windows/mode/listservices.pm
@@ -1,0 +1,104 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::monitoring::nodeexporter::windows::mode::listservices;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::common::monitoring::openmetrics::scrape;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => { });
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $raw_metrics = centreon::common::monitoring::openmetrics::scrape::parse(%options, strip_chars => "[\"']");
+
+    return $raw_metrics;
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    my $raw_services = $self->manage_selection(%options);
+
+    foreach my $metric (keys %{$raw_services}) {
+        next if ($metric ne "windows_service_state" );
+
+        foreach my $service (@{$raw_services->{$metric}->{data}}) {
+            $self->{output}->output_add(long_msg => '[name = ' . $service->{dimensions}->{name} . "]") if $service->{value} == 1;
+        }
+    }
+    $self->{output}->output_add(severity => 'OK',
+                                short_msg => 'List Services:');
+    $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+    $self->{output}->exit();
+
+}
+
+sub disco_format {
+    my ($self, %options) = @_;
+
+    $self->{output}->add_disco_format(elements => ['name']);
+}
+
+sub disco_show {
+    my ($self, %options) = @_;
+
+    my $raw_services = $self->manage_selection(%options);
+
+    foreach my $metric (keys %{$raw_services}) {
+        next if ($metric ne "windows_service_state" );
+
+        foreach my $service (@{$raw_services->{$metric}->{data}}) {
+            $self->{output}->add_disco_entry(             
+                name => $service->{dimensions}->{name}
+            ) if $service->{value} == 1;
+        }
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+List services
+
+=over 8
+
+=back
+
+=cut

--- a/apps/monitoring/nodeexporter/windows/mode/listservices.pm
+++ b/apps/monitoring/nodeexporter/windows/mode/listservices.pm
@@ -20,7 +20,7 @@
 
 package apps::monitoring::nodeexporter::windows::mode::listservices;
 
-use base qw(centreon::plugins::templates::counter);
+use base qw(centreon::plugins::mode);
 
 use strict;
 use warnings;

--- a/apps/monitoring/nodeexporter/windows/mode/liststorages.pm
+++ b/apps/monitoring/nodeexporter/windows/mode/liststorages.pm
@@ -20,7 +20,7 @@
 
 package apps::monitoring::nodeexporter::windows::mode::liststorages;
 
-use base qw(centreon::plugins::templates::counter);
+use base qw(centreon::plugins::mode);
 
 use strict;
 use warnings;

--- a/apps/monitoring/nodeexporter/windows/plugin.pm
+++ b/apps/monitoring/nodeexporter/windows/plugin.pm
@@ -33,6 +33,7 @@ sub new {
     %{$self->{modes}} = (
         'cpu'             => 'apps::monitoring::nodeexporter::windows::mode::cpu',
         'list-interfaces' => 'apps::monitoring::nodeexporter::windows::mode::listinterfaces',
+        'list-services'   => 'apps::monitoring::nodeexporter::windows::mode::listservices',
         'list-storages'   => 'apps::monitoring::nodeexporter::windows::mode::liststorages',
         'memory'          => 'apps::monitoring::nodeexporter::windows::mode::memory',
         'services'        => 'apps::monitoring::nodeexporter::windows::mode::services',


### PR DESCRIPTION
Adding mode to list services on a Windows server based on node exporter metrics. 