### PR TITLE
Fix option name in snmp interfaces plugin

### DIFF
--- a/snmp_standard/mode/interfaces.pm
+++ b/snmp_standard/mode/interfaces.pm
@@ -405,7 +405,7 @@ sub set_counters_global {
                 ]
             }
         },
-        { label => 'global-admin-up', filter => 'add_global', nlabel => 'total.interfaces.admin.up.count', set => {
+        { label => 'total-admin-up', filter => 'add_global', nlabel => 'total.interfaces.admin.up.count', set => {
                 key_values => [ { name => 'global_admin_up' }, { name => 'total_port' } ],
                 output_template => 'AdminStatus Up : %s', output_error_template => 'AdminStatus Up : %s',
                 output_use => 'global_admin_up',  threshold_use => 'global_admin_up',


### PR DESCRIPTION
## Description

Options --warning-total-admin-up and  --critical-total-admin-up are unknown (bad name between global/total)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Extract from the help message of any snmp interfaces plugin:
```
/usr/lib/centreon/centreon-plugins/centreon_plugins.pl --plugin=os::linux::snmp::plugin --mode=interfaces --help

    --warning-* --critical-*
            Thresholds. Can be: 'total-port', 'total-admin-up',
            'total-admin-down', 'total-oper-up', 'total-oper-down',
            'in-traffic', 'out-traffic', 'in-error', 'in-discard',
            'out-error', 'out-discard', 'in-ucast', 'in-bcast', 'in-mcast',
            'out-ucast', 'out-bcast', 'out-mcast', 'speed' (b/s).
```

Command successfull with admin down:
```
/usr/lib/centreon/centreon-plugins/centreon_plugins.pl --plugin=os::linux::snmp::plugin --mode=interfaces --hostname=127.0.0.1 --warning-total-admin-down=10

OK: All interfaces are ok 
```

Command failed with admin up:
```
/usr/lib/centreon/centreon-plugins/centreon_plugins.pl --plugin=os::linux::snmp::plugin --mode=interfaces --hostname=127.0.0.1 --warning-total-admin-up=10

Unknown option: warning-total-admin-up at /usr/lib/centreon/centreon-plugins.master/centreon/plugins/alternative/Getopt.pm line 67. 
```

It works with `--warning-global-admin-up` but it's not the expected option name.


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
