### PR TITLE
[Plugins] - MON-16256 Retrieve alerts from kadiska

### DIFF
--- a/src/apps/monitoring/kadiska/mode/alerts.pm
+++ b/src/apps/monitoring/kadiska/mode/alerts.pm
@@ -1,0 +1,252 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::monitoring::kadiska::mode::alerts;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+    return 'Rules: ';
+}
+
+sub prefix_warning_output {
+    my ($self, %options) = @_;
+    return 'Warnings: ';
+}
+
+sub prefix_critical_output {
+    my ($self, %options) = @_;
+    return 'Criticals: ';
+}
+
+sub prefix_nodata_output {
+    my ($self, %options) = @_;
+    return 'No data: ';
+}
+
+sub prefix_rules_output {
+    my ($self, %options) = @_;
+    return sprintf('Rule id: "%s", Rule name: "%s" ',
+        $options{instance_value}->{id},
+        $options{instance_value}->{name});
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output', skipped_code => { -10 => 1 } },
+        { name => 'total_critical', type => 0, cb_prefix_output => 'prefix_critical_output'},
+        { name => 'total_warning', type => 0, cb_prefix_output => 'prefix_warning_output'},
+        { name => 'total_nodata', type => 0, cb_prefix_output => 'prefix_nodata_output'},
+        { name => 'rules', type => 1, cb_prefix_output => 'prefix_rules_output' }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'rules-total', nlabel => 'rules.total.count', set => {
+                key_values => [ { name => 'total' }  ],
+                output_template => 'total rules: %s',
+                perfdatas => [ { template => '%d', min => 0 } ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{total_critical} = [
+        { label => 'criticals-total', nlabel => 'criticals.total.count', set
+                => {
+                key_values => [ { name => 'total_critical' }  ],
+                output_template => 'total critical: %s',
+                perfdatas => [ { template => '%d', min => 0 } ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{total_warning} = [
+        { label => 'warnings-total', nlabel => 'warnings.total.count', set => {
+                key_values => [ { name => 'total_warning' }  ],
+                output_template => 'total warning: %s',
+                perfdatas => [ { template => '%d', min => 0 } ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{total_nodata} = [
+        { label => 'no-data-total', nlabel => 'no.data.total.count', set => {
+                key_values => [ { name => 'total_nodata' }  ],
+                output_template => 'total no data: %s',
+                perfdatas => [ { template => '%d', min => 0 } ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{rules} = [
+        { label => 'rule-ok-count',
+            type => 1,
+            set => {
+                key_values => [ { name => 'ok_count' } ],
+                output_template => 'ok count: %s',
+                display_ok => 0,
+                closure_custom_perfdata => sub { return 0; }
+            }
+        },
+        { label => 'rule-warning-count',
+            type => 1,
+            set => {
+                key_values => [ { name => 'warning_count' } ],
+                output_template => 'warning count: %s',
+                display_ok => 0,
+                closure_custom_perfdata => sub { return 0; }
+            }
+        },
+        { label => 'rule-critical-count',
+            type => 1,
+            set => {
+                key_values => [ { name => 'critical_count' } ],
+                output_template => 'critical count: %s',
+                display_ok => 0,
+                closure_custom_perfdata => sub { return 0; }
+            }
+        },
+        { label => 'rule-nodata-count',
+            type => 1,
+            set => {
+                key_values => [ { name => 'nodata_count' } ],
+                output_template => 'no data count: %s',
+                display_ok => 0,
+                closure_custom_perfdata => sub { return 0; }
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s'     => { name => 'filter_name' }
+    });
+
+    return $self;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $raw_form_post = {
+        "select" => [
+            {
+                "rule_id:group" => "rule_id"
+            },
+            {
+                "rule_name:any" => ["any","rule_name"]
+            },
+            {
+                ["any","rule_name"] => ["any","rule_id"]
+            },
+            {
+                "critical:count" => ["sum","critical_count"]
+            },
+            {
+                "warning:count" => ["sum","warning_count"]
+            },
+            {
+                "ok:count" => ["sum","ok_count"]
+            },
+            {
+                "nodata:count" => ["sum","nodata_count"]
+            }
+        ],
+        "from" => "alert",
+        "groupby" => [
+            "rule_id:group"
+        ],
+        "orderby" => [
+            ["rule_name:any","desc"]
+        ],
+        "offset" => 0,
+        "limit" => 61
+    };
+
+    my $results = $options{custom}->request_api(
+        method => 'POST',
+        endpoint => 'query',
+        query_form_post => $raw_form_post
+    );
+
+    #Check if bad API request is submit
+    if (!exists $results->{data}) {
+        $self->{output}->add_option_msg(short_msg => 'No data result in API request.');
+        $self->{output}->option_exit();
+    }
+
+    $self->{total_critical}->{total_critical}=0;
+    $self->{total_warning}->{total_warning}=0;
+    $self->{total_nodata}->{total_nodata}=0;
+
+    foreach (@{$results->{data}}) {
+        my $rule = $_;
+
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
+             $rule->{'rule_name:any'} !~ /$self->{option_results}->{filter_name}/);
+
+        $self->{rules}->{$rule->{'rule_id:group'}} = {
+            id             => $rule->{'rule_id:group'},
+            name           => $rule->{'rule_name:any'},
+            ok_count       => $rule->{'ok:count'},
+            warning_count  => $rule->{'warning:count'},
+            critical_count => $rule->{'critical:count'},
+            nodata_count   => $rule->{'nodata:count'}
+        };
+        $self->{total_critical}->{total_critical}+=$rule->{'critical:count'};
+        $self->{total_warning}->{total_warning}+=$rule->{'warning:count'};
+        $self->{total_nodata}->{total_nodata}+=$rule->{'nodata:count'};
+    }
+    $self->{global}->{total} = scalar (keys %{$self->{rules}});
+
+    if (scalar(keys %{$self->{rules}}) <= 0) {
+        $self->{output}->add_option_msg(short_msg => 'No rule found.');
+        $self->{output}->option_exit();
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Kadiska rules alerts status.
+
+=over 8
+
+=item B<--filter-name>
+
+Only get rules by name (can be a regexp).
+
+=back
+
+=cut

--- a/src/apps/monitoring/kadiska/mode/alerts.pm
+++ b/src/apps/monitoring/kadiska/mode/alerts.pm
@@ -47,26 +47,32 @@ sub set_counters {
     ];
 
     $self->{maps_counters}->{global} = [
-        { label => 'rules-total', nlabel => 'rules.total.count', set => {
+        { label => 'rules-total-count', nlabel => 'rules.total.count', set => {
                 key_values => [ { name => 'total' }  ],
                 output_template => 'total rules: %s',
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
         },
-        { label => 'criticals-total', nlabel => 'criticals.total.count', set
+        { label => 'rules-criticals-total-count', nlabel => 'criticals.total
+        .count',
+            set
                 => {
                 key_values => [ { name => 'total_critical' }  ],
-                output_template => 'total critical: %s',
+                output_template => 'total criticals: %s',
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
         },
-        { label => 'warnings-total', nlabel => 'warnings.total.count', set => {
+        { label => 'rules-warnings-total-count', nlabel => 'warnings.total
+        .count',
+            set => {
                 key_values => [ { name => 'total_warning' }  ],
-                output_template => 'total warning: %s',
+                output_template => 'total warnings: %s',
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
         },
-        { label => 'no-data-total', nlabel => 'no.data.total.count', set => {
+        { label => 'rules-nodata-total-count', nlabel => 'no.data.total.count',
+            set
+                => {
                 key_values => [ { name => 'total_nodata' }  ],
                 output_template => 'total no data: %s',
                 perfdatas => [ { template => '%d', min => 0 } ]

--- a/src/apps/monitoring/kadiska/mode/alerts.pm
+++ b/src/apps/monitoring/kadiska/mode/alerts.pm
@@ -74,28 +74,28 @@ sub set_counters {
     ];
 
     $self->{maps_counters}->{rules} = [
-        { label => 'rule-ok-count', nlabel => 'rule-ok-count', set => {
+        { label => 'rule-ok-count', nlabel => 'rule.ok.count', set => {
                 key_values => [ { name => 'ok_count' } ],
                 output_template => 'ok count: %s',
                 display_ok => 0,
                 perfdatas => [ {template => '%s', min => 0, label_extra_instance => 1, instance_use => 'name' } ]
             }
         },
-        { label => 'rule-warning-count', nlabel => 'rule-warning-count', set => {
+        { label => 'rule-warning-count', nlabel => 'rule.warning.count', set => {
                 key_values => [ { name => 'warning_count' } ],
                 output_template => 'warning count: %s',
                 display_ok => 0,
                 perfdatas => [ {template => '%s', min => 0, label_extra_instance => 1, instance_use => 'name' } ]
             }
         },
-        { label => 'rule-critical-count', nlabel => 'rule-critical-count', set => {
+        { label => 'rule-critical-count', nlabel => 'rule.critical.count', set => {
                 key_values => [ { name => 'critical_count' } ],
                 output_template => 'critical count: %s',
                 display_ok => 0,
                 perfdatas => [ {template => '%s', min => 0, label_extra_instance => 1, instance_use => 'name' } ]
             }
         },
-        { label => 'rule-nodata-count', nlabel => 'rule-nodata-count', set => {
+        { label => 'rule-nodata-count', nlabel => 'rule.nodata.count', set => {
                 key_values => [ { name => 'nodata_count' } ],
                 output_template => 'no data count: %s',
                 display_ok => 0,

--- a/src/apps/monitoring/kadiska/mode/alerts.pm
+++ b/src/apps/monitoring/kadiska/mode/alerts.pm
@@ -53,8 +53,7 @@ sub set_counters {
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
         },
-        { label => 'rules-criticals-total-count', nlabel => 'criticals.total
-        .count',
+        { label => 'rules-criticals-total-count', nlabel => 'criticals.total.count',
             set
                 => {
                 key_values => [ { name => 'total_critical' }  ],
@@ -62,8 +61,7 @@ sub set_counters {
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
         },
-        { label => 'rules-warnings-total-count', nlabel => 'warnings.total
-        .count',
+        { label => 'rules-warnings-total-count', nlabel => 'warnings.total.count',
             set => {
                 key_values => [ { name => 'total_warning' }  ],
                 output_template => 'total warnings: %s',

--- a/src/apps/monitoring/kadiska/mode/alerts.pm
+++ b/src/apps/monitoring/kadiska/mode/alerts.pm
@@ -75,39 +75,39 @@ sub set_counters {
 
     $self->{maps_counters}->{rules} = [
         { label => 'rule-ok-count',
-            type => 1,
             set => {
                 key_values => [ { name => 'ok_count' } ],
                 output_template => 'ok count: %s',
                 display_ok => 0,
-                closure_custom_perfdata => sub { return 0; }
+                closure_custom_perfdata => sub { return 0; },
+                perfdatas => [ {template => '%s', min => 0, label_extra_instance => 1, instance_use => 'name' } ]
             }
         },
         { label => 'rule-warning-count',
-            type => 1,
             set => {
                 key_values => [ { name => 'warning_count' } ],
                 output_template => 'warning count: %s',
                 display_ok => 0,
-                closure_custom_perfdata => sub { return 0; }
+                closure_custom_perfdata => sub { return 0; },
+                perfdatas => [ {template => '%s', min => 0, label_extra_instance => 1, instance_use => 'name' } ]
             }
         },
         { label => 'rule-critical-count',
-            type => 1,
             set => {
                 key_values => [ { name => 'critical_count' } ],
                 output_template => 'critical count: %s',
                 display_ok => 0,
-                closure_custom_perfdata => sub { return 0; }
+                closure_custom_perfdata => sub { return 0; },
+                perfdatas => [ {template => '%s', min => 0, label_extra_instance => 1, instance_use => 'name' } ]
             }
         },
         { label => 'rule-nodata-count',
-            type => 1,
             set => {
                 key_values => [ { name => 'nodata_count' } ],
                 output_template => 'no data count: %s',
                 display_ok => 0,
-                closure_custom_perfdata => sub { return 0; }
+                closure_custom_perfdata => sub { return 0; },
+                perfdatas => [ {template => '%s', min => 0, label_extra_instance => 1, instance_use => 'name' } ]
             }
         }
     ];

--- a/src/apps/monitoring/kadiska/mode/alerts.pm
+++ b/src/apps/monitoring/kadiska/mode/alerts.pm
@@ -53,24 +53,19 @@ sub set_counters {
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
         },
-        { label => 'rules-criticals-total-count', nlabel => 'rules.criticals.count',
-            set
-                => {
+        { label => 'rules-criticals-total-count', nlabel => 'rules.criticals.count', set => {
                 key_values => [ { name => 'total_critical' }  ],
                 output_template => 'total criticals: %s',
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
         },
-        { label => 'rules-warnings-total-count', nlabel => 'rules.warnings.count',
-            set => {
+        { label => 'rules-warnings-total-count', nlabel => 'rules.warnings.count', set => {
                 key_values => [ { name => 'total_warning' }  ],
                 output_template => 'total warnings: %s',
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
         },
-        { label => 'rules-nodata-total-count', nlabel => 'rules.nodata.count',
-            set
-                => {
+        { label => 'rules-nodata-total-count', nlabel => 'rules.nodata.count', set => {
                 key_values => [ { name => 'total_nodata' }  ],
                 output_template => 'total no data: %s',
                 perfdatas => [ { template => '%d', min => 0 } ]
@@ -180,9 +175,7 @@ sub manage_selection {
         $self->{output}->option_exit();
     }
 
-    $self->{total_critical}->{total_critical}=0;
-    $self->{total_warning}->{total_warning}=0;
-    $self->{total_nodata}->{total_nodata}=0;
+    $self->{global} = { total_critical => 0, total_warning => 0, total_nodata => 0 };
 
     foreach (@{$results->{data}}) {
         my $rule = $_;

--- a/src/apps/monitoring/kadiska/mode/alerts.pm
+++ b/src/apps/monitoring/kadiska/mode/alerts.pm
@@ -31,21 +31,6 @@ sub prefix_global_output {
     return 'Rules: ';
 }
 
-sub prefix_warning_output {
-    my ($self, %options) = @_;
-    return 'Warnings: ';
-}
-
-sub prefix_critical_output {
-    my ($self, %options) = @_;
-    return 'Criticals: ';
-}
-
-sub prefix_nodata_output {
-    my ($self, %options) = @_;
-    return 'No data: ';
-}
-
 sub prefix_rules_output {
     my ($self, %options) = @_;
     return sprintf('Rule id: "%s", Rule name: "%s" ',
@@ -57,10 +42,7 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output', skipped_code => { -10 => 1 } },
-        { name => 'total_critical', type => 0, cb_prefix_output => 'prefix_critical_output'},
-        { name => 'total_warning', type => 0, cb_prefix_output => 'prefix_warning_output'},
-        { name => 'total_nodata', type => 0, cb_prefix_output => 'prefix_nodata_output'},
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output'},
         { name => 'rules', type => 1, cb_prefix_output => 'prefix_rules_output' }
     ];
 
@@ -70,29 +52,20 @@ sub set_counters {
                 output_template => 'total rules: %s',
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
-        }
-    ];
-
-    $self->{maps_counters}->{total_critical} = [
+        },
         { label => 'criticals-total', nlabel => 'criticals.total.count', set
                 => {
                 key_values => [ { name => 'total_critical' }  ],
                 output_template => 'total critical: %s',
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
-        }
-    ];
-
-    $self->{maps_counters}->{total_warning} = [
+        },
         { label => 'warnings-total', nlabel => 'warnings.total.count', set => {
                 key_values => [ { name => 'total_warning' }  ],
                 output_template => 'total warning: %s',
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
-        }
-    ];
-
-    $self->{maps_counters}->{total_nodata} = [
+        },
         { label => 'no-data-total', nlabel => 'no.data.total.count', set => {
                 key_values => [ { name => 'total_nodata' }  ],
                 output_template => 'total no data: %s',
@@ -221,9 +194,9 @@ sub manage_selection {
             critical_count => $rule->{'critical:count'},
             nodata_count   => $rule->{'nodata:count'}
         };
-        $self->{total_critical}->{total_critical}+=$rule->{'critical:count'};
-        $self->{total_warning}->{total_warning}+=$rule->{'warning:count'};
-        $self->{total_nodata}->{total_nodata}+=$rule->{'nodata:count'};
+        $self->{global}->{total_critical}+=$rule->{'critical:count'};
+        $self->{global}->{total_warning}+=$rule->{'warning:count'};
+        $self->{global}->{total_nodata}+=$rule->{'nodata:count'};
     }
     $self->{global}->{total} = scalar (keys %{$self->{rules}});
 

--- a/src/apps/monitoring/kadiska/mode/alerts.pm
+++ b/src/apps/monitoring/kadiska/mode/alerts.pm
@@ -74,39 +74,31 @@ sub set_counters {
     ];
 
     $self->{maps_counters}->{rules} = [
-        { label => 'rule-ok-count',
-            set => {
+        { label => 'rule-ok-count', nlabel => 'rule-ok-count', set => {
                 key_values => [ { name => 'ok_count' } ],
                 output_template => 'ok count: %s',
                 display_ok => 0,
-                closure_custom_perfdata => sub { return 0; },
                 perfdatas => [ {template => '%s', min => 0, label_extra_instance => 1, instance_use => 'name' } ]
             }
         },
-        { label => 'rule-warning-count',
-            set => {
+        { label => 'rule-warning-count', nlabel => 'rule-warning-count', set => {
                 key_values => [ { name => 'warning_count' } ],
                 output_template => 'warning count: %s',
                 display_ok => 0,
-                closure_custom_perfdata => sub { return 0; },
                 perfdatas => [ {template => '%s', min => 0, label_extra_instance => 1, instance_use => 'name' } ]
             }
         },
-        { label => 'rule-critical-count',
-            set => {
+        { label => 'rule-critical-count', nlabel => 'rule-critical-count', set => {
                 key_values => [ { name => 'critical_count' } ],
                 output_template => 'critical count: %s',
                 display_ok => 0,
-                closure_custom_perfdata => sub { return 0; },
                 perfdatas => [ {template => '%s', min => 0, label_extra_instance => 1, instance_use => 'name' } ]
             }
         },
-        { label => 'rule-nodata-count',
-            set => {
+        { label => 'rule-nodata-count', nlabel => 'rule-nodata-count', set => {
                 key_values => [ { name => 'nodata_count' } ],
                 output_template => 'no data count: %s',
                 display_ok => 0,
-                closure_custom_perfdata => sub { return 0; },
                 perfdatas => [ {template => '%s', min => 0, label_extra_instance => 1, instance_use => 'name' } ]
             }
         }

--- a/src/apps/monitoring/kadiska/mode/alerts.pm
+++ b/src/apps/monitoring/kadiska/mode/alerts.pm
@@ -53,7 +53,7 @@ sub set_counters {
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
         },
-        { label => 'rules-criticals-total-count', nlabel => 'criticals.total.count',
+        { label => 'rules-criticals-total-count', nlabel => 'rules.criticals.count',
             set
                 => {
                 key_values => [ { name => 'total_critical' }  ],
@@ -61,14 +61,14 @@ sub set_counters {
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
         },
-        { label => 'rules-warnings-total-count', nlabel => 'warnings.total.count',
+        { label => 'rules-warnings-total-count', nlabel => 'rules.warnings.count',
             set => {
                 key_values => [ { name => 'total_warning' }  ],
                 output_template => 'total warnings: %s',
                 perfdatas => [ { template => '%d', min => 0 } ]
             }
         },
-        { label => 'rules-nodata-total-count', nlabel => 'no.data.total.count',
+        { label => 'rules-nodata-total-count', nlabel => 'rules.nodata.count',
             set
                 => {
                 key_values => [ { name => 'total_nodata' }  ],

--- a/src/apps/monitoring/kadiska/mode/listalertrules.pm
+++ b/src/apps/monitoring/kadiska/mode/listalertrules.pm
@@ -20,7 +20,7 @@
 
 package apps::monitoring::kadiska::mode::listalertrules;
 
-use base qw(centreon::plugins::templates::counter);
+use base qw(centreon::plugins::mode);
 
 use strict;
 use warnings;

--- a/src/apps/monitoring/kadiska/mode/listalertrules.pm
+++ b/src/apps/monitoring/kadiska/mode/listalertrules.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package apps::monitoring::kadiska::mode::listrules;
+package apps::monitoring::kadiska::mode::listalertrules;
 
 use base qw(centreon::plugins::templates::counter);
 
@@ -113,7 +113,7 @@ sub run {
     }
 
     $self->{output}->output_add(severity => 'OK',
-                                short_msg => 'List rules:');
+                                short_msg => 'List alert rules:');
     $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
     $self->{output}->exit();
 }

--- a/src/apps/monitoring/kadiska/mode/listrules.pm
+++ b/src/apps/monitoring/kadiska/mode/listrules.pm
@@ -1,0 +1,155 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::monitoring::kadiska::mode::listrules;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        "filter-name:s" => { name => 'filter_name' },
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+        my $raw_form_post = {
+        "select" => [
+            {
+                "rule_id:group" => "rule_id"
+            },
+            {
+                "rule_name:any" => ["any","rule_name"]
+            },
+            {
+                ["any","rule_name"] => ["any","rule_id"]
+            }
+        ],
+        "from" => "alert",
+        "groupby" => [
+            "rule_id:group"
+        ],
+        "orderby" => [
+            ["rule_name:any","desc"]
+        ],
+        "offset" => 0,
+        "limit" => 61
+    };
+
+    my $results = $options{custom}->request_api(
+    method => 'POST',
+    endpoint => 'query',
+    query_form_post => $raw_form_post
+    );
+
+    #Check if bad API request is submit
+    if (!exists $results->{data}) {
+        $self->{output}->add_option_msg(short_msg => 'No data result in API request.');
+        $self->{output}->option_exit();
+    }
+
+    foreach (@{$results->{data}}) {
+        my $rule = $_;
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
+             $rule->{'rule_name:any'} !~ /$self->{option_results}->{filter_name}/);
+
+        my @tags;
+        foreach my $tag (@{$rule->{tags}}) {
+            push @tags, (keys %{$tag})[0] . ':' . (values %{$tag})[0];
+        }
+
+        $self->{rules}->{$rule->{'rule_id:group'}} = {
+            id   => $rule->{'rule_id:group'},
+            name => $rule->{'rule_name:any'}
+        }
+    }
+
+    if (scalar(keys %{$self->{rules}}) <= 0) {
+        $self->{output}->add_option_msg(short_msg => 'No rule found.');
+        $self->{output}->option_exit();
+    }
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    $self->manage_selection(%options);
+    foreach my $rule (sort keys %{$self->{rules}}) {
+        $self->{output}->output_add(long_msg => sprintf("[name = %s] [id = %s]",
+                                                         $self->{rules}->{$rule}->{name},
+                                                         $self->{rules}->{$rule}->{id}));
+    }
+
+    $self->{output}->output_add(severity => 'OK',
+                                short_msg => 'List rules:');
+    $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+    $self->{output}->exit();
+}
+
+sub disco_format {
+    my ($self, %options) = @_;
+
+    $self->{output}->add_disco_format(elements => ['name', 'id']);
+}
+
+sub disco_show {
+    my ($self, %options) = @_;
+
+    $self->manage_selection(%options);
+    foreach my $rule (sort keys %{$self->{rules}}) {
+        $self->{output}->add_disco_entry(
+            name => $self->{rules}->{$rule}->{name},
+            id => $self->{rules}->{$rule}->{id}
+        );
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+List kadiska alert rules.
+
+=over 8
+
+=item B<--filter-name>
+
+Filter rule name (can be a regexp).
+
+=back
+
+=cut

--- a/src/apps/monitoring/kadiska/plugin.pm
+++ b/src/apps/monitoring/kadiska/plugin.pm
@@ -30,6 +30,7 @@ sub new {
     bless $self, $class;
 
     $self->{modes} = {
+        'alerts'                => 'apps::monitoring::kadiska::mode::alerts',
         'list-watchers'         => 'apps::monitoring::kadiska::mode::listwatchers',
         'list-runners'          => 'apps::monitoring::kadiska::mode::listrunners',
         'list-targets'          => 'apps::monitoring::kadiska::mode::listtargets',

--- a/src/apps/monitoring/kadiska/plugin.pm
+++ b/src/apps/monitoring/kadiska/plugin.pm
@@ -31,7 +31,7 @@ sub new {
 
     $self->{modes} = {
         'alerts'                => 'apps::monitoring::kadiska::mode::alerts',
-        'list-rules'            => 'apps::monitoring::kadiska::mode::listrules',
+        'list-alertrules'       => 'apps::monitoring::kadiska::mode::listalertrules',
         'list-runners'          => 'apps::monitoring::kadiska::mode::listrunners',
         'list-targets'          => 'apps::monitoring::kadiska::mode::listtargets',
         'list-watchers'         => 'apps::monitoring::kadiska::mode::listwatchers',

--- a/src/apps/monitoring/kadiska/plugin.pm
+++ b/src/apps/monitoring/kadiska/plugin.pm
@@ -31,11 +31,12 @@ sub new {
 
     $self->{modes} = {
         'alerts'                => 'apps::monitoring::kadiska::mode::alerts',
-        'list-watchers'         => 'apps::monitoring::kadiska::mode::listwatchers',
+        'list-rules'            => 'apps::monitoring::kadiska::mode::listrules',
         'list-runners'          => 'apps::monitoring::kadiska::mode::listrunners',
         'list-targets'          => 'apps::monitoring::kadiska::mode::listtargets',
-        'watcher-statistics'    => 'apps::monitoring::kadiska::mode::watcherstatistics',
-        'nettracer-statistics'  => 'apps::monitoring::kadiska::mode::nettracerstatistics'
+        'list-watchers'         => 'apps::monitoring::kadiska::mode::listwatchers',
+        'nettracer-statistics'  => 'apps::monitoring::kadiska::mode::nettracerstatistics',
+        'watcher-statistics'    => 'apps::monitoring::kadiska::mode::watcherstatistics'
     };
 
     $self->{custom_modes}->{api} = 'apps::monitoring::kadiska::custom::api';

--- a/src/apps/monitoring/kadiska/plugin.pm
+++ b/src/apps/monitoring/kadiska/plugin.pm
@@ -31,7 +31,7 @@ sub new {
 
     $self->{modes} = {
         'alerts'                => 'apps::monitoring::kadiska::mode::alerts',
-        'list-alertrules'       => 'apps::monitoring::kadiska::mode::listalertrules',
+        'list-alert-rules'       => 'apps::monitoring::kadiska::mode::listalertrules',
         'list-runners'          => 'apps::monitoring::kadiska::mode::listrunners',
         'list-targets'          => 'apps::monitoring::kadiska::mode::listtargets',
         'list-watchers'         => 'apps::monitoring::kadiska::mode::listwatchers',


### PR DESCRIPTION
## Description

Retrieve rules alerts from Kadiska with new mode alerts.
New discovery service for rules alerts.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

<h2> How this pull request can be tested ? </h2>

To test this PR you need access to Kadiska credentials (client-id and client-secret)
Also you need to set up alert rules 

Example how to test alerts.pm : (period=120 minutes => 2 hours)
```
perl centreon_plugins.pl     --plugin=apps::monitoring::kadiska::plugin --mode=alerts --client-id=CLIENT_ID --client-secret=CLIENT_SECRET --period=120 --verbose
```

Example how to test listrules.pm : (period=120 minutes => 2 hours)
```
perl centreon_plugins.pl     --plugin=apps::monitoring::kadiska::plugin --mode=list-rules --client-id=CLIENT_ID --client-secret=CLIENT_SECRET --period=120 --verbose
```

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
