### PR TITLE
(plugin) os::linux::local - add mode systemd-journal

### DIFF
--- a/src/os/linux/local/mode/cpu.pm
+++ b/src/os/linux/local/mode/cpu.pm
@@ -107,7 +107,7 @@ sub set_counters {
                 output_template => 'CPU(s) average usage is %.2f %%',
                 output_use => 'prct_used', threshold_use => 'prct_used',
                 perfdatas => [
-                    { label => 'total_cpu_avg', value => 'prct_used', template => '%.2f',
+                    { value => 'prct_used', template => '%.2f',
                       min => 0, max => 100, unit => '%' }
                 ]
             }
@@ -124,7 +124,7 @@ sub set_counters {
                 output_template => 'usage : %.2f %%',
                 output_use => 'prct_used', threshold_use => 'prct_used',
                 perfdatas => [
-                    { label => 'cpu', value => 'prct_used', template => '%.2f',
+                    { value => 'prct_used', template => '%.2f',
                       min => 0, max => 100, unit => '%', label_extra_instance => 1 }
                 ]
             }
@@ -140,7 +140,7 @@ sub prefix_cpu_core_output {
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(package => __PACKAGE__, %options, statefile => 1);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, statefile => 1, force_new_perfdata => 1);
     bless $self, $class;
 
     $options{options}->add_options(arguments => {

--- a/src/os/linux/local/mode/filesdate.pm
+++ b/src/os/linux/local/mode/filesdate.pm
@@ -28,7 +28,7 @@ use centreon::plugins::misc;
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
     
     $options{options}->add_options(arguments => {
@@ -115,8 +115,11 @@ sub run {
                 short_msg => sprintf('%s: %s seconds (time: %s)', $name, $diff_time, scalar(localtime($time)))
             );
         }
+
         $self->{output}->perfdata_add(
-            label => $name, unit => 's',
+            nlabel => 'file.mtime.last.seconds',
+            instances => $name,
+            unit => 's',
             value => $diff_time,
             warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning'),
             critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical')

--- a/src/os/linux/local/mode/filessize.pm
+++ b/src/os/linux/local/mode/filessize.pm
@@ -28,7 +28,7 @@ use centreon::plugins::misc;
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
     
     $options{options}->add_options(arguments => {
@@ -123,7 +123,9 @@ sub run {
             );
         }
         $self->{output}->perfdata_add(
-            label => $name, unit => 'B',
+            nlabel => 'file.size.bytes',
+            instances => $name,
+            unit => 'B',
             value => $size,
             warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning_one'),
             critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical_one'),
@@ -145,7 +147,8 @@ sub run {
         );
     }
     $self->{output}->perfdata_add(
-        label => 'total', unit => 'B',
+        nlabel => 'files.size.bytes',
+        unit => 'B',
         value => $total_size,
         warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning_total'),
         critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical_total'),

--- a/src/os/linux/local/mode/inodes.pm
+++ b/src/os/linux/local/mode/inodes.pm
@@ -39,7 +39,7 @@ sub set_counters {
     ];
     
     $self->{maps_counters}->{inodes} = [
-        { label => 'usage', set => {
+        { label => 'usage', nlabel => 'storage.inodes.usage.percentage', set => {
                 key_values => [ { name => 'used' }, { name => 'display' } ],
                 output_template => 'used: %s %%',
                 perfdatas => [
@@ -53,7 +53,7 @@ sub set_counters {
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
     
     $options{options}->add_options(arguments => {

--- a/src/os/linux/local/mode/packeterrors.pm
+++ b/src/os/linux/local/mode/packeterrors.pm
@@ -75,46 +75,46 @@ sub set_counters {
                 closure_custom_threshold_check => \&catalog_status_threshold_ng
             }
         },
-        { label => 'in-discard', set => {
+        { label => 'in-discard', nlabel => 'interface.packets.in.discard.percentage', set => {
                 key_values => [ { name => 'discard_in', diff => 1 }, { name => 'total_in', diff => 1 }, { name => 'display' } ],
                 closure_custom_calc => $self->can('custom_packet_calc'), closure_custom_calc_extra_options => { type => 'discard', label_ref => 'in' },
                 closure_custom_output => $self->can('custom_packet_output'), output_error_template => 'Discard In : %s',
                 threshold_use => 'result_prct',
                 perfdatas => [
-                    { label => 'packets_discard_in', value => 'result_prct', template => '%.2f', min => 0, max => 100,
+                    { value => 'result_prct', template => '%.2f', min => 0, max => 100,
                       unit => '%', label_extra_instance => 1, instance_use => 'display' }
                 ]
             }
         },
-        { label => 'out-discard', set => {
+        { label => 'out-discard', nlabel => 'interface.packets.out.discard.percentage', set => {
                 key_values => [ { name => 'discard_out', diff => 1 }, { name => 'total_out', diff => 1 }, { name => 'display' } ],
                 closure_custom_calc => $self->can('custom_packet_calc'), closure_custom_calc_extra_options => { type => 'discard', label_ref => 'out' },
                 closure_custom_output => $self->can('custom_packet_output'), output_error_template => 'Discard Out : %s',
                 threshold_use => 'result_prct',
                 perfdatas => [
-                    { label => 'packets_discard_out', value => 'result_prct', template => '%.2f', min => 0, max => 100,
+                    { value => 'result_prct', template => '%.2f', min => 0, max => 100,
                       unit => '%', label_extra_instance => 1, instance_use => 'display' }
                 ]
             }
         },
-        { label => 'in-error', set => {
+        { label => 'in-error', nlabel => 'interface.packets.in.error.percentage', set => {
                 key_values => [ { name => 'error_in', diff => 1 }, { name => 'total_in', diff => 1 }, { name => 'display' } ],
                 closure_custom_calc => $self->can('custom_packet_calc'), closure_custom_calc_extra_options => { type => 'error', label_ref => 'in' },
                 closure_custom_output => $self->can('custom_packet_output'), output_error_template => 'Error In : %s',
                 threshold_use => 'result_prct',
                 perfdatas => [
-                    { label => 'packets_error_in', value => 'result_prct', template => '%.2f', min => 0, max => 100,
+                    { value => 'result_prct', template => '%.2f', min => 0, max => 100,
                       unit => '%', label_extra_instance => 1, instance_use => 'display' }
                 ]
             }
         },
-        { label => 'out-error', set => {
+        { label => 'out-error', nlabel => 'interface.packets.out.error.percentage', set => {
                 key_values => [ { name => 'error_out', diff => 1 }, { name => 'total_out', diff => 1 }, { name => 'display' } ],
                 closure_custom_calc => $self->can('custom_packet_calc'), closure_custom_calc_extra_options => { type => 'error', label_ref => 'out' },
                 closure_custom_output => $self->can('custom_packet_output'), output_error_template => 'Error In : %s',
                 threshold_use => 'result_prct',
                 perfdatas => [
-                    { label => 'packets_error_out', value => 'result_prct', template => '%.2f', min => 0, max => 100,
+                    { value => 'result_prct', template => '%.2f', min => 0, max => 100,
                       unit => '%', label_extra_instance => 1, instance_use => 'display' }
                 ]
             }
@@ -124,7 +124,7 @@ sub set_counters {
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(package => __PACKAGE__, %options, statefile => 1);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, statefile => 1, force_new_perfdata => 1);
     bless $self, $class;
 
     $options{options}->add_options(arguments => {

--- a/src/os/linux/local/mode/packeterrors.pm
+++ b/src/os/linux/local/mode/packeterrors.pm
@@ -235,6 +235,21 @@ Command used: /sbin/ip -s addr 2>&1
 
 =over 8
 
+=item B<--unknown-status>
+
+Define the conditions to match for the status to be UNKNOWN.
+You can use the following variables: %{status}, %{display}
+
+=item B<--warning-status>
+
+Define the conditions to match for the status to be WARNING.
+You can use the following variables: %{status}, %{display}
+
+=item B<--critical-status>
+
+Define the conditions to match for the status to be CRITICAL (default: '%{status} ne "RU"').
+You can use the following variables: %%{status}, %{display}
+
 =item B<--warning-*>
 
 Warning threshold in percent of total packets. Can be:

--- a/src/os/linux/local/mode/quota.pm
+++ b/src/os/linux/local/mode/quota.pm
@@ -28,13 +28,13 @@ use warnings;
 sub custom_usage_perfdata {
     my ($self, %options) = @_;
 
-    my ($extra_label, $unit) = ('', '');
+    my $unit = '';
     $unit = 'B' if ($self->{result_values}->{label_ref} eq 'data');
-    if (!defined($options{extra_instance}) || $options{extra_instance} != 0) {
-        $extra_label .= '_' . $self->{result_values}->{display};
-    }
+
     $self->{output}->perfdata_add(
-        label => $self->{result_values}->{label_ref} . '_used' . $extra_label, unit => $unit,
+        nlabel => $self->{nlabel}, 
+        unit => $unit,
+        instances => $self->{result_values}->{display},
         value => $self->{result_values}->{used},
         warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{result_values}->{warn_label}, total => $self->{result_values}->{total}, cast_int => 1),
         critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{result_values}->{crit_label}, total => $self->{result_values}->{total}, cast_int => 1),
@@ -72,7 +72,7 @@ sub custom_usage_output {
     }
 
     return sprintf(
-        "%s Used: %s%s%s",
+        "%s used: %s%s%s",
         ucfirst($self->{result_values}->{label_ref}),
         $value,
         $limit_soft, $limit_hard
@@ -120,7 +120,7 @@ sub set_counters {
     ];
     
     $self->{maps_counters}->{quota} = [
-        { label => 'data-usage', set => {
+        { label => 'data-usage', nlabel => 'quota.data.usage.bytes', set => {
                 key_values => [ { name => 'display' }, { name => 'data_used' }, { name => 'data_soft' }, { name => 'data_hard' } ],
                 closure_custom_calc => $self->can('custom_usage_calc'), closure_custom_calc_extra_options => { label_ref => 'data' },
                 closure_custom_output => $self->can('custom_usage_output'),
@@ -128,7 +128,7 @@ sub set_counters {
                 closure_custom_threshold_check => $self->can('custom_usage_threshold')
             }
         },
-        { label => 'inode-usage', set => {
+        { label => 'inode-usage', nlabel => 'quota.files.usage.count', set => {
                 key_values => [ { name => 'display' }, { name => 'inode_used' }, { name => 'inode_soft' }, { name => 'inode_hard' } ],
                 closure_custom_calc => $self->can('custom_usage_calc'), closure_custom_calc_extra_options => { label_ref => 'inode' },
                 closure_custom_output => $self->can('custom_usage_output'),
@@ -141,7 +141,7 @@ sub set_counters {
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
     
     $options{options}->add_options(arguments => {

--- a/src/os/linux/local/mode/storage.pm
+++ b/src/os/linux/local/mode/storage.pm
@@ -28,10 +28,10 @@ use warnings;
 sub custom_usage_perfdata {
     my ($self, %options) = @_;
 
-    my $label = 'used';
+    my $label = $self->{nlabel};
     my $value_perf = $self->{result_values}->{used};
     if (defined($self->{instance_mode}->{option_results}->{free})) {
-        $label = 'free';
+        $label = 'storage.space.free.bytes';
         $value_perf = $self->{result_values}->{free};
     }
 
@@ -42,8 +42,9 @@ sub custom_usage_perfdata {
     }
 
     $self->{output}->perfdata_add(
-        label => $label, unit => 'B',
-        instances => $self->use_instances(extra_instance => $options{extra_instance}) ? $self->{result_values}->{display} : undef,
+        nlabel => $label,
+        unit => 'B',
+        instances => $self->{result_values}->{display},
         value => $value_perf,
         warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{thlabel}, %total_options),
         critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{thlabel}, %total_options),
@@ -110,7 +111,7 @@ sub set_counters {
     ];
     
     $self->{maps_counters}->{disks} = [
-        { label => 'usage', set => {
+        { label => 'usage', nlabel => 'storage.space.usage.bytes', set => {
                 key_values => [ { name => 'display' }, { name => 'used' }, { name => 'free' }, { name => 'total' } ],
                 closure_custom_calc => $self->can('custom_usage_calc'),
                 closure_custom_output => $self->can('custom_usage_output'),
@@ -123,7 +124,7 @@ sub set_counters {
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
 
     $options{options}->add_options(arguments => {

--- a/src/os/linux/local/mode/systemdjournal.pm
+++ b/src/os/linux/local/mode/systemdjournal.pm
@@ -1,0 +1,180 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package os::linux::local::mode::systemdjournal;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use DateTime;
+use Digest::MD5 qw(md5_hex);
+use JSON::XS;
+
+sub set_counters {
+    my ($self, %options) = @_;
+    
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0 }
+    ];
+    
+    $self->{maps_counters}->{global} = [
+        { label => 'entries', nlabel => 'journal.entries.count', set => {
+                key_values => [ { name => 'entries' } ],
+                output_template => 'Journal entries: %s',
+                perfdatas => [
+                    { template => '%s', min => 0 }
+                ]
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, statefile => 1, force_new_perfdata => 1);
+    bless $self, $class;
+    
+    $options{options}->add_options(arguments => {
+        'unit:s'           => { name => 'unit' },
+        'filter-message:s' => { name => 'filter_message' },
+        'since:s'          => { name => 'since', default => 'cache' },
+        'timezone:s'       => { name => 'timezone', default => 'local' }
+    });
+
+    return $self;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    $self->{cache_name} = 'cache_linux_local_' . $options{custom}->get_identifier()  . '_' . $self->{mode} . '_' .
+        (defined($self->{option_results}->{filter_message}) ? md5_hex($self->{option_results}->{filter_message}) : md5_hex('all')) . '_' .
+        (defined($self->{option_results}->{since}) ? md5_hex($self->{option_results}->{since}) : md5_hex('all'));
+
+    my $command_options = '--output json --output-fields MESSAGE --no-pager';
+
+    if (defined($self->{option_results}->{unit}) && $self->{option_results}->{unit} ne '') {
+        $command_options .= ' --unit ' . $self->{option_results}->{unit};
+    }
+
+    if (defined($self->{option_results}->{since}) && $self->{option_results}->{since} ne '') {
+        if ($self->{option_results}->{since} eq "cache") {
+            my $last_timestamp = $self->read_statefile_key(key => 'last_timestamp');
+            $last_timestamp = time() - (5 * 60) if (!defined($last_timestamp));
+            my $dt = DateTime->from_epoch(epoch => $last_timestamp);
+            $dt->set_time_zone($self->{option_results}->{timezone});
+            $command_options .= ' --since "' . $dt->ymd . ' ' . $dt->hms . '"';
+        } elsif ($self->{option_results}->{since} =~ /\d+/) {
+            $command_options .= ' --since "' . $self->{option_results}->{since} . ' minutes ago"';
+        }
+    }
+
+    my ($stdout) = $options{custom}->execute_command(
+        command => 'journalctl',
+        command_options => $command_options . ' 2>&1'
+    );
+
+    $self->{global} = { entries => 0 };
+
+    my @lines = split /\n/, $stdout;
+    foreach (@lines) {
+        my $decoded;
+        eval {
+            $decoded = JSON::XS->new->utf8->decode($_);
+        };
+        if ($@) {
+            $self->{output}->add_option_msg(short_msg => "Cannot decode json response");
+            $self->{output}->option_exit();
+        }
+
+        next if (defined($self->{option_results}->{filter_message}) && $self->{option_results}->{filter_message} ne '' &&
+            $decoded->{MESSAGE} !~ /$self->{option_results}->{filter_message}/);
+        
+        $self->{global}->{entries}++;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Count journal entries.
+
+Command used: journalctl --output json --output-fields MESSAGE --no-pager
+
+Examples:
+
+Look for sent emails by Postfix:
+
+# perl centreon_plugins.pl --plugin=os::linux::local::plugin --mode=systemd-journal --unit=postfix.service
+--filter-message='status=sent' --since=10 --change-short-output='Journal entries~Emails sent'
+--change-perfdata='journal.entries.count,emails.sent.count'
+
+OK: Emails sent: 17 | 'emails.sent.count'=17;;;0;
+
+Look for Puppet errors:
+
+# perl centreon_plugins.pl --plugin=os::linux::local::plugin --mode=systemd-journal
+--unit=puppet.service --filter-message='error' --since=30
+
+OK: Journal entries: 1 | 'journal.entries.count'=1;;;0;
+
+Look for the number of Centreon Engine reloads
+
+# perl centreon_plugins.pl --plugin=os::linux::local::plugin --mode=systemd-journal
+--unit=centengine.service --filter-message='Reloaded.*Engine' --since=60
+--change-short-output='Journal entries~Centreon Engine reloads over the last hour'
+--change-perfdata='journal.entries.count,centreon.engine.reload.count'
+
+OK: Centreon Engine reloads over the last hour: 0 | 'centreon.engine.reload.count'=0;;;0;
+
+=over 8
+
+=item B<--unit>
+
+Only look for messages of the specified unit, ie the
+name of the systemd service who created the message.
+
+=item B<--filter-message>
+
+Filter on message content (can be a regexp).
+
+=item B<--since>
+
+Defines the amount of time to look back at messages.
+Can be minutes (ie 5 "minutes ago") or 'cache' to use the
+timestamp from last execution. (Default: 'cache')
+
+=item B<--timezone>
+
+Defines the timezone to convert date/time to the host
+timezone when using timestamp from cache. (Default: 'local')
+
+=item B<--warning-entries> B<--critical-entries>
+
+Thresholds on the number of entries found
+in the journal for the specified parameters.
+
+=back
+
+=cut

--- a/src/os/linux/local/mode/systemdjournal.pm
+++ b/src/os/linux/local/mode/systemdjournal.pm
@@ -30,11 +30,11 @@ use JSON::XS;
 
 sub set_counters {
     my ($self, %options) = @_;
-    
+
     $self->{maps_counters_type} = [
         { name => 'global', type => 0 }
     ];
-    
+
     $self->{maps_counters}->{global} = [
         { label => 'entries', nlabel => 'journal.entries.count', set => {
                 key_values => [ { name => 'entries' } ],
@@ -51,7 +51,7 @@ sub new {
     my ($class, %options) = @_;
     my $self = $class->SUPER::new(package => __PACKAGE__, %options, statefile => 1, force_new_perfdata => 1);
     bless $self, $class;
-    
+
     $options{options}->add_options(arguments => {
         'unit:s'           => { name => 'unit' },
         'filter-message:s' => { name => 'filter_message' },

--- a/src/os/linux/local/mode/traffic.pm
+++ b/src/os/linux/local/mode/traffic.pm
@@ -46,8 +46,9 @@ sub custom_traffic_perfdata {
     }
 
     $self->{output}->perfdata_add(
-        label => 'traffic_' . $self->{result_values}->{label}, unit => 'b/s',
-        instances => $self->use_instances(extra_instance => $options{extra_instance}) ? $self->{result_values}->{display} : undef,
+        label => $self->{nlabel},
+        unit => 'b/s',
+        instances => $self->{result_values}->{display},
         value => sprintf("%.2f", $self->{result_values}->{traffic_per_seconds}),
         warning => $warning,
         critical => $critical,
@@ -117,7 +118,7 @@ sub set_counters {
                 closure_custom_threshold_check => \&catalog_status_threshold_ng
             }
         },
-        { label => 'in', set => {
+        { label => 'in', nlabel => 'interface.traffic.in.bitspersecond', set => {
                 key_values => [ { name => 'in', diff => 1 }, { name => 'speed_in' }, { name => 'display' } ],
                 closure_custom_calc => $self->can('custom_traffic_calc'), closure_custom_calc_extra_options => { label_ref => 'in' },
                 closure_custom_output => $self->can('custom_traffic_output'), output_error_template => 'Traffic In : %s',
@@ -125,7 +126,7 @@ sub set_counters {
                 closure_custom_threshold_check => $self->can('custom_traffic_threshold')
             }
         },
-        { label => 'out', set => {
+        { label => 'out', nlabel => 'interface.traffic.out.bitspersecond', set => {
                 key_values => [ { name => 'out', diff => 1 }, { name => 'speed_out' }, { name => 'display' } ],
                 closure_custom_calc => $self->can('custom_traffic_calc'), closure_custom_calc_extra_options => { label_ref => 'out' },
                 closure_custom_output => $self->can('custom_traffic_output'), output_error_template => 'Traffic Out : %s',
@@ -138,7 +139,7 @@ sub set_counters {
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(package => __PACKAGE__, %options, statefile => 1);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, statefile => 1, force_new_perfdata => 1);
     bless $self, $class;
 
     $options{options}->add_options(arguments => {

--- a/src/os/linux/local/mode/uptime.pm
+++ b/src/os/linux/local/mode/uptime.pm
@@ -28,7 +28,7 @@ use POSIX;
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
     
     $options{options}->add_options(arguments => { 
@@ -77,7 +77,8 @@ sub run {
         threshold => [ { label => 'critical', exit_litteral => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]
     );
     $self->{output}->perfdata_add(
-        label => 'uptime', unit => 's',
+        nlabel => 'system.uptime.seconds',
+        unit => 's',
         value => floor($uptime),
         warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning'),
         critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical'),

--- a/src/os/linux/local/plugin.pm
+++ b/src/os/linux/local/plugin.pm
@@ -59,6 +59,7 @@ sub new {
         'quota'                 => 'os::linux::local::mode::quota',
         'storage'               => 'os::linux::local::mode::storage',
         'swap'                  => 'os::linux::local::mode::swap',
+        'systemd-journal'       => 'os::linux::local::mode::systemdjournal',
         'systemd-sc-status'     => 'os::linux::local::mode::systemdscstatus',
         'traffic'               => 'os::linux::local::mode::traffic',
         'uptime'                => 'os::linux::local::mode::uptime'


### PR DESCRIPTION
Simple mode to read systemd journal and count entries based on unit name and message content.

```
# perl centreon_plugins.pl --plugin=os::linux::local::plugin --mode=systemd-journal --unit=postfix.service --filter-message='status=sent' --since=10 --change-short-output='Journal entries~Emails sent' --change-perfdata='journal.entries.count,emails.sent.count'
OK: Emails sent: 17 | 'emails.sent.count'=17;;;0;
```

```
# perl centreon_plugins.pl --plugin=os::linux::local::plugin --mode=systemd-journal --unit=puppet.service --filter-message='error' --since=30
OK: Journal entries: 1 | 'journal.entries.count'=1;;;0;
```

```
# perl centreon_plugins.pl --plugin=os::linux::local::plugin --mode=systemd-journal --unit=centengine.service --filter-message='Reloaded.*Engine' --since=60 --change-short-output='Journal entries~Centreon Engine reloads over the last hour' --change-perfdata='journal.entries.count,centreon.engine.reload.count'
OK: Centreon Engine reloads over the last hour: 0 | 'centreon.engine.reload.count'=0;;;0;
```