### PR TITLE
add modes to cloud::azure::compute::aks::plugin

### DIFF
--- a/src/cloud/azure/compute/aks/mode/memory.pm
+++ b/src/cloud/azure/compute/aks/mode/memory.pm
@@ -1,0 +1,180 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::compute::aks::mode::memory;
+use base qw(cloud::azure::custom::mode);
+
+
+use strict;
+use warnings;
+
+sub get_metrics_mapping {
+    my ($self, %options) = @_;
+
+    my $metrics_mapping = {
+        'node_memory_rss_bytes' => { 
+            'output' => 'memory RSS Usage',
+            'label'  => 'memory-rss-usage',
+            'nlabel' => 'aks.node.memory.rss.bytes',
+            'unit'   => 'B',
+            'min'    => '0'
+        },
+        'node_memory_rss_percentage' => {
+            'output' => 'Memory RSS Percent',
+            'label'  => 'memory-rss-percent',
+            'nlabel' => 'aks.node.memory.rss.percentage',
+            'unit'   => '%',
+            'min'    => '0',
+            'max'    => '100'
+        },
+        'node_memory_working_set_bytes' => { 
+            'output' => 'memory Usage',
+            'label'  => 'memory-usage',
+            'nlabel' => 'aks.node.memory.working.set.bytes',
+            'unit'   => 'B',
+            'min'    => '0'
+        },
+        'node_memory_working_set_percentage' => {
+            'output' => 'Memory Percent',
+            'label'  => 'memory-percent',
+            'nlabel' => 'aks.node.memory.working.set.percentage',
+            'unit'   => '%',
+            'min'    => '0',
+            'max'    => '100'
+        }
+
+    };
+
+    return $metrics_mapping;
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-metric:s'  => { name => 'filter_metric' },
+        'resource:s'       => { name => 'resource' },
+        'resource-group:s' => { name => 'resource_group' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{resource}) || $self->{option_results}->{resource} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify either --resource <name> with --resource-group option or --resource <id>.');
+        $self->{output}->option_exit();
+    }
+
+    my $resource = $self->{option_results}->{resource};
+    my $resource_group = defined($self->{option_results}->{resource_group}) ? $self->{option_results}->{resource_group} : '';
+    my $resource_type = $self->{option_results}->{resource_type};
+    if ($resource =~ /^\/subscriptions\/.*\/resourceGroups\/(.*)\/providers\/Microsoft\.ContainerService\/managedClusters\/(.*)$/) {
+        $resource_group = $1;
+        $resource = $2;
+    }
+
+    $self->{az_resource} = $resource;
+    $self->{az_resource_group} = $resource_group;
+    $self->{az_resource_type} = 'managedClusters';
+    $self->{az_resource_namespace} = 'Microsoft.ContainerService';
+    $self->{az_timeframe} = defined($self->{option_results}->{timeframe}) ? $self->{option_results}->{timeframe} : 900;
+    $self->{az_interval} = defined($self->{option_results}->{interval}) ? $self->{option_results}->{interval} : 'PT5M';
+    $self->{az_aggregations} = ['Average'];
+ 
+    foreach my $metric (keys %{$self->{metrics_mapping}}) {
+        next if (defined($self->{option_results}->{filter_metric}) && $self->{option_results}->{filter_metric} ne ''
+            && $metric !~ /$self->{option_results}->{filter_metric}/);
+        push @{$self->{az_metrics}}, $metric;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Memory usage on Azure Kubernetes Cluster. 
+
+Example:
+
+Using resource name :
+
+perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=memory --custommode=api
+--resource=<cluster_id> --resource-group=<resourcegroup_id> --warning-memory-percent='90' --critical-memory-percent='95'
+
+Using resource id :
+
+perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=storage --custommode=api
+--resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.ContainerService/managedClusters/<cluster_id>' 
+--warning-memory-percent='90' --critical-memory-percent='95'
+
+=over 8
+
+=item B<--resource>
+
+Set resource name or id (Required).
+
+=item B<--resource-group>
+
+Set resource group (Required if resource's name is used).
+
+=item B<--warning-memory-usage>
+
+Warning threshold in Bytes.
+
+=item B<--critical-memory-usage>
+
+Critical threshold in Bytes.
+
+=item B<--warning-memory-percent>
+
+Warning threshold in percent.
+
+=item B<--critical-memory-percent>
+
+Critical threshold in percent.
+
+=item B<--warning-rss-memory-usage>
+
+Warning threshold in Bytes.
+
+=item B<--critical-rss-memory-usage>
+
+Critical threshold in Bytes.
+
+=item B<--warning-rss-memory-percent>
+
+Warning threshold in percent.
+
+=item B<--critical-rss-memory-percent>
+
+Critical threshold in percent.
+
+
+=back
+
+=cut

--- a/src/cloud/azure/compute/aks/mode/nodestate.pm
+++ b/src/cloud/azure/compute/aks/mode/nodestate.pm
@@ -1,0 +1,132 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::compute::aks::mode::nodestate;
+
+use base qw(cloud::azure::custom::mode);
+
+use strict;
+use warnings;
+
+sub get_metrics_mapping {
+    my ($self, %options) = @_;
+
+    my $metrics_mapping = {
+        'kube_node_status_condition' => {
+            'output' => 'Kube Node State Condition',
+            'label'  => 'node-state-condition',
+            'nlabel' => 'aks.kube.node.status.condition',
+            'unit'   => '',
+            'min'    => '0'
+        }
+    };
+
+    return $metrics_mapping;
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-metric:s'  => { name => 'filter_metric' },
+        'resource:s'       => { name => 'resource' },
+        'resource-group:s' => { name => 'resource_group' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{resource}) || $self->{option_results}->{resource} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify either --resource <name> with --resource-group option or --resource <id>.');
+        $self->{output}->option_exit();
+    }
+
+    my $resource = $self->{option_results}->{resource};
+    my $resource_group = defined($self->{option_results}->{resource_group}) ? $self->{option_results}->{resource_group} : '';
+    my $resource_type = $self->{option_results}->{resource_type};
+    if ($resource =~ /^\/subscriptions\/.*\/resourceGroups\/(.*)\/providers\/Microsoft\.ContainerService\/managedClusters\/(.*)$/) {
+        $resource_group = $1;
+        $resource = $2;
+    }
+
+    $self->{az_resource} = $resource;
+    $self->{az_resource_group} = $resource_group;
+    $self->{az_resource_type} = 'managedClusters';
+    $self->{az_resource_namespace} = 'Microsoft.ContainerService';
+    $self->{az_timeframe} = defined($self->{option_results}->{timeframe}) ? $self->{option_results}->{timeframe} : 900;
+    $self->{az_interval} = defined($self->{option_results}->{interval}) ? $self->{option_results}->{interval} : 'PT5M';
+    $self->{az_aggregations} = ['Average'];
+ 
+    foreach my $metric (keys %{$self->{metrics_mapping}}) {
+        next if (defined($self->{option_results}->{filter_metric}) && $self->{option_results}->{filter_metric} ne ''
+            && $metric !~ /$self->{option_results}->{filter_metric}/);
+        push @{$self->{az_metrics}}, $metric;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Azure Kubernetes Number uf Pods by State.
+
+Example:
+
+Using resource name :
+
+perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=nodestate --custommode=api
+--resource=<cluster_id> --resource-group=<resourcegroup_id> --zeroed --warning-node-state-condition=5 --critical-node-state-condition=10
+
+Using resource id :
+
+perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=nodestate --custommode=api
+--resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.ContainerService/managedClusters/<cluster_id>' 
+--zeroed --warning-node-state-condition=5 --critical-node-state-condition=10
+
+
+=over 8
+
+=item B<--resource>
+
+Set resource name or id (Required).
+
+=item B<--resource-group>
+
+Set resource group (Required if resource's name is used).
+
+=item B<--warning-node-state-condition>
+
+Set warning threshold for number of condition nodes.
+
+=item B<--critical-node-state-condition>
+
+Set critical threshold for number of condition nodes.
+
+=back
+
+=cut

--- a/src/cloud/azure/compute/aks/mode/nodestate.pm
+++ b/src/cloud/azure/compute/aks/mode/nodestate.pm
@@ -93,7 +93,7 @@ __END__
 
 =head1 MODE
 
-Check Azure Kubernetes Number uf Pods by State.
+Check Azure Kubernetes Number uf Nodes by State.
 
 Example:
 

--- a/src/cloud/azure/compute/aks/mode/podstate.pm
+++ b/src/cloud/azure/compute/aks/mode/podstate.pm
@@ -1,0 +1,148 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::compute::aks::mode::podstate;
+
+use base qw(cloud::azure::custom::mode);
+
+use strict;
+use warnings;
+
+sub get_metrics_mapping {
+    my ($self, %options) = @_;
+
+    my $metrics_mapping = {
+        'kube_pod_status_ready' => {
+            'output' => 'Kube Pods State Ready',
+            'label'  => 'pod-state-ready',
+            'nlabel' => 'aks.kube.pod.status.ready',
+            'unit'   => '',
+            'min'    => '0'
+        },
+        'kube_pod_status_phase' => {
+            'output' => 'Kube Pods State Phase',
+            'label'  => 'pod-state-phase',
+            'nlabel' => 'aks.kube.pod.status.phase',
+            'unit'   => '',
+            'min'    => '0'
+        }
+
+    };
+
+    return $metrics_mapping;
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-metric:s'  => { name => 'filter_metric' },
+        'resource:s'       => { name => 'resource' },
+        'resource-group:s' => { name => 'resource_group' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{resource}) || $self->{option_results}->{resource} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify either --resource <name> with --resource-group option or --resource <id>.');
+        $self->{output}->option_exit();
+    }
+
+    my $resource = $self->{option_results}->{resource};
+    my $resource_group = defined($self->{option_results}->{resource_group}) ? $self->{option_results}->{resource_group} : '';
+    my $resource_type = $self->{option_results}->{resource_type};
+    if ($resource =~ /^\/subscriptions\/.*\/resourceGroups\/(.*)\/providers\/Microsoft\.ContainerService\/managedClusters\/(.*)$/) {
+        $resource_group = $1;
+        $resource = $2;
+    }
+
+    $self->{az_resource} = $resource;
+    $self->{az_resource_group} = $resource_group;
+    $self->{az_resource_type} = 'managedClusters';
+    $self->{az_resource_namespace} = 'Microsoft.ContainerService';
+    $self->{az_timeframe} = defined($self->{option_results}->{timeframe}) ? $self->{option_results}->{timeframe} : 900;
+    $self->{az_interval} = defined($self->{option_results}->{interval}) ? $self->{option_results}->{interval} : 'PT5M';
+    $self->{az_aggregations} = ['Average'];
+ 
+    foreach my $metric (keys %{$self->{metrics_mapping}}) {
+        next if (defined($self->{option_results}->{filter_metric}) && $self->{option_results}->{filter_metric} ne ''
+            && $metric !~ /$self->{option_results}->{filter_metric}/);
+        push @{$self->{az_metrics}}, $metric;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Azure Kubernetes Number uf Pods by State.
+
+Example:
+
+Using resource name :
+
+perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=nodestate --custommode=api
+--resource=<cluster_id> --resource-group=<resourcegroup_id> --zeroed --warning-node-state-phase=5 --critical-node-state-phase=10
+
+Using resource id :
+
+perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=nodestate --custommode=api
+--resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.ContainerService/managedClusters/<cluster_id>' 
+--zeroed --warning-node-state-phase=5 --critical-node-state-phase=10
+
+
+=over 8
+
+=item B<--resource>
+
+Set resource name or id (Required).
+
+=item B<--resource-group>
+
+Set resource group (Required if resource's name is used).
+
+=item B<--warning-pod-state-ready>
+
+Set warning threshold for number of Pods State Ready.
+
+=item B<--critical-pod-state-ready>
+
+Set critical threshold for number of Pods State Ready.
+
+=item B<--warning-pod-state-phase>
+
+Set warning threshold for number of Pods State Phase.
+
+=item B<--critical-pod-state-phase>
+
+Set critical threshold for number of Pods State Phase.
+
+=back
+
+=cut

--- a/src/cloud/azure/compute/aks/mode/podstate.pm
+++ b/src/cloud/azure/compute/aks/mode/podstate.pm
@@ -107,14 +107,14 @@ Example:
 
 Using resource name :
 
-perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=nodestate --custommode=api
---resource=<cluster_id> --resource-group=<resourcegroup_id> --zeroed --warning-node-state-phase=5 --critical-node-state-phase=10
+perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=pod-state --custommode=api
+--resource=<cluster_id> --resource-group=<resourcegroup_id> --zeroed --warning-pod-state-phase=5 --critical-pod-state-phase=10
 
 Using resource id :
 
-perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=nodestate --custommode=api
+perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=pod-state --custommode=api
 --resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.ContainerService/managedClusters/<cluster_id>' 
---zeroed --warning-node-state-phase=5 --critical-node-state-phase=10
+--zeroed --warning-pod-state-phase=5 --critical-pod-state-phase=10
 
 
 =over 8

--- a/src/cloud/azure/compute/aks/mode/unschedulablepods.pm
+++ b/src/cloud/azure/compute/aks/mode/unschedulablepods.pm
@@ -1,0 +1,132 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::compute::aks::mode::unschedulablepods;
+
+use base qw(cloud::azure::custom::mode);
+
+use strict;
+use warnings;
+
+sub get_metrics_mapping {
+    my ($self, %options) = @_;
+
+    my $metrics_mapping = {
+        'cluster_autoscaler_unschedulable_pods_count' => {
+            'output' => 'Cluster Autoscaler Unschedulable Pods',
+            'label'  => 'unschedulable-pods',
+            'nlabel' => 'aks.cluster.autoscaler.unschedulable.pods',
+            'unit'   => '',
+            'min'    => '0',
+        }
+    };
+
+    return $metrics_mapping;
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-metric:s'  => { name => 'filter_metric' },
+        'resource:s'       => { name => 'resource' },
+        'resource-group:s' => { name => 'resource_group' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{resource}) || $self->{option_results}->{resource} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify either --resource <name> with --resource-group option or --resource <id>.');
+        $self->{output}->option_exit();
+    }
+
+    my $resource = $self->{option_results}->{resource};
+    my $resource_group = defined($self->{option_results}->{resource_group}) ? $self->{option_results}->{resource_group} : '';
+    my $resource_type = $self->{option_results}->{resource_type};
+    if ($resource =~ /^\/subscriptions\/.*\/resourceGroups\/(.*)\/providers\/Microsoft\.ContainerService\/managedClusters\/(.*)$/) {
+        $resource_group = $1;
+        $resource = $2;
+    }
+
+    $self->{az_resource} = $resource;
+    $self->{az_resource_group} = $resource_group;
+    $self->{az_resource_type} = 'managedClusters';
+    $self->{az_resource_namespace} = 'Microsoft.ContainerService';
+    $self->{az_timeframe} = defined($self->{option_results}->{timeframe}) ? $self->{option_results}->{timeframe} : 900;
+    $self->{az_interval} = defined($self->{option_results}->{interval}) ? $self->{option_results}->{interval} : 'PT5M';
+    $self->{az_aggregations} = ['Average'];
+ 
+    foreach my $metric (keys %{$self->{metrics_mapping}}) {
+        next if (defined($self->{option_results}->{filter_metric}) && $self->{option_results}->{filter_metric} ne ''
+            && $metric !~ /$self->{option_results}->{filter_metric}/);
+        push @{$self->{az_metrics}}, $metric;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Azure Kubernetes Cluster Autoscaler unschedulable pods.
+
+Example:
+
+Using resource name :
+
+perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=unschedulablepods --custommode=api
+--resource=<cluster_id> --resource-group=<resourcegroup_id> --zeroed --warning-unschedulable-pods=5 --critical-unschedulable-pods=10
+
+Using resource id :
+
+perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=unschedulablepods --custommode=api
+--resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.ContainerService/managedClusters/<cluster_id>' 
+--zeroed --warning-unschedulable-pods=5 --critical-unschedulable-pods=10
+
+
+=over 8
+
+=item B<--resource>
+
+Set resource name or id (Required).
+
+=item B<--resource-group>
+
+Set resource group (Required if resource's name is used).
+
+=item B<--warning-unschedulable-pods>
+
+Set warning threshold for number of unschedulable pods.
+
+=item B<--critical-unschedulable-pods>
+
+Set critical threshold for number of unschedulable pods.
+
+=back
+
+=cut

--- a/src/cloud/azure/compute/aks/mode/unschedulablepods.pm
+++ b/src/cloud/azure/compute/aks/mode/unschedulablepods.pm
@@ -99,12 +99,12 @@ Example:
 
 Using resource name :
 
-perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=unschedulablepods --custommode=api
+perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=unschedulable-pods --custommode=api
 --resource=<cluster_id> --resource-group=<resourcegroup_id> --zeroed --warning-unschedulable-pods=5 --critical-unschedulable-pods=10
 
 Using resource id :
 
-perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=unschedulablepods --custommode=api
+perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --mode=unschedulable-pods --custommode=api
 --resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegroup_id>/providers/Microsoft.ContainerService/managedClusters/<cluster_id>' 
 --zeroed --warning-unschedulable-pods=5 --critical-unschedulable-pods=10
 

--- a/src/cloud/azure/compute/aks/plugin.pm
+++ b/src/cloud/azure/compute/aks/plugin.pm
@@ -34,10 +34,14 @@ sub new {
         'allocatable-resources' => 'cloud::azure::compute::aks::mode::allocatableresources',
         'cpu'                   => 'cloud::azure::compute::aks::mode::cpu',
         'discovery'             => 'cloud::azure::compute::aks::mode::discovery',
+	'memory'                => 'cloud::azure::compute::aks::mode::memory',
+	'node-state'            => 'cloud::azure::compute::aks::mode::nodestate',
+	'pod-state'             => 'cloud::azure::compute::aks::mode::podstate',
 	'health'		=> 'cloud::azure::compute::aks::mode::health',
         'storage'               => 'cloud::azure::compute::aks::mode::storage',
         'traffic'               => 'cloud::azure::compute::aks::mode::traffic',
-        'unneeded-nodes'        => 'cloud::azure::compute::aks::mode::unneedednodes'
+        'unneeded-nodes'        => 'cloud::azure::compute::aks::mode::unneedednodes',
+	'unschedulable-pods'    => 'cloud::azure::compute::aks::mode::unschedulablepods'
     };
 
     $self->{custom_modes}->{azcli} = 'cloud::azure::custom::azcli';


### PR DESCRIPTION
## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [*] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [*] 21.10.x
- [*] 22.04.x
- [*] 22.10.x
- [*] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist
Add the modes memory, node-state, pod-state, unschedulable-pods to azure aks plugin
centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin --list-mode
....
Modes Available:
   allocatable-resources
   cpu
   discovery
   health
   memory
   node-state
   pod-state
   storage
   traffic
   unneeded-nodes
   unschedulable-pods

------------------------------------------------------------------------------------------------------------------------------------------
Mode:
    Check Memory usage on Azure Kubernetes Cluster.

    Example:

    Using resource name :

    perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin
    --mode=memory --custommode=api --resource=<cluster_id>
    --resource-group=<resourcegroup_id> --warning-memory-percent='90'
    --critical-memory-percent='95'

    Using resource id :

    perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin
    --mode=storage --custommode=api
    --resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegro
    up_id>/providers/Microsoft.ContainerService/managedClusters/<cluster_id>
    ' --warning-memory-percent='90' --critical-memory-percent='95'

    --resource
            Set resource name or id (Required).

    --resource-group
            Set resource group (Required if resource's name is used).

    --warning-memory-usage
            Warning threshold in Bytes.

    --critical-memory-usage
            Critical threshold in Bytes.

    --warning-memory-percent
            Warning threshold in percent.

    --critical-memory-percent
            Critical threshold in percent.

    --warning-rss-memory-usage
            Warning threshold in Bytes.

    --critical-rss-memory-usage
            Critical threshold in Bytes.

    --warning-rss-memory-percent
            Warning threshold in percent.

    --critical-rss-memory-percent
            Critical threshold in percent.

Output: 
OK: Instance 'aks' Statistic 'average' Metrics memory RSS Usage: 5.27GB, Memory RSS Percent: 45.66%, Memory Percent: 78.15%, memory Usage: 8.68GB

------------------------------------------------------------------------------------------------------------------------------------------
Mode:
    Check Azure Kubernetes Number uf Node by State.

    Example:

    Using resource name :

    perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin
    --mode=nodestate --custommode=api --resource=<cluster_id>
    --resource-group=<resourcegroup_id> --zeroed
    --warning-node-state-condition=5 --critical-node-state-condition=10

    Using resource id :

    perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin
    --mode=nodestate --custommode=api
    --resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegro
    up_id>/providers/Microsoft.ContainerService/managedClusters/<cluster_id>
    ' --zeroed --warning-node-state-condition=5
    --critical-node-state-condition=10

    --resource
            Set resource name or id (Required).

    --resource-group
            Set resource group (Required if resource's name is used).

    --warning-node-state-condition
            Set warning threshold for number of condition nodes.

    --critical-node-state-condition
            Set critical threshold for number of condition nodes.

Output:
OK: Instance 'aks' Statistic 'average' Metrics Kube Node State Condition: 196.00

------------------------------------------------------------------------------------------------------------------------------------------
Mode:
    Check Azure Kubernetes Number of Pods by State.

    Example:

    Using resource name :

    perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin
    --mode=pod-state --custommode=api --resource=<cluster_id>
    --resource-group=<resourcegroup_id> --zeroed
    --warning-pod-state-phase=5 --critical-pod-state-phase=10

    Using resource id :

    perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin
    --mode=nodestate --custommode=api
    --resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegro
    up_id>/providers/Microsoft.ContainerService/managedClusters/<cluster_id>
    ' --zeroed --warning-pod-state-phase=5 --critical-pod-state-phase=10

    --resource
            Set resource name or id (Required).

    --resource-group
            Set resource group (Required if resource's name is used).

    --warning-pod-state-ready
            Set warning threshold for number of Pods State Ready.

    --critical-pod-state-ready
            Set critical threshold for number of Pods State Ready.

    --warning-pod-state-phase
            Set warning threshold for number of Pods State Phase.

    --critical-pod-state-phase
            Set critical threshold for number of Pods State Phase.

Output:
OK: Instance 'aks' Statistic 'average' Metrics Kube Pods State Ready: 340.00, Kube Pods State Phase: 340.00

------------------------------------------------------------------------------------------------------------------------------------------
Mode:
    Check Azure Kubernetes Cluster Autoscaler unschedulable pods.

    Example:

    Using resource name :

    perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin
    --mode=unschedulable-pods --custommode=api --resource=<cluster_id>
    --resource-group=<resourcegroup_id> --zeroed
    --warning-unschedulable-pods=5 --critical-unschedulable-pods=10

    Using resource id :

    perl centreon_plugins.pl --plugin=cloud::azure::compute::aks::plugin
    --mode=unschedulable-pods --custommode=api
    --resource='/subscriptions/<subscription_id>/resourceGroups/<resourcegro
    up_id>/providers/Microsoft.ContainerService/managedClusters/<cluster_id>
    ' --zeroed --warning-unschedulable-pods=5
    --critical-unschedulable-pods=10

    --resource
            Set resource name or id (Required).

    --resource-group
            Set resource group (Required if resource's name is used).

    --warning-unschedulable-pods
            Set warning threshold for number of unschedulable pods.

    --critical-unschedulable-pods
            Set critical threshold for number of unschedulable pods.
Output:
OK: Instance 'aks-test' Statistic 'average' Metrics Cluster Autoscaler Unschedulable Pods: 0.00

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
