### PR TITLE
(plugin) network::aruba::clearpass::snmp - new

### DIFF
--- a/packaging/centreon-plugin-Network-Aruba-ClearPass-Snmp/deb.json
+++ b/packaging/centreon-plugin-Network-Aruba-ClearPass-Snmp/deb.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": [
+        "libsnmp-perl"
+    ]
+}

--- a/packaging/centreon-plugin-Network-Aruba-ClearPass-Snmp/pkg.json
+++ b/packaging/centreon-plugin-Network-Aruba-ClearPass-Snmp/pkg.json
@@ -1,0 +1,13 @@
+{
+    "pkg_name": "centreon-plugin-Network-Aruba-ClearPass-Snmp",
+    "pkg_summary": "Centreon Plugin to monitor ClearPass using SNMP",
+    "plugin_name": "centreon_aruba_clearpass_snmp.pl",
+    "files": [
+        "centreon/plugins/script_snmp.pm",
+        "centreon/plugins/snmp.pm",
+		"snmp_standard/mode/listinterfaces.pm",
+		"snmp_standard/mode/resources/",
+		"snmp_standard/mode/interfaces.pm",
+        "network/aruba/clearpass/snmp/"
+    ]
+}

--- a/packaging/centreon-plugin-Network-Aruba-ClearPass-Snmp/rpm.json
+++ b/packaging/centreon-plugin-Network-Aruba-ClearPass-Snmp/rpm.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": [
+        "perl(SNMP)"
+    ]
+}

