### PR TITLE
improve splunk api handling

### DIFF
--- a/src/apps/monitoring/splunk/custom/api.pm
+++ b/src/apps/monitoring/splunk/custom/api.pm
@@ -275,7 +275,7 @@ sub query_count {
 
     my $retries = 0;
     my $success = false;
-    while ($retries =< $options{splunk_retries}) {
+    while ($retries <= $options{splunk_retries}) {
         my $query_status = $self->request_api(
             method => 'GET',
             endpoint => '/services/search/jobs/' . $query_sid->{sid},

--- a/src/apps/monitoring/splunk/custom/api.pm
+++ b/src/apps/monitoring/splunk/custom/api.pm
@@ -279,7 +279,7 @@ sub query_count {
     while ($retries < $self->{http}->{options}->{splunk_retries}) {
         my $query_status = $self->request_api(
             method => 'GET',
-            endpoint => '/services/search/jobs/' . $query_sid->{sid},
+            endpoint => '/services/search/jobs/' . $query_sid->{sid}
         );
 
         foreach (@{$query_status->{content}->{'s:dict'}->{'s:key'}}) {
@@ -296,7 +296,7 @@ sub query_count {
             last;
         }
 
-        $retries++
+        $retries++;
         sleep($self->{http}->{options}->{splunk_wait});
     }
 
@@ -308,7 +308,7 @@ sub query_count {
 
     my $query_res = $self->request_api(
         method => 'GET',
-        endpoint => '/services/search/jobs/' . $query_sid->{sid} . '/results',
+        endpoint => '/services/search/jobs/' . $query_sid->{sid} . '/results'
     );
 
     my $query_count = $query_res->{result}->{field}->{value}->{text};

--- a/src/apps/monitoring/splunk/custom/api.pm
+++ b/src/apps/monitoring/splunk/custom/api.pm
@@ -298,7 +298,7 @@ sub query_count {
         }
     }
 
-    $query_count = 0;
+    my $query_count = 0;
     if ($success) {
         my $query_res = $self->request_api(
             method => 'GET',

--- a/src/apps/monitoring/splunk/custom/api.pm
+++ b/src/apps/monitoring/splunk/custom/api.pm
@@ -291,7 +291,6 @@ sub query_count {
                     $self->{output}->add_option_msg(short_msg => "Search command didn't finish in time. Considere tweaking --splunk-wait and --splunk-retries if the search is just slow");
                     $self->{output}->option_exit();
                 }
-
                 next;
             } elsif ($_->{name} eq 'isFailed' && $_->{content} == 1) {
                 $self->{output}->add_option_msg(short_msg => "Search command failed.");
@@ -403,7 +402,7 @@ Set HTTP timeout.
 
 =item B<--splunk-retries>
 
-How many times queries we should retry queries to splunk. To use in par with the --splunk-wait paramater (Default: 5) 
+How many times we should retry queries to splunk. To use in par with the --splunk-wait paramater (Default: 5) 
 
 =item B<--splunk-wait>
 

--- a/src/apps/monitoring/splunk/custom/api.pm
+++ b/src/apps/monitoring/splunk/custom/api.pm
@@ -291,6 +291,7 @@ sub query_count {
                     $self->{output}->add_option_msg(short_msg => "Search command didn't finish in time. Considere tweaking --splunk-wait and --splunk-retries if the search is just slow");
                     $self->{output}->option_exit();
                 }
+
                 next;
             } elsif ($_->{name} eq 'isFailed' && $_->{content} == 1) {
                 $self->{output}->add_option_msg(short_msg => "Search command failed.");
@@ -402,7 +403,7 @@ Set HTTP timeout.
 
 =item B<--splunk-retries>
 
-How many times we should retry queries to splunk. To use in par with the --splunk-wait paramater (Default: 5) 
+How many times queries we should retry queries to splunk. To use in par with the --splunk-wait paramater (Default: 5) 
 
 =item B<--splunk-wait>
 

--- a/src/apps/monitoring/splunk/custom/api.pm
+++ b/src/apps/monitoring/splunk/custom/api.pm
@@ -413,7 +413,7 @@ How many times we should retry queries to splunk. To use in par with the --splun
 
 =item B<--splunk-wait>
 
-How long (in seconds) should we wait between each retry. To use in par with the --splunk-retries paramater (Default: 1)
+How long (in seconds) should we wait between each retry. To use in par with the --splunk-retries paramater (Default: 2)
 
 =back
 

--- a/src/apps/monitoring/splunk/custom/api.pm
+++ b/src/apps/monitoring/splunk/custom/api.pm
@@ -55,8 +55,8 @@ sub new {
             'unknown-http-status:s'  => { name => 'unknown_http_status' },
             'warning-http-status:s'  => { name => 'warning_http_status' },
             'critical-http-status:s' => { name => 'critical_http_status' },
-            'splunk-retries:s'         => { name => 'splunk_retries' },
-            'splunk-wait:s'            => { name => 'splunk_wait' }
+            'splunk-retries:s'       => { name => 'splunk_retries' },
+            'splunk-wait:s'          => { name => 'splunk_wait' }
         });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'XMLAPI OPTIONS', once => 1);


### PR DESCRIPTION
having a fixed 1.5 seconds wait time to let splunk finish its query might be way too short. 

To have a better control of that, it adds two new parameters 
--splunk-wait
--splunk-retries

