### PR TITLE
Add a Service Discovery Rule to discover APs for Cisco WLC controllers

### DIFF
--- a/src/centreon/common/airespace/snmp/mode/listaps.pm
+++ b/src/centreon/common/airespace/snmp/mode/listaps.pm
@@ -1,0 +1,132 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::common::airespace::snmp::mode::listaps;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+    
+    $options{options}->add_options(arguments => {
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    # Collecting all the relevant informations user may needs when using discovery function for AP in Cisco WLC controllers.
+    # They had been select with https://oidref.com/1.3.6.1.4.1.14179.2.2.1.1.3 as support.
+    my $mapping = {
+        name => { oid => '.1.3.6.1.4.1.14179.2.2.1.1.3' }, # bsnAPName
+        location => { oid => '.1.3.6.1.4.1.14179.2.2.1.1.4' }, # bsnAPLocation
+        model => { oid => '.1.3.6.1.4.1.14179.2.2.1.1.16' } # bsnAPModel
+    };
+    # parent oid for all the mapping usage
+    my $oid_bsnAPEntry = '.1.3.6.1.4.1.14179.2.2.1.1';
+
+    my $snmp_result = $options{snmp}->get_table(
+        oid => $oid_bsnAPEntry,
+        start => $mapping->{name}->{oid}, # First oid of the mapping => here : 3
+        end => $mapping->{model}->{oid} # Last oid of the mapping => here : 16
+    );
+
+    my $results = {};
+    # Iterate for all oids catch in snmp result above
+    foreach my $oid (keys %$snmp_result) {
+        next if ($oid !~ /^$mapping->{name}->{oid}\.(.*)$/);
+        my $oid_path = $1;
+
+        my $result = $options{snmp}->map_instance(mapping => $mapping, results => $snmp_result, instance => $oid_path);
+
+        $results->{$oid_path} = {
+            name => $result->{name},
+            location => $result->{location},
+            model => $result->{model}
+        };
+    }
+
+    return $results;
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    my $results = $self->manage_selection(snmp => $options{snmp});
+    foreach my $oid_path (sort keys %$results) {
+        $self->{output}->output_add(
+            long_msg => sprintf(
+                '[oid_path: %s] [name: %s] [location: %s] [model: %s]',
+                $oid_path,
+                $results->{$oid_path}->{name},
+                $results->{$oid_path}->{location},
+                $results->{$oid_path}->{model}
+            )
+        );
+    }
+    
+    $self->{output}->output_add(
+        severity => 'OK',
+        short_msg => 'List aps'
+    );
+    $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+    $self->{output}->exit();
+}
+
+sub disco_format {
+    my ($self, %options) = @_;
+    
+    $self->{output}->add_disco_format(elements => ['oid_path', 'name','location','model']);
+}
+
+sub disco_show {
+    my ($self, %options) = @_;
+
+    my $results = $self->manage_selection(snmp => $options{snmp});
+    foreach my $oid_path (sort keys %$results) {
+        $self->{output}->add_disco_entry(
+            oid_path => $oid_path,
+            name => $results->{$oid_path}->{name},
+            location => $results->{$oid_path}->{location},
+            model => $results->{$oid_path}->{model}
+        );
+    }
+}
+
+1;
+
+__END__
+=head1 MODE
+List wireless name.
+=over 8
+=back
+=cut

--- a/src/centreon/common/airespace/snmp/mode/listaps.pm
+++ b/src/centreon/common/airespace/snmp/mode/listaps.pm
@@ -105,7 +105,7 @@ sub run {
 sub disco_format {
     my ($self, %options) = @_;
     
-    $self->{output}->add_disco_format(elements => ['oid_path', 'name','location','model']);
+    $self->{output}->add_disco_format(elements => ['name','location','model']);
 }
 
 sub disco_show {
@@ -114,7 +114,6 @@ sub disco_show {
     my $results = $self->manage_selection(snmp => $options{snmp});
     foreach my $oid_path (sort keys %$results) {
         $self->{output}->add_disco_entry(
-            oid_path => $oid_path,
             name => $results->{$oid_path}->{name},
             location => $results->{$oid_path}->{location},
             model => $results->{$oid_path}->{model}
@@ -125,8 +124,13 @@ sub disco_show {
 1;
 
 __END__
+
 =head1 MODE
+
 List wireless name.
+
 =over 8
+
 =back
+
 =cut

--- a/src/network/cisco/wlc/snmp/plugin.pm
+++ b/src/network/cisco/wlc/snmp/plugin.pm
@@ -39,6 +39,7 @@ sub new {
         'discovery'                => 'centreon::common::airespace::snmp::mode::discovery',
         'hardware'                 => 'centreon::common::airespace::snmp::mode::hardware',
         'interfaces'               => 'snmp_standard::mode::interfaces', 
+        'list-aps'                 => 'centreon::common::airespace::snmp::mode::listaps',
         'list-groups'              => 'centreon::common::airespace::snmp::mode::listgroups',
         'list-interfaces'          => 'snmp_standard::mode::listinterfaces',
         'list-radius-acc-servers'  => 'centreon::common::airespace::snmp::mode::listradiusaccservers',


### PR DESCRIPTION
## Description

Add a Service Discovery Rule to discover APs for Cisco WLC controllers

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
