### PR TITLE
rittal CMCIII plugin

### DIFF
--- a/src/hardware/sensors/rittal/cmc3/snmp/mode/devicestatus.pm
+++ b/src/hardware/sensors/rittal/cmc3/snmp/mode/devicestatus.pm
@@ -1,0 +1,194 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package hardware::sensors::rittal::cmc3::snmp::mode::devicestatus;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng catalog_status_calc);
+
+my $map_status = {
+    1 => 'notAvail',
+    2 => 'ok',
+    3 => 'detect',
+    4 => 'lost',
+    5 => 'changed',
+    6 => 'error',
+    7 => 'fwUpdate',
+    8 => 'fwUpdateRun',
+};
+
+my $mapping = {
+    status => { oid => '.1.3.6.1.4.1.2606.7.4.1.2.1.6', map => $map_status },
+    alias  => { oid => '.1.3.6.1.4.1.2606.7.4.1.2.1.3' },
+    name   => { oid => '.1.3.6.1.4.1.2606.7.4.1.2.1.2' },
+    text   => { oid => '.1.3.6.1.4.1.2606.7.4.1.2.1.19' },
+};
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'device_status', type => 1, message_multiple => 'All devices are ok', skipped_code => { -10 => 1 } },
+    ];
+
+    $self->{maps_counters}->{device_status} = [
+        {
+            label => 'status',
+            warning_default  => '%{status} =~ /detect|changed|fwUpdate|fwUpdateRun/i',
+            critical_default => '%{status} =~ /notAvail|lost|error/i',
+            type  => 2,
+            set   => {
+                key_values                     => [
+                    { name => 'status' },
+                    { name => 'alias' },
+                    { name => 'name' },
+                    { name => 'text' },
+                    { name => 'index' },
+                ],
+                closure_custom_calc            => \&catalog_status_calc,
+                closure_custom_threshold_check => \&catalog_status_threshold_ng,
+                closure_custom_perfdata        => sub {return 0;},
+                closure_custom_output          => $self->can('status_custom_output')
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(
+        arguments =>
+            {
+                'filter-name:s'         => { name => 'filter_name' },
+                'filter-alias:s'        => { name => 'filter_alias' },
+                'index:s'               => { name => 'index' }
+            }
+    );
+
+    return $self;
+}
+
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $snmp_result = $options{snmp}->get_multiple_table(
+        oids         => [
+            { oid => $mapping->{status}->{oid} },
+            { oid => $mapping->{name}->{oid} },
+            { oid => $mapping->{alias}->{oid} },
+            { oid => $mapping->{text}->{oid} },
+        ],
+        return_type  => 1,
+        nothing_quit => 1
+    );
+
+    $self->{device_status} = {};
+    foreach my $oid (keys %{$snmp_result}) {
+        next if ($oid !~ /^$mapping->{status}->{oid}\.(.*)$/);
+        my $instance = $1;
+        my $data = $options{snmp}->map_instance(mapping => $mapping, results => $snmp_result, instance => $instance);
+
+        if (defined($self->{option_results}->{index}) && $self->{option_results}->{index} ne '' &&
+            $instance != $self->{option_results}->{index}) {
+            $self->{output}->output_add(long_msg => "skipping  '" . $instance . "': no matching filter.");
+            next;
+        }
+
+        if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
+            $data->{name} !~ /$self->{option_results}->{filter_name}/) {
+            $self->{output}->output_add(long_msg => "skipping  '" . $data->{name} . "': no matching filter.");
+            next;
+        }
+
+        if (defined($self->{option_results}->{filter_alias}) && $self->{option_results}->{filter_alias} ne '' &&
+            $data->{alias} !~ /$self->{option_results}->{filter_alias}/) {
+            $self->{output}->output_add(long_msg => "skipping  '" . $data->{alias} . "': no matching filter.");
+            next;
+        }
+
+        $self->{device_status}->{$instance} = {
+            index  => $instance,
+            name   => $data->{name},
+            status => $data->{status},
+            alias  => $data->{alias},
+            text   => $data->{text},
+        };
+    }
+};
+
+sub status_custom_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "Device '%s' %s [alias: %s] [status text: %s]",
+        $self->{result_values}->{name},
+        $self->{result_values}->{status},
+        $self->{result_values}->{alias},
+        $self->{result_values}->{text},
+    );
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check devices status.
+
+=over 8
+
+=item B<--filter-name>
+
+Filter device name (can be a regexp).
+
+=item B<--filter-alias>
+
+Filter devices alias (can be a regexp).
+
+=item B<--index>
+
+Filter device index (exact match).
+
+=item B<--unknown-status>
+
+Set unknown threshold for status.
+You can use the following variables: %{status}
+
+=item B<--warning-status>
+
+Set warning threshold for status (Default: '%{status} =~ /detect|changed|fwUpdate|fwUpdateRun/i').
+You can use the following variables: %{status}
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: '%{status} =~ /notAvail|lost|error/i').
+You can use the following variables: %{status}
+
+=back
+
+=cut

