### PR TITLE
hardware::ups::apc::snmp, Add time running on battery

### DIFF
--- a/hardware/ups/apc/snmp/mode/batterystatus.pm
+++ b/hardware/ups/apc/snmp/mode/batterystatus.pm
@@ -106,6 +106,14 @@ sub set_counters {
                 closure_custom_threshold_check => \&catalog_status_threshold_ng
             }
         },
+        { label => 'timeon', nlabel => 'battery.timeon.minutes', set => {
+                key_values => [ { name => 'upsBasicBatteryTimeOnBattery' } ],
+                output_template => 'running on battery: %.2f minutes',
+                perfdatas => [
+                    { label => 'timeon', template => '%.2f', min => 0, unit => 'm' }
+                ]
+            }
+        },
         { label => 'load', nlabel => 'battery.charge.remaining.percent', set => {
                 key_values => [ { name => 'upsAdvBatteryCapacity' } ],
                 output_template => 'remaining capacity: %s %%',
@@ -377,7 +385,7 @@ Can used special variables like: %{status}
 
 Thresholds.
 Can be: 'load', 'voltage', 'current', 
-'temperature', 'time', 'replace-lasttime'.
+'temperature', 'time', 'replace-lasttime', 'timeon'.
 
 =back
 


### PR DESCRIPTION
Need to know  since how long the APC is on battery and alert on it.

## Description

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

<h2> How this pull request can be tested ? </h2>
Tested on APC Smart-UPS VT

The new metric is  : timeon

`./centreon_plugins.pl --plugin hardware::ups::apc::snmp::plugin --mode battery-status --hostname 10.79.1.124 --snmp-community xxxxxx  --critical-timeon=1:
CRITICAL: running on battery: 0.00 minutes | 'timeon'=0.00m;;1:;0; 'load'=100%;;;0;100 'load_time'=72.00m;;;0; 'current'=0A;;;0; 'voltage'=218V;;;; 'temperature'=22C;;;;
`

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
