### PR TITLE
Fix variable for ssl_opt option

### DIFF
--- a/centreon/plugins/nrpe.pm
+++ b/centreon/plugins/nrpe.pm
@@ -90,7 +90,7 @@ sub check_options {
 
     $self->{ssl_context} = centreon::plugins::misc::eval_ssl_options(
         output => $self->{output},
-        ssl_opt => $self->{option_results}->{ssl_opt}
+        ssl_opt => $options{option_results}->{ssl_opt}
     );
 }
 


### PR DESCRIPTION
Fix ssl_opt variable when calling centreon::plugins::misc::eval_ssl_options

## Description

Error introduced by https://github.com/centreon/centreon-plugins/commit/71d000525cb1badcbe568a9265bc7da55e74c12f

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Actual code failed when using NRPE to check a host when it's required to disable the SSL verification : 
```
./centreon_plugins.pl --plugin=apps::protocols::nrpe::plugin --custommode=nrpe --mode=query --hostname=127.0.0.1 --nrpe-version=2 --nrpe-port=5666 --command="check_uptime" --nrpe-use-ipv4 --ssl-opt "SSL_verify_mode => SSL_VERIFY_NONE"

UNKNOWN: No response from remote host. 
```
Because the ssl-opt from command line are not taken correctly.


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
