### PR TITLE
storage::ibm::storwize::ssh::plugin - mode replication

### DIFF
--- a/src/storage/ibm/storwize/ssh/mode/replication.pm
+++ b/src/storage/ibm/storwize/ssh/mode/replication.pm
@@ -1,0 +1,131 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package storage::ibm::storwize::ssh::mode::replication;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+
+sub prefix_replication_output {
+         my ($self, %options) = @_;
+
+         return sprintf(
+                "Volume %s [group_name: %s, vdisk_name: %s]",
+                $options{instance_value}->{name},
+                $options{instance_value}->{group_name},
+                $options{instance_value}->{vdisk_name}
+        );
+}
+
+sub set_counters {
+        my ($self, %options) = @_;
+
+        $self->{maps_counters_type} = [
+                { name => 'replication', type => 1, cb_prefix_output => 'prefix_replication_output', message_multiple => 'All volumes are in consistent_synchronized state'}
+        ];
+
+        $self->{maps_counters}->{replication} = [
+                {
+                        label => 'status',
+                        type => 2,
+                        warning_default => '%{status} =~ /idling/i',
+                        critical_default => '%{status} =~ //i',
+                        set => {
+                                 key_values => [ { name => 'status' } ],
+                                 output_template => ' status: %s',
+                                 closure_custom_perfdata => sub { return 0; },
+                                 closure_custom_threshold_check => \&catalog_status_threshold_ng
+                        }
+
+                }
+        ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+    
+    $options{options}->add_options(arguments => { 
+        'filter-consistency-group-name:s' => { name => 'filter_group' },
+    });
+
+    return $self;
+}
+
+
+sub manage_selection {
+         my ($self, %options) = @_;
+
+         $self->{replication} = {};
+         my ($content) = $options{custom}->execute_command(command => 'lsrcrelationship -delim :');
+         my $result = $options{custom}->get_hasharray(content => $content, delim => ':');
+         foreach my $item (@$result) {
+
+                if (defined($self->{option_results}->{filter_group}) && $self->{option_results}->{filter_group} ne '' &&  $item->{consistency_group_name} !~ /$self->{option_results}->{filter_group}/) {
+                $self->{output}->output_add(long_msg => "skipping '" . $item->{consistency_group_name} . "': no matching filter.", debug => 1);
+                next;
+
+                }
+
+                $self->{replication}->{$item->{id}} = {
+                        name => $item->{name},
+                        vdisk_name => $item->{aux_vdisk_name},
+                        group_name => $item->{consistency_group_name},
+                        status => $item->{state}
+                };
+        }
+        if (scalar(keys %{$self->{replication}}) <= 0){
+                 $self->{output}->add_option_msg(short_msg => 'No volume found.');
+                 $self->{output}->option_exit();
+        }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check replication usages.
+
+=over 8
+
+=item B<--filter-consistency-group-name>
+
+Filter group name (can be a regexp).
+
+=item B<--warning-status>
+
+Set warning threshold for status (Default: '%{status} =~ /idling/i').
+Can used special variables like: %{status}
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: ).
+Can used special variables like: %{status}
+
+=back
+
+=cut

--- a/src/storage/ibm/storwize/ssh/plugin.pm
+++ b/src/storage/ibm/storwize/ssh/plugin.pm
@@ -34,6 +34,7 @@ sub new {
         'components'   => 'storage::ibm::storwize::ssh::mode::hardware',
         'eventlog'     => 'storage::ibm::storwize::ssh::mode::eventlog',
         'pool-usage'   => 'storage::ibm::storwize::ssh::mode::poolusage',
+		'replication'  => 'storage::ibm::storwize::ssh::mode::replication'
     );
     $self->{custom_modes}{api} = 'storage::ibm::storwize::ssh::custom::api';
 


### PR DESCRIPTION
Bonjour, 

Suite à une demande en interne, concernant la supervision de la réplication des volumes d'une baie de type **IBM/Storwize**,
nous avons réalisé un mode pour le plugin : **storage::ibm::storwize::ssh::plugin** que nous avons nommé replication

## Description de la demande
*  Pour la REPLICATION ->il faut lancer la  commande sur la baie :  **_lsrcrelationship_**
* C’est OK quand tous les volumes sont  dans l’état « **_consistent_synchronized_** »
* C’est en WARNING quand au moins un des volumes est dans un autre état (exemple : idling)

Ce mode permettra de recupérer l'état de chaque volume et retourner une alerte en fonction des valeurs définies au niveau warning-status ou critical-status

Pourriez vous valider ce code, l'améliorer si nécessaire et l'intégrer dans les plugins centreon si tout est OK ?
N'hésitez pas à me faire un retour au cas où il y aurait des modifications à faire.

A votre disposition

Dans l'attente 

Cordialement, 

**Chris MVILA**
Administrateur Centreon
**Email :** **chris.mvila@cheops.fr**
**CHEOPS TECHNOLOGY** - **33610 CANEJAN**