### PR TITLE
3 new modes to Azure/Management/Costs plugin

### DIFF
--- a/cloud/azure/custom/api.pm
+++ b/cloud/azure/custom/api.pm
@@ -503,18 +503,34 @@ sub azure_list_vms_set_url {
 
     my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription};
     $url .= "/resourceGroups/" . $options{resource_group} if (defined($options{resource_group}) && $options{resource_group} ne '');
-    $url .= "/providers/Microsoft.Compute/virtualMachines?api-version=" . $self->{api_version};
+    $url .= "/providers/Microsoft.Compute/virtualMachines";
+
+    if (defined($options{api_version_override})) {
+	$url .= "?api-version=" . $options{api_version_override};
+    }
+    else {
+	$url .= "?api-version=" . $self->{api_version};
+    }
 
     return $url;
 }
 
 sub azure_list_vms {
     my ($self, %options) = @_;
-
+    
+    my $full_response = [];
     my $full_url = $self->azure_list_vms_set_url(%options);
-    my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
-
-    return $response->{value};
+    while (1) {
+	my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+	foreach (@{$response->{value}}) {
+	    push @$full_response, $_;
+	}
+	
+	last if (!defined($response->{nextLink}));
+	$full_url = $response->{nextLink};
+    }
+    
+    return $full_response;
 }
 
 sub azure_list_groups_set_url {
@@ -682,18 +698,33 @@ sub azure_list_sqlservers_set_url {
 
     my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription};
     $url .= "/resourceGroups/" . $options{resource_group} if (defined($options{resource_group}) && $options{resource_group} ne '');
-    $url .= "/providers/Microsoft.Sql/servers?api-version=" . $self->{api_version};
+    $url .= "/providers/Microsoft.Sql/servers";
 
+    if (defined($options{api_version_override})) {
+	$url .= "?api-version=" . $options{api_version_override};
+    }
+    else {
+	$url .= "?api-version=" . $self->{api_version};
+    }
     return $url;
 }
 
 sub azure_list_sqlservers {
     my ($self, %options) = @_;
 
+    my $full_response = [];
     my $full_url = $self->azure_list_sqlservers_set_url(%options);
-    my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+    while (1) {
+	my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+	foreach (@{$response->{value}}) {
+	    push @$full_response, $_;
+	}
 
-    return $response->{value};
+	last if (!defined($response->{nextLink}));
+	$full_url = $response->{nextLink};
+    }
+
+    return $full_response;
 }
 
 sub azure_list_sqldatabases_set_url {
@@ -702,18 +733,32 @@ sub azure_list_sqldatabases_set_url {
     my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription};
     $url .= "/resourceGroups/" . $options{resource_group} if (defined($options{resource_group}) && $options{resource_group} ne '');
     $url .= "/providers/Microsoft.Sql/servers/" . $options{server} if (defined($options{server}) && $options{server} ne '');
-    $url .= "/databases?api-version=" . $self->{api_version};
 
+    if (defined($options{api_version_override})) {
+	$url .= "/databases?api-version=" . $options{api_version_override};
+    }
+    else {
+	$url .= "/databases?api-version=" . $self->{api_version};
+    }
     return $url;
 }
 
 sub azure_list_sqldatabases {
     my ($self, %options) = @_;
 
+    my $full_response = [];
     my $full_url = $self->azure_list_sqldatabases_set_url(%options);
-    my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+    while (1) {
+	my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+	foreach (@{$response->{value}}) {
+	    push @$full_response, $_;
+	}
 
-    return $response->{value};
+	last if (!defined($response->{nextLink}));
+	$full_url = $response->{nextLink};
+    }
+
+    return $full_response;
 }
 
 sub azure_get_log_analytics_set_url {
@@ -854,6 +899,278 @@ sub azure_get_usagedetails {
 
         last if (!defined($response->{nextLink}));
         $full_url = $response->{nextLink};
+    }
+
+    return $full_response;
+}
+
+sub azure_list_compute_disks_set_url {
+    my ($self, %options) = @_;
+
+    my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription};
+    $url .= "/resourceGroups/" . $options{resource_group} if (defined($options{resource_group}) && $options{resource_group} ne '');
+    $url .= "/providers/Microsoft.Compute/disks";
+
+    if (defined($options{api_version_override})) {
+	$url .= "?api-version=" . $options{api_version_override};
+    }
+    else {
+	$url .= "?api-version=" . $self->{api_version};
+    }
+    return $url;
+}
+
+sub azure_list_compute_disks {
+    my ($self, %options) = @_;
+
+    my $full_response = [];
+    my $full_url = $self->azure_list_compute_disks_set_url(%options);
+    while (1) {
+	my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+	foreach (@{$response->{value}}) {
+	    push @$full_response, $_;
+	}
+
+	last if (!defined($response->{nextLink}));
+	$full_url = $response->{nextLink};
+    }
+
+    return $full_response;
+}
+
+sub azure_list_nics_set_url {
+    my ($self, %options) = @_;
+
+    my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription};
+    $url .= "/resourceGroups/" . $options{resource_group} if (defined($options{resource_group}) && $options{resource_group} ne '');
+    $url .= "/providers/Microsoft.Network/networkInterfaces";
+
+    if (defined($options{api_version_override})) {
+	$url .= "?api-version=" . $options{api_version_override};
+    }
+    else {
+	$url .= "?api-version=" . $self->{api_version};
+    }
+    return $url;
+}
+
+sub azure_list_nics {
+    my ($self, %options) = @_;
+
+    my $full_response = [];
+    my $full_url = $self->azure_list_nics_set_url(%options);
+    while (1) {
+	my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+	foreach (@{$response->{value}}) {
+	    push @$full_response, $_;
+	}
+
+	last if (!defined($response->{nextLink}));
+	$full_url = $response->{nextLink};
+    }
+
+    return $full_response;
+}
+
+sub azure_list_nsgs_set_url {
+    my ($self, %options) = @_;
+
+    my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription};
+    $url .= "/resourceGroups/" . $options{resource_group} if (defined($options{resource_group}) && $options{resource_group} ne '');
+    $url .= "/providers/Microsoft.Network/networkSecurityGroups";
+
+    if (defined($options{api_version_override})) {
+	$url .= "?api-version=" . $options{api_version_override};
+    }
+    else {
+	$url .= "?api-version=" . $self->{api_version};
+    }
+    return $url;
+}
+
+sub azure_list_nsgs {
+    my ($self, %options) = @_;
+
+    my $full_response = [];
+    my $full_url = $self->azure_list_nsgs_set_url(%options);
+    while (1) {
+	my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+	foreach (@{$response->{value}}) {
+	    push @$full_response, $_;
+	}
+
+	last if (!defined($response->{nextLink}));
+	$full_url = $response->{nextLink};
+    }
+
+    return $full_response;
+}
+
+sub azure_list_publicips_set_url {
+    my ($self, %options) = @_;
+
+    my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription};
+    $url .= "/resourceGroups/" . $options{resource_group} if (defined($options{resource_group}) && $options{resource_group} ne '');
+    $url .= "/providers/Microsoft.Network/publicIPAddresses";
+
+    if (defined($options{api_version_override})) {
+	$url .= "?api-version=" . $options{api_version_override};
+    }
+    else {
+	$url .= "?api-version=" . $self->{api_version};
+    }
+    return $url;
+}
+
+sub azure_list_publicips {
+    my ($self, %options) = @_;
+
+    my $full_response = [];
+    my $full_url = $self->azure_list_publicips_set_url(%options);
+    while (1) {
+	my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+	foreach (@{$response->{value}}) {
+	    push @$full_response, $_;
+	}
+
+	last if (!defined($response->{nextLink}));
+	$full_url = $response->{nextLink};
+    }
+
+    return $full_response;
+}
+
+sub azure_list_route_tables_set_url {
+    my ($self, %options) = @_;
+
+    my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription};
+    $url .= "/resourceGroups/" . $options{resource_group} if (defined($options{resource_group}) && $options{resource_group} ne '');
+    $url .= "/providers/Microsoft.Network/routeTables";
+
+    if (defined($options{api_version_override})) {
+	$url .= "?api-version=" . $options{api_version_override};
+    }
+    else {
+	$url .= "?api-version=" . $self->{api_version};
+    }
+    return $url;
+}
+
+sub azure_list_route_tables {
+    my ($self, %options) = @_;
+
+    my $full_response = [];
+    my $full_url = $self->azure_list_route_tables_set_url(%options);
+    while (1) {
+	my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+	foreach (@{$response->{value}}) {
+	    push @$full_response, $_;
+	}
+
+	last if (!defined($response->{nextLink}));
+	$full_url = $response->{nextLink};
+    }
+
+    return $full_response;
+}
+
+sub azure_list_snapshots_set_url {
+    my ($self, %options) = @_;
+
+    my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription};
+    $url .= "/resourceGroups/" . $options{resource_group} if (defined($options{resource_group}) && $options{resource_group} ne '');
+    $url .= "/providers/Microsoft.Compute/snapshots";
+
+    if (defined($options{api_version_override})) {
+	$url .= "?api-version=" . $options{api_version_override};
+    }
+    else {
+	$url .= "?api-version=" . $self->{api_version};
+    }
+    return $url;
+}
+
+sub azure_list_snapshots {
+    my ($self, %options) = @_;
+
+    my $full_response = [];
+    my $full_url = $self->azure_list_snapshots_set_url(%options);
+    while (1) {
+	my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+	foreach (@{$response->{value}}) {
+	    push @$full_response, $_;
+	}
+
+	last if (!defined($response->{nextLink}));
+	$full_url = $response->{nextLink};
+    }
+
+    return $full_response;
+}
+
+sub azure_list_sqlvms_set_url {
+    my ($self, %options) = @_;
+
+    my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription};
+    $url .= "/resourceGroups/" . $options{resource_group} if (defined($options{resource_group}) && $options{resource_group} ne '');
+    $url .= "/providers/Microsoft.SqlVirtualMachine/sqlVirtualMachines";
+
+    if (defined($options{api_version_override})) {
+	$url .= "?api-version=" . $options{api_version_override};
+    }
+    else {
+	$url .= "?api-version=" . $self->{api_version};
+    }
+    return $url;
+}
+
+sub azure_list_sqlvms {
+    my ($self, %options) = @_;
+
+    my $full_response = [];
+    my $full_url = $self->azure_list_sqlvms_set_url(%options);
+    while (1) {
+	my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+	foreach (@{$response->{value}}) {
+	    push @$full_response, $_;
+	}
+
+	last if (!defined($response->{nextLink}));
+	$full_url = $response->{nextLink};
+    }
+
+    return $full_response;
+}
+
+sub azure_list_sqlelasticpools_set_url {
+    my ($self, %options) = @_;
+
+    my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription};
+    $url .= "/resourceGroups/" . $options{resource_group} if (defined($options{resource_group}) && $options{resource_group} ne '');
+    $url .= "/providers/Microsoft.Sql/servers/" . $options{server} if (defined($options{server}) && $options{server} ne '');
+
+    if (defined($options{api_version_override})) {
+	$url .= "/elasticPools?api-version=" . $options{api_version_override};
+    }
+    else {
+	$url .= "/elasticPools?api-version=" . $self->{api_version};
+    }
+    return $url;
+}
+
+sub azure_list_sqlelasticpools {
+    my ($self, %options) = @_;
+
+    my $full_response = [];
+    my $full_url = $self->azure_list_sqlelasticpools_set_url(%options);
+    while (1) {
+	my $response = $self->request_api(method => 'GET', full_url => $full_url, hostname => '');
+	foreach (@{$response->{value}}) {
+	    push @$full_response, $_;
+	}
+
+	last if (!defined($response->{nextLink}));
+	$full_url = $response->{nextLink};
     }
 
     return $full_response;

--- a/cloud/azure/management/costs/mode/hybridbenefits.pm
+++ b/cloud/azure/management/costs/mode/hybridbenefits.pm
@@ -1,0 +1,209 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::management::costs::mode::hybridbenefits;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'no-vm-hybrid-benefits'               => { name => 'no_vm_hybrid_benefits' },
+        'no-sql-vm-hybrid-benefits'           => { name => 'no_sql_vm_hybrid_benefits' },
+        'no-sql-database-hybrid-benefits'     => { name => 'no_sql_database_hybrid_benefits' },
+        'no-sql-elastic-pool-hybrid-benefits' => { name => 'no_sql_elastic_pool_hybrid_benefits' },
+	'exclude-name:s'                      => { name => 'exclude_name' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $output_error = "";
+    my $output = "";
+    my $items;
+
+    # non HUB VMs
+    if (!defined($self->{option_results}->{no_vm_hybrid_benefits})) {
+	$items = $options{custom}->azure_list_vms(
+	    resource_group => $self->{option_results}->{resource_group},
+	    api_version_override => "2022-03-01"
+	    );
+	$self->{vm_hybrid_benefits} = {not_enabled => 0, total => 0, name => ""};
+	foreach my $item (@{$items}) {
+	    $self->{vm_hybrid_benefits}->{total}++;;
+	    next if (defined($self->{option_results}->{exclude_name}) && $self->{option_results}->{exclude_name} ne ''
+		     && $item->{name} =~ /$self->{option_results}->{exclude_name}/);
+	    next if (!defined($item->{properties}->{licenseType}) || (defined($item->{properties}->{licenseType}) && $item->{properties}->{licenseType} !~ /None/));
+	    $self->{vm_hybrid_benefits}->{not_enabled}++;
+	    $self->{vm_hybrid_benefits}->{name} .= $item->{name} . " ";
+	}
+	if ($self->{vm_hybrid_benefits}->{not_enabled}) {
+	    $output_error .= "Found " . $self->{vm_hybrid_benefits}->{not_enabled} . " VM(s) with VmHybridBenefits not enabled ( " . $self->{vm_hybrid_benefits}->{name} . ")\n";
+	}
+	else {
+	    $output .= "VmHybridBenefits is enabled on all " . $self->{vm_hybrid_benefits}->{total} . " VM(s)\n";
+	}
+    }
+
+    # non HUB SQL VMs
+    if (!defined($self->{option_results}->{no_sql_vm_hybrid_benefits})) {
+        $items = $options{custom}->azure_list_sqlvms(
+            resource_group => $self->{option_results}->{resource_group},
+	    api_version_override => "2022-02-01"
+            );
+        $self->{sql_vm_hybrid_benefits} = {not_enabled => 0, total => 0, name => ""};
+        foreach my $item (@{$items}) {
+            $self->{sql_vm_hybrid_benefits}->{total}++;;
+            next if (defined($self->{option_results}->{exclude_name}) && $self->{option_results}->{exclude_name} ne ''
+                     && $item->{name} =~ /$self->{option_results}->{exclude_name}/);
+	    next if ($item->{properties}->{sqlServerLicenseType } =~ /AHUB/ || $item->{properties}->{sqlImageSku} =~ /Express/);
+            $self->{sql_vm_hybrid_benefits}->{not_enabled}++;
+            $self->{sql_vm_hybrid_benefits}->{name} .= $item->{name} . " ";
+        }
+        if ($self->{sql_vm_hybrid_benefits}->{not_enabled}) {
+            $output_error .= "Found " . $self->{sql_vm_hybrid_benefits}->{not_enabled} . " SQL VM(s) with VmHybridBenefits not enabled ( " . $self->{sql_vm_hybrid_benefits}->{name} . ")\n";
+        }
+        else {
+            $output .= "SqlVmHybridBenefits is enabled on all " . $self->{sql_vm_hybrid_benefits}->{total} . " SQL VM(s)\n";
+        }
+    }
+
+    if (!defined($self->{option_results}->{no_sql_database_hybrid_benefits}) || !defined($self->{option_results}->{no_sql_elastic_pool_hybrid_benefits})) {
+        $items = $options{custom}->azure_list_sqlservers(
+            resource_group => $self->{option_results}->{resource_group},
+            api_version_override => "2021-11-01"
+            );
+	$self->{sql_database_hybrid_benefits} = {not_enabled => 0, total => 0, name => ""};
+	$self->{sql_elastic_pool_hybrid_benefits} = {not_enabled => 0, total => 0, name => ""};
+        foreach my $item (@{$items}) {
+	    my @sqlserver_id = split /\//, $item->{id};
+	
+	    # non HUB SQL databases
+	    if (!defined($self->{option_results}->{no_sql_database_hybrid_benefits})) {
+		my $items_sub = $options{custom}->azure_list_sqldatabases(
+		    resource_group => $sqlserver_id[4],
+		    server => $item->{name},
+		    api_version_override => "2021-11-01"
+		    );
+		
+		foreach my $item_sub (@{$items_sub}) {
+		    next if ($item_sub->{properties}->{currentSku}->{name} =~ /ElasticPool/);
+		    next if (defined($item_sub->{properties}->{currentSku}->{tier}) && $item_sub->{properties}->{currentSku}->{tier} !~ /GeneralPurpose/);
+		    $self->{sql_database_hybrid_benefits}->{total}++;;
+		    next if (defined($self->{option_results}->{exclude_name}) && $self->{option_results}->{exclude_name} ne ''
+			     && $item_sub->{name} =~ /$self->{option_results}->{exclude_name}/);
+		    next if (defined($item_sub->{properties}->{licenseType}) && $item_sub->{properties}->{licenseType} =~ /BasePrice/);
+		    if (defined($item_sub->{properties}->{licenseType})) {
+			$self->{sql_database_hybrid_benefits}->{not_enabled}++;
+			$self->{sql_database_hybrid_benefits}->{name} .= $item_sub->{name} . " ";
+		    }
+		}
+	    }
+
+	    # non HUB Elastic pool
+	    if (!defined($self->{option_results}->{no_sql_elastic_pool_hybrid_benefits})) {
+		my $items_sub = $options{custom}->azure_list_sqlelasticpools(
+		    resource_group => $sqlserver_id[4],
+		    server => $item->{name},
+		    api_version_override => "2021-11-01"
+		    );
+		
+		foreach my $item_sub (@{$items_sub}) {
+		    $self->{sql_elastic_pool_hybrid_benefits}->{total}++;;
+		    next if (defined($self->{option_results}->{exclude_name}) && $self->{option_results}->{exclude_name} ne ''
+			     && $item_sub->{name} =~ /$self->{option_results}->{exclude_name}/);
+		    next if (defined($item_sub->{properties}->{licenseType}) && $item_sub->{properties}->{licenseType} =~ /BasePrice/);
+		    $self->{sql_elastic_pool_hybrid_benefits}->{not_enabled}++;
+		    $self->{sql_elastic_pool_hybrid_benefits}->{name} .= $item_sub->{name} . " ";
+		}
+	    }
+	}
+	if (!defined($self->{option_results}->{no_sql_database_hybrid_benefits})) {
+	    if ($self->{sql_database_hybrid_benefits}->{not_enabled}) {
+		$output_error .= "Found " . $self->{sql_database_hybrid_benefits}->{not_enabled} . " SQL database(s) with SqlDatabaseHybridBenefits not enabled ( " . $self->{sql_database_hybrid_benefits}->{name} . ")\n";
+	    }
+	    else {
+		$output .= "SqlDatabaseHybridBenefits is enabled on all " . $self->{sql_database_hybrid_benefits}->{total} . " eligible SQL database(s)\n";
+	    }
+	}
+
+	if (!defined($self->{option_results}->{no_sql_elastic_pool_hybrid_benefits})) {
+	    if ($self->{sql_elastic_pool_hybrid_benefits}->{not_enabled}) {
+		$output_error .= "Found " . $self->{sql_elastic_pool_hybrid_benefits}->{not_enabled} . " SQL elastic pool(s) with SqlElasticPoolHybridBenefits not enabled ( " . $self->{sql_elastic_pool_hybrid_benefits}->{name} . ")\n";
+	    }
+	    else {
+	    $output .= "SqlElasticPoolHybridBenefits is enabled on all " . $self->{sql_elastic_pool_hybrid_benefits}->{total} . " eligible SQL elastic pool(s)\n";
+	    }	
+	}
+    }
+    if ($output_error) {
+	$self->{output}->output_add(severity => "CRITICAL", short_msg => $output_error . $output);
+    }
+    else {
+	$self->{output}->output_add(severity => "OK", short_msg => "Everything is OK\n" . $output);
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check if hybrid benefits is enabled on eligible resources.
+
+Since there are multiple calls to multiple Rest APIs versions, api-version parameter is hardcoded in the mode code.
+
+Example: 
+perl centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --custommode=api --mode=hybrid-benefits
+{--resource-group='MYRESOURCEGROUP'] --exclude-name='MyDb|MyEpool.*' [--no-vm-hybrid-benefits] [--no-sql-vm-hybrid-benefits] [--no-sql-database-hybrid-benefits] [--no-sql-elastic-pool-hybrid-benefits]
+
+
+=over 8
+
+=item B<--resource-group>
+
+Set resource group (Required).
+
+=item B<--exclude-name>
+
+Exclude resource from check (Can be a regexp).
+
+=item B<--no-vm-hybrid-benefits --no-sql-vm-hybrid-benefits --no-sql-database-hybrid-benefits --no-sql-elastic-pool-hybrid-benefits>
+
+Exclude resource type from check
+
+=back
+
+=cut

--- a/cloud/azure/management/costs/mode/orphanresource.pm
+++ b/cloud/azure/management/costs/mode/orphanresource.pm
@@ -1,0 +1,236 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::management::costs::mode::orphanresource;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'no-managed-disks'   => { name => 'no_managed_disks' },
+        'no-nics'            => { name => 'no_nics' },
+        'no-nsgs'            => { name => 'no_nsgs' },
+        'no-public-ips'      => { name => 'no_public_ips' },
+        'no-route-tables'    => { name => 'no_route_tables' },
+        'no-snapshots'       => { name => 'no_snapshots' },
+	'exclude-name:s'     => { name => 'exclude_name' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $output_error = "";
+    my $output = "";
+    my $items;
+
+    # orphan managed disks
+    if (!defined($self->{option_results}->{no_managed_disks})) {
+	$items = $options{custom}->azure_list_compute_disks(
+	    resource_group => $self->{option_results}->{resource_group},
+	    api_version_override => "2022-07-02"
+	    );
+	$self->{disks} = {orphan => 0, total => 0, name => ""};
+	foreach my $item (@{$items}) {
+	    $self->{disks}->{total}++;;
+	    next if (defined($self->{option_results}->{exclude_name}) && $self->{option_results}->{exclude_name} ne ''
+		     && $item->{name} =~ /$self->{option_results}->{exclude_name}/);
+	    next if ($item->{properties}->{diskState} !~ /Unattached/);
+	    $self->{disks}->{orphan}++;
+	    $self->{disks}->{name} .= $item->{name} . " ";
+	}
+	if ($self->{disks}->{orphan}) {
+	    $output_error .= "Found " . $self->{disks}->{orphan} . " orphan managed disk(s) ( " . $self->{disks}->{name} . ")\n";
+	}
+	else {
+	    $output .= "No orphan managed disk found on " . $self->{disks}->{total} . " total disk(s)\n";
+	}
+    }
+
+    # orphan NICs
+    if (!defined($self->{option_results}->{no_nics})) {
+        $items = $options{custom}->azure_list_nics(
+            resource_group => $self->{option_results}->{resource_group},
+	    api_version_override => "2022-05-01"
+            );
+        $self->{nics} = {orphan => 0, total => 0, name => ""};
+        foreach my $item (@{$items}) {
+            $self->{nics}->{total}++;;
+            next if (defined($self->{option_results}->{exclude_name}) && $self->{option_results}->{exclude_name} ne ''
+                     && $item->{name} =~ /$self->{option_results}->{exclude_name}/);
+            next if (scalar(keys %{$item->{properties}->{virtualMachine}}) != 0 || defined($item->{properties}->{privateEndpoint}));
+            $self->{nics}->{orphan}++;
+	    $self->{nics}->{name} .= $item->{name} . " ";
+        }
+        if ($self->{nics}->{orphan}) {
+            $output_error .= "Found " . $self->{nics}->{orphan} . " orphan NIC(s) ( " . $self->{nics}->{name} . ")\n";
+        }
+	else {
+	    $output .= "No orphan NIC found on " . $self->{nics}->{total} . " total NIC(s)\n";
+	}
+    }
+
+    # orphan NSGs
+    if (!defined($self->{option_results}->{no_nsgs})) {
+        $items = $options{custom}->azure_list_nsgs(
+            resource_group => $self->{option_results}->{resource_group},
+            api_version_override => "2022-05-01"
+            );
+        $self->{nsgs} = {orphan => 0, total => 0, name => ""};
+        foreach my $item (@{$items}) {
+            $self->{nsgs}->{total}++;;
+            next if (defined($self->{option_results}->{exclude_name}) && $self->{option_results}->{exclude_name} ne ''
+                     && $item->{name} =~ /$self->{option_results}->{exclude_name}/);
+            next if (defined($item->{properties}->{subnets}) && scalar($item->{properties}->{subnets}) != 0);
+            next if (defined($item->{properties}->{networkInterface}) && scalar($item->{properties}->{networkInterface}) != 0);
+            next if (defined($item->{properties}->{networkInterfaces}) && scalar($item->{properties}->{networkInterfaces}) != 0);
+            $self->{nsgs}->{orphan}++;
+            $self->{nsgs}->{name} .= $item->{name} . " ";
+        }
+        if ($self->{nsgs}->{orphan}) {
+            $output_error .= "Found " . $self->{nsgs}->{orphan} . " orphan NSG(s) ( " . $self->{nsgs}->{name} . ")\n";
+        }
+        else {
+            $output .= "No orphan NSG found on " . $self->{nsgs}->{total} . " total NSG(s)\n";
+        }
+    }
+
+    # orphan public IPs
+    if (!defined($self->{option_results}->{no_public_ips})) {
+        $items = $options{custom}->azure_list_publicips(
+            resource_group => $self->{option_results}->{resource_group},
+            api_version_override => "2022-01-01"
+            );
+        $self->{public_ips} = {orphan => 0, total => 0, name => ""};
+        foreach my $item (@{$items}) {
+            $self->{public_ips}->{total}++;;
+            next if (defined($self->{option_results}->{exclude_name}) && $self->{option_results}->{exclude_name} ne ''
+                     && $item->{name} =~ /$self->{option_results}->{exclude_name}/);
+            next if (defined($item->{properties}->{ipConfiguration}) && scalar($item->{properties}->{ipConfiguration}) != 0);
+            $self->{public_ips}->{orphan}++;
+            $self->{public_ips}->{name} .= $item->{name} . " ";
+        }
+        if ($self->{public_ips}->{orphan}) {
+            $output_error .= "Found " . $self->{public_ips}->{orphan} . " orphan public IP(s) ( " . $self->{public_ips}->{name} . ")\n";
+        }
+        else {
+            $output .= "No orphan public IP found on " . $self->{public_ips}->{total} . " total public IP(s)\n";
+        }
+    }
+
+    # orphan route tables
+    if (!defined($self->{option_results}->{no_route_tables})) {
+        $items = $options{custom}->azure_list_route_tables(
+            resource_group => $self->{option_results}->{resource_group},
+            api_version_override => "2022-01-01"
+            );
+        $self->{route_tables} = {orphan => 0, total => 0, name => ""};
+        foreach my $item (@{$items}) {
+            $self->{route_tables}->{total}++;;
+            next if (defined($self->{option_results}->{exclude_name}) && $self->{option_results}->{exclude_name} ne ''
+                     && $item->{name} =~ /$self->{option_results}->{exclude_name}/);
+            next if (defined($item->{properties}->{subnets}) && scalar($item->{properties}->{subnets}) != 0);
+            $self->{route_tables}->{orphan}++;
+            $self->{route_tables}->{name} .= $item->{name} . " ";
+        }
+        if ($self->{route_tables}->{orphan}) {
+            $output_error .= "Found " . $self->{route_tables}->{orphan} . " orphan route table(s) ( " . $self->{route_tables}->{name} . ")\n";
+        }
+        else {
+            $output .= "No orphan route table found on " . $self->{route_tables}->{total} . " total route table(s)\n";
+        }
+    }
+
+    # orphan snapshots
+    if (!defined($self->{option_results}->{no_snapshots})) {
+        $items = $options{custom}->azure_list_snapshots(
+            resource_group => $self->{option_results}->{resource_group},
+            api_version_override => "2021-12-01"
+            );
+        $self->{snapshots} = {orphan => 0, total => 0, name => ""};
+        foreach my $item (@{$items}) {
+            $self->{snapshots}->{total}++;;
+            next if (defined($self->{option_results}->{exclude_name}) && $self->{option_results}->{exclude_name} ne ''
+                     && $item->{name} =~ /$self->{option_results}->{exclude_name}/);
+            $self->{snapshots}->{orphan}++;
+            $self->{snapshots}->{name} .= $item->{name} . " ";
+        }
+        if ($self->{snapshots}->{orphan}) {
+            $output_error .= "Found " . $self->{snapshots}->{orphan} . " orphan snapshot(s) ( " . $self->{snapshots}->{name} . ")\n";
+        }
+        else {
+            $output .= "No orphan snapshot found on " . $self->{snapshots}->{total} . " total snapshot(s)\n";
+        }
+    }
+
+    if ($output_error) {
+	$self->{output}->output_add(severity => "CRITICAL", short_msg => $output_error . $output);
+    }
+    else {
+	$self->{output}->output_add(severity => "OK", short_msg => "No orphan resource found\n" . $output);
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check orphan resources.
+
+Since there are multiple calls to multiple Rest APIs versions, api-version parameter is hardcoded in the mode code.
+
+Example: 
+perl centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --custommode=api --mode=orphan-resource
+{--resource-group='MYRESOURCEGROUP'] --exclude-name='MyDisk|DataDisk.*' [--no-managed-disks] [--no-nics] [--no-nsgs] [--no-public-ips] [--no-route-tables] [--no-snapshots]
+
+
+=over 8
+
+=item B<--resource-group>
+
+Set resource group (Required).
+
+=item B<--exclude-name>
+
+Exclude resource from check (Can be a regexp).
+
+=item B--no-managed-disks --no-nics --no-nsgs --no-public-ips --no-route-tables --no-snapshots
+
+Exclude resource type from check
+
+=back
+
+=cut

--- a/cloud/azure/management/costs/mode/tagonresources.pm
+++ b/cloud/azure/management/costs/mode/tagonresources.pm
@@ -1,0 +1,124 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::management::costs::mode::tagonresources;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'vms'               => { name => 'vms' },
+        'tag-name:s'        => { name => 'tag_name' },
+	'exclude-name:s'    => { name => 'exclude_name' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{tag_name}) || $self->{option_results}->{tag_name} eq '') {
+	$self->{output}->add_option_msg(short_msg => "Need to specify --tag-name option");
+	$self->{output}->option_exit();
+    }
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $output_error = "";
+    my $output = "";
+    my $items;
+
+    # VMs
+    if (defined($self->{option_results}->{vms})) {
+	$items = $options{custom}->azure_list_vms(
+	    resource_group => $self->{option_results}->{resource_group}
+	    );
+	$self->{vms} = {no_tag => 0, total => 0, name => ""};
+	foreach my $item (@{$items}) {
+	    $self->{vms}->{total}++;;
+	    next if (defined($self->{option_results}->{exclude_name}) && $self->{option_results}->{exclude_name} ne ''
+		     && $item->{name} =~ /$self->{option_results}->{exclude_name}/);
+	    next if (defined($item->{tags}->{finopsstartstop}));
+	    $self->{vms}->{no_tag}++;
+	    $self->{vms}->{name} .= $item->{name} . " ";	    
+	}
+	if ($self->{vms}->{no_tag}) {
+	    $output_error .= "Found " . $self->{vms}->{no_tag} . " VM(s) with no " . $self->{option_results}->{tag_name}  . " tag ( " . $self->{vms}->{name} . ")\n";
+	}
+	else {
+	    $output .= "All " . $self->{vms}->{total} . "VM(s) have a " . $self->{option_results}->{tag_name}  . " tag\n";
+	}
+    }
+    
+    if ($output_error) {
+	$self->{output}->output_add(severity => "CRITICAL", short_msg => $output_error . $output);
+    }
+    else {
+	$self->{output}->output_add(severity => "OK", short_msg => "Everything is OK\n" . $output);
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check if a specified tag is present on every resource of the specified resource type(s)
+Can be useful for example if you use tags to start/stop VMs and need to identify VMs
+that do NOT have such a tag 
+
+Example: 
+perl centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --custommode=api --mode=tag-on-resources
+{--resource-group='MYRESOURCEGROUP'] --exclude-name='MyVM1|MyVM2.*' [--vms] --tag-name='startstoptag' --api-version='2022-08-01'
+
+
+=over 8
+
+=item B<--resource-group>
+
+Set resource group (Optional).
+
+=item B<--exclude-name>
+
+Exclude resource from check (Can be a regexp).
+
+=item B<--vms>
+
+Check tag on Virtual machines
+
+=item B<--tag-name>
+
+Name of the tag to check (Required).
+
+=back
+
+=cut

--- a/cloud/azure/management/costs/mode/tagonresources.pm
+++ b/cloud/azure/management/costs/mode/tagonresources.pm
@@ -74,7 +74,7 @@ sub manage_selection {
 	    $output_error .= "Found " . $self->{vms}->{no_tag} . " VM(s) with no " . $self->{option_results}->{tag_name}  . " tag ( " . $self->{vms}->{name} . ")\n";
 	}
 	else {
-	    $output .= "All " . $self->{vms}->{total} . "VM(s) have a " . $self->{option_results}->{tag_name}  . " tag\n";
+	    $output .= "All " . $self->{vms}->{total} . " VM(s) have a " . $self->{option_results}->{tag_name}  . " tag\n";
 	}
     }
     

--- a/cloud/azure/management/costs/mode/tagonresources.pm
+++ b/cloud/azure/management/costs/mode/tagonresources.pm
@@ -66,7 +66,7 @@ sub manage_selection {
 	    $self->{vms}->{total}++;;
 	    next if (defined($self->{option_results}->{exclude_name}) && $self->{option_results}->{exclude_name} ne ''
 		     && $item->{name} =~ /$self->{option_results}->{exclude_name}/);
-	    next if (defined($item->{tags}->{finopsstartstop}));
+	    next if (defined($item->{tags}->{$self->{option_results}->{tag_name}}));
 	    $self->{vms}->{no_tag}++;
 	    $self->{vms}->{name} .= $item->{name} . " ";	    
 	}

--- a/cloud/azure/management/costs/plugin.pm
+++ b/cloud/azure/management/costs/plugin.pm
@@ -32,7 +32,10 @@ sub new {
     $self->{version} = '0.1';
     %{ $self->{modes} } = (
         'budgets' => 'cloud::azure::management::costs::mode::budgets',
-        'list-budgets' => 'cloud::azure::management::costs::mode::listbudgets'
+        'list-budgets' => 'cloud::azure::management::costs::mode::listbudgets',
+        'orphan-resource'   => 'cloud::azure::management::costs::mode::orphanresource',
+        'hybrid-benefits'   => 'cloud::azure::management::costs::mode::hybridbenefits',
+        'tag-on-resources'  => 'cloud::azure::management::costs::mode::tagonresources'
     );
 
     $self->{custom_modes}{api} = 'cloud::azure::custom::api';


### PR DESCRIPTION
## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [X] 21.04.x
- [X] 21.10.x
- [X] 22.04.x
- [X] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

New modes for the Azure "costs" plugin:

- Mode to identify orphan ressources like snapshots, managed disks, NICs, NSGs, public IPs, route tables
- Mode to identify ressources with Hybrid Benefits not enabled (VMs, SQL VMs, SQL Database, SQL Elastic Pools)
- Mode to check the presence of a tag on a particular type of ressource (VMs only for now but other type might be added in the future). This is useful to be sure that VMs have a start/stop tag for exemple.

Note that for orphan and hybrid-benefits modes, there are call to several rest API that have incompatible api-version between them so it's not possible to use the global variable api-version give in parameter. That's why i proposed a way to override the API version on some functions on the custom/api.pm file.

Note2: i also updated some functions on the custom/api.pm file to use the nextlink the 1 API call is not enough (that occurs if many objects are returned).


## Checklist

#### Orphan Resources:
/usr/lib/centreon/plugins/centreon-plugins/centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --custommode='api' --mode='orphan-resource' --subscription='xxxx' --tenant='xxxx' --client-id='xxxx' --client-secret='xxxx' 
CRITICAL: Found 1 orphan snapshot(s) ( OSdiskxxxx )
No orphan managed disk found on 70 total disk(s)
No orphan NIC found on 50 total NIC(s)
No orphan NSG found on 6 total NSG(s)
No orphan public IP found on 1 total public IP(s)
No orphan route table found on 12 total route table(s)

/usr/lib/centreon/plugins/centreon-plugins/centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --custommode='api' --mode='orphan-resource' --subscription='xxxx' --tenant='xxxx' --client-id='xxxx' --client-secret='xxxx' --no-snapshots
OK: No orphan resource found
No orphan managed disk found on 70 total disk(s)
No orphan NIC found on 50 total NIC(s)
No orphan NSG found on 6 total NSG(s)
No orphan public IP found on 1 total public IP(s)
No orphan route table found on 12 total route table(s)

/usr/lib/centreon/plugins/centreon-plugins/centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --custommode='api' --mode='orphan-resource' --subscription='xxxx' --tenant='xxxx' --client-id='xxxx' --client-secret='xxxx' --exclude-name='OSdisk'
OK: No orphan resource found
No orphan managed disk found on 70 total disk(s)
No orphan NIC found on 50 total NIC(s)
No orphan NSG found on 6 total NSG(s)
No orphan public IP found on 1 total public IP(s)
No orphan route table found on 12 total route table(s)
No orphan snapshot found on 1 total snapshot(s)


#### Hybrid Benefits:
/usr/lib/centreon/plugins/centreon-plugins/centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --custommode='api' --mode='hybrid-benefits' --subscription='xxxx' --tenant='xxxx' --client-id='xxxx' --client-secret='xxxx' 
CRITICAL: Found 2 SQL database(s) with SqlDatabaseHybridBenefits not enabled ( sqldb-xxxx sqldb-yyyyy )
VmHybridBenefits is enabled on all 11 VM(s)
SqlVmHybridBenefits is enabled on all 3 SQL VM(s)

/usr/lib/centreon/plugins/centreon-plugins/centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --custommode='api' --mode='hybrid-benefits' --subscription='xxxx' --tenant='xxxx' --client-id='xxxx' --client-secret='xxxx' --no-sql-database-hybrid-benefits
OK: Everything is OK
VmHybridBenefits is enabled on all 11 VM(s)
SqlVmHybridBenefits is enabled on all 3 SQL VM(s)
SqlElasticPoolHybridBenefits is enabled on all 0 eligible SQL elastic pool(s)

/usr/lib/centreon/plugins/centreon-plugins/centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --custommode='api' --mode='hybrid-benefits' --subscription='xxxx' --tenant='xxxx' --client-id='xxxx' --client-secret='xxxx' --exclude-name='sqldb-.*'
OK: Everything is OK
VmHybridBenefits is enabled on all 11 VM(s)
SqlVmHybridBenefits is enabled on all 3 SQL VM(s)
SqlDatabaseHybridBenefits is enabled on all 2 eligible SQL database(s)
SqlElasticPoolHybridBenefits is enabled on all 0 eligible SQL elastic pool(s)


#### Tags:
/usr/lib/centreon/plugins//centreon-plugins/centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --custommode='api' --mode='tag-on-resources' --subscription='xxxx' --tenant='xxxx' --client-id='xxxx' --client-secret='xxxx' --vms --tag-name='startstoptag' --api-version='2022-08-01'
CRITICAL: Found 3 VM(s) with no startstoptag tag ( vm1 vm2 vm3 )

/usr/lib/centreon/plugins//centreon-plugins/centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --custommode='api' --mode='tag-on-resources' --subscription='xxxx' --tenant='xxxx' --client-id='xxxx' --client-secret='xxxx' --vms --tag-name='startstoptag' --api-version='2022-08-01' --exclude-name='vm.*'
OK: Everything is OK
All 12 VM(s) have a startstoptag tag


#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
