### PR TITLE
(plugin) cloud::azure::management::recovery - adding mode to monitor Azure replication health

### DIFF
--- a/cloud/azure/custom/api.pm
+++ b/cloud/azure/custom/api.pm
@@ -462,7 +462,7 @@ sub azure_list_resources {
 sub azure_list_replication_protected_items_set_url {
     my ($self, %options) = @_;
 
-    my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription} . "/resourcegroups/" .
+    my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription} . "/resourceGroups/" .
         $options{resource_group} . "/providers/Microsoft.RecoveryServices/vaults/" .
         $options{vault_name} . "/replicationProtectedItems?api-version=" . $self->{api_version};
 

--- a/cloud/azure/custom/api.pm
+++ b/cloud/azure/custom/api.pm
@@ -459,6 +459,25 @@ sub azure_list_resources {
     return $full_response;
 }
 
+sub azure_list_replication_protected_items_set_url {
+    my ($self, %options) = @_;
+
+    my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription} . "/resourcegroups/" .
+        $options{resource_group} . "/providers/Microsoft.RecoveryServices/vaults/" .
+        $options{vault_name} . "/replicationProtectedItems?api-version=" . $self->{api_version};
+
+    return $url;
+} 
+
+sub azure_list_replication_protected_items {
+    my ($self, %options) = @_;
+
+    my $full_url = $self->azure_list_replication_protected_items_set_url(%options);
+    my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+
+    return $response;
+} 
+
 sub azure_list_subscriptions_set_url {
     my ($self, %options) = @_;
 

--- a/cloud/azure/custom/azcli.pm
+++ b/cloud/azure/custom/azcli.pm
@@ -264,7 +264,6 @@ sub azure_list_replication_protected_items {
 
     $self->{output}->add_option_msg(short_msg => "Unsupported custom mode for plugin mode 'replication-health'. Please use --custommode='api'.");
     $self->{output}->option_exit();
-
 } 
 
 sub azure_list_vm_sizes_set_cmd {

--- a/cloud/azure/custom/azcli.pm
+++ b/cloud/azure/custom/azcli.pm
@@ -259,6 +259,14 @@ sub azure_list_resources {
     return $raw_results;
 }
 
+sub azure_list_replication_protected_items {
+    my ($self, %options) = @_;
+
+    $self->{output}->add_option_msg(short_msg => "Unsupported custom mode for plugin mode 'replication-health'. Please use --custommode='api'.");
+    $self->{output}->option_exit();
+
+} 
+
 sub azure_list_vm_sizes_set_cmd {
     my ($self, %options) = @_;
 

--- a/cloud/azure/management/recovery/mode/listreplicateditems.pm
+++ b/cloud/azure/management/recovery/mode/listreplicateditems.pm
@@ -1,0 +1,153 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::management::recovery::mode::listreplicateditems;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+    
+    $options{options}->add_options(arguments =>
+                                {
+                                    "vault-name:s"          => { name => 'vault_name' },
+                                    "resource-group:s"      => { name => 'resource_group' },
+                                    "filter-name:s"         => { name => 'filter_name' },
+                                });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+
+    if (!defined($self->{option_results}->{resource_group}) || $self->{option_results}->{resource_group} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --resource-group option");
+        $self->{output}->option_exit();
+    }
+    if (!defined($self->{option_results}->{vault_name}) || $self->{option_results}->{vault_name} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --vault-name option");
+        $self->{output}->option_exit();
+    }
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    $self->{replicated_items} = $options{custom}->azure_list_replication_protected_items(
+        vault_name => $self->{option_results}->{vault_name},
+        resource_group => $self->{option_results}->{resource_group}
+    );
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    $self->manage_selection(%options);
+    foreach my $replicated_item (@{$self->{replicated_items}->{value}}) {
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $replicated_item->{properties}->{friendlyName} !~ /$self->{option_results}->{filter_name}/);
+        my $resource_group = '-';
+        $resource_group = $replicated_item->{resourceGroup} if (defined($replicated_item->{resourceGroup}));
+        $resource_group = $1 if ($resource_group eq '-' && defined($replicated_item->{id}) && $replicated_item->{id} =~ /resource[gG]roups\/(.*)\/providers/);
+        
+        my @tags;
+        foreach my $tag (keys %{$replicated_item->{tags}}) {
+            push @tags, $tag . ':' . $replicated_item->{tags}->{$tag};
+        }
+
+        $self->{output}->output_add(long_msg => sprintf("[name = %s][resourcegroup = %s][id = %s][replication_health = %s][failover_health = %s]",
+            $replicated_item->{properties}->{friendlyName},
+            $resource_group,
+            $replicated_item->{id},
+            $replicated_item->{properties}->{replicationHealth},
+            $replicated_item->{properties}->{failoverHealth},
+            join(',', @tags))
+        );
+    }
+    
+    $self->{output}->output_add(severity => 'OK',
+                                short_msg => 'List replicated items:');
+    $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+    $self->{output}->exit();
+}
+
+sub disco_format {
+    my ($self, %options) = @_;
+    
+    $self->{output}->add_disco_format(elements => ['name', 'resourcegroup', 'id', 'replication_health', 'failover_health']);
+}
+
+sub disco_show {
+    my ($self, %options) = @_;
+
+    $self->manage_selection(%options);
+    foreach my $replicated_item (@{$self->{replicated_items}->{value}}) {
+        my $resource_group = '-';
+        $resource_group = $replicated_item->{resourceGroup} if (defined($replicated_item->{resourceGroup}));
+        $resource_group = $1 if ($resource_group eq '-' && defined($replicated_item->{id}) && $replicated_item->{id} =~ /resourceGroups\/(.*)\/providers/);
+
+        my @tags;
+        foreach my $tag (keys %{$replicated_item->{tags}}) {
+            push @tags, $tag . ':' . $replicated_item->{tags}->{$tag};
+        }
+
+        $self->{output}->add_disco_entry(
+            name => $replicated_item->{properties}->{FriendlyName},
+            resourcegroup => $resource_group,
+            id => $replicated_item->{id},
+            replication_health => $replicated_item->{properties}->{replicationHealth},
+            failover_health => $replicated_item->{properties}->{failoverHealth},
+            tags => join(',', @tags)
+        );
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+List replicated items.
+
+=over 8
+
+=item B<--vault-name>
+
+Set vault name (Mandatory).
+
+=item B<--resource-group>
+
+Set resource group (Mandatory).
+
+=item B<--filter-name>
+
+Filter on item name (Can be a regexp).
+
+=back
+
+=cut

--- a/cloud/azure/management/recovery/mode/listreplicateditems.pm
+++ b/cloud/azure/management/recovery/mode/listreplicateditems.pm
@@ -36,7 +36,6 @@ sub new {
                                     "resource-group:s"      => { name => 'resource_group' },
                                     "filter-name:s"         => { name => 'filter_name' },
                                 });
-
     return $self;
 }
 

--- a/cloud/azure/management/recovery/mode/replicationhealth.pm
+++ b/cloud/azure/management/recovery/mode/replicationhealth.pm
@@ -29,7 +29,7 @@ use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_
 sub custom_replication_status_output {
     my ($self, %options) = @_;
     
-    my $msg = sprintf("Replicated status '%s'", $self->{result_values}->{replication_status});
+    my $msg = sprintf("Replication status '%s'", $self->{result_values}->{replication_status});
     return $msg;
 }
 

--- a/cloud/azure/management/recovery/mode/replicationhealth.pm
+++ b/cloud/azure/management/recovery/mode/replicationhealth.pm
@@ -54,14 +54,20 @@ sub set_counters {
     ];
 
     $self->{maps_counters}->{items} = [
-        { label => 'replication-status', critical_default => '%{replication_status} eq "Critical"', type => 2, set => {
+        { label => 'replication-status', 
+          critical_default => '%{replication_status} eq "Critical"', 
+          warning_default => '%{replication_status} eq "Warning"',
+          type => 2, set => {
                 key_values => [ { name => 'replication_status' }, { name => 'display' } ],
                 closure_custom_output => $self->can('custom_replication_status_output'),
                 closure_custom_perfdata => sub { return 0; },
                 closure_custom_threshold_check => \&catalog_status_threshold_ng
             }
         },
-        { label => 'failover-status', critical_default => '%{failover_status} eq "Critical"', type => 2, set => {
+        { label => 'failover-status', 
+          critical_default => '%{failover_status} eq "Critical"',
+          warning_default => '%{failover_status} eq "Warning"',
+          type => 2, set => {
                 key_values => [ { name => 'failover_status' }, { name => 'display' } ],
                 closure_custom_output => $self->can('custom_failover_status_output'),
                 closure_custom_perfdata => sub { return 0; },
@@ -151,7 +157,7 @@ Filter item name (Can be a regexp).
 
 =item B<--warning-replication-status>
 
-Set warning threshold for replication health (Default: '').
+Set warning threshold for replication health (Default: '%{replication_status} eq "Warning"').
 Can used special variables like: %{status}, %{display}
 
 =item B<--critical-replication-status>
@@ -161,7 +167,7 @@ Can used special variables like: %{status}, %{display}
 
 =item B<--warning-failover-status>
 
-Set warning threshold for failover status (Default: '').
+Set warning threshold for failover status (Default: '%{failover_status} eq "Warning"').
 Can used special variables like: %{status}, %{display}
 
 =item B<--critical-failover-status>

--- a/cloud/azure/management/recovery/mode/replicationhealth.pm
+++ b/cloud/azure/management/recovery/mode/replicationhealth.pm
@@ -29,7 +29,7 @@ use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_
 sub custom_replication_status_output {
     my ($self, %options) = @_;
     
-    my $msg = sprintf("Replication status '%s'", $self->{result_values}->{replication_status});
+    my $msg = sprintf("Replicated status '%s'", $self->{result_values}->{replication_status});
     return $msg;
 }
 
@@ -43,14 +43,14 @@ sub custom_failover_status_output {
 sub prefix_replication_item_output {
     my ($self, %options) = @_;
     
-    return "Replication item '" . $options{instance_value}->{display} . "' ";
+    return "Replicated item '" . $options{instance_value}->{display} . "' ";
 }
 
 sub set_counters {
     my ($self, %options) = @_;
     
     $self->{maps_counters_type} = [
-        { name => 'items', type => 1, cb_prefix_output => 'prefix_replication_item_output', message_multiple => 'All replication items are OK' }
+        { name => 'items', type => 1, cb_prefix_output => 'prefix_replication_item_output', message_multiple => 'All replicated items are OK' }
     ];
 
     $self->{maps_counters}->{items} = [
@@ -80,9 +80,7 @@ sub new {
                                 {
                                     "api-version:s"         => { name => 'api_version', default => '2021-08-01'},
                                     "vault-name:s"          => { name => 'vault_name' },
-                                    "resource-group:s"      => { name => 'resource_group' },
-                                    "filter-name:s"         => { name => 'filter_name' },
-                                    "filter-counters:s"     => { name => 'filter_counters' }
+                                    "resource-group:s"      => { name => 'resource_group' }
                                 });
     
     return $self;
@@ -110,9 +108,6 @@ sub manage_selection {
         vault_name => $self->{option_results}->{vault_name},
         resource_group => $self->{option_results}->{resource_group}
     );
-    
-    # use Data::Dumper;
-    # print Dumper $replicated_items;
 
     foreach my $replicated_item (@{$replicated_items->{value}}) {
 
@@ -123,10 +118,10 @@ sub manage_selection {
         };
     }
     
-    # if (scalar(keys %{$self->{items}}) <= 0) {
-    #     $self->{output}->add_option_msg(short_msg => "No replication site found.");
-    #     $self->{output}->option_exit();
-    # }
+    if (scalar(keys %{$self->{items}}) <= 0) {
+        $self->{output}->add_option_msg(short_msg => "No replicated item found.");
+        $self->{output}->option_exit();
+    }
 }
 
 1;
@@ -135,7 +130,7 @@ __END__
 
 =head1 MODE
 
-Check replication site health status. 
+Check replicated items health status and failover status. 
 
 =over 8
 
@@ -147,15 +142,25 @@ Set vault name (Required).
 
 Set resource group (Required).
 
-=item B<--warning-status>
+=item B<--warning-replication-status>
 
-Set warning threshold for status (Default: '').
-Can used special variables like: %{status}
+Set warning threshold for replication health (Default: '').
+Can used special variables like: %{status}, %{display}
 
-=item B<--critical-status>
+=item B<--critical-replication-status>
 
-Set critical threshold for status (Default: '%{status} eq "Failed"').
-Can used special variables like: %{status}
+Set critical threshold for replication health (Default: '%{replication_status} eq "Critical"').
+Can used special variables like: %{status}, %{display}
+
+=item B<--warning-failover-status>
+
+Set warning threshold for failover status (Default: '').
+Can used special variables like: %{status}, %{display}
+
+=item B<--critical-failover-status>
+
+Set critical threshold for failover status (Default: '%{failover_status} eq "Critical"').
+Can used special variables like: %{status}, %{display}
 
 =back
 

--- a/cloud/azure/management/recovery/mode/replicationhealth.pm
+++ b/cloud/azure/management/recovery/mode/replicationhealth.pm
@@ -1,0 +1,129 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::management::recovery::mode::replicationhealth;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+    
+    my $msg = sprintf("Status '%s'", $self->{result_values}->{status});
+    return $msg;
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+    
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'status', critical_default => '%{status} eq "Failed"', type => 2, set => {
+                key_values => [ { name => 'status' }, { name => 'display' } ],
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng,
+            }
+        },
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+    
+    $options{options}->add_options(arguments =>
+                                {
+                                    "vault-name:s"          => { name => 'vault_name' },
+                                    "resource-group:s"      => { name => 'resource_group' },
+                                    "filter-name:s"         => { name => 'filter_name' },
+                                    "filter-counters:s"     => { name => 'filter_counters' }
+                                });
+    
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{resource_group}) || $self->{option_results}->{resource_group} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --resource-group option");
+        $self->{output}->option_exit();
+    }
+    if (!defined($self->{option_results}->{vault_name}) || $self->{option_results}->{vault_name} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --vault-name option");
+        $self->{output}->option_exit();
+    }
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    $self->{global} = {};
+    my $replication_items = $options{custom}->azure_list_replication_protected_items(
+        vault_name => $self->{option_results}->{vault_name},
+        resource_group => $self->{option_results}->{resource_group}
+    );
+
+    
+    # if (scalar(keys %{$self->{jobs}}) <= 0) {
+    #     $self->{output}->add_option_msg(short_msg => "No replication site found.");
+    #     $self->{output}->option_exit();
+    # }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check replication site health status. 
+
+=over 8
+
+=item B<--vault-name>
+
+Set vault name (Required).
+
+=item B<--resource-group>
+
+Set resource group (Required).
+
+=item B<--warning-status>
+
+Set warning threshold for status (Default: '').
+Can used special variables like: %{status}
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: '%{status} eq "Failed"').
+Can used special variables like: %{status}
+
+=back
+
+=cut

--- a/cloud/azure/management/recovery/mode/replicationhealth.pm
+++ b/cloud/azure/management/recovery/mode/replicationhealth.pm
@@ -79,6 +79,7 @@ sub new {
     $options{options}->add_options(arguments =>
                                 {
                                     "api-version:s"         => { name => 'api_version', default => '2021-08-01'},
+                                    "filter-name:s"         => { name => 'filter_name' },
                                     "vault-name:s"          => { name => 'vault_name' },
                                     "resource-group:s"      => { name => 'resource_group' }
                                 });
@@ -110,6 +111,8 @@ sub manage_selection {
     );
 
     foreach my $replicated_item (@{$replicated_items->{value}}) {
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $replicated_item->{properties}->{friendlyName} !~ /$self->{option_results}->{filter_name}/);
 
         $self->{items}->{$replicated_item->{properties}->{friendlyName}} = {
             display => $replicated_item->{properties}->{friendlyName},
@@ -130,7 +133,7 @@ __END__
 
 =head1 MODE
 
-Check replicated items health status and failover status. 
+Check replicated items replication and failover health. 
 
 =over 8
 
@@ -141,6 +144,10 @@ Set vault name (Required).
 =item B<--resource-group>
 
 Set resource group (Required).
+
+=item B<--filter-name>
+
+Filter item name (Can be a regexp).
 
 =item B<--warning-replication-status>
 

--- a/cloud/azure/management/recovery/mode/replicationhealth.pm
+++ b/cloud/azure/management/recovery/mode/replicationhealth.pm
@@ -26,27 +26,48 @@ use strict;
 use warnings;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
-sub custom_status_output {
+sub custom_replication_status_output {
     my ($self, %options) = @_;
     
-    my $msg = sprintf("Status '%s'", $self->{result_values}->{status});
+    my $msg = sprintf("Replication status '%s'", $self->{result_values}->{replication_status});
     return $msg;
+}
+
+sub custom_failover_status_output {
+    my ($self, %options) = @_;
+    
+    my $msg = sprintf("Failover status '%s'", $self->{result_values}->{failover_status});
+    return $msg;
+}
+
+sub prefix_replication_item_output {
+    my ($self, %options) = @_;
+    
+    return "Replication item '" . $options{instance_value}->{display} . "' ";
 }
 
 sub set_counters {
     my ($self, %options) = @_;
     
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' }
+        { name => 'items', type => 1, cb_prefix_output => 'prefix_replication_item_output', message_multiple => 'All replication items are OK' }
     ];
 
-    $self->{maps_counters}->{global} = [
-        { label => 'status', critical_default => '%{status} eq "Failed"', type => 2, set => {
-                key_values => [ { name => 'status' }, { name => 'display' } ],
+    $self->{maps_counters}->{items} = [
+        { label => 'replication-status', critical_default => '%{replication_status} eq "Critical"', type => 2, set => {
+                key_values => [ { name => 'replication_status' }, { name => 'display' } ],
+                closure_custom_output => $self->can('custom_replication_status_output'),
                 closure_custom_perfdata => sub { return 0; },
-                closure_custom_threshold_check => \&catalog_status_threshold_ng,
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
             }
         },
+        { label => 'failover-status', critical_default => '%{failover_status} eq "Critical"', type => 2, set => {
+                key_values => [ { name => 'failover_status' }, { name => 'display' } ],
+                closure_custom_output => $self->can('custom_failover_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
     ];
 }
 
@@ -57,6 +78,7 @@ sub new {
     
     $options{options}->add_options(arguments =>
                                 {
+                                    "api-version:s"         => { name => 'api_version', default => '2021-08-01'},
                                     "vault-name:s"          => { name => 'vault_name' },
                                     "resource-group:s"      => { name => 'resource_group' },
                                     "filter-name:s"         => { name => 'filter_name' },
@@ -84,13 +106,24 @@ sub manage_selection {
     my ($self, %options) = @_;
 
     $self->{global} = {};
-    my $replication_items = $options{custom}->azure_list_replication_protected_items(
+    my $replicated_items = $options{custom}->azure_list_replication_protected_items(
         vault_name => $self->{option_results}->{vault_name},
         resource_group => $self->{option_results}->{resource_group}
     );
-
     
-    # if (scalar(keys %{$self->{jobs}}) <= 0) {
+    # use Data::Dumper;
+    # print Dumper $replicated_items;
+
+    foreach my $replicated_item (@{$replicated_items->{value}}) {
+
+        $self->{items}->{$replicated_item->{properties}->{friendlyName}} = {
+            display => $replicated_item->{properties}->{friendlyName},
+            replication_status => $replicated_item->{properties}->{replicationHealth},
+            failover_status => $replicated_item->{properties}->{failoverHealth}
+        };
+    }
+    
+    # if (scalar(keys %{$self->{items}}) <= 0) {
     #     $self->{output}->add_option_msg(short_msg => "No replication site found.");
     #     $self->{output}->option_exit();
     # }

--- a/cloud/azure/management/recovery/plugin.pm
+++ b/cloud/azure/management/recovery/plugin.pm
@@ -31,12 +31,13 @@ sub new {
 
     $self->{version} = '0.1';
     %{ $self->{modes} } = (
-        'backup-items-status'   => 'cloud::azure::management::recovery::mode::backupitemsstatus',
-        'backup-jobs-status'    => 'cloud::azure::management::recovery::mode::backupjobsstatus',
-        'discovery'             => 'cloud::azure::management::recovery::mode::discovery',
-        'list-backup-jobs'      => 'cloud::azure::management::recovery::mode::listbackupjobs',
-        'list-vaults'           => 'cloud::azure::management::recovery::mode::listvaults',
-        'replication-health'    => 'cloud::azure::management::recovery::mode::replicationhealth'
+        'backup-items-status'    => 'cloud::azure::management::recovery::mode::backupitemsstatus',
+        'backup-jobs-status'     => 'cloud::azure::management::recovery::mode::backupjobsstatus',
+        'discovery'              => 'cloud::azure::management::recovery::mode::discovery',
+        'list-backup-jobs'       => 'cloud::azure::management::recovery::mode::listbackupjobs',
+        'list-vaults'            => 'cloud::azure::management::recovery::mode::listvaults',
+        'list-replicated-items'  => 'cloud::azure::management::recovery::mode::listreplicateditems',
+        'replication-health'     => 'cloud::azure::management::recovery::mode::replicationhealth'
     );
 
     $self->{custom_modes}{azcli} = 'cloud::azure::custom::azcli';

--- a/cloud/azure/management/recovery/plugin.pm
+++ b/cloud/azure/management/recovery/plugin.pm
@@ -36,6 +36,7 @@ sub new {
         'discovery'             => 'cloud::azure::management::recovery::mode::discovery',
         'list-backup-jobs'      => 'cloud::azure::management::recovery::mode::listbackupjobs',
         'list-vaults'           => 'cloud::azure::management::recovery::mode::listvaults',
+        'replication-health'    => 'cloud::azure::management::recovery::mode::replicationhealth'
     );
 
     $self->{custom_modes}{azcli} = 'cloud::azure::custom::azcli';
@@ -58,6 +59,6 @@ __END__
 
 =head1 PLUGIN DESCRIPTION
 
-Check Microsoft Azure backup service.
+Check Microsoft Azure backup service and replication health status.
 
 =cut

--- a/cloud/azure/management/recovery/plugin.pm
+++ b/cloud/azure/management/recovery/plugin.pm
@@ -60,6 +60,6 @@ __END__
 
 =head1 PLUGIN DESCRIPTION
 
-Check Microsoft Azure backup service and replication health status.
+Check Microsoft Azure backup service, replication and failover health.
 
 =cut


### PR DESCRIPTION
Adding mode to Azure management recovery plugin to monitor replication and failover health.

Closes https://github.com/centreon/centreon-plugins/issues/3726.