### PR TITLE
(plugin) cloud::aws::custom::paws - fix

### DIFF
--- a/src/cloud/aws/custom/paws.pm
+++ b/src/cloud/aws/custom/paws.pm
@@ -798,7 +798,7 @@ sub directconnect_describe_connections {
         my $connections = $ec->DescribeConnections();
 
         foreach (@{$connections->{Connections}}) {
-            $results->{ $_->{ConnectionId} } = { {
+            $results->{ $_->{ConnectionId} } = {
                 name => $_->{ConnectionName},
                 state => $_->{ConnectionState},
                 bandwidth => $_->{Bandwidth}


### PR DESCRIPTION
Fixing the following error when using the paws custom mode:

 ```
perl ../centreon-plugins/src/centreon_plugins.pl --plugin=cloud::aws::lambda::plugin --mode=invocations --custommode=paws
UNKNOWN: Cannot load module --custommode. 
syntax error at /home/itoussies/repos/centreon-plugins/src/cloud/aws/custom/paws.pm line 806, near "}" Missing right curly or square bracket at /home/itoussies/repos/centreon-plugins/src/cloud/aws/custom/paws.pm line 844, at end of line Compilation failed in require at /home/itoussies/repos/centreon-plugins/src/centreon/plugins/misc.pm line 223.

```