### PR TITLE
fix(plugin): network::mikrotik::snmp - fix the SSIDs listing

### DIFF
--- a/src/network/mikrotik/snmp/mode/listssids.pm
+++ b/src/network/mikrotik/snmp/mode/listssids.pm
@@ -73,7 +73,7 @@ sub run {
         $self->{output}->option_exit();
     }
     
-    my $mktFrequenOid = '.1.3.6.1.4.1.14988.1.1.1.3.1.4';
+    my $mktFrequenOid = '.1.3.6.1.4.1.14988.1.1.1.3.1.4.';
 
     foreach (sort @{$self->{datas}->{all_ids}}) {
         my $display_value = $self->get_display_value(id => $_);


### PR DESCRIPTION
## Description

https://thewatch.centreon.com/data-usage-and-visualization-38/mikrotik-snmp-plugin-2127

A missing dot prevents the plugin SSIDs list from being displayed

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
