### PR TITLE
fix(pkg): missing include of uptime module

### DIFF
--- a/packaging/centreon-plugin-Hardware-Sensors-Rittal-Cmc3-Snmp/pkg.json
+++ b/packaging/centreon-plugin-Hardware-Sensors-Rittal-Cmc3-Snmp/pkg.json
@@ -5,6 +5,7 @@
     "files": [
         "centreon/plugins/script_snmp.pm",
         "centreon/plugins/snmp.pm",
+        "snmp_standard/mode/uptime.pm",
         "hardware/sensors/rittal/cmc3/snmp/"
     ]
 }


### PR DESCRIPTION
## Description

missing include of uptime module in packaging

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
