### PR TITLE
[storage::huawei::oceanstor::snmp::plugin] add lun discover and check usage

### DIFF
--- a/storage/huawei/oceanstor/snmp/mode/listluns.pm
+++ b/storage/huawei/oceanstor/snmp/mode/listluns.pm
@@ -1,0 +1,126 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package storage::huawei::oceanstor::snmp::mode::listluns;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+}
+
+my $mapping = {
+    name       => { oid => '.1.3.6.1.4.1.34774.4.1.23.4.8.1.2' }, # hwInfoLunName
+    capacity   => { oid => '.1.3.6.1.4.1.34774.4.1.23.4.8.1.5' }, # hwInfoLunCapacity (MB)
+    usage      => { oid => '.1.3.6.1.4.1.34774.4.1.23.4.8.1.6' }, # hwInfoLunSubscribedCapacity (MB)
+    protection => { oid => '.1.3.6.1.4.1.34774.4.1.23.4.8.1.7' }, # hwInfoLunProtectionCapacity (KB)
+    isexposed  => { oid => '.1.3.6.1.4.1.34774.4.1.23.4.8.1.14'}, # hwInfoLunExposedToInitiator (1 if exposed, 0 if not, i.e : snapshot are not exposed by default) 
+};
+my $oid_lun_entry = '.1.3.6.1.4.1.34774.4.1.23.4.8.1'; # hwInfoLunTable
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $snmp_result = $options{snmp}->get_table(
+        oid => $oid_lun_entry
+    );
+
+    my $lun = {};
+    foreach my $oid (keys %$snmp_result) {
+        next if ($oid !~ /^$mapping->{name}->{oid}\.(.*)$/);
+        my $result = $options{snmp}->map_instance(mapping => $mapping, results => $snmp_result, instance => $1);
+        if($result->{isexposed} == 0) {next;}
+        $lun->{$1} = $result;
+    }
+
+    return $lun;
+}
+
+sub run {
+    my ($self, %options) = @_;
+  
+    my $lun = $self->manage_selection(%options);
+    foreach (sort keys %$lun) {
+        $self->{output}->output_add(
+            long_msg => sprintf(
+                '[exposed: %s] [name: %s] [capacity: %s] [usage: %s] [protection: %s]',
+                $lun->{$_}->{isexposed},
+                $lun->{$_}->{name},
+                $lun->{$_}->{capacity}*1024*1024,
+                $lun->{$_}->{usage}*1024*1024,
+                $lun->{$_}->{protection}*1024                
+            )
+        );
+    }
+
+    $self->{output}->output_add(
+        severity => 'OK',
+        short_msg => 'List LUNs:'
+    );
+    $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+    $self->{output}->exit();
+}
+
+sub disco_format {
+    my ($self, %options) = @_;
+
+    $self->{output}->add_disco_format(elements => [keys %$mapping]);
+}
+
+sub disco_show {
+    my ($self, %options) = @_;
+
+    my $lun = $self->manage_selection(%options);
+    foreach (sort keys %$lun) { 
+        $self->{output}->add_disco_entry(
+            %{$lun->{$_}}
+        );
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+List storage pools.
+
+=over 8
+
+=back
+
+=cut
+    

--- a/storage/huawei/oceanstor/snmp/mode/luns.pm
+++ b/storage/huawei/oceanstor/snmp/mode/luns.pm
@@ -1,0 +1,229 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package storage::huawei::oceanstor::snmp::mode::luns;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_calc);
+#use storage::huawei::oceanstor::snmp::mode::resources qw($health_status $running_status);
+
+#sub custom_status_output {
+#    my ($self, %options) = @_;
+
+    #return sprintf(
+#        'health status: %s [running status: %s]',
+#        $self->{result_values}->{health_status},
+#        $self->{result_values}->{running_status}
+#    );
+#}
+
+sub custom_space_usage_output {
+    my ($self, %options) = @_;
+
+    my ($total_size_value, $total_size_unit) = $self->{perfdata}->change_bytes(value => $self->{result_values}->{total_space});
+    my ($total_used_value, $total_used_unit) = $self->{perfdata}->change_bytes(value => $self->{result_values}->{used_space});
+    my ($total_free_value, $total_free_unit) = $self->{perfdata}->change_bytes(value => $self->{result_values}->{free_space});
+    my ($total_prot_value, $total_prot_unit) = $self->{perfdata}->change_bytes(value => $self->{result_values}->{prot_space});
+    return sprintf(
+        'space usage total: %s used: %s (%.2f%%) free: %s (%.2f%%) protection: %s',
+        $total_size_value . " " . $total_size_unit,
+        $total_used_value . " " . $total_used_unit, $self->{result_values}->{prct_used_space},
+        $total_free_value . " " . $total_free_unit, $self->{result_values}->{prct_free_space},
+        $total_prot_value . " " . $total_prot_unit, $self->{result_values}->{prot_space}
+    );
+}
+
+sub lun_long_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "checking LUN '%s' [sp: %s]",
+        $options{instance_value}->{name},
+        $options{instance_value}->{storage_pool}
+    );
+}
+
+sub prefix_lun_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "LUN '%s' [sp: %s] ",
+        $options{instance_value}->{name},
+        $options{instance_value}->{storage_pool}
+    );
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'lun', type => 3, cb_prefix_output => 'prefix_lun_output', cb_long_output => 'lun_long_output',
+          indent_long_output => '    ', message_multiple => 'All LUNs are ok',
+            group => [
+                #{ name => 'status', type => 0, skipped_code => { -10 => 1 } },
+                { name => 'space', type => 0, skipped_code => { -10 => 1 } }
+            ]
+        }
+    ];
+
+    $self->{maps_counters}->{space} = [
+         { label => 'space-usage', nlabel => 'lun.space.usage.bytes', set => {
+                key_values => [ { name => 'used_space' }, { name => 'free_space' }, { name => 'prct_used_space' }, { name => 'prct_free_space' }, { name => 'total_space' }, { name => 'prot_space' } ],
+                closure_custom_output => $self->can('custom_space_usage_output'),
+                perfdatas => [
+                    { template => '%d', min => 0, max => 'total_space', unit => 'B', cast_int => 1, label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'space-usage-free', nlabel => 'lun.space.free.bytes', display_ok => 0, set => {
+                key_values => [ { name => 'free_space' }, { name => 'used_space' }, { name => 'prct_used_space' }, { name => 'prct_free_space' }, { name => 'total_space' },{ name => 'prot_space' } ],
+                closure_custom_output => $self->can('custom_space_usage_output'),
+                perfdatas => [
+                    { template => '%d', min => 0, max => 'total_space', unit => 'B', cast_int => 1, label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'space-usage-prct', nlabel => 'lun.space.usage.percentage', display_ok => 0, set => {
+                key_values => [ { name => 'prct_used_space' }, { name => 'used_space' }, { name => 'free_space' }, { name => 'prct_free_space' }, { name => 'total_space' },{ name => 'prot_space' } ],
+                closure_custom_output => $self->can('custom_space_usage_output'),
+                perfdatas => [
+                    { template => '%.2f', min => 0, max => 100, unit => '%', label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'space-usage-prot', nlabel => 'lun.space.prot.bytes', display_ok => 0, set => {
+                key_values => [ { name => 'prot_space' },  { name => 'used_space' }, { name => 'prct_used_space' }, { name => 'prct_free_space' }, { name => 'total_space' },{ name => 'free_space' } ],
+                closure_custom_output => $self->can('custom_space_usage_output'),
+                perfdatas => [
+                    { template => '%d', min => 0, max => 'total_space', unit => 'B', cast_int => 1, label_extra_instance => 1 }
+                ]
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s'        => { name => 'filter_name' },
+        'include-non-exposed-luns' => { name => 'include_non_exposed_luns' }
+    });
+
+    return $self;
+}
+
+my $mapping = {
+    name           => { oid => '.1.3.6.1.4.1.34774.4.1.23.4.8.1.2' }, # hwInfoLunName
+    storage_pool   => { oid => '.1.3.6.1.4.1.34774.4.1.23.4.8.1.4' }, # hwInfoLunPoolName
+    total_space    => { oid => '.1.3.6.1.4.1.34774.4.1.23.4.8.1.5' }, # hwInfoLunCapacity (MB)
+    used_space     => { oid => '.1.3.6.1.4.1.34774.4.1.23.4.8.1.6' }, # hwInfoLunSubscribedCapacity (MB)
+    prot_space     => { oid => '.1.3.6.1.4.1.34774.4.1.23.4.8.1.7' }, # hwInfoLunProtectionCapacity (KB)
+    exposed        => { oid => '.1.3.6.1.4.1.34774.4.1.23.4.8.1.14' } # hwInfoLunExposedToInitiator	
+};
+
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    if ($options{snmp}->is_snmpv1()) {
+        $self->{output}->add_option_msg(short_msg => "Need to use SNMP v2c or v3.");
+        $self->{output}->option_exit();
+    }
+
+
+    my $oid_sp_entry = '.1.3.6.1.4.1.34774.4.1.23.4.8.1'; # hwInfoLunTable
+    my $snmp_result = $options{snmp}->get_table(
+        oid => $oid_sp_entry,
+        nothing_quit => 1
+    );
+
+    $self->{lun} = {};
+    
+    foreach my $oid (keys %$snmp_result) {
+        next if ($oid !~ /^$mapping->{name}->{oid}\.(.*)$/);
+
+        my $result = $options{snmp}->map_instance(mapping => $mapping, results => $snmp_result, instance => $1);
+
+        if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
+            $result->{name} !~ /$self->{option_results}->{filter_name}/) {
+            $self->{output}->output_add(long_msg => "skipping LUN '" . $result->{name} . "'.", debug => 1);
+            next;
+        }
+        
+        if (!defined($self->{option_results}->{include_non_exposed_luns}) && $result->{exposed} == 0){
+            $self->{output}->output_add(long_msg => "skipping LUN '" . $result->{name} . "'.", debug => 1);
+            next;
+        }
+        
+        $self->{lun}->{$result->{name}} = $result; # if(defined($1));
+    }
+
+    foreach (keys %{$self->{lun}}) {
+    
+        my $result = $self->{lun}->{$_};
+        $result->{total_space} *=1024*1024;
+        $result->{used_space} *=1024*1024;
+        my $free_space=$result->{total_space} - $result->{used_space};
+        
+        $self->{lun}->{$_}->{space} = {
+            name => $_,
+            total_space => $result->{total_space},
+            used_space => $result->{used_space},
+            free_space => $free_space,
+            prot_space => $result->{prot_space}*1024,
+            prct_used_space => 100 - ($free_space * 100 / $result->{total_space}),
+            prct_free_space => ($free_space * 100 / $result->{total_space})
+        };
+        
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check storage pools.
+
+=over 8
+
+=item B<--filter-name>
+
+Filter LUN by name (can be a regexp).
+
+=item B<--include-non-exposed-luns>
+
+Include LUN not exposed to an iniator, usually LUN snapshots.
+
+=item B<--warning-*> B<--critical-*>
+
+Thresholds.
+Can be: 'space-usage', 'space-usage-free', 'space-usage-prct'.
+
+=back
+
+=cut

--- a/storage/huawei/oceanstor/snmp/plugin.pm
+++ b/storage/huawei/oceanstor/snmp/plugin.pm
@@ -35,7 +35,9 @@ sub new {
         'hardware'           => 'storage::huawei::oceanstor::snmp::mode::hardware',
         'list-controllers'   => 'storage::huawei::oceanstor::snmp::mode::listcontrollers',
         'list-storage-pools' => 'storage::huawei::oceanstor::snmp::mode::liststoragepools',
-        'storage-pools'      => 'storage::huawei::oceanstor::snmp::mode::storagepools'
+        'storage-pools'      => 'storage::huawei::oceanstor::snmp::mode::storagepools',
+        'list-luns'          => 'storage::huawei::oceanstor::snmp::mode::listluns',
+        'luns'               => 'storage::huawei::oceanstor::snmp::mode::luns'
     };
 
     return $self;


### PR DESCRIPTION
adding huawei oceanstor "lun" usage and discovery

tested on Huawei storage with dorado v6 and v5 OS on multiple hardware

this will get individual lun disk usage on oceanstor device with block (Lun) allocated

the plugin was initially based on the storage-pool plugin, removing "statuses" and adding a new metric "protection" which correspond to the number of bytes all the snapshots and protection feature on oceanstore uses on a lun
and finally I had to rewrite  everything after the selection, as the filter and philosophy behind a lun is different from the pool


Auto-discover is filtering on an OID "hwInfoLunExposedToInitiator" which tells if the lun is presented (usable) to a host
(all snaphot are Lun not exposed, it makes no sense to discover or list these lun)

I added a --include-non-exposed-luns on the check command, in case someone wants that

if there is a way to filter based on a macro in the discovery rule, I have implemented a "isdiscovered" macro in the discover command, but no idea how to filter that in the discovery rules, if it is filterable in the UI then the line 64 in listluns.pm is not necessary

### **implementation**

- check command : HW-Storage-Huawei-Oceanstor-SNMP-luns

`--plugin=storage::huawei::oceanstor::snmp::plugin --mode=luns --hostname='$HOSTADDRESS$' --snmp-version='$_HOSTSNMPVERSION$' --snmp-community='$_HOSTSNMPCOMMUNITY$' $_HOSTSNMPEXTRAOPTIONS$ --filter-name='$_SERVICEFILTERNAME$' --warning-space-usage='$_SERVICEWARNINGSPACEUSAGE$' --critical-space-usage='$_SERVICECRITICALSPACEUSAGE$' --warning-space-usage-free='$_SERVICEWARNINGSPACEUSAGEFREE$' --critical-space-usage-free='$_SERVICECRITICALSPACEUSAGEFREE$' --warning-space-usage-prct='$_SERVICEWARNINGSPACEUSAGEPRCT$' --critical-space-usage-prct='$_SERVICECRITICALSPACEUSAGEPRCT$' $_SERVICEEXTRAOPTIONS$`

- service Template

Template name : HW-Storage-Huawei-Oceanstor-LUN-SNMP (-custom)
Template Alias : Lun-Usage

- discover command: HW-Storage-Huawei-Oceanstor-SNMP-luns-Discover

`--plugin=storage::huawei::oceanstor::snmp::plugin --mode=list-luns --hostname='$HOSTADDRESS$' --snmp-version='$_HOSTSNMPVERSION$' --snmp-community='$_HOSTSNMPCOMMUNITY$' $_HOSTSNMPEXTRAOPTIONS$ --disco-show`

- macro command HW-Storage-Huawei-Oceanstor-SNMP-luns-Macro

`--plugin=storage::huawei::oceanstor::snmp::plugin --mode=list-luns --hostname=127.0.0.1 --disco-format`


- Discovery rule : HW-Storage-Huawei-Oceanstor-SNMP-Lun-Usage-Name

Service display name : Lun-Usage-$name$
host template : HW-Storage-Huawei-Oceanstor-SNMP-custom
MACRO : FILTERNAME=^$name$$
