### PR TITLE
(plugin) cloud::azure::management::cost - adding mode to query subscription costs

### DIFF
--- a/cloud/azure/custom/api.pm
+++ b/cloud/azure/custom/api.pm
@@ -306,6 +306,35 @@ sub json_decode {
     return $decoded;
 }
 
+
+sub azure_get_subscription_cost_management_set_url {
+    my ($self, %options) = @_;
+
+    my $uri = URI::Encode->new({encode_reserved => 1});
+    my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription} . "/providers/Microsoft.CostManagement/query?api-version=" . $self->{api_version} ;
+
+    return $url;
+}
+
+sub azure_get_subscription_cost_management {
+    my ($self, %options) = @_;
+
+    my $results = {};
+    my $encoded_form_post;
+
+    my $full_url = $self->azure_get_subscription_cost_management_set_url(); 
+
+    eval {
+        $encoded_form_post = JSON::XS->new->utf8->encode($options{body_post});
+    };
+
+    $self->{http}->add_header(key => 'Content-Type', value => 'application/json');
+
+    my $response = $self->request_api(method => 'POST', full_url => $full_url, query_form_post => $encoded_form_post, hostname => '');  
+
+    return $response->{properties}->{rows};
+}
+
 sub azure_get_metrics_set_url {
     my ($self, %options) = @_;
 

--- a/cloud/azure/custom/api.pm
+++ b/cloud/azure/custom/api.pm
@@ -310,7 +310,6 @@ sub json_decode {
 sub azure_get_subscription_cost_management_set_url {
     my ($self, %options) = @_;
 
-    my $uri = URI::Encode->new({encode_reserved => 1});
     my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription} . "/providers/Microsoft.CostManagement/query?api-version=" . $self->{api_version} ;
 
     return $url;
@@ -329,7 +328,6 @@ sub azure_get_subscription_cost_management {
     };
 
     $self->{http}->add_header(key => 'Content-Type', value => 'application/json');
-
     my $response = $self->request_api(method => 'POST', full_url => $full_url, query_form_post => $encoded_form_post, hostname => '');  
 
     return $response->{properties}->{rows};

--- a/cloud/azure/management/costs/mode/costsexplorer.pm
+++ b/cloud/azure/management/costs/mode/costsexplorer.pm
@@ -207,7 +207,7 @@ sub manage_selection {
             currency => $currency
         };
     }
-    if (defined($self->{option_results}->{resource_group}) || defined($self->{option_results}->{tags})){
+    if (defined($self->{option_results}->{resource_group}) || defined($self->{option_results}->{tags}) && keys %{$self->{tags}} > 0){
         my $resource_group_total_costs;
 
         foreach my $daily_resource_group_cost (@{$costs}){

--- a/cloud/azure/management/costs/mode/costsexplorer.pm
+++ b/cloud/azure/management/costs/mode/costsexplorer.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package cloud::azure::management::costs::mode::querysubscriptions;
+package cloud::azure::management::costs::mode::costsexplorer;
 
 use base qw(centreon::plugins::templates::counter);
 
@@ -63,7 +63,6 @@ sub set_counters {
             }
         }
     ];
-
     $self->{maps_counters}->{resource_group} = [
         { label => 'resource-group-costs', nlabel => 'resourcegroup.costs', set => {
                 key_values => [ { name => 'resource_group_cost' }, { name => 'currency'} ],
@@ -82,12 +81,11 @@ sub new {
     my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
 
-    $options{options}->add_options(arguments =>
-                                {
-                                    "lookup-days:s"          => { name => 'lookup_days', default => 30 },
-                                    "resource-group:s@"      => { name => 'resource_group' },
-                                    "tags:s@"                => { name => 'tags' }
-                                });
+    $options{options}->add_options(arguments => {
+        "lookup-days:s"          => { name => 'lookup_days', default => 30 },
+        "resource-group:s@"      => { name => 'resource_group' },
+        "tags:s@"                => { name => 'tags' }
+    });
 
     return $self;
 }
@@ -197,13 +195,15 @@ sub manage_selection {
     my $sum_costs;
     my $currency; 
     
-    if ((!defined($self->{option_results}->{resource_group}) || $self->{option_results}->{resource_group} eq "") && !defined($self->{option_results}->{tags})){
+    if ((!defined($self->{option_results}->{resource_group}) || $self->{option_results}->{resource_group} eq "") 
+            && !defined($self->{option_results}->{tags})){
         foreach my $daily_subscription_cost (@{$costs}){
             $sum_costs += ${$daily_subscription_cost}[0];
             $currency = ${$daily_subscription_cost}[2];
         }
-        $self->{global} = { subscription_cost => $sum_costs,
-                            currency => $currency
+        $self->{global} = { 
+            subscription_cost => $sum_costs,
+            currency => $currency
         };
     }
     if (defined($self->{option_results}->{resource_group}) || defined($self->{option_results}->{tags})){
@@ -219,8 +219,9 @@ sub manage_selection {
         }
 
         foreach my $resource_group (keys %$resource_group_total_costs){
-            $self->{resource_group}->{$resource_group} = { resource_group_cost => $resource_group_total_costs->{$resource_group}->{sum},
-                                                           currency => $resource_group_total_costs->{$resource_group}->{currency}
+            $self->{resource_group}->{$resource_group} = {
+                resource_group_cost => $resource_group_total_costs->{$resource_group}->{sum},
+                currency => $resource_group_total_costs->{$resource_group}->{currency}
             };
         }
     }

--- a/cloud/azure/management/costs/mode/costsexplorer.pm
+++ b/cloud/azure/management/costs/mode/costsexplorer.pm
@@ -54,7 +54,7 @@ sub set_counters {
     ];
 
     $self->{maps_counters}->{global} = [
-        { label => 'subscription-costs', nlabel => 'subscription.global.costs', set => {
+        { label => 'subscription-costs', nlabel => 'azure.subscription.global.costs', set => {
                 key_values => [ { name => 'subscription_cost' }, { name => 'currency' } ],
                 closure_custom_output => $self->can('custom_subscription_output'),
                 perfdatas => [
@@ -64,7 +64,7 @@ sub set_counters {
         }
     ];
     $self->{maps_counters}->{resource_group} = [
-        { label => 'resource-group-costs', nlabel => 'resourcegroup.costs', set => {
+        { label => 'resource-group-costs', nlabel => 'azure.resourcegroup.costs', set => {
                 key_values => [ { name => 'resource_group_cost' }, { name => 'currency'} ],
                 closure_custom_output => $self->can('custom_resource_group_output'),
                 perfdatas => [

--- a/cloud/azure/management/costs/mode/costsexplorer.pm
+++ b/cloud/azure/management/costs/mode/costsexplorer.pm
@@ -98,7 +98,7 @@ sub check_options {
         foreach my $tag_pair (@{$self->{option_results}->{tags}}) {
             my ($key, $value) = split / => /, $tag_pair;
             $value = "" if !defined($value);
-            centreon::plugins::misc::trim($value) if defined($value);
+            centreon::plugins::misc::trim($value);
             push @{$self->{tags}->{ centreon::plugins::misc::trim($key) }}, $value;
         }
     }

--- a/cloud/azure/management/costs/mode/costsexplorer.pm
+++ b/cloud/azure/management/costs/mode/costsexplorer.pm
@@ -245,11 +245,11 @@ If you don't specify a resource group or any tags then you will have costs for t
 You can specify resource groups and tags to filter on. 
 
 Example to get costs per subscription for the last 30 days:
-perl centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --mode=query-subscriptions --custommode=api --client-id='xxx' 
+perl centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --mode=costs-explorer --custommode=api --client-id='xxx' 
 --client-secret='xxx' --tenant='xxx' --subscription='xxx' --lookup-days=30 
 
 Example to get costs for a resource group:
-perl centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --mode=query-subscriptions --custommode=api --client-id='xxx' 
+perl centreon_plugins.pl --plugin=cloud::azure::management::costs::plugin --mode=costs-explorer --custommode=api --client-id='xxx' 
 --client-secret='xxx' --tenant='xxx' --subscription='xxx' --lookup-days=30 --resource-group=MYRESOURCEGROUP --tags='Environment => integration'
 
 =over 8

--- a/cloud/azure/management/costs/mode/querysubscriptions.pm
+++ b/cloud/azure/management/costs/mode/querysubscriptions.pm
@@ -112,7 +112,7 @@ sub create_body_filter {
     my $filter;
     my $resource_group_filter;
 
-    # group by resource group if we want costs for whole subscription
+    # group by resource group if we want costs for one or multiple resource groups
     if (defined($self->{option_results}->{resource_group}) && $self->{option_results}->{resource_group} ne ""){ 
         $resource_group_filter->{dimensions}->{name} = "ResourceGroup";
         $resource_group_filter->{dimensions}->{operator} = "In";

--- a/cloud/azure/management/costs/mode/querysubscriptions.pm
+++ b/cloud/azure/management/costs/mode/querysubscriptions.pm
@@ -136,7 +136,7 @@ sub create_body_filter {
     }
 
     # if we have at least one tag and no resource group we need to set the filter on this tag, without the 'and'
-    if (defined($self->{tags}) && keys %{$self->{tags}} >= 0 && !defined($self->{option_results}->{resource_group}) && $self->{option_results}->{resource_group} eq ""){
+    if (defined($self->{tags}) && keys %{$self->{tags}} >= 0 && (!defined($self->{option_results}->{resource_group}) || $self->{option_results}->{resource_group} eq "")){
         foreach my $tag (keys %{$self->{tags}}){
             $filter = {
                 tags => {
@@ -197,7 +197,7 @@ sub manage_selection {
     my $sum_costs;
     my $currency; 
     
-    if (!defined($self->{option_results}->{resource_group}) || $self->{option_results}->{resource_group} eq ""){
+    if ((!defined($self->{option_results}->{resource_group}) || $self->{option_results}->{resource_group} eq "") && !defined($self->{option_results}->{tags})){
         foreach my $daily_subscription_cost (@{$costs}){
             $sum_costs += ${$daily_subscription_cost}[0];
             $currency = ${$daily_subscription_cost}[2];
@@ -206,7 +206,7 @@ sub manage_selection {
                             currency => $currency
         };
     }
-    if (defined($self->{option_results}->{resource_group})){
+    if (defined($self->{option_results}->{resource_group}) || defined($self->{option_results}->{tags})){
         my $resource_group_total_costs;
 
         foreach my $daily_resource_group_cost (@{$costs}){

--- a/cloud/azure/management/costs/mode/querysubscriptions.pm
+++ b/cloud/azure/management/costs/mode/querysubscriptions.pm
@@ -116,15 +116,17 @@ sub manage_selection {
     my $sum_costs;
     my $currency; 
     
-    foreach my $daily_subscription_cost (@{$subscription_costs}){
-        $sum_costs += ${$daily_subscription_cost}[0];
-        $currency = ${$daily_subscription_cost}[2];
+    if (!defined($self->{option_results}->{resource_group}) || $self->{option_results}->{resource_group} eq ""){
+        foreach my $daily_subscription_cost (@{$subscription_costs}){
+            $sum_costs += ${$daily_subscription_cost}[0];
+            $currency = ${$daily_subscription_cost}[2];
+        }
 
+        $self->{global} = { subscription_cost => $sum_costs,
+                            currency => $currency
+        };
     }
-    
-    $self->{global} = { subscription_cost => $sum_costs,
-                        currency => $currency
-    };
+
 }
 
 1;

--- a/cloud/azure/management/costs/mode/querysubscriptions.pm
+++ b/cloud/azure/management/costs/mode/querysubscriptions.pm
@@ -32,13 +32,13 @@ sub resource_group_prefix_output {
     return sprintf( "Resource group '%s' ", $options{instance});
 }
 
-sub custom_status_output {
+sub custom_subscription_output {
     my ($self, %options) = @_;
 
     return sprintf( "Subscription costs for specified period: %.2f %s", $self->{result_values}->{subscription_cost}, $self->{result_values}->{currency});
 }
 
-sub custom_resource_group_status_output {
+sub custom_resource_group_output {
     my ($self, %options) = @_;
 
     return sprintf( "costs for specified period: %.2f %s", $self->{result_values}->{resource_group_cost}, $self->{result_values}->{currency});
@@ -56,7 +56,7 @@ sub set_counters {
     $self->{maps_counters}->{global} = [
         { label => 'subscription-costs', nlabel => 'subscription.global.costs', set => {
                 key_values => [ { name => 'subscription_cost' }, { name => 'currency' } ],
-                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_output => $self->can('custom_subscription_output'),
                 perfdatas => [
                     { template => '%.2f', min => 0 }
                 ]
@@ -67,7 +67,7 @@ sub set_counters {
     $self->{maps_counters}->{resource_group} = [
         { label => 'resource-group-costs', nlabel => 'resourcegroup.costs', set => {
                 key_values => [ { name => 'resource_group_cost' }, { name => 'currency'} ],
-                closure_custom_output => $self->can('custom_resource_group_status_output'),
+                closure_custom_output => $self->can('custom_resource_group_output'),
                 perfdatas => [
                     { template => '%.2f', min => 0, label_extra_instance => 1 },
                 ]

--- a/cloud/azure/management/costs/mode/querysubscriptions.pm
+++ b/cloud/azure/management/costs/mode/querysubscriptions.pm
@@ -1,0 +1,140 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::management::costs::mode::querysubscriptions;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use DateTime;
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf( "Subscription costs for specified period: %.2f %s", $self->{result_values}->{subscription_cost}, $self->{result_values}->{currency});
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, skipped_code => { -10 => 1 } }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'subscription-costs', nlabel => 'subscription.global.costs', set => {
+                key_values => [ { name => 'subscription_cost' }, { name => 'currency' } ],
+                closure_custom_output => $self->can('custom_status_output'),
+                perfdatas => [
+                    { template => '%.2f', min => 0 }
+                ]
+            }
+        }
+    ];
+
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments =>
+                                {
+                                    "loopback:s"             => { name => 'loopback' },
+                                    "resource-group:s@"      => { name => 'resource_group' }
+                                });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+}
+
+sub create_body_payload {
+    my ($self, %options) = @_;
+
+    
+    my $start_date = DateTime->now->subtract( days => $options{loopback} );
+    my $end_date = DateTime->now;
+
+    my $form_post = {
+        "type" => "Usage",
+        "timeframe" => "Custom",
+        "dataset" => {
+            "aggregation" => {
+                "totalCost" => {
+                    "name" => "PreTaxCost",
+                    "function" => "Sum"
+                }
+            },
+            "granularity" => "daily",
+        }
+    };  
+
+    $form_post->{timeperiod}->{from} = $start_date->ymd;
+    $form_post->{timeperiod}->{to} = $end_date->ymd;
+
+    if (defined($options{resource_group}) && $options{resource_group} ne ""){
+        push @{$form_post->{dataset}->{grouping}}, { "type" => "Dimension", "name" => "ResourceGroup"};
+        $form_post->{dataset}->{filter}->{dimensions}->{name} = "ResourceGroup";
+        $form_post->{dataset}->{filter}->{dimensions}->{operator} = "In";
+        $form_post->{dataset}->{filter}->{dimensions}->{values} = $options{resource_group};
+    }
+
+    return $form_post;
+}
+
+
+sub manage_selection {
+    my ($self, %options) = @_;
+   
+    my $raw_form_post = $self->create_body_payload(loopback => $self->{option_results}->{loopback}, resource_group => $self->{option_results}->{resource_group});
+    my $subscription_costs = $options{custom}->azure_get_subscription_cost_management(body_post => $raw_form_post);
+    
+    my $sum_costs;
+    my $currency; 
+    
+    foreach my $daily_subscription_cost (@{$subscription_costs}){
+        $sum_costs += ${$daily_subscription_cost}[0];
+        $currency = ${$daily_subscription_cost}[2];
+
+    }
+    
+    $self->{global} = { subscription_cost => $sum_costs,
+                        currency => $currency
+    };
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+=over 8
+
+=back
+
+=cut

--- a/cloud/azure/management/costs/plugin.pm
+++ b/cloud/azure/management/costs/plugin.pm
@@ -32,6 +32,7 @@ sub new {
     $self->{version} = '0.1';
     %{ $self->{modes} } = (
         'budgets'             => 'cloud::azure::management::costs::mode::budgets',
+        'costs-explorer'      => 'cloud::azure::management::costs::mode::costsexplorer',
         'list-budgets'        => 'cloud::azure::management::costs::mode::listbudgets',
         'query-subscriptions' => 'cloud::azure::management::costs::mode::querysubscriptions'
     );

--- a/cloud/azure/management/costs/plugin.pm
+++ b/cloud/azure/management/costs/plugin.pm
@@ -33,8 +33,7 @@ sub new {
     %{ $self->{modes} } = (
         'budgets'             => 'cloud::azure::management::costs::mode::budgets',
         'costs-explorer'      => 'cloud::azure::management::costs::mode::costsexplorer',
-        'list-budgets'        => 'cloud::azure::management::costs::mode::listbudgets',
-        'query-subscriptions' => 'cloud::azure::management::costs::mode::querysubscriptions'
+        'list-budgets'        => 'cloud::azure::management::costs::mode::listbudgets'
     );
 
     $self->{custom_modes}{api} = 'cloud::azure::custom::api';

--- a/cloud/azure/management/costs/plugin.pm
+++ b/cloud/azure/management/costs/plugin.pm
@@ -31,8 +31,9 @@ sub new {
 
     $self->{version} = '0.1';
     %{ $self->{modes} } = (
-        'budgets' => 'cloud::azure::management::costs::mode::budgets',
-        'list-budgets' => 'cloud::azure::management::costs::mode::listbudgets'
+        'budgets'             => 'cloud::azure::management::costs::mode::budgets',
+        'list-budgets'        => 'cloud::azure::management::costs::mode::listbudgets',
+        'query-subscriptions' => 'cloud::azure::management::costs::mode::querysubscriptions'
     );
 
     $self->{custom_modes}{api} = 'cloud::azure::custom::api';


### PR DESCRIPTION
Adding mode to check subscriptions costs, per subscription and resource groups. 
It is also possible to filter per tags.