### PR TITLE
(fix) Adapt plugins tests from bash to robot framework

### DIFF
--- a/.github/workflows/tests-functional.yml
+++ b/.github/workflows/tests-functional.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: "16.x"
 
       - name: Install Mockoon CLI
-        run: npm install -g -D @mockoon/cli
+        run: npm install -g -D @mockoon/cli@3.1.0
 
       - name: Install libs
         run: sudo apt-get install libcurl4-openssl-dev


### PR DESCRIPTION
Fix mockoon (use version 3 and not the latest)