### PR TITLE
new(plugin): add sailpoint identitynow restapi plugin

### DIFF
--- a/packaging/centreon-plugin-Applications-Sailpoint-Identitynow-Restapi/deb.json
+++ b/packaging/centreon-plugin-Applications-Sailpoint-Identitynow-Restapi/deb.json
@@ -1,0 +1,4 @@
+{
+    "dependencies": [
+    ]
+}

--- a/packaging/centreon-plugin-Applications-Sailpoint-Identitynow-Restapi/pkg.json
+++ b/packaging/centreon-plugin-Applications-Sailpoint-Identitynow-Restapi/pkg.json
@@ -1,0 +1,9 @@
+{
+    "pkg_name": "centreon-plugin-Applications-Sailpoint-Identitynow-Restapi",
+    "pkg_summary": "Centreon Plugin to monitor SailPoint IdentityNow throught RestAPI",
+    "plugin_name": "centreon_sailpoint_identitynow_restapi.pl",
+    "files": [
+        "centreon/plugins/script_custom.pm",
+        "apps/sailpoint/identitynow/restapi/"
+    ]
+}

--- a/packaging/centreon-plugin-Applications-Sailpoint-Identitynow-Restapi/rpm.json
+++ b/packaging/centreon-plugin-Applications-Sailpoint-Identitynow-Restapi/rpm.json
@@ -1,0 +1,4 @@
+{
+    "dependencies": [
+    ]
+}

