### PR TITLE
(core) can use variable to defined unitary options

### DIFF
--- a/centreon/plugins/alternative/Getopt.pm
+++ b/centreon/plugins/alternative/Getopt.pm
@@ -61,17 +61,20 @@ sub GetOptions {
     for (my $i = 0; $i < $num_args;) {
         if (defined($ARGV[$i]) && $ARGV[$i] =~ /^--(.*?)(?:=|$)((?s).*)/) {
             my ($option, $value) = ($1, $2);
-            
+
             # find type of option
             if ($search_str !~ /,((?:[^,]*?\|){0,}$option(?:\|.*?){0,}(:.*?){0,1}),/) {
                 warn "Unknown option: $option" if ($warn_message == 1);
                 $i++;
                 next;
             }
-            
+
             my ($option_selected, $type_opt) = ($1, $2);
             if (!defined($type_opt)) {
-                ${$opts{$option_selected}} = 1;
+                ($num_args, my $assigned) = get_assigned_value(num_args => $num_args, pos => $i, val => $value);
+                if ($assigned ne '0') {
+                    ${$opts{$option_selected}} = 1;
+                }
             } elsif ($type_opt =~ /:s$/) {
                 ($num_args, my $assigned) = get_assigned_value(num_args => $num_args, pos => $i, val => $value);
                 ${$opts{$option_selected}} = $assigned;


### PR DESCRIPTION
Now we can use following syntax (option[=[0|1]]):
```
perl centreon_plugins.pl --plugin=os/linux/snmp/plugin.pm --mode=interfaces --hostname=127.0.0.1 --statefile-dir=/tmp  --verbose  --add-duplex-status=1
CRITICAL: Interface 'enp0s31f6' Status : down (admin: up) (duplex: unknown) - Interface 'anbox0' Status : down (admin: up) (duplex: n/a) 
Interface 'lo' Status : up (admin: up) (duplex: n/a)
Interface 'enp0s31f6' Status : down (admin: up) (duplex: unknown)
Interface 'wlp1s0' Status : up (admin: up) (duplex: n/a)
Interface 'anbox0' Status : down (admin: up) (duplex: n/a)
Interface 'tun0' Status : up (admin: up) (duplex: n/a)
```

```
perl centreon_plugins.pl --plugin=os/linux/snmp/plugin.pm --mode=interfaces --hostname=127.0.0.1 --statefile-dir=/tmp  --verbose  --add-duplex-status=0
CRITICAL: Interface 'enp0s31f6' Status : down (admin: up) - Interface 'anbox0' Status : down (admin: up) 
Interface 'lo' Status : up (admin: up)
Interface 'enp0s31f6' Status : down (admin: up)
Interface 'wlp1s0' Status : up (admin: up)
Interface 'anbox0' Status : down (admin: up)
Interface 'tun0' Status : up (admin: up)
```
