### PR TITLE
(plugin) cloud::aws::* - Implement --skip-ssl-check - the not ideal way

### DIFF
--- a/cloud/aws/custom/awscli.pm
+++ b/cloud/aws/custom/awscli.pm
@@ -216,7 +216,7 @@ sub cloudwatch_get_metrics_set_cmd {
         $cmd_options .= " 'Name=$entry->{Name},Value=$entry->{Value}'";
     }
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check})));
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }

--- a/cloud/aws/custom/awscli.pm
+++ b/cloud/aws/custom/awscli.pm
@@ -216,7 +216,7 @@ sub cloudwatch_get_metrics_set_cmd {
         $cmd_options .= " 'Name=$entry->{Name},Value=$entry->{Value}'";
     }
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check})));
 
     return $cmd_options;
 }
@@ -270,7 +270,7 @@ sub discovery_set_cmd {
 
     my $cmd_options = $options{service} . " " . $options{command} . " --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -291,7 +291,7 @@ sub cloudwatch_get_alarms_set_cmd {
 
     my $cmd_options = "cloudwatch describe-alarms --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -325,7 +325,7 @@ sub cloudwatch_list_metrics_set_cmd {
     $cmd_options .= " --namespace $options{namespace}" if (defined($options{namespace}));
     $cmd_options .= " --metric-name $options{metric}" if (defined($options{metric}));
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -346,7 +346,7 @@ sub cloudwatchlogs_describe_log_groups_set_cmd {
 
     my $cmd_options = "logs describe-log-groups --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -374,7 +374,7 @@ sub cloudwatchlogs_filter_log_events_set_cmd {
         }
     }
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -395,7 +395,7 @@ sub ebs_list_volumes_set_cmd {
 
     my $cmd_options = "ec2 describe-volumes --no-dry-run --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -432,7 +432,7 @@ sub ec2_get_instances_status_set_cmd {
 
     my $cmd_options = "ec2 describe-instance-status --include-all-instances --no-dry-run --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -462,7 +462,7 @@ sub ec2spot_get_active_instances_set_cmd {
     my $cmd_options = "ec2 describe-spot-fleet-instances --no-dry-run --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
     $cmd_options .= " --spot-fleet-request-id " . $options{spot_fleet_request_id};
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -492,7 +492,7 @@ sub ec2spot_list_fleet_requests_set_cmd {
 
     my $cmd_options = "ec2 describe-spot-fleet-requests --no-dry-run --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -522,7 +522,7 @@ sub ec2_list_resources_set_cmd {
 
     my $cmd_options = "ec2 describe-instances --no-dry-run --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -591,7 +591,7 @@ sub asg_get_resources_set_cmd {
 
     my $cmd_options = "autoscaling describe-auto-scaling-groups --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -612,7 +612,7 @@ sub rds_get_instances_status_set_cmd {
 
     my $cmd_options = "rds describe-db-instances --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -638,7 +638,7 @@ sub rds_list_instances_set_cmd {
 
     my $cmd_options = "rds describe-db-instances --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -671,7 +671,7 @@ sub rds_list_clusters_set_cmd {
 
     my $cmd_options = "rds describe-db-clusters --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -703,7 +703,7 @@ sub vpn_list_connections_set_cmd {
 
     my $cmd_options = "ec2 describe-vpn-connections --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -748,7 +748,7 @@ sub health_describe_events_set_cmd {
 
     $cmd_options .= " --filter '$filter'" if ($filter ne '');
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -776,7 +776,7 @@ sub health_describe_affected_entities_set_cmd {
 
     $cmd_options .= " --filter '$filter'" if ($filter ne '');
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -801,7 +801,7 @@ sub sqs_list_queues_set_cmd {
 
     my $cmd_options = "sqs list-queues --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -822,7 +822,7 @@ sub sns_list_topics_set_cmd {
 
     my $cmd_options = "sns list-topics --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -847,7 +847,7 @@ sub tgw_list_gateways_set_cmd {
 
     my $cmd_options = "ec2 describe-transit-gateways --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
-    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check}));
 
     return $cmd_options;
 }
@@ -949,6 +949,10 @@ Only use for testing purpose, when you want to set ALL parameters of a command b
 =item B<--proxyurl>
 
 Proxy URL if any
+
+=item B<--skip-ssl-check>
+
+Avoid certificate issuer verification. Useful when AWS resources are hosted by a third-party like Dell. 
 
 =back
 

--- a/cloud/aws/custom/awscli.pm
+++ b/cloud/aws/custom/awscli.pm
@@ -57,6 +57,7 @@ sub new {
             'command:s'           => { name => 'command', default => 'aws' },
             'command-path:s'      => { name => 'command_path' },
             'command-options:s'   => { name => 'command_options', default => '' },
+            'skip-ssl-check'      => { name => 'skip_ssl_check' },
             'proxyurl:s'          => { name => 'proxyurl' }
         });
     }
