### PR TITLE
(plugin) cloud::azure::database::sqldatabase::plugin - fix health options

### DIFF
--- a/cloud/azure/database/sqldatabase/mode/health.pm
+++ b/cloud/azure/database/sqldatabase/mode/health.pm
@@ -29,8 +29,8 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::check_options(%options);
 
-    $self->{resource_namespace} = 'Microsoft.Sql';
-    $self->{resource_type} = 'servers/databases';
+    $self->{az_resource_namespace} = 'Microsoft.Sql';
+    $self->{az_resource_type} = 'servers/databases';
 }
 
 1;

--- a/cloud/azure/database/sqldatabase/mode/health.pm
+++ b/cloud/azure/database/sqldatabase/mode/health.pm
@@ -29,8 +29,8 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::check_options(%options);
 
-    $self->{namespace} = 'Microsoft.Sql';
-    $self->{type} = 'servers/databases';
+    $self->{resource_namespace} = 'Microsoft.Sql';
+    $self->{resource_type} = 'servers/databases';
 }
 
 1;


### PR DESCRIPTION
## Description

Change option names to match options defined in cloud/azure/management/monitor/mode/health.pm

**Fixes** MON-16411

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)
