### PR TITLE
(plugin) cloud::azure::database::sqldatabase::plugin - fix deadlocks metric name

### DIFF
--- a/cloud/azure/database/sqldatabase/mode/deadlocks.pm
+++ b/cloud/azure/database/sqldatabase/mode/deadlocks.pm
@@ -29,7 +29,7 @@ sub get_metrics_mapping {
     my ($self, %options) = @_;
 
     my $metrics_mapping = {
-        'deadlocks' => {
+        'deadlock' => {
             'output' => 'Deadlocks ',
             'label'  => 'deadlocks',
             'nlabel' => 'sqldatabase.deadlocks.count',


### PR DESCRIPTION
## Description

Change the metric name from deadlocks to deadlock

Before the change, we had this error message:

> "Failed to find metric configuration for provider: Microsoft.Sql, resource Type: servers/databases, metric: deadlocks, Valid metrics: cpu_percent,physical_data_read_percent,log_write_percent,storage,connection_successful,connection_failed,connection_failed_user_error,blocked_by_firewall,deadlock,storage_percent,xtp_storage_percent,workers_percent,sessions_percent,sessions_count,cpu_limit,cpu_used,sqlserver_process_core_percent,sqlserver_process_memory_percent,tempdb_data_size,tempdb_log_size,tempdb_log_used_percent,app_cpu_billed,app_cpu_percent,app_memory_percent,allocated_data_storage,full_backup_size_bytes,diff_backup_size_bytes,log_backup_size_bytes,ledger_digest_upload_success,ledger_digest_upload_failed

**Fixes** MON-16411

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)