--- a/src/hardware/sensors/rittal/cmc3/snmp/mode/listdevices.pm
+++ b/src/hardware/sensors/rittal/cmc3/snmp/mode/listdevices.pm
@@ -1,0 +1,171 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package hardware::sensors::rittal::cmc3::snmp::mode::listdevices;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+my $map_status = {
+    1 => 'Device not available',
+    2 => 'OK',
+    3 => 'Device detected, confirmation required',
+    4 => 'Device lost (disconnected), confirmation required',
+    5 => 'Device changed',
+    6 => 'Error',
+    7 => 'Firmware update pending',
+    8 => 'Firmware update runnning',
+};
+
+my $mapping = {
+    dev_name        => { oid => '.1.3.6.1.4.1.2606.7.4.1.2.1.2' },
+    dev_alias       => { oid => '.1.3.6.1.4.1.2606.7.4.1.2.1.3' },
+    dev_status      => { oid => '.1.3.6.1.4.1.2606.7.4.1.2.1.6', map => $map_status },
+    dev_status_text => { oid => '.1.3.6.1.4.1.2606.7.4.1.2.1.19' },
+};
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(
+        arguments =>
+            {
+                'filter-name:s'  => { name => 'filter_name' },
+                'filter-alias:s' => { name => 'filter_alias' },
+            }
+    );
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $snmp_result = $options{snmp}->get_multiple_table(
+        oids         => [
+            { oid => $mapping->{dev_name}->{oid} },
+            { oid => $mapping->{dev_alias}->{oid} },
+            { oid => $mapping->{dev_status}->{oid} },
+            { oid => $mapping->{dev_status_text}->{oid} },
+        ],
+        return_type  => 1,
+        nothing_quit => 1
+    );
+
+    $self->{devices} = {};
+    foreach my $oid (keys %{$snmp_result}) {
+        next if ($oid !~ /^$mapping->{dev_name}->{oid}\.(.*)$/);
+        my $instance = $1;
+        my $data = $options{snmp}->map_instance(mapping => $mapping, results => $snmp_result, instance => $instance);
+
+        if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
+            $data->{dev_name} !~ /$self->{option_results}->{filter_name}/) {
+            $self->{output}->output_add(long_msg => "skipping  '" . $data->{dev_name} . "': no matching filter.");
+            next;
+        }
+
+        if (defined($self->{option_results}->{filter_alias}) && $self->{option_results}->{filter_alias} ne '' &&
+            $data->{dev_alias} !~ /$self->{option_results}->{filter_alias}/) {
+            $self->{output}->output_add(long_msg => "skipping  '" . $data->{dev_alias} . "': no matching filter.");
+            next;
+        }
+
+        $self->{devices}->{$instance} = {
+            index       => $instance,
+            name        => $data->{dev_name},
+            alias       => $data->{dev_alias},
+            status      => $data->{dev_status},
+            status_text => $data->{dev_status_text},
+        };
+    }
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    my $results = $self->manage_selection(%options);
+    foreach my $instance (sort keys %{$self->{devices}}) {
+        $self->{output}->output_add(long_msg => sprintf(
+            "[index: %d] [name: '%s'] [alias: '%s'] [status: '%s'] [status text: '%s']",
+            $self->{devices}->{$instance}->{index},
+            $self->{devices}->{$instance}->{name},
+            $self->{devices}->{$instance}->{alias},
+            $self->{devices}->{$instance}->{status},
+            $self->{devices}->{$instance}->{status_text},
+        ));
+    }
+
+    $self->{output}->output_add(
+        severity  => 'OK',
+        short_msg => 'Devices list:'
+    );
+    $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+    $self->{output}->exit();
+}
+
+sub disco_format {
+    my ($self, %options) = @_;
+
+    $self->{output}->add_disco_format(elements => [ 'index', 'name', 'alias', 'status', 'status_text' ]);
+}
+
+sub disco_show {
+    my ($self, %options) = @_;
+
+    $self->manage_selection(%options);
+    foreach my $instance (sort keys %{$self->{devices}}) {
+        $self->{output}->add_disco_entry(
+            index      => $self->{devices}->{$instance}->{index},
+            name       => $self->{devices}->{$instance}->{name},
+            alias      => $self->{devices}->{$instance}->{alias},
+            status     => $self->{devices}->{$instance}->{status},
+            statusText => $self->{devices}->{$instance}->{status_text},
+        );
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+List devices
+
+=over 8
+
+=item B<--filter-name>
+
+Filter device name (can be a regexp).
+
+=item B<--filter-alias>
+
+Filter devices alias (can be a regexp).
+
+=cut

--- a/src/hardware/sensors/rittal/cmc3/snmp/mode/load.pm
+++ b/src/hardware/sensors/rittal/cmc3/snmp/mode/load.pm
@@ -1,0 +1,118 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package hardware::sensors::rittal::cmc3::snmp::mode::load;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'unit_load', type => 0 },
+    ];
+
+    $self->{maps_counters}->{unit_load} = [
+        {
+            label => 'unit-load-1m',
+            set   => {
+                key_values      => [ { name => 'unit_load1' } ],
+                output_template => '%.2f (1m)',
+                perfdatas       => [
+                    { template => '%.2f', min => 0, max => 100, unit => '%' }
+                ]
+            }
+        },
+        {
+            label => 'unit-load-5m',
+            set   => {
+                key_values      => [ { name => 'unit_load5' } ],
+                output_template => '%.2f (5m)',
+                perfdatas       => [
+                    { template => '%.2f', min => 0, max => 100, unit => '%' }
+                ]
+            }
+        },
+        {
+            label => 'unit-load-10m',
+            set   => {
+                key_values      => [ { name => 'unit_load10' } ],
+                output_template => '%.2f (10m)',
+                perfdatas       => [
+                    { template => '%.2f', min => 0, max => 100, unit => '%' }
+                ]
+            }
+        },
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {});
+
+    return $self;
+}
+
+my $mapping = {
+    unit_load => { oid => '.1.3.6.1.4.1.2606.7.2.14.1.2' },
+};
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $oid_cmcIIIUnitLoadEntry = '.1.3.6.1.4.1.2606.7.2.14.1';
+    my $results = $options{snmp}->get_table(
+        oid          => $oid_cmcIIIUnitLoadEntry,
+        nothing_quit => 1
+    );
+
+    $self->{unit_load} = {};
+    foreach (keys %$results) {
+        next if (!/^$mapping->{unit_load}->{oid}\.(\d+)$/);
+        my $result = $options{snmp}->map_instance(mapping => $mapping, results => $results, instance => $1);
+        $self->{unit_load}->{'unit_load' . $1} = $result->{unit_load} / 100;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check unit load
+
+=over 8
+
+=item B<--warning-*> B<--critical-*>
+
+Load threshold in %
+
+Thresholds: unit-load-1m, unit-load-5m, unit-load-10m
+
+=back
+
+=cut

--- a/src/hardware/sensors/rittal/cmc3/snmp/mode/unitstatus.pm
+++ b/src/hardware/sensors/rittal/cmc3/snmp/mode/unitstatus.pm
@@ -1,0 +1,164 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package hardware::sensors::rittal::cmc3::snmp::mode::unitstatus;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng catalog_status_calc);
+
+my $map_unit_status = {
+    1 => 'OK',
+    2 => 'failed',
+    3 => 'overload'
+};
+
+my $map_overall_device_status = {
+    1 => 'ok',
+    2 => 'warning',
+    3 => 'alarm',
+    4 => 'detected',
+    5 => 'lost',
+    6 => 'changed',
+    7 => 'update',
+};
+
+my $map_unit_mode = {
+    1  => 'local init ini progress',
+    2  => 'start local system first time',
+    3  => 'first start delay',
+    4  => 'restart bus system, reread configuration',
+    5  => 'locally online',
+    6  => 'collect all slaves at the bus',
+    7  => 'reorganize bus',
+    8  => 'up and running',
+    9  => 'prepare for sensor upgrade',
+    10 => 'upgrade sensors',
+    11 => 'gentle termination',
+};
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [ { name => 'status', type => 0 } ];
+
+    $self->{maps_counters}->{status} = [
+        {
+            label            => 'status',
+            unknown_default  => '%{overall_device_status} =~ /detected|lost|changed|update/i',
+            warning_default  => '%{unit_status} =~ /overload/i || %{overall_device_status} =~ /warning/i',
+            critical_default => '%{unit_status} =~ /failed/i || %{overall_device_status} =~ /alarm/i',
+            type             => 2,
+            set              => {
+                key_values                     => [
+                    { name => 'unit_status' },
+                    { name => 'overall_device_status' },
+                    { name => 'mode' },
+                    { name => 'available_devices' },
+                ],
+                closure_custom_calc            => \&catalog_status_calc,
+                closure_custom_threshold_check => \&catalog_status_threshold_ng,
+                closure_custom_perfdata        => sub {return 0;},
+                closure_custom_output          => $self->can('status_custom_output'),
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    return $self;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $oid_cmcIIIUnitStatus = '.1.3.6.1.4.1.2606.7.2.1.0';
+    my $oid_cmcIIIUnitMode = '.1.3.6.1.4.1.2606.7.2.13.0';
+    my $oid_cmcIIIOverallDevStatus = '.1.3.6.1.4.1.2606.7.4.1.1.1.0';
+    my $oid_cmcIIINumberOfDevs = '.1.3.6.1.4.1.2606.7.4.1.1.2.0';
+
+    my $snmp_result = $options{snmp}->get_leef(
+        oids         => [
+            $oid_cmcIIIUnitStatus,
+            $oid_cmcIIIUnitMode,
+            $oid_cmcIIIOverallDevStatus,
+            $oid_cmcIIINumberOfDevs,
+        ],
+        nothing_quit => 1
+    );
+
+    $self->{status} = {
+        unit_status           => $map_unit_status->{$snmp_result->{$oid_cmcIIIUnitStatus}},
+        overall_device_status => $map_overall_device_status->{$snmp_result->{$oid_cmcIIIOverallDevStatus}},
+        mode                  => $map_unit_mode->{$snmp_result->{$oid_cmcIIIUnitMode}},
+        available_devices     => $snmp_result->{$oid_cmcIIINumberOfDevs},
+    };
+}
+
+sub status_custom_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "Unit status: '%s' - Unit mode: %s - Overall device status: '%s' [available devices: %d]",
+        $self->{result_values}->{unit_status},
+        $self->{result_values}->{mode},
+        $self->{result_values}->{overall_device_status},
+        $self->{result_values}->{available_devices}
+    );
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check status
+
+=over 8
+
+=item B<--warning-*> B<--critical-*>
+
+Variables: %{available_devices}
+
+=item B<--unknown-status>
+
+Set unknown threshold for status (Default: '%{overall_device_status} =~ /detected|lost|changed|update/i').
+You can use the following variables: %{unit_status}, %{overall_device_status}, %{mode}, %{available_devices}
+
+=item B<--warning-status>
+
+Set warning threshold for status (Default: '%{unit_status} =~ /overload/i || %{overall_device_status} =~ /warning/i').
+You can use the following variables: %{unit_status}, %{overall_device_status}, %{mode}, %{available_devices}
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: '%{unit_status} =~ /failed/i || %{overall_device_status} =~ /alarm/i').
+You can use the following variables: %{unit_status}, %{overall_device_status}, %{mode}, %{available_devices}
+
+=back
+
+=cut

