### PR TITLE
apps::protocol::x509 - opensslcli custom mode - fix usage

### DIFF
--- a/packaging/centreon-plugin-Applications-Protocol-X509/pkg.json
+++ b/packaging/centreon-plugin-Applications-Protocol-X509/pkg.json
@@ -4,6 +4,8 @@
     "plugin_name": "centreon_protocol_x509.pl",
     "files": [
         "centreon/plugins/script_custom.pm",
+        "centreon/plugins/backend/ssh/",
+	    "centreon/plugins/ssh.pm",
         "apps/protocols/x509/"
     ]
 }


### PR DESCRIPTION
## Description

Resolve "UNKNOWN: Cannot load module --custommode." when using the opensslcli custom mode with the packaged plugin.

