### PR TITLE
(plugin) cloud::azure::database::sqldatabase::plugin - fix health resource type

### DIFF
--- a/cloud/azure/database/sqldatabase/mode/health.pm
+++ b/cloud/azure/database/sqldatabase/mode/health.pm
@@ -30,7 +30,7 @@ sub check_options {
     $self->SUPER::check_options(%options);
 
     $self->{az_resource_namespace} = 'Microsoft.Sql';
-    $self->{az_resource_type} = 'servers/databases';
+    $self->{az_resource_type} = 'servers';
 }
 
 1;

--- a/cloud/azure/database/sqldatabase/mode/health.pm
+++ b/cloud/azure/database/sqldatabase/mode/health.pm
@@ -29,8 +29,8 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::check_options(%options);
 
-    $self->{az_resource_namespace} = 'Microsoft.Sql';
-    $self->{az_resource_type} = 'servers';
+    $self->{az_resource_namespace} = 'Microsoft.Sql' if (!defined($self->{az_resource_namespace}) || $self->{az_resource_namespace} eq '');
+    $self->{az_resource_type} = 'servers/databases' if (!defined($self->{az_resource_type}) || $self->{az_resource_type} eq '');
 }
 
 1;


### PR DESCRIPTION
## Description

With the old resource type we get this error message:
> The Resource 'Microsoft.Sql/servers/databases' under resource group 'XXXXXXXXX' was not found. For more details please go to https://aka.ms/ARMResourceNotFoundFix

This command works after the fix:
`./centreon_azure_database_sqldatabase_api.pl --plugin=cloud::azure::database::sqldatabase::plugin --mode=health --custommode='api' --resource='xxxx-sql01/databases/Datawarehouse' --resource-group='XXXXXXXXXX' --subscription='xxx' --tenant='xxx' --client-id=’xxx' --client-secret=’xxx' `

**Fixes** MON-16411

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)
