### PR TITLE
apps::monitoring::kadiska::plugin - fix metric format

### DIFF
--- a/src/apps/monitoring/kadiska/mode/watcherstatistics.pm
+++ b/src/apps/monitoring/kadiska/mode/watcherstatistics.pm
@@ -46,7 +46,7 @@ sub custom_usage_perfdata {
     $self->{output}->perfdata_add(
         nlabel => $self->{nlabel},
         instances => [ $self->{result_values}->{watcher_name}, $self->{result_values}->{site_name}, $self->{result_values}->{gateway_name} ],
-        value => sprintf('%s', $self->{result_values}->{ $self->{key_values}->[0]->{name} } ),
+        value => sprintf('%.2f', $self->{result_values}->{ $self->{key_values}->[0]->{name} } ),
         warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{thlabel}),
         critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{thlabel}),
         min => 0

--- a/src/apps/monitoring/kadiska/mode/watcherstatistics.pm
+++ b/src/apps/monitoring/kadiska/mode/watcherstatistics.pm
@@ -33,7 +33,7 @@ sub custom_usage_perfdata_ms {
         nlabel => $self->{nlabel},
         unit => 'ms',
         instances => [ $self->{result_values}->{watcher_name}, $self->{result_values}->{site_name}, $self->{result_values}->{gateway_name} ],
-        value => sprintf('%s', $self->{result_values}->{ $self->{key_values}->[0]->{name} } ),
+        value => sprintf('%.2f', $self->{result_values}->{ $self->{key_values}->[0]->{name} } ),
         warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{thlabel}),
         critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{thlabel}),
         min => 0


### PR DESCRIPTION

Kadiska API can return values with 8+ decimals, which is not pretty. 
This aims to format *time* metrics perfdatas as .2f instead of s