--- a/src/hardware/sensors/rittal/cmc3/snmp/mode/uptime.pm
+++ b/src/hardware/sensors/rittal/cmc3/snmp/mode/uptime.pm
@@ -1,0 +1,77 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package hardware::sensors::rittal::cmc3::snmp::mode::uptime;
+
+use base qw(snmp_standard::mode::uptime);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check system uptime.
+
+=over 8
+
+=item B<--warning-uptime>
+
+Threshold warning.
+
+=item B<--critical-uptime>
+
+Threshold critical.
+
+=item B<--add-sysdesc>
+
+Display system description.
+
+=item B<--force-oid>
+
+Can choose your oid (numeric format only).
+
+=item B<--check-overload>
+
+Uptime counter limit is 4294967296 and overflow.
+With that option, we manage the counter going back. But there is a few chance we can miss a reboot.
+
+=item B<--reboot-window>
+
+To be used with check-overload option. Time in milliseconds (Default: 5000)
+You increase the chance of not missing a reboot if you decrease that value.
+
+=item B<--unit>
+
+Select the unit for performance data and thresholds. May be 's' for seconds, 'm' for minutes,
+'h' for hours, 'd' for days, 'w' for weeks.  Default is seconds
+
+=back

--- a/src/hardware/sensors/rittal/cmc3/snmp/plugin.pm
+++ b/src/hardware/sensors/rittal/cmc3/snmp/plugin.pm
@@ -1,0 +1,51 @@
+#
+# Copyright 2022 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package hardware::sensors::rittal::cmc3::snmp::plugin;
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_snmp);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{version} = '1.0';
+    $self->{modes} = {
+        'unit-status'   => 'hardware::sensors::rittal::cmc3::snmp::mode::unitstatus',
+        'load'          => 'hardware::sensors::rittal::cmc3::snmp::mode::load',
+        'list-devices'  => 'hardware::sensors::rittal::cmc3::snmp::mode::listdevices',
+        'device-status' => 'hardware::sensors::rittal::cmc3::snmp::mode::devicestatus',
+        'uptime'        => 'hardware::sensors::rittal::cmc3::snmp::mode::uptime'
+    };
+
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 PLUGIN DESCRIPTION
+
+Check Rittal cmc3 sensors in SNMP.
+
+=cut


### PR DESCRIPTION
New plugin for rittal cmc 3

plugin-name: hardware::sensors::rittal::cmc3::snmp::plugin

Modes Available:
   device-status
   list-devices
   load
   unit-status
   uptime

snmpwalk file: attached
[rittal.snmpwalk.txt](https://github.com/centreon/centreon-plugins/files/11848908/rittal.snmpwalk.txt)

mib file: attached
[RITTAL-CMC-III-MIB.txt](https://github.com/centreon/centreon-plugins/files/11848912/RITTAL-CMC-III-MIB.txt)


