### PR TITLE
(plugin) storage::netapp:ontap::restapi - fix missing counters for space usage and bug in listvolumes

### DIFF
--- a/storage/netapp/ontap/restapi/mode/listvolumes.pm
+++ b/storage/netapp/ontap/restapi/mode/listvolumes.pm
@@ -53,10 +53,11 @@ sub run {
     my $volumes = $self->manage_selection(%options);
     foreach (@{$volumes->{records}}) {
         my $vserver_name = defined($_->{svm}) && $_->{svm}->{name} ne '' ? $_->{svm}->{name} : '-';
+        my $volume_state = defined($_->{state}) && $_->{state} ne '' ? $_->{state} : '-';
         $self->{output}->output_add(long_msg => sprintf(
             '[name = %s][state = %s][vserver = %s]',
             $_->{name},
-            $_->{state},
+            $volume_state,
             $vserver_name
         ));
     }
@@ -81,10 +82,11 @@ sub disco_show {
     my $volumes = $self->manage_selection(%options);
     foreach (@{$volumes->{records}}) {
         my $vserver_name = defined($_->{svm}) && $_->{svm}->{name} ne '' ? $_->{svm}->{name} : '-';
+        my $volume_state = defined($_->{state}) && $_->{state} ne '' ? $_->{state} : '-';
         $self->{output}->add_disco_entry(
             name => $_->{name},
-            state => $_->{state},
-            vserver_name => $_->{svm}->{name}
+            state => $volume_state,
+            vserver_name => $vserver_name
         );
     }
 }


### PR DESCRIPTION
Fixing missing space usage counters as well as missing option to filter on aggregate name for aggregate mode. 
Fixing bug in list-volumes output. 

Should close https://github.com/centreon/centreon-plugins/issues/4025 