--- a/src/apps/sailpoint/identitynow/restapi/custom/api.pm
+++ b/src/apps/sailpoint/identitynow/restapi/custom/api.pm
@@ -1,0 +1,387 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::sailpoint::identitynow::restapi::custom::api;
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use centreon::plugins::statefile;
+use JSON::XS;
+use Digest::MD5 qw(md5_hex);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = {};
+    bless $self, $class;
+
+    if (!defined($options{output})) {
+        print "Class Custom: Need to specify 'output' argument.\n";
+        exit 3;
+    }
+    if (!defined($options{options})) {
+        $options{output}->add_option_msg(short_msg => "Class Custom: Need to specify 'options' argument.");
+        $options{output}->option_exit();
+    }
+
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            'tenant:s'        => { name => 'tenant' },
+            'domain:s'        => { name => 'domain' },
+            'port:s'          => { name => 'port' },
+            'proto:s'         => { name => 'proto' },
+            'api-version:s'   => { name => 'api_version' },
+            'client-id:s'     => { name => 'client_id' },
+            'client-secret:s' => { name => 'client_secret' },
+            'timeout:s'       => { name => 'timeout' }
+        });
+    }
+    $options{options}->add_help(package => __PACKAGE__, sections => 'SAILPOINT IDENTITYNOW REST API OPTIONS', once => 1);
+
+    $self->{output} = $options{output};
+    $self->{http} = centreon::plugins::http->new(%options, default_backend => 'curl');
+    $self->{cache} = centreon::plugins::statefile->new(%options);
+
+    return $self;
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+
+    $self->{option_results} = $options{option_results};
+}
+
+sub set_defaults {}
+
+sub check_options {
+    my ($self, %options) = @_;
+
+    $self->{tenant} = (defined($self->{option_results}->{tenant})) ? $self->{option_results}->{tenant} : '';
+    $self->{domain} = (defined($self->{option_results}->{domain})) ? $self->{option_results}->{domain} : 'identitynow';
+    $self->{proto} = (defined($self->{option_results}->{proto})) ? $self->{option_results}->{proto} : 'https';
+    $self->{port} = (defined($self->{option_results}->{port})) ? $self->{option_results}->{port} : 443;
+    $self->{api_version} = (defined($self->{option_results}->{api_version})) ? $self->{option_results}->{api_version} : 'v3';
+    $self->{client_id} = (defined($self->{option_results}->{client_id})) ? $self->{option_results}->{client_id} : '';
+    $self->{client_secret} = (defined($self->{option_results}->{client_secret})) ? $self->{option_results}->{client_secret} : '';
+    $self->{timeout} = (defined($self->{option_results}->{timeout})) ? $self->{option_results}->{timeout} : 10;
+
+    if ($self->{tenant} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify --tenant option.');
+        $self->{output}->option_exit();
+    }
+    if ($self->{client_id} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --client-id option.");
+        $self->{output}->option_exit();
+    }
+    if ($self->{client_secret} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --client-secret option.");
+        $self->{output}->option_exit();
+    }
+
+    $self->{hostname} = $self->{tenant} . '.api.' . $self->{domain} . '.com';
+
+    $self->{cache}->check_options(option_results => $self->{option_results});
+
+    return 0;
+}
+
+sub get_connection_infos {
+    my ($self, %options) = @_;
+
+    return $self->{hostname} . '_' . $self->{http}->get_port();
+}
+
+sub get_hostname {
+    my ($self, %options) = @_;
+
+    return $self->{hostname};
+}
+
+sub get_port {
+    my ($self, %options) = @_;
+
+    return $self->{port};
+}
+
+sub build_options_for_httplib {
+    my ($self, %options) = @_;
+
+    $self->{option_results}->{port} = $self->{port};
+    $self->{option_results}->{proto} = $self->{proto};
+}
+
+sub settings {
+    my ($self, %options) = @_;
+
+    $self->build_options_for_httplib();
+    $self->{http}->add_header(key => 'Accept', value => 'application/json');
+    $self->{http}->set_options(%{$self->{option_results}});
+}
+
+sub clean_token {
+    my ($self, %options) = @_;
+
+    my $datas = {};
+    $options{statefile}->write(data => $datas);
+    $self->{access_token} = undef;
+    $self->{http}->add_header(key => 'Authorization', value => undef);
+}
+
+sub get_auth_token {
+    my ($self, %options) = @_;
+
+    my $has_cache_file = $options{statefile}->read(
+        statefile => 'sailpoint_identitynow_api_' . md5_hex($self->{option_results}->{tenant}) . '_' . md5_hex($self->{option_results}->{client_id})
+    );
+    my $access_token = $options{statefile}->get(name => 'access_token');
+    my $expires_on = $options{statefile}->get(name => 'expires_on');
+    my $md5_secret_cache = $self->{cache}->get(name => 'md5_secret');
+    my $md5_secret = md5_hex($self->{client_id} . $self->{client_secret});
+
+    if ($has_cache_file == 0 || !defined($access_token) || (time() > $expires_on) ||
+        (defined($md5_secret_cache) && $md5_secret_cache ne $md5_secret)) {
+        my ($content) = $self->{http}->request(
+            method => 'POST',
+            hostname => $self->{hostname},
+            url_path => '/oauth/token',
+            post_param => [
+                'grant_type=client_credentials',
+                'client_id=' . $self->{client_id},
+                'client_secret=' . $self->{client_secret}
+            ],
+            unknown_status => '',
+            warning_status => '',
+            critical_status => ''
+        );
+
+        if (!defined($content) || $content eq '') {
+            $self->{output}->add_option_msg(short_msg => "Authentication endpoint returns empty content [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']");
+            $self->{output}->option_exit();
+        }
+
+        my $decoded;
+        eval {
+            $decoded = JSON::XS->new->utf8->decode($content);
+        };
+        if ($@) {
+            $self->{output}->output_add(long_msg => $@, debug => 1);
+            $self->{output}->add_option_msg(short_msg => "Cannot decode response (add --debug option to display returned content)");
+            $self->{output}->option_exit();
+        }
+        if (ref($decoded) eq 'HASH' && defined($decoded->{error})) {
+            $self->{output}->output_add(long_msg => "Error message : " . $decoded->{error_description}, debug => 1);
+            $self->{output}->add_option_msg(short_msg => "Authentication endpoint returns error code '" . $decoded->{error} . "' (add --debug option for detailed message)");
+            $self->{output}->option_exit();
+        }
+        if (ref($decoded) eq 'HASH' && defined($decoded->{detailCode})) {
+            $self->{output}->add_option_msg(short_msg => "Authentication endpoint returns error code '" . $decoded->{detailCode} . "' (add --debug option for detailed message)");
+            $self->{output}->option_exit();
+        }
+
+        if (!defined($decoded->{access_token})) {
+            $self->{output}->add_option_msg(short_msg => "Cannot get token");
+            $self->{output}->option_exit();
+        }
+
+        $access_token = $decoded->{access_token};
+        my $datas = {
+            access_token => $access_token,
+            expires_on => time() + $decoded->{expires_in},
+            md5_secret => $md5_secret
+        };
+        $options{statefile}->write(data => $datas);
+    }
+
+    $self->{access_token} = $access_token;
+    $self->{http}->add_header(key => 'Authorization', value => 'Bearer ' . $self->{access_token});
+}
+
+sub request_api {
+    my ($self, %options) = @_;
+
+    $self->settings();
+    if (!defined($self->{access_token})) {
+        $self->get_auth_token(statefile => $self->{cache});
+    }
+
+    my @results;
+    my $decoded;
+
+    my @get_param;
+    @get_param = (@get_param, @{$options{get_param}}) if (defined($options{get_param}) && scalar(@{$options{get_param}}));
+    # Dealing with pagination without using count parameter as recommended
+    # here https://developer.sailpoint.com/idn/api/standard-collection-parameters#paginating-results
+    my $limit = 250;
+    push @get_param, 'limit=' . $limit;
+    my $offset = 0;
+    push @get_param, 'offset=' . $offset;
+
+    do {
+        my $content = $self->{http}->request(
+            method => 'GET',
+            hostname => $self->{hostname},
+            url_path => $options{endpoint},
+            get_param => \@get_param,
+            unknown_status => '',
+            warning_status => '',
+            critical_status => ''
+        );
+
+        eval {
+            $decoded = JSON::XS->new->utf8->decode($content);
+        };
+        if ($@) {
+            $self->{output}->output_add(long_msg => $@, debug => 1);
+            $self->{output}->add_option_msg(short_msg => "Cannot decode response (add --debug option to display returned content)");
+            $self->{output}->option_exit();
+        }
+        if (ref($decoded) eq 'HASH' && defined($decoded->{error})) {
+            $self->{output}->add_option_msg(short_msg => "Endpoint returns error code '" . $decoded->{error} . "' (add --debug option for detailed message)");
+            $self->{output}->option_exit();
+        }
+        if (ref($decoded) eq 'HASH' && defined($decoded->{detailCode})) {
+            $self->{output}->add_option_msg(short_msg => "Endpoint returns error code '" . $decoded->{detailCode} . "' (add --debug option for detailed message)");
+            $self->{output}->option_exit();
+        }
+        if ($self->{http}->get_code() != 200) {
+            $self->{output}->add_option_msg(short_msg => "Endpoint error [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "'] (add --debug option for detailed message)");
+            $self->{output}->option_exit();
+        }
+
+        push @results, @$decoded if (ref($decoded) eq 'ARRAY');
+        push @results, $decoded if (ref($decoded) ne 'ARRAY');
+        pop @get_param;
+        $offset += $limit;
+        push @get_param, 'offset=' . $offset;
+    } while (ref($decoded) eq 'ARRAY' && scalar(@$decoded) eq $limit);
+
+    return \@results;
+}
+
+sub get_sources {
+    my ($self, %options) = @_;
+
+    my $result;
+
+    if (defined($options{id}) && $options{id} ne '') {
+        $result = $self->request_api(
+            endpoint => '/' . $self->{api_version} . '/sources/' . $options{id}
+        );
+    } else {
+        $result = $self->request_api(
+            endpoint => '/' . $self->{api_version} . '/sources'
+        );
+    }
+
+    return $result;
+}
+
+sub search_count {
+    my ($self, %options) = @_;
+
+    $self->settings();
+    if (!defined($self->{access_token})) {
+        $self->get_auth_token(statefile => $self->{cache});
+    }
+    $self->{http}->add_header(key => 'Content-Type', value => 'application/json');
+
+    my ($content) = $self->{http}->request(
+        method => 'POST',
+        hostname => $self->{hostname},
+        url_path => '/' . $self->{api_version} . '/search/count',
+        query_form_post => $options{query},
+        unknown_status => '%{http_code} < 200 or %{http_code} >= 300',
+        warning_status => '',
+        critical_status => ''
+    );
+    
+    if ($self->{http}->get_code() != 204) {
+        my $decoded;
+        eval {
+            $decoded = JSON::XS->new->utf8->decode($content);
+        };
+        if ($@) {
+            $self->{output}->output_add(long_msg => $@, debug => 1);
+            $self->{output}->add_option_msg(short_msg => "Cannot decode response (add --debug option to display returned content)");
+            $self->{output}->option_exit();
+        }
+        if (ref($decoded) eq 'HASH' && defined($decoded->{detailCode})) {
+            $self->{output}->add_option_msg(short_msg => "Endpoint returns error code '" . $decoded->{detailCode} . "' (add --debug option for detailed message)");
+            $self->{output}->option_exit();
+        } else {
+            $self->{output}->add_option_msg(short_msg => "Endpoint error [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "'] (add --debug option for detailed message)");
+            $self->{output}->option_exit();
+        }
+    }
+    
+    return $self->{http}->get_header(name => 'X-Total-Count');
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+SailPoint IdentityNow API
+
+=head1 SYNOPSIS
+
+SailPoint IdentityNow API
+
+=head1 SAILPOINT IDENTITYNOW REST API OPTIONS
+
+=over 8
+
+=item B<--tenant>
+
+SailPoint IdentityNow API tenant.
+
+=item B<--domain>
+
+SailPoint IdentityNow API domain  (Default: identitynow)
+
+=item B<--port>
+
+SailPoint IdentityNow API port (Default: 443)
+
+=item B<--proto>
+
+Specify https if needed (Default: 'https')
+
+=item B<--client-id>
+
+SailPoint IdentityNow Client ID
+
+=item B<--client-secret>
+
+SailPoint IdentityNow Client Secret
+
+=item B<--timeout>
+
+Set HTTP timeout
+
+=back
+
+=head1 DESCRIPTION
+
+B<custom>.
+
+=cut

--- a/src/apps/sailpoint/identitynow/restapi/mode/listsources.pm
+++ b/src/apps/sailpoint/identitynow/restapi/mode/listsources.pm
@@ -1,0 +1,122 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::sailpoint::identitynow::restapi::mode::listsources;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+    
+    $options{options}->add_options(arguments => {
+        'filter-name:s' => { name => 'filter_name' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $sources = $options{custom}->get_sources();
+    my $results = [];
+    foreach my $source (@{$sources}) {
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
+            $source->{name} !~ /$self->{option_results}->{filter_name}/);
+        
+        push @$results, {
+            id => $source->{id},
+            name => $source->{name},
+            description => $source->{description},
+            type => $source->{type},
+            status => $source->{status}
+        };
+    }
+
+    return $results;
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    my $sources = $self->manage_selection(%options);
+    foreach my $source (@$sources) {
+        $self->{output}->output_add(
+            long_msg => sprintf(
+                "[id: %s][name: %s][description: %s][type: %s][status: %s]",
+                $source->{id},
+                $source->{name},
+                $source->{description},
+                $source->{type},
+                $source->{status}
+            )
+        );
+    }
+    
+    $self->{output}->output_add(
+        severity => 'OK',
+        short_msg => 'List sources:'
+    );
+    $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+    $self->{output}->exit();
+}
+
+sub disco_format {
+    my ($self, %options) = @_;
+    
+    $self->{output}->add_disco_format(elements => ['id', 'name', 'description', 'type', 'status']);
+}
+
+sub disco_show {
+    my ($self, %options) = @_;
+
+    my $sources = $self->manage_selection(%options);
+    foreach my $source (@$sources) {
+        $self->{output}->add_disco_entry(%$source);
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+List sources.
+
+=over 8
+
+=item B<--filter-name>
+
+Filter source name (Can be a regexp).
+
+=back
+
+=cut

--- a/src/apps/sailpoint/identitynow/restapi/mode/searchcount.pm
+++ b/src/apps/sailpoint/identitynow/restapi/mode/searchcount.pm
@@ -1,0 +1,113 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::sailpoint::identitynow::restapi::mode::searchcount;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0 },
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'results-count', nlabel => 'query.results.count', set => {
+                key_values => [ { name => 'count' } ],
+                closure_custom_output => $self->can('custom_status_output'),
+                perfdatas => [
+                    { template => '%s', min => 0 }
+                ]
+            }
+        }
+    ];
+}
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    my $msg = $self->{instance_mode}->{option_results}->{output};
+    while ($msg =~ /%\{(.*?)\}/g) {
+        my $key = $1;
+        if (defined($self->{result_values}->{$key})) {
+            $msg =~ s/%\{$key\}/$self->{result_values}->{$key}/g;
+        }
+    }
+
+    return $msg;
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+    
+    $options{options}->add_options(arguments => {
+        'query:s'   => { name => 'query' },
+        'output:s'  => { name => 'output', default => 'Number of results: %{count}' },
+    });
+
+    return $self;
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    $self->{global}->{count} = $options{custom}->search_count(query => $self->{option_results}->{query});
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Performs a search with a provided query and returns the
+count of results.
+
+More information on 'https://developer.sailpoint.com/idn/api/v3/search-count/'.
+
+=over 8
+
+=item B<--query>
+
+Query parameters used to construct an Elasticsearch query
+object (see documentation).
+
+=item B<--output>
+
+Output to print after retrieving the count of results
+(Default: "Number of results: %{count}").
+
+=item B<--warning-results-count> B<--critical-results-count>
+
+Thresholds on count of results.
+
+=back
+
+=cut

--- a/src/apps/sailpoint/identitynow/restapi/mode/sourcehealth.pm
+++ b/src/apps/sailpoint/identitynow/restapi/mode/sourcehealth.pm
@@ -1,0 +1,162 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::sailpoint::identitynow::restapi::mode::sourcehealth;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output', skipped_code => { -10 => 1 } },
+        { name => 'sources', type => 1, cb_prefix_output => 'custom_prefix_output', message_multiple => 'All sources health are ok' },
+    ];
+    
+    $self->{maps_counters}->{global} = [];
+    foreach ('healthy', 'error', 'failure', 'unchecked') {
+        push @{$self->{maps_counters}->{global}}, {
+            label => 'sources-' . $_, nlabel => 'sources.status.' . $_ . '.count', set => {
+                key_values => [ { name => $_ } ],
+                output_template => $_ . ': %s',
+                perfdatas => [
+                    { template => '%s' }
+                ]
+            }
+        };
+    }
+
+    $self->{maps_counters}->{sources} = [
+        { label => 'health-status', type => 2, critical_default => '%{status} ne "SOURCE_STATE_HEALTHY"', set => {
+                key_values => [ { name => 'status' }, { name => 'id' }, { name => 'name' } ],
+                output_template => "health status is '%s'",
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+
+    return 'Number of sources ';
+}
+
+sub custom_prefix_output {
+    my ($self, %options) = @_;
+
+    return "Source '" . $options{instance_value}->{name} . "' ";
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+    
+    $options{options}->add_options(arguments => {
+        'source-id:s'   => { name => 'source_id' },
+        'filter-name:s' => { name => 'filter_name' },
+        'filter-type:s' => { name => 'filter_type' }
+    });
+
+    return $self;
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    $self->{global} = { healthy => 0, error => 0, failure => 0, unchecked => 0 };
+
+    my $sources = $options{custom}->get_sources(id => $self->{option_results}->{source_id});
+
+    foreach my $source (@{$sources}) {
+        if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
+            $source->{name} !~ /$self->{option_results}->{filter_name}/) {
+            $self->{output}->output_add(long_msg => "skipping '" . $source->{name} . "': no matching filter name.", debug => 1);
+            next;
+        }
+        if (defined($self->{option_results}->{filter_type}) && $self->{option_results}->{filter_type} ne '' &&
+            $source->{type} !~ /$self->{option_results}->{filter_type}/) {
+            $self->{output}->output_add(long_msg => "skipping '" . $source->{type} . "': no matching filter type.", debug => 1);
+            next;
+        }
+        
+        $self->{global}->{healthy}++ if ($source->{status} eq 'SOURCE_STATE_HEALTHY');
+        $self->{global}->{error}++ if ($source->{status} =~ /SOURCE_STATE_ERROR/);
+        $self->{global}->{failure}++ if ($source->{status} =~ /SOURCE_STATE_FAILURE/);
+        $self->{global}->{unchecked}++ if ($source->{status} =~ /SOURCE_STATE_UNCHECKED/);
+
+        $self->{sources}->{$source->{id}} = {
+            id => $source->{id},
+            name => $source->{name},
+            status => $source->{status}
+        };
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check sources health status.
+
+More information on 'https://developer.sailpoint.com/idn/api/v3/list-sources'.
+
+=over 8
+
+=item B<--source-id>
+
+Define source ID to retrieve only one source health status (useful with service discovery).
+
+=item B<--filter-name>
+
+Filter source name (Can be a regexp).
+
+=item B<--filter-type>
+
+Filter source type (Can be a regexp).
+
+=item B<--warning-health-status>
+
+Set warning threshold for each source health status (Default: none).
+
+=item B<--critical-health-status>
+
+Set critical threshold for each source health status (Default: '%{status} ne "SOURCE_STATE_HEALTHY"').
+
+=item B<--warning-sources-*> B<--critical-sources-*>
+
+Set threshold for each status counter.
+Can be: 'healthy', 'error', 'failure', 'unchecked'.
+
+=back
+
+=cut

--- a/src/apps/sailpoint/identitynow/restapi/plugin.pm
+++ b/src/apps/sailpoint/identitynow/restapi/plugin.pm
@@ -1,0 +1,54 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::sailpoint::identitynow::restapi::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_custom);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{modes} = {
+        'list-sources'  => 'apps::sailpoint::identitynow::restapi::mode::listsources',
+        'search-count'  => 'apps::sailpoint::identitynow::restapi::mode::searchcount',
+        'source-health' => 'apps::sailpoint::identitynow::restapi::mode::sourcehealth',
+    };
+
+    $self->{custom_modes}->{api} = 'apps::sailpoint::identitynow::restapi::custom::api';
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 PLUGIN DESCRIPTION
+
+Check SailPoint IdentityNow using Rest API.
+
+=over 8
+
+=back
+
+=cut


### PR DESCRIPTION
```
perl centreon_plugins.pl --plugin=apps::sailpoint::identitynow::restapi::plugin --mode=source-health --tenant='mytenant' --client-id='***' --client-secret='***' --source-id='' --filter-name='' --filter-type='' --warning-sources-healthy='' --critical-sources-healthy='' --warning-sources-error='' --critical-sources-error='' --warning-sources-failure='' --critical-sources-failure='' --warning-sources-unchecked='' --critical-sources-unchecked='' --warning-health-status='' --critical-health-status='%{status} ne "SOURCE_STATE_HEALTHY"' --verbose
CRITICAL: Source 'Centreon' health status is 'SOURCE_STATE_FAILURE_SOURCE' | 'sources.status.healthy.count'=4;;;; 'sources.status.error.count'=0;;;; 'sources.status.failure.count'=1;;;; 'sources.status.unchecked.count'=0;;;;
Source 'Toto' health status is 'SOURCE_STATE_HEALTHY'
Source 'Azure' health status is 'SOURCE_STATE_HEALTHY'
Source 'Centreon' health status is 'SOURCE_STATE_FAILURE_SOURCE'
Source 'Blabla' health status is 'SOURCE_STATE_HEALTHY'
Source 'Tchoutchou' health status is 'SOURCE_STATE_HEALTHY'
````

````
perl centreon_plugins.pl --plugin=apps::sailpoint::identitynow::restapi::plugin --mode=search-count --tenant='mytenant' --client-id='***' --client-secret='***' --query='{"indices":["accountactivities"],"query":{"query":"sources:\"Centreon\" AND created:[now-1h TO now] AND (status:\"Failure\" OR status:\"Incomplete\")"}}' --output='Number of results: %{count}' --warning-results-count='' --critical-results-count=''
OK: Number of results: 0 | 'query.results.count'=0;;;0;
````