### PR TITLE
Update collection.pm

### DIFF
--- a/src/apps/protocols/snmp/mode/collection.pm
+++ b/src/apps/protocols/snmp/mode/collection.pm
@@ -59,7 +59,7 @@ sub custom_select_perfdata {
 
     return if (!defined($self->{result_values}->{config}->{perfdatas}));
     foreach (@{$self->{result_values}->{config}->{perfdatas}}) {
-        next if (!defined($_->{value}) || $_->{value} !~ /^\d+(?:\.\d+)?$/);
+        next if (!defined($_->{value}) || $_->{value} !~ /^[+-]?\d+(?:\.\d+)?$/);
         $self->{output}->perfdata_add(%$_);
     }
 }


### PR DESCRIPTION
Fixes negative values not displayed at perfdatas : perfdata regex doesn't capture minus or plus signs

## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
This change only modifies the capture regex of the custom_select_perfdata function used in the collection mode.
It will allow to use + or - signs at the beginning of the perfdata value.

* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

With a valid json configuration file, retrieve SNMP values, some of which are negative, and translate them into perfdatas.

Value example : 
```
    .1.3.6.1.4.1.637.61.1.56.5.1.7.4354.0 = -12.74 dBm
    snmp.tables.sfpDiagEntry.[4354.0].sfpDiagRxPower = -12.74 dBm
```

Config file :
```
	"functions": [
	    {
	        "type": "replace",
	        "src": "%(sfpDiagEntry.sfpDiagRxPower)",
	        "expression": "s/.*?(-?\\d+(?:\\.\\d+)?).*/sprintf('%.1f', $1)/e"
	    }
	],
	"perfdatas": [
	    {
	        "nlabel": "isam.sfp.%(eqptBoardEntry.eqptBoardContainerOffset).%(sfpDiagEntry.sfpId).rxpower",
	        "value": "%(sfpDiagEntry.sfpDiagRxPower)",
	        "min": -40,
	        "unit": "dBm"
	    }
	],
	"formatting": {
		"printf_msg": "Card %s.sfp%s:\n  - Rx Power : '%s' dBm",
		"printf_var": [
            "%(eqptBoardEntry.eqptBoardContainerOffset)",
			"%(sfpDiagEntry.sfpId)",
			"%(sfpDiagEntry.sfpDiagRxPower)"
		],
		"display_ok": true
	}
```

With the original collection.pm file, the targeted values are not selected as perfdatas : 
```
All SFP Modules are OK | 'isam.sfp.noLos.count'=3;;;0; 'isam.sfp.nt-a.0.temp'=31.4°C;;;0; 'isam.sfp.nt-a.1.temp'=29.2°C;;;0; 'isam.sfp.nt-b.0.temp'=27.4°C;;;0; 'isam.sfp.nt-b.1.temp'=26.6°C;;;0; 'isam.sfp.los.count'=1;;;0;
Card nt-a.sfp0:
  - Rx Power : '-12.8' dBm
Card nt-a.sfp1:
  - Rx Power : '-10.2' dBm
Card nt-b.sfp0:
  - Rx Power : '-12.7' dBm
Card nt-b.sfp1:
  - Rx Power : 'No Power' dBm
```
  
With the fix, the values are now handle as perfdatas : 
```
OK: All SFP Modules are OK | 'isam.sfp.noLos.count'=3;;;0; 'isam.sfp.nt-a.0.temp'=31.4°C;;;0; 'isam.sfp.nt-a.0.rxpower'=-12.5dBm;;;-40; 'isam.sfp.nt-a.1.temp'=29.2°C;;;0; 'isam.sfp.nt-a.1.rxpower'=-10.1dBm;;;-40; 'isam.sfp.nt-b.0.temp'=27.6°C;;;0; 'isam.sfp.nt-b.0.rxpower'=-12.6dBm;;;-40; 'isam.sfp.nt-b.1.temp'=26.7°C;;;0; 'isam.sfp.los.count'=1;;;0;
Card nt-a.sfp0:
  - Rx Power : '-12.5' dBm
Card nt-a.sfp1:
  - Rx Power : '-10.1' dBm
Card nt-b.sfp0:
  - Rx Power : '-12.6' dBm
Card nt-b.sfp1:
  - Rx Power : 'No Power' dBm
```

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
