### PR TITLE
enh(plugin): update email notification mode

### DIFF
--- a/src/notification/email/mode/alert.pm
+++ b/src/notification/email/mode/alert.pm
@@ -360,8 +360,6 @@ sub host_message {
 	    }
     </style>
     <![endif]-->
-
-    <!--[if !mso]><!-->
     <link href="https://fonts.googleapis.com/css?family=Red+Hat+Display
     </head>
     <body width="100%" bgcolor="#f6f6f6" style="margin: 0;line-height:1.4;padding:0;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;">
@@ -738,8 +736,6 @@ sub service_message {
         }
     </style>
     <![endif]-->
-
-    <!--[if !mso]><!-->
     <link href="https://fonts.googleapis.com/css?family=Red+Hat+Display
     </head>
     <body width="100%" bgcolor="#f6f6f6" style="margin: 0;line-height:1.4;padding:0;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;">

--- a/src/notification/email/mode/alert.pm
+++ b/src/notification/email/mode/alert.pm
@@ -923,7 +923,6 @@ sub set_payload {
     }
 }
 
-
 sub run {
     my ($self, %options) = @_;
 

--- a/src/notification/email/mode/alert.pm
+++ b/src/notification/email/mode/alert.pm
@@ -360,7 +360,6 @@ sub host_message {
 	    }
     </style>
     <![endif]-->
-    <link href="https://fonts.googleapis.com/css?family=Red+Hat+Display
     </head>
     <body width="100%" bgcolor="#f6f6f6" style="margin: 0;line-height:1.4;padding:0;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;">
         <center style="width: 100%; background: #f6f6f6; text-align: left;">
@@ -736,7 +735,6 @@ sub service_message {
         }
     </style>
     <![endif]-->
-    <link href="https://fonts.googleapis.com/css?family=Red+Hat+Display
     </head>
     <body width="100%" bgcolor="#f6f6f6" style="margin: 0;line-height:1.4;padding:0;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;">
             <center style="width: 100%; background: #f6f6f6; text-align: left;">

--- a/src/notification/email/mode/alert.pm
+++ b/src/notification/email/mode/alert.pm
@@ -263,6 +263,7 @@ sub host_message {
 		    padding: 0 !important;
 		    height: 100% !important;
 		    width: 100% !important;
+		    background-color: #F2F2F2;
 	    }
 	
 	    * {
@@ -638,6 +639,7 @@ sub service_message {
             padding: 0 !important;
             height: 100% !important;
             width: 100% !important;
+		    background-color: #F2F2F2;
         }
         
         * {

--- a/src/notification/email/mode/alert.pm
+++ b/src/notification/email/mode/alert.pm
@@ -578,7 +578,7 @@ sub service_message {
     
     my $img;
     if ($self->{http}->get_code() !~ /200/ || $content =~ /^OK/) {
-         $img = '<h2 style="font-family: CoconPro-BoldCond, Open Sans, Verdana, sans-serif; margin:0; font-size:20px; padding-left:5%;">No graph</h2>';
+        $img = '<h2 style="font-family: CoconPro-BoldCond, Open Sans, Verdana, sans-serif; margin:0; font-size:20px; padding-left:5%;">No graph</h2>';
     } else {
         $self->{payload_attachment}->{png} = $content;
         $img = '<img src="cid:' . $self->{option_results}->{host_name} . '_' . $self->{option_results}->{service_description} . "\" style=\"display:block; width:98%; height:auto;margin:0 10px 0 10px;\">\n";
@@ -857,10 +857,6 @@ sub service_message {
                     <tr>
                         <td width="98%" style="vertical-align:middle;font-size:14px;width:98%;margin:0 10px 0 10px;">
                             <h4 style="font-family: CoconPro-BoldCond, Open Sans, Verdana, sans-serif; margin:0; font-size:15px; color:#b0b0b0; padding-left:3%;text-decoration:underline;">Service Graph:</h4>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
                             '. $img . '
                         </td>
                     </tr>


### PR DESCRIPTION
Update the mode so : 
 - the message can be shown in Outlook (if condition not closed, and useless),
 - an empty attachment is removed for host notification,
 - the graph (or No Graph string) is centered,
 - the background around the body is grey (sexier).