### PR TITLE
(plugin) network::cisco::umbrella - Fix regex in appliance.pm mode

### DIFF
--- a/network/cisco/umbrella/snmp/mode/appliance.pm
+++ b/network/cisco/umbrella/snmp/mode/appliance.pm
@@ -44,7 +44,7 @@ sub set_counters {
             label => 'status', type => 2, 
             critical_default => '%{status} =~ /red/' , 
             warning_default => '%{status} =~ /yellow/', 
-            unknown_default => '%{status} =~ /(green|yellow|red|white)/',
+            unknown_default => '%{status} !~ /(green|yellow|red|white)/',
             set => {
                 key_values => [ { name => 'status' } ],
                 closure_custom_output => $self->can('custom_status_output'),


### PR DESCRIPTION
Fixing regex for UNKNOWN default state in appliance.pm mode