### PR TITLE
(plugin) cloud::azure::custom::azcli - adding missing function to azcli custom mode

### DIFF
--- a/cloud/azure/custom/azcli.pm
+++ b/cloud/azure/custom/azcli.pm
@@ -149,6 +149,30 @@ sub convert_duration {
     return $duration;
 }
 
+sub convert_iso8601_to_epoch {
+    my ($self, %options) = @_;
+    
+    if ($options{time_string} =~ /(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2}).(\d.*)[Z+]/) {
+        my $dt = DateTime->new(
+            year       => $1,
+            month      => $2,
+            day        => $3,
+            hour       => $4,
+            minute     => $5,
+            second     => $6,
+            nanosecond => $7
+        );
+
+        my $epoch_time = $dt->epoch;
+        return $epoch_time;
+
+    }
+    
+    $self->{output}->add_option_msg(short_msg => "Wrong date format: $options{time_string}");
+    $self->{output}->option_exit();
+
+}
+
 sub azure_get_metrics_set_cmd {
     my ($self, %options) = @_;
 


### PR DESCRIPTION
Adding missing function that was causing error when using --lookback option for backup-jobs-status mode from Azure recovery management plugin. 