### PR TITLE
(plugin) cloud::azure::network::expressroute - fix wrong perfdata name in traffic mode

### DIFF
--- a/cloud/azure/network/expressroute/mode/traffic.pm
+++ b/cloud/azure/network/expressroute/mode/traffic.pm
@@ -40,7 +40,7 @@ sub get_metrics_mapping {
         'BitsOutPerSecond' => {
             'output' => 'Traffic Out',
             'label'  => 'traffic-out',
-            'nlabel' => 'azexpressroute.traffic.in.bitspersecond',
+            'nlabel' => 'azexpressroute.traffic.out.bitspersecond',
             'unit'   => 'b/s',
             'min'    => '0',
             'max'    => ''


### PR DESCRIPTION
Closes https://github.com/centreon/centreon-plugins/issues/4016