### PR TITLE
enh(ci): do not stop delivery when one job fails

### DIFF
--- a/.github/workflows/plugin-delivery.yml
+++ b/.github/workflows/plugin-delivery.yml
@@ -64,6 +64,7 @@ jobs:
   deliver-rpm:
     runs-on: [self-hosted, common]
     strategy:
+      fail-fast: false
       matrix:
         distrib: [el7, el8, el9]
 
@@ -83,6 +84,7 @@ jobs:
   deliver-rpm-legacy:
     runs-on: [self-hosted, common]
     strategy:
+      fail-fast: false
       matrix:
         distrib: [el7, el8]
         major_version: ["21.10", "22.04", "22.10"]
@@ -107,6 +109,7 @@ jobs:
   deliver-deb:
     runs-on: [self-hosted, common]
     strategy:
+      fail-fast: false
       matrix:
         distrib: [bullseye]
 
@@ -125,6 +128,7 @@ jobs:
   deliver-deb-legacy:
     runs-on: [self-hosted, common]
     strategy:
+      fail-fast: false
       matrix:
         distrib: [bullseye]
         major_version: ["22.04", "22.10"]


### PR DESCRIPTION
## Description

do not stop delivery when one job fails

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)