### PR TITLE
Change mapping values for PSU

### DIFF
--- a/src/network/citrix/netscaler/snmp/mode/components/psu.pm
+++ b/src/network/citrix/netscaler/snmp/mode/components/psu.pm
@@ -24,10 +24,10 @@ use strict;
 use warnings;
 
 my %map_psu_status = (
-    0 => 'normal',
+    0 => 'not supported',
     1 => 'not present',
     2 => 'failed',
-    3 => 'not supported',
+    3 => 'normal',
 );
 
 my $mapping = {


### PR DESCRIPTION
## Description

According to customer tests and to the following article, it seems 0 and 3 values were inverted:
https://support.citrix.com/article/CTX133887/citrix-adc-system-counters
![image](https://github.com/centreon/centreon-plugins/assets/11076322/293b4c29-f405-427d-929b-c3945919720e)

**Fixes** MON-21051

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)