@@ -215,6 +216,7 @@ sub cloudwatch_get_metrics_set_cmd {
         $cmd_options .= " 'Name=$entry->{Name},Value=$entry->{Value}'";
     }
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -268,6 +270,7 @@ sub discovery_set_cmd {
 
     my $cmd_options = $options{service} . " " . $options{command} . " --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -288,6 +291,7 @@ sub cloudwatch_get_alarms_set_cmd {
 
     my $cmd_options = "cloudwatch describe-alarms --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -321,6 +325,7 @@ sub cloudwatch_list_metrics_set_cmd {
     $cmd_options .= " --namespace $options{namespace}" if (defined($options{namespace}));
     $cmd_options .= " --metric-name $options{metric}" if (defined($options{metric}));
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -341,6 +346,7 @@ sub cloudwatchlogs_describe_log_groups_set_cmd {
 
     my $cmd_options = "logs describe-log-groups --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -368,6 +374,7 @@ sub cloudwatchlogs_filter_log_events_set_cmd {
         }
     }
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -388,6 +395,7 @@ sub ebs_list_volumes_set_cmd {
 
     my $cmd_options = "ec2 describe-volumes --no-dry-run --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -424,6 +432,7 @@ sub ec2_get_instances_status_set_cmd {
 
     my $cmd_options = "ec2 describe-instance-status --include-all-instances --no-dry-run --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -453,6 +462,7 @@ sub ec2spot_get_active_instances_set_cmd {
     my $cmd_options = "ec2 describe-spot-fleet-instances --no-dry-run --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
     $cmd_options .= " --spot-fleet-request-id " . $options{spot_fleet_request_id};
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -482,6 +492,7 @@ sub ec2spot_list_fleet_requests_set_cmd {
 
     my $cmd_options = "ec2 describe-spot-fleet-requests --no-dry-run --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -511,6 +522,7 @@ sub ec2_list_resources_set_cmd {
 
     my $cmd_options = "ec2 describe-instances --no-dry-run --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -579,6 +591,7 @@ sub asg_get_resources_set_cmd {
 
     my $cmd_options = "autoscaling describe-auto-scaling-groups --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -599,6 +612,7 @@ sub rds_get_instances_status_set_cmd {
 
     my $cmd_options = "rds describe-db-instances --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -624,6 +638,7 @@ sub rds_list_instances_set_cmd {
 
     my $cmd_options = "rds describe-db-instances --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -656,6 +671,7 @@ sub rds_list_clusters_set_cmd {
 
     my $cmd_options = "rds describe-db-clusters --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -687,6 +703,7 @@ sub vpn_list_connections_set_cmd {
 
     my $cmd_options = "ec2 describe-vpn-connections --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -731,6 +748,7 @@ sub health_describe_events_set_cmd {
 
     $cmd_options .= " --filter '$filter'" if ($filter ne '');
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -758,6 +776,7 @@ sub health_describe_affected_entities_set_cmd {
 
     $cmd_options .= " --filter '$filter'" if ($filter ne '');
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -782,6 +801,7 @@ sub sqs_list_queues_set_cmd {
 
     my $cmd_options = "sqs list-queues --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -802,6 +822,7 @@ sub sns_list_topics_set_cmd {
 
     my $cmd_options = "sns list-topics --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -826,6 +847,7 @@ sub tgw_list_gateways_set_cmd {
 
     my $cmd_options = "ec2 describe-transit-gateways --region $self->{option_results}->{region} --output json";
     $cmd_options .= " --endpoint-url $self->{endpoint_url}" if (defined($self->{endpoint_url}) && $self->{endpoint_url} ne '');
+    $cmd_options .= " --no-verify-ssl" if (defined($self->{option_results}->{skip_ssl_check});
 
     return $cmd_options;
 }
@@ -922,6 +944,7 @@ Command path (Default: none).
 =item B<--command-options>
 
 Command options (Default: none).
+Only use for testing purpose, when you want to set ALL parameters of a command by yourself.
 
 =item B<--proxyurl>
 

--- a/cloud/aws/custom/awscli.pm
+++ b/cloud/aws/custom/awscli.pm
@@ -954,6 +954,22 @@ Proxy URL if any
 
 Avoid certificate issuer verification. Useful when AWS resources are hosted by a third-party like Dell. 
 
+Need dirty hack that require commenting some code in the method _validate_conn from /usr/lib/python3/dist-packages/urllib3/connectionpool.py
+
+Comment the warning displayed: 
+#        if not conn.is_verified:
+#            warnings.warn(
+#                (
+#                    "Unverified HTTPS request is being made to host '%s'. "
+#                    "Adding certificate verification is strongly advised. See: "
+#                    "https://urllib3.readthedocs.io/en/latest/advanced-usage.html"
+#                    "#ssl-warnings" % conn.host
+#                ),
+#                InsecureRequestWarning,
+#            )
+
+Ref https://github.com/aws/aws-cli/issues/7375
+
 =back
 
 =head1 DESCRIPTION


### PR DESCRIPTION
## Description

Allow to set the --no-verify-ssl option to awscli cmd. 

Side effect is a warning displayed from a Python library. 

Added some details in the help and the link to the issue I raised with awscli github.