### PR TITLE
(enh) apps::protocols::x509::custom::https - add --no-follow

### DIFF
--- a/apps/protocols/x509/custom/https.pm
+++ b/apps/protocols/x509/custom/https.pm
@@ -48,6 +48,7 @@ sub new {
             'method:s'    => { name => 'method' },
             'urlpath:s'   => { name => 'url_path' },
             'timeout:s'   => { name => 'timeout' },
+            'no-follow'   => { name => 'no_follow' },
             'header:s@'   => { name => 'header' }
         });
     }
@@ -223,6 +224,10 @@ Threshold for HTTP timeout (Default: 5)
 =item B<--header>
 
 Set HTTP headers (Multiple option)
+
+=item B<--no-follow>
+
+Do not follow http redirect
 
 =back
 


### PR DESCRIPTION
## Description
Add --no-follow parameter to ignore http redirects in x509 certificate check

**Fixes** #4130

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Setup a https website which produces a 301/302 redirect and check the x509 with --debug to see two requests beeing generated. After this is verified use --no-follow to suppress the second request

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
