### PR TITLE
(enh) double-dash support for arguments

### DIFF
--- a/apps/protocols/nrpe/mode/query.pm
+++ b/apps/protocols/nrpe/mode/query.pm
@@ -33,6 +33,7 @@ sub new {
     $options{options}->add_options(arguments => {
         'command:s'          => { name => 'command' },
         'arg:s@'             => { name => 'arg' },
+        'extra-args'         => { name => 'extra_args' },
         'sanitize-message:s' => { name => 'sanitize_message' }
     });
 
@@ -70,9 +71,12 @@ sub sanitize_message {
 sub run {
     my ($self, %options) = @_;
 
+    my @arg = defined($self->{option_results}->{arg}) ? @{$self->{option_results}->{arg}} : ();
+    push @arg, @{$self->{option_extras}} if ($self->{option_results}->{extra_args});
+
     my $result = $options{custom}->request(
         command => $self->{option_results}->{command},
-        arg => $self->{option_results}->{arg}
+        arg => \@arg
     );
 
     $self->{output}->output_add(
@@ -111,6 +115,13 @@ In nrpe use following command to get server version: --command='_NRPE_CHECK'
 =item B<--arg>
 
 Set arguments (Multiple option. Example: --arg='arg1' --arg='arg2').
+
+=item B<--extra-args>
+
+Use extra arguments from command line (all values placed after a double-dash '--')
+as additional "--arg" options for the NRPE command.
+
+Example: --arg='arg1' --extra-args -- 'arg2' 'arg3' 'arg4'
 
 =item B<--sanitize-message>
 

--- a/centreon/plugins/alternative/Getopt.pm
+++ b/centreon/plugins/alternative/Getopt.pm
@@ -62,6 +62,15 @@ sub GetOptions {
         if (defined($ARGV[$i]) && $ARGV[$i] =~ /^--(.*?)(?:=|$)((?s).*)/) {
             my ($option, $value) = ($1, $2);
 
+            # The special argument "--" forces an end of option-scanning.
+            # All arguments placed after are stored in a list with the special option key '_double_dash_'.
+            if ($option eq '' && $value eq '') {
+                my @values = splice @ARGV, $i + 1, $num_args - $i - 1;
+                push @{${$opts{'_double_dash_'}}}, @values;
+                splice @ARGV, $i, 1;
+                last;
+            }
+
             # find type of option
             if ($search_str !~ /,((?:[^,]*?\|){0,}$option(?:\|.*?){0,}(:.*?){0,1}),/) {
                 warn "Unknown option: $option" if ($warn_message == 1);

--- a/centreon/plugins/mode.pm
+++ b/centreon/plugins/mode.pm
@@ -32,6 +32,7 @@ sub new {
     $self->{perfdata} = centreon::plugins::perfdata->new(output => $options{output});
     
     %{$self->{option_results}} = ();
+    @{$self->{option_extras}} = @{$options{options}->{extra_arguments}};
     $self->{output} = $options{output};
     $self->{output}->use_new_perfdata(value => 1)
         if (defined($options{force_new_perfdata}) && $options{force_new_perfdata} == 1);

--- a/centreon/plugins/options.pm
+++ b/centreon/plugins/options.pm
@@ -37,6 +37,7 @@ sub new {
     $self->{options} = {};
     @{$self->{pod_package}} = ();
     $self->{pod_packages_once} = {};
+    $self->{extra_arguments} = [];
 
     if ($alternative == 0) {
         require Getopt::Long;
@@ -144,6 +145,9 @@ sub parse_options {
             $self->{output}->option_exit(nolabel => 1);
         };
     }
+
+    # Store all arguments placed after the special argument "--" in the 'extra_arguments' list
+    $self->{options}->{'_double_dash_'} = \$self->{extra_arguments};
 
     GetOptions(
        %{$self->{options}}


### PR DESCRIPTION
## Description

Arguments list can be passed to the command line after the special `--` option:

- in `Getopt.pm` when the `--` is found, all remaining parameters are stored in the options hash with the special key `_double_dash_`
- in `options.pm` the special key `_double_dash_` is linked to the new `extra_arguments` property (array ref).
- in `mode.pm` the `extra_arguments` list from options is copied into a new property `option_extras` in order to make these arguments available to the plugin

As an example of use, the NRPE plugin can use the arguments list (all parameters after `--`) as arguments for the NRPE command to execute (but without having to use the `--arg` option for each).

**Fixes** #4055 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

With this patch, it's possible to run command like this...
```
centreon_plugins.pl --plugin=apps::protocols::nrpe::plugin --mode=query --custommode=nrpe ... \
--hostname=$HOSTADDRESS$ --command=check_memory \
--arg="filter=$_SERVICEFILTER$" --arg="detail-syntax=$_SERVICEDETAILSYNTAX$" \
--arg="warning=$_SERVICEWARNING$" --arg="critical=$_SERVICECRITICAL$" 
```
...with this alternative syntax:
```
centreon_plugins.pl --plugin=apps::protocols::nrpe::plugin --mode=query --custommode=nrpe ... \
--hostname=$HOSTADDRESS$ --command=check_memory --extra-args -- \
filter=$_SERVICEFILTER$ detail-syntax=$_SERVICEDETAILSYNTAX$ \
warning=$_SERVICEWARNING$ critical=$_SERVICECRITICAL$
```

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
