### PR TITLE
(plugin) apps::protocols::x509 - add support for verify_hostname

### DIFF
--- a/src/apps/protocols/x509/custom/tcp.pm
+++ b/src/apps/protocols/x509/custom/tcp.pm
@@ -209,6 +209,21 @@ sub get_certificate_informations {
     $cert_infos->{subject} = $socket->peer_certificate('commonName');
     $cert_infos->{issuer} = $socket->peer_certificate('authority');
 
+    if (defined($self->{ssl_context}->{SSL_verify_mode}) &&
+        defined($self->{option_results}->{servername}) &&
+        $self->{ssl_context}->{SSL_verify_mode} == SSL_VERIFY_NONE) {
+        $cert_infos->{verify_hostname} =  $socket->verify_hostname(
+            $self->{option_results}->{servername},
+            # like default scheme
+            {
+                wildcards_in_cn => 'anywhere',
+                wildcards_in_alt => 'anywhere',
+                check_cn => 'always',
+                ip_in_cn => 1,
+            }
+        );
+    }
+
     my @subject_alt_names = $socket->peer_certificate('subjectAltNames');
     my $append = '';
     $cert_infos->{alt_subjects} = '';

--- a/src/apps/protocols/x509/mode/certificate.pm
+++ b/src/apps/protocols/x509/mode/certificate.pm
@@ -34,8 +34,14 @@ sub custom_status_output {
         $self->{result_values}->{subject}, $self->{result_values}->{expiration}, $self->{result_values}->{date},
         $self->{result_values}->{issuer}
     );
+    if (defined($self->{result_values}->{verify_hostname}) && $self->{result_values}->{verify_hostname} eq 'FAILED') {
+        $msg = sprintf("Verify hostname status '%s'. ", $self->{result_values}->{verify_hostname}).$msg;
+    }
     if (defined($self->{result_values}->{alt_subjects}) && $self->{result_values}->{alt_subjects} ne '') {
         $self->{output}->output_add(long_msg => sprintf("Alternative subject names: %s.", $self->{result_values}->{alt_subjects}));
+    }
+    if (defined($self->{result_values}->{verify_hostname}) && $self->{result_values}->{verify_hostname} ne '-') {
+        $self->{output}->output_add(long_msg => sprintf("Verify hostname result: %s.", $self->{result_values}->{verify_hostname}));
     }
     return $msg;
 }
@@ -48,6 +54,7 @@ sub custom_status_calc {
     $self->{result_values}->{expiration} = ($options{new_datas}->{$self->{instance} . '_expiration'} - time()) / 86400;
     $self->{result_values}->{date} = $options{new_datas}->{$self->{instance} . '_date'};
     $self->{result_values}->{alt_subjects} = $options{new_datas}->{$self->{instance} . '_alt_subjects'};
+    $self->{result_values}->{verify_hostname} = $options{new_datas}->{$self->{instance} . '_verify_hostname'};
     return 0;
 }
 
@@ -63,11 +70,13 @@ sub set_counters {
             label => 'status', type => 2,
             warning_default => '%{expiration} < 60',
             critical_default => '%{expiration} < 30',
+            unknown_default => '%{verify_hostname} eq "FAILED"',
             set => {
                 key_values => [
                     { name => 'subject' }, { name => 'issuer' },
                     { name => 'expiration' }, { name => 'date' },
-                    { name => 'alt_subjects' }
+                    { name => 'alt_subjects' },
+                    { name => 'verify_hostname' },
                 ],
                 closure_custom_calc => $self->can('custom_status_calc'),
                 closure_custom_output => $self->can('custom_status_output'),
@@ -99,7 +108,9 @@ sub manage_selection {
         issuer => defined($cert->{issuer}) ? $cert->{issuer} : '-',
         expiration => $cert->{expiration},
         date => $cert->{expiration_date},
-        alt_subjects => $cert->{alt_subjects}
+        alt_subjects => $cert->{alt_subjects},
+        verify_hostname => defined($cert->{verify_hostname})
+            ? ($cert->{verify_hostname} ? "OK" : "FAILED") : '-',
     };
 }
 


### PR DESCRIPTION
This patch allows to get an UNKNOWN state when the following conditions are all true:

- plugin custommode tcp is used
- SSL_verify_mode => SSL_VERIFY_NONE is used (above all we check certicate expiration here)
- the CN/SANs in the certificate returned by the server does not match the servername given in the plugin options

It allows to check for certificate expiration and ensures the certificate presented by the server matches the name requested. Otherwise a valid certificate (dates) for an invalid servername would return an OK state, which ones can interpret as a wrong status considering the given servername option.

```
/opt/centreon-plugins/centreon_plugins.pl \
    --plugin 'apps::protocols::x509::plugin' \
    --mode 'certificate' \
    --custommode 'tcp' \
    --ssl-opt 'SSL_verify_mode => SSL_VERIFY_NONE' \
    --ssl-ignore-errors \
    --hostname '1.2.3.4' \
    --port '443' \
    --servername 'www.domain.tld' \
    --warning-status '%{expiration} < 45' \
    --critical-status '%{expiration} < 25' \
    --timeout '5'
```