--- a/src/network/aruba/clearpass/snmp/mode/disk.pm
+++ b/src/network/aruba/clearpass/snmp/mode/disk.pm
@@ -1,0 +1,134 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Alexandre Moreau <alexandre.moreau@cheops.fr> (@SpyL1nk)
+
+package network::aruba::clearpass::snmp::mode::disk;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        "warning:s"       => { name => 'warning' },
+        "critical:s"      => { name => 'critical' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+
+    if (($self->{perfdata}->threshold_validate(label => 'warning', value => $self->{option_results}->{warning})) == 0) {
+       $self->{output}->add_option_msg(short_msg => "Wrong warning threshold '" . $self->{option_results}->{warning} . "'.");
+       $self->{output}->option_exit();
+    }
+    if (($self->{perfdata}->threshold_validate(label => 'critical', value => $self->{option_results}->{critical})) == 0) {
+       $self->{output}->add_option_msg(short_msg => "Wrong critical threshold '" . $self->{option_results}->{critical} . "'.");
+       $self->{output}->option_exit();
+    }
+}
+
+sub run {
+    my ($self, %options) = @_;
+    $self->{snmp} = $options{snmp};
+
+    my $oid_cppmSystemDiskSpaceFree = '.1.3.6.1.4.1.14823.1.6.1.1.1.1.1.15.0';
+    my $oid_cppmSystemDiskSpaceTotal = '.1.3.6.1.4.1.14823.1.6.1.1.1.1.1.14.0';
+
+    my $result = $self->{snmp}->get_leef(
+        oids => [$oid_cppmSystemDiskSpaceFree, $oid_cppmSystemDiskSpaceTotal],
+        nothing_quit => 1
+    );
+
+    my $disk = {
+        free => $result->{$oid_cppmSystemDiskSpaceFree},
+        total => $result->{$oid_cppmSystemDiskSpaceTotal}
+    };
+
+    $disk->{used} = $disk->{total} - $disk->{free};
+    $disk->{used_prct} = ($disk->{used} / $disk->{total}) * 100 ;
+    $disk->{free_prct} = 100 - $disk->{used_prct};
+
+    my $exit = $self->{perfdata}->threshold_check(value => $disk->{used_prct}, threshold => [ { label => 'critical', exit_litteral => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
+
+    $self->{output}->output_add(
+        severity => $exit,
+        short_msg => sprintf(
+            "Disk total: %skB used: %skB (%.2f%%) free: %skB (%.2f%%)",
+                        $disk->{total} / 1024,
+                        $disk->{used} / 1024,
+                        $disk->{used_prct},
+                        $disk->{free} / 1024,
+                        $disk->{free_prct}
+        )
+    );
+
+    my $warning_value = 0;
+    my $critical_value = 0;
+
+    if (defined($self->{option_results}->{warning}) && $self->{option_results}->{warning} ne '') {
+        $warning_value = int(($self->{option_results}->{warning}/100) * $disk->{total});
+    }
+    if (defined($self->{option_results}->{critical}) && $self->{option_results}->{critical} ne '') {
+        $critical_value = int(($self->{option_results}->{critical}/100) * $disk->{total});
+    }
+
+    $self->{output}->perfdata_add(
+        label => "used", unit => 'B',
+        value => $disk->{used},
+        min => 0,
+        warning => $warning_value,
+        critical => $critical_value,
+        max => $disk->{total},
+    );
+
+    $self->{output}->display();
+    $self->{output}->exit();
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check ClearPass server disk.
+
+=over 8
+
+=item B<--warning>
+
+Threshold warning in percent.
+
+=item B<--critical>
+
+Threshold critical in percent.
+
+=back
+
+=cut

--- a/src/network/aruba/clearpass/snmp/mode/memory.pm
+++ b/src/network/aruba/clearpass/snmp/mode/memory.pm
@@ -1,0 +1,134 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Alexandre Moreau <alexandre.moreau@cheops.fr> (@SpyL1nk)
+
+package network::aruba::clearpass::snmp::mode::memory;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        "warning:s"       => { name => 'warning' },
+        "critical:s"      => { name => 'critical' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+
+    if (($self->{perfdata}->threshold_validate(label => 'warning', value => $self->{option_results}->{warning})) == 0) {
+       $self->{output}->add_option_msg(short_msg => "Wrong warning threshold '" . $self->{option_results}->{warning} . "'.");
+       $self->{output}->option_exit();
+    }
+    if (($self->{perfdata}->threshold_validate(label => 'critical', value => $self->{option_results}->{critical})) == 0) {
+       $self->{output}->add_option_msg(short_msg => "Wrong critical threshold '" . $self->{option_results}->{critical} . "'.");
+       $self->{output}->option_exit();
+    }
+}
+
+sub run {
+    my ($self, %options) = @_;
+    $self->{snmp} = $options{snmp};
+
+    my $oid_cppmSystemMemoryFree = '.1.3.6.1.4.1.14823.1.6.1.1.1.1.1.13.0';
+    my $oid_cppmSystemMemoryTotal = '.1.3.6.1.4.1.14823.1.6.1.1.1.1.1.12.0';
+
+    my $result = $self->{snmp}->get_leef(
+        oids => [$oid_cppmSystemMemoryFree, $oid_cppmSystemMemoryTotal],
+        nothing_quit => 1
+    );
+
+    my $memory = {
+        free => $result->{$oid_cppmSystemMemoryFree},
+        total => $result->{$oid_cppmSystemMemoryTotal}
+    };
+
+    $memory->{used} = $memory->{total} - $memory->{free};
+    $memory->{used_prct} = ($memory->{used} / $memory->{total}) * 100 ;
+    $memory->{free_prct} = 100 - $memory->{used_prct};
+
+    my $exit = $self->{perfdata}->threshold_check(value => $memory->{used_prct}, threshold => [ { label => 'critical', exit_litteral => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
+
+    $self->{output}->output_add(
+        severity => $exit,
+        short_msg => sprintf(
+            "Memory total: %skB used: %skB (%.2f%%) free: %skB (%.2f%%)",
+                        $memory->{total} / 1024,
+                        $memory->{used} / 1024,
+                        $memory->{used_prct},
+                        $memory->{free} / 1024,
+                        $memory->{free_prct}
+        )
+    );
+
+    my $warning_value = 0;
+    my $critical_value = 0;
+
+    if (defined($self->{option_results}->{warning}) && $self->{option_results}->{warning} ne '') {
+        $warning_value = int(($self->{option_results}->{warning}/100) * $memory->{total});
+    }
+    if (defined($self->{option_results}->{critical}) && $self->{option_results}->{critical} ne '') {
+        $critical_value = int(($self->{option_results}->{critical}/100) * $memory->{total});
+    }
+
+    $self->{output}->perfdata_add(
+        label => "used", unit => 'B',
+        value => $memory->{used},
+        min => 0,
+        warning => $warning_value,
+        critical => $critical_value,
+        max => $memory->{total},
+    );
+
+    $self->{output}->display();
+    $self->{output}->exit();
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check ClearPass server memory.
+
+=over 8
+
+=item B<--warning>
+
+Threshold warning in percent.
+
+=item B<--critical>
+
+Threshold critical in percent.
+
+=back
+
+=cut

--- a/src/network/aruba/clearpass/snmp/mode/radius.pm
+++ b/src/network/aruba/clearpass/snmp/mode/radius.pm
@@ -1,0 +1,196 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Alexandre Moreau <alexandre.moreau@cheops.fr> (@SpyL1nk)
+
+package network::aruba::clearpass::snmp::mode::radius;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        "warning:s"         => { name => 'warning' },
+        "critical:s"        => { name => 'critical' },
+        "filter-counter:s"  => { name => 'filter_counter' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+
+    if (($self->{perfdata}->threshold_validate(label => 'warning', value => $self->{option_results}->{warning})) == 0) {
+       $self->{output}->add_option_msg(short_msg => "Wrong warning threshold '" . $self->{option_results}->{warning} . "'.");
+       $self->{output}->option_exit();
+    }
+    if (($self->{perfdata}->threshold_validate(label => 'critical', value => $self->{option_results}->{critical})) == 0) {
+       $self->{output}->add_option_msg(short_msg => "Wrong critical threshold '" . $self->{option_results}->{critical} . "'.");
+       $self->{output}->option_exit();
+    }
+}
+
+sub run {
+    my ($self, %options) = @_;
+    $self->{snmp} = $options{snmp};
+
+    my $oid_radPolicyEvalTime       = '.1.3.6.1.4.1.14823.1.6.1.1.2.1.1.1.0';
+    my $oid_radAuthRequestTime      = '.1.3.6.1.4.1.14823.1.6.1.1.2.1.1.2.0';
+    my $oid_radServerCounterSuccess = '.1.3.6.1.4.1.14823.1.6.1.1.2.1.1.3.0';
+    my $oid_radServerCounterFailure = '.1.3.6.1.4.1.14823.1.6.1.1.2.1.1.4.0';
+    my $oid_radServerCounterCount   = '.1.3.6.1.4.1.14823.1.6.1.1.2.1.1.5.0';
+
+    my $result = $self->{snmp}->get_leef(
+        oids => [$oid_radPolicyEvalTime,
+            $oid_radAuthRequestTime,
+            $oid_radServerCounterSuccess,
+            $oid_radServerCounterFailure,
+            $oid_radServerCounterCount],
+        nothing_quit => 1
+    );
+
+    my $radius = {
+        policy_eval_time    => $result->{$oid_radPolicyEvalTime},
+        auth_req_time       => $result->{$oid_radAuthRequestTime},
+        auth_success        => $result->{$oid_radServerCounterSuccess},
+        auth_failure        => $result->{$oid_radServerCounterFailure},
+        auth_total          => $result->{$oid_radServerCounterCount},
+    };
+
+    my $exit = $self->{perfdata}->threshold_check(value => $radius->{auth_req_time}, threshold => [ { label => 'critical', exit_litteral => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
+
+    $self->{output}->output_add(
+        severity => $exit,
+        short_msg => sprintf(
+            "RADIUS policy eval time: %sms request time: %sms total request (success/failure): %s (%s/%s)",
+                        $radius->{policy_eval_time},
+                        $radius->{auth_req_time},
+                        $radius->{auth_total},
+                        $radius->{auth_success},
+                        $radius->{auth_failure}
+        )
+    );
+
+    if (defined($self->{option_results}->{filter_counter}) && $self->{option_results}->{filter_counter} ne '') {
+        if  ("policy_eval_time" =~ /$self->{option_results}->{filter_counter}/) {
+            $self->{output}->perfdata_add(
+                label => "policy_eval_time", unit => 'ms',
+                value => $radius->{policy_eval_time},
+                min => 0,
+            );
+        }
+
+        if  ("auth_req_time" =~ /$self->{option_results}->{filter_counter}/) {
+            $self->{output}->perfdata_add(
+                label => "auth_req_time", unit => 'ms',
+                value => $radius->{auth_req_time},
+                min => 0,
+            );
+        }
+    
+        if  ("auth_success" =~ /$self->{option_results}->{filter_counter}/) {
+            $self->{output}->perfdata_add(
+                label => "auth_success",
+                value => $radius->{auth_success},
+                min => 0,
+            );
+        }
+
+        if  ("auth_failure" =~ /$self->{option_results}->{filter_counter}/) {
+            $self->{output}->perfdata_add(
+                label => "auth_failure",
+                value => $radius->{auth_failure},
+                min => 0,
+            );
+        }
+
+        if  ("auth_total" =~ /$self->{option_results}->{filter_counter}/) {
+            $self->{output}->perfdata_add(
+                label => "auth_total",
+                value => $radius->{auth_total},
+                min => 0,
+            );
+        }
+    } else {
+        $self->{output}->perfdata_add(
+            label => "policy_eval_time", unit => 'ms',
+            value => $radius->{policy_eval_time},
+            min => 0,
+        );
+        $self->{output}->perfdata_add(
+            label => "auth_req_time", unit => 'ms',
+            value => $radius->{auth_req_time},
+            min => 0,
+        );
+        $self->{output}->perfdata_add(
+            label => "auth_success",
+            value => $radius->{auth_success},
+            min => 0,
+        );
+        $self->{output}->perfdata_add(
+            label => "auth_failure",
+            value => $radius->{auth_failure},
+            min => 0,
+        );
+        $self->{output}->perfdata_add(
+            label => "auth_total",
+            value => $radius->{auth_total},
+            min => 0,
+        );
+    }
+
+    $self->{output}->display();
+    $self->{output}->exit();
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check ClearPass server RADIUS statistics.
+
+=over 8
+
+=item B<--warning>
+
+Threshold warning in miliseconds.
+
+=item B<--critical>
+
+Threshold critical in miliseconds.
+
+=item B<--filter-counter>
+
+Filter perfdata output, match regular expression.
+Existing counters are: policy_eval_time,auth_req_time,
+auth_success,auth_failure,auth_total
+
+=back
+
+=cut

--- a/src/network/aruba/clearpass/snmp/mode/repository.pm
+++ b/src/network/aruba/clearpass/snmp/mode/repository.pm
@@ -1,0 +1,197 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Alexandre Moreau <alexandre.moreau@cheops.fr> (@SpyL1nk)
+
+package network::aruba::clearpass::snmp::mode::repository;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        "warning:s"         => { name => 'warning' },
+        "critical:s"        => { name => 'critical' },
+        "filter-name:s"     => { name => 'filter_name' },
+        "filter-counter:s"  => { name => 'filter_counter' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+
+    if (($self->{perfdata}->threshold_validate(label => 'warning', value => $self->{option_results}->{warning})) == 0) {
+       $self->{output}->add_option_msg(short_msg => "Wrong warning threshold '" . $self->{option_results}->{warning} . "'.");
+       $self->{output}->option_exit();
+    }
+    if (($self->{perfdata}->threshold_validate(label => 'critical', value => $self->{option_results}->{critical})) == 0) {
+       $self->{output}->add_option_msg(short_msg => "Wrong critical threshold '" . $self->{option_results}->{critical} . "'.");
+       $self->{output}->option_exit();
+    }
+}
+
+sub run {
+    my ($self, %options) = @_;
+    $self->{snmp} = $options{snmp};
+
+    my $mapping = {
+        radAuthSourceName       => { oid => '.1.3.6.1.4.1.14823.1.6.1.1.2.2.1.2' },
+        radAuthCounterSuccess   => { oid => '.1.3.6.1.4.1.14823.1.6.1.1.2.2.1.3' },
+        radAuthCounterFailure   => { oid => '.1.3.6.1.4.1.14823.1.6.1.1.2.2.1.4' },
+        radAuthCounterCount     => { oid => '.1.3.6.1.4.1.14823.1.6.1.1.2.2.1.5' },
+        radAuthCounterTime      => { oid => '.1.3.6.1.4.1.14823.1.6.1.1.2.2.1.6' },
+    };
+
+    my $oid_radiusServerAuthTableEntry = '.1.3.6.1.4.1.14823.1.6.1.1.2.2.1';
+
+    my $snmp_result = $options{snmp}->get_multiple_table(
+        oids => [
+            { oid => $oid_radiusServerAuthTableEntry,
+                start => $mapping->{radAuthSourceName}->{oid},
+                end => $mapping->{radAuthCounterTime}->{oid}
+            },
+        ],
+    );
+
+    my $authsource_count = 0;
+    foreach my $oid (keys %{$snmp_result->{$oid_radiusServerAuthTableEntry}}) {
+        next if ($oid !~ /^$mapping->{radAuthSourceName}->{oid}\.(.*)$/);
+        my $instance = $1;
+        my $result = $options{snmp}->map_instance(mapping => $mapping, results => $snmp_result->{$oid_radiusServerAuthTableEntry}, instance => $instance);
+
+        if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
+            $result->{radAuthSourceName} !~ /$self->{option_results}->{filter_name}/) {
+            $self->{output}->output_add(long_msg => "skipping authentication source '" . $result->{radAuthSourceName} . "'.", debug => 1);
+            next;
+        }
+
+        $authsource_count++;
+        my $exit = $self->{perfdata}->threshold_check(value => $result->{radAuthCounterTime}, threshold => [ { label => 'critical', exit_litteral => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
+
+        $self->{output}->output_add(
+            severity => $exit,
+            short_msg => sprintf(
+                "%s: total request (success/failure): %s (%s/%s) average request time: %sms",
+                            $result->{radAuthSourceName},
+                            $result->{radAuthCounterCount},
+                            $result->{radAuthCounterSuccess},
+                            $result->{radAuthCounterFailure},
+                            $result->{radAuthCounterTime}
+            )
+        );
+
+        if (defined($self->{option_results}->{filter_counter}) && $self->{option_results}->{filter_counter} ne '') {
+            if  ("auth_total" =~ /$self->{option_results}->{filter_counter}/) {
+                $self->{output}->perfdata_add(
+                    label => $result->{radAuthSourceName} . "_auth_total",
+                    value => $result->{radAuthCounterCount},
+                    min => 0,
+                );
+            }
+
+            if  ("auth_success" =~ /$self->{option_results}->{filter_counter}/) {
+                $self->{output}->perfdata_add(
+                    label => $result->{radAuthSourceName} . "_auth_success",
+                    value => $result->{radAuthCounterSuccess},
+                    min => 0,
+                );
+            }
+
+            if  ("auth_failure" =~ /$self->{option_results}->{filter_counter}/) {
+                $self->{output}->perfdata_add(
+                    label => $result->{radAuthSourceName} . "_auth_failure",
+                    value => $result->{radAuthCounterFailure},
+                    min => 0,
+                );
+            }
+
+            if  ("auth_time" =~ /$self->{option_results}->{filter_counter}/) {
+                $self->{output}->perfdata_add(
+                    label => $result->{radAuthSourceName} . "_auth_time", unit => 'ms',
+                    value => $result->{radAuthCounterTime},
+                    min => 0,
+                );
+            }
+        } else {
+            $self->{output}->perfdata_add(
+                label => $result->{radAuthSourceName} . "_auth_total",
+                value => $result->{radAuthCounterCount},
+                min => 0,
+            );
+            $self->{output}->perfdata_add(
+                label => $result->{radAuthSourceName} . "_auth_success",
+                value => $result->{radAuthCounterSuccess},
+                min => 0,
+            );
+            $self->{output}->perfdata_add(
+                label => $result->{radAuthSourceName} . "_auth_failure",
+                value => $result->{radAuthCounterFailure},
+                min => 0,
+            );
+            $self->{output}->perfdata_add(
+                label => $result->{radAuthSourceName} . "_auth_time", unit => 'ms',
+                value => $result->{radAuthCounterTime},
+                min => 0,
+            );
+        }
+    }
+
+    $self->{output}->display();
+    $self->{output}->exit();
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check ClearPass authentication repository statistics.
+
+=over 8
+
+=item B<--warning>
+
+Threshold warning in miliseconds.
+
+=item B<--critical>
+
+Threshold critical in miliseconds.
+
+=item B<--filter-counters>
+
+Only display some counters (regexp can be used).
+Example: --filter-counters='^cpu$'
+
+=item B<--filter-name>
+
+Filter authentication source name (can be a regexp).
+
+=back
+
+=cut

--- a/src/network/aruba/clearpass/snmp/mode/tacacs.pm
+++ b/src/network/aruba/clearpass/snmp/mode/tacacs.pm
@@ -1,0 +1,245 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Alexandre Moreau <alexandre.moreau@cheops.fr> (@SpyL1nk)
+
+package network::aruba::clearpass::snmp::mode::tacacs;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        "warning:s"         => { name => 'warning' },
+        "critical:s"        => { name => 'critical' },
+        "filter-counter:s"  => { name => 'filter_counter' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+
+    if (($self->{perfdata}->threshold_validate(label => 'warning', value => $self->{option_results}->{warning})) == 0) {
+       $self->{output}->add_option_msg(short_msg => "Wrong warning threshold '" . $self->{option_results}->{warning} . "'.");
+       $self->{output}->option_exit();
+    }
+    if (($self->{perfdata}->threshold_validate(label => 'critical', value => $self->{option_results}->{critical})) == 0) {
+       $self->{output}->add_option_msg(short_msg => "Wrong critical threshold '" . $self->{option_results}->{critical} . "'.");
+       $self->{output}->option_exit();
+    }
+}
+
+sub run {
+    my ($self, %options) = @_;
+    $self->{snmp} = $options{snmp};
+
+    my $oid_tacAuthCounterSuccess       = '.1.3.6.1.4.1.14823.1.6.1.1.2.7.1.1.0';
+    my $oid_tacAuthCounterFailure       = '.1.3.6.1.4.1.14823.1.6.1.1.2.7.1.2.0';
+    my $oid_tacAuthCounterCount         = '.1.3.6.1.4.1.14823.1.6.1.1.2.7.1.3.0';
+    my $oid_tacAuthCounterTime          = '.1.3.6.1.4.1.14823.1.6.1.1.2.7.1.4.0';
+    my $oid_tacAuthCounterAuthTime      = '.1.3.6.1.4.1.14823.1.6.1.1.2.7.1.5.0';
+    my $oid_tacServicePolicyEvalTime    = '.1.3.6.1.4.1.14823.1.6.1.1.2.7.1.6.0';
+    my $oid_tacPolicyEvalTime           = '.1.3.6.1.4.1.14823.1.6.1.1.2.7.1.7.0';
+
+    my $result = $self->{snmp}->get_leef(
+        oids => [$oid_tacAuthCounterSuccess,
+            $oid_tacAuthCounterFailure,
+            $oid_tacAuthCounterCount,
+            $oid_tacAuthCounterTime,
+            $oid_tacAuthCounterAuthTime,
+            $oid_tacServicePolicyEvalTime,
+            $oid_tacPolicyEvalTime],
+        nothing_quit => 1
+    );
+
+    my $tacacs = {
+        auth_success        => $result->{$oid_tacAuthCounterSuccess},
+        auth_failure        => $result->{$oid_tacAuthCounterFailure},
+        auth_total          => $result->{$oid_tacAuthCounterCount},
+        auth_e2e_time       => $result->{$oid_tacAuthCounterTime},
+        auth_req_time       => $result->{$oid_tacAuthCounterAuthTime},
+        service_eval_time   => $result->{$oid_tacServicePolicyEvalTime},
+        policy_eval_time    => $result->{$oid_tacPolicyEvalTime},
+    };
+
+    my $exit = $self->{perfdata}->threshold_check(value => $tacacs->{auth_req_time}, threshold => [ { label => 'critical', exit_litteral => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
+
+    $self->{output}->output_add(
+        severity => $exit,
+        short_msg => sprintf(
+            "TACACS+ policy eval time: %sms service eval time: %sms request time: %sms request end-to-end: %sms total request (success/failure): %s (%s/%s)",
+                        $tacacs->{policy_eval_time},
+                        $tacacs->{service_eval_time},
+                        $tacacs->{auth_req_time},
+                        $tacacs->{auth_e2e_time},
+                        $tacacs->{auth_total},
+                        $tacacs->{auth_success},
+                        $tacacs->{auth_failure}
+        )
+    );
+
+    if (defined($self->{option_results}->{filter_counter}) && $self->{option_results}->{filter_counter} ne '') {
+        if  ("auth_success" =~ /$self->{option_results}->{filter_counter}/) {
+
+            $self->{output}->perfdata_add(
+                label => "auth_success",
+                value => $tacacs->{auth_success},
+                min => 0,
+            );
+        }
+
+        if ("auth_failure" =~ /$self->{option_results}->{filter_counter}/) {
+
+            $self->{output}->perfdata_add(
+                label => "auth_failure",
+                value => $tacacs->{auth_failure},
+                min => 0,
+            );
+        }
+
+        if ("auth_total" =~ /$self->{option_results}->{filter_counter}/) {
+
+            $self->{output}->perfdata_add(
+                label => "auth_total",
+                value => $tacacs->{auth_total},
+                min => 0,
+            );
+        }
+
+        if ("auth_e2e_time" =~ /$self->{option_results}->{filter_counter}/) {
+
+            $self->{output}->perfdata_add(
+                label => "auth_e2e_time", unit => 'ms',
+                value => $tacacs->{auth_e2e_time},
+                min => 0,
+            );
+        }
+
+        if ("auth_req_time" =~ /$self->{option_results}->{filter_counter}/) {
+
+            $self->{output}->perfdata_add(
+                label => "auth_req_time", unit => 'ms',
+                value => $tacacs->{auth_req_time},
+                min => 0,
+            );
+        }
+
+        if ("service_eval_time" =~ /$self->{option_results}->{filter_counter}/) {
+
+            $self->{output}->perfdata_add(
+                label => "service_eval_time", unit => 'ms',
+                value => $tacacs->{service_eval_time},
+                min => 0,
+            );
+        }
+
+        if ("policy_eval_time" =~ /$self->{option_results}->{filter_counter}/) {
+
+            $self->{output}->perfdata_add(
+                label => "policy_eval_time", unit => 'ms',
+                value => $tacacs->{policy_eval_time},
+                min => 0,
+            );
+        }
+    } else {
+        $self->{output}->perfdata_add(
+            label => "auth_success",
+            value => $tacacs->{auth_success},
+            min => 0,
+        );
+
+        $self->{output}->perfdata_add(
+            label => "auth_failure",
+            value => $tacacs->{auth_failure},
+            min => 0,
+        );
+
+        $self->{output}->perfdata_add(
+            label => "auth_total",
+            value => $tacacs->{auth_total},
+            min => 0,
+        );
+
+        $self->{output}->perfdata_add(
+            label => "auth_e2e_time", unit => 'ms',
+            value => $tacacs->{auth_e2e_time},
+            min => 0,
+        );
+
+        $self->{output}->perfdata_add(
+            label => "auth_req_time", unit => 'ms',
+            value => $tacacs->{auth_req_time},
+            min => 0,
+        );
+
+        $self->{output}->perfdata_add(
+            label => "service_eval_time", unit => 'ms',
+            value => $tacacs->{service_eval_time},
+            min => 0,
+        );
+
+        $self->{output}->perfdata_add(
+            label => "policy_eval_time", unit => 'ms',
+            value => $tacacs->{policy_eval_time},
+            min => 0,
+        );
+    }
+
+
+    $self->{output}->display();
+    $self->{output}->exit();
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check ClearPass server TACACS+ statistics.
+
+=over 8
+
+=item B<--warning>
+
+Threshold warning in miliseconds.
+
+=item B<--critical>
+
+Threshold critical in miliseconds.
+
+=item B<--filter-counter>
+
+Filter perfdata output, match regular expression.
+Existing counters are: auth_success,auth_failure,auth_total,
+auth_e2e_time,auth_req_time,service_eval_time,policy_eval_time
+
+
+=back
+
+=cut

--- a/src/network/aruba/clearpass/snmp/plugin.pm
+++ b/src/network/aruba/clearpass/snmp/plugin.pm
@@ -1,0 +1,55 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Alexandre Moreau <alexandre.moreau@cheops.fr> (@SpyL1nk)
+
+package network::aruba::clearpass::snmp::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_snmp);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{version} = '1.0';
+    %{$self->{modes}} = (
+        'cpu'               => 'snmp_standard::mode::cpu',
+        'memory'            => 'network::aruba::clearpass::snmp::mode::memory',
+        'disk'              => 'network::aruba::clearpass::snmp::mode::disk',
+        'radius-counter'    => 'network::aruba::clearpass::snmp::mode::radius-counter',
+        'radius'            => 'network::aruba::clearpass::snmp::mode::radius',
+        'tacacs'            => 'network::aruba::clearpass::snmp::mode::tacacs',
+        'repository'        => 'network::aruba::clearpass::snmp::mode::repository',
+    );
+
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 PLUGIN DESCRIPTION
+
+Check Aruba ClearPass in SNMP.
+
+=cut


### PR DESCRIPTION
## Description

New plugin used to monitor Aruba's ClearPass server (Network Access Control solution).
Typical monitor system monitor are used with other mode specific regarding RADIUS & TACACS+ requests.
Developped internaly for Cheops Technology and provided to the community.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
