### PR TITLE
fix(plugin) Always output headers giving file names to avoid issues.

### DIFF
--- a/src/os/linux/local/mode/process.pm
+++ b/src/os/linux/local/mode/process.pm
@@ -343,7 +343,7 @@ sub add_extra_metrics {
     $self->set_timestamp(timestamp => Time::HiRes::time());
     my ($content) = $options{custom}->execute_command(
         command => 'bash',
-        command_options => "-c 'tail -n +1 /proc/$proc_arg/$files_arg'",
+        command_options => "-c 'tail -vn +1 /proc/$proc_arg/$files_arg'",
         no_quit => 1
     );
 


### PR DESCRIPTION
## Description

When using the centreon_linux_ssh.pl probe with the following plugin:

/usr/lib/centreon/plugins/centreon_linux_ssh.pl --plugin=os::linux::local::plugin --mode=process

If I only use --add-cpu then the CPU is always zero. This is because tail output with a single file is not in the same format as when used with several files.

Example with a single file:

user@XXX:/proc/1416$ bash -c 'tail -n +1 /proc/1416/statm'

0 0 0 0 0 0 0

Example with several files:

user@XXX:/proc/1416$ bash -c 'tail -n +1 /proc/1416/{statm,stat}'

==> /proc/1416/statm <==

0 0 0 0 0 0 0

==> /proc/1416/stat <==

1416 (xfs-data/dm-11) S 2 0 0 0 -1 69247072 0 0 0 0 0 0 0 0 0 0 -20 1 0 489 0 0 18446744073709551615 0 0 0 0 0 0 0 0 0 2147483647 0 18446744073709551615 0 0 17 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0

However, the regexes defined by the plugin (/==>\s*\/proc\/$pid\/io\s+.*?\n(.*?)(?:==>|\Z)/ms) only take into account output with several files, which is why the cpu or memory calculation is not performed when there is only one argument.

To solve this problem, add -v to tail:

user@XXX:/proc/1416$ bash -c 'tail -v -n +1 /proc/1416/statm'

==> /proc/1416/statm <==

0 0 0 0 0 0 0

**Fixes** # MON-20957

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
