### PR TITLE
[MON-21523] Plugin mode not-so-dummy - Add min and max duration to simulate plugin execution time

### DIFF
--- a/src/apps/centreon/local/mode/notsodummy.pm
+++ b/src/apps/centreon/local/mode/notsodummy.pm
@@ -320,7 +320,7 @@ The duration is chosen in the [min,max) range.
 
 Max duration thresholds (in seconds) use to set the range used to randomly simulate the execution of a plugin.
 If this option is set, min-duration is mandatory.
-The duration is chosen in the [min,max) range (max is exclude).
+The duration is chosen in the [min,max) range (max is excluded).
 
 =back
 

--- a/src/apps/centreon/local/mode/notsodummy.pm
+++ b/src/apps/centreon/local/mode/notsodummy.pm
@@ -124,7 +124,7 @@ sub check_options {
             $self->{output}->option_exit();
         }
         if ($self-> {option_results}->{max_duration} <= $self->{option_results}->{min_duration} ){
-            $self->{output}->add_option_msg(short_msg => "--max-duration should be higher than min-duration .");
+            $self->{output}->add_option_msg(short_msg => "--max-duration should be higher than min-duration.");
             $self->{output}->option_exit();
         }
     }
@@ -312,14 +312,15 @@ Restart the sequence from the beginning (ie. reset the sequence in cache file).
 
 =item B<--min-duration>
 
-Min duration thresholds (in secondes) use to set the range used to randomly simulate the execution of a plugin.
+Min duration thresholds (in seconds) use to set the range used to randomly simulate the execution of a plugin.
 If this option is set, max-duration is mandatory.
+The duration is chosen in the [min,max) range.
 
 =item B<--max-duration>
 
-Max duration thresholds (in secondes) use to set the range used to randomly simulate the execution of a plugin.
+Max duration thresholds (in seconds) use to set the range used to randomly simulate the execution of a plugin.
 If this option is set, min-duration is mandatory.
-Max duration value is not include in the range.
+The duration is chosen in the [min,max) range (max is exclude).
 
 =back
 

--- a/src/apps/centreon/local/mode/notsodummy.pm
+++ b/src/apps/centreon/local/mode/notsodummy.pm
@@ -178,7 +178,6 @@ sub run {
     my ($self, %options) = @_;
 
     # Adding duration
-    # my $x = $minimum + int(rand($maximum - $minimum));
     # rand(n) returns a random number between 0 and n-1
     if (defined($self->{option_results}->{min_duration}) && defined($self->{option_results}->{max_duration})) {
         my $sleep_duration = $self->{option_results}->{min_duration} + rand($self->{option_results}->{max_duration} + 1 - $self->{option_results}->{min_duration});

--- a/src/apps/centreon/local/mode/notsodummy.pm
+++ b/src/apps/centreon/local/mode/notsodummy.pm
@@ -177,12 +177,10 @@ sub get_sequence_output {
 sub run {
     my ($self, %options) = @_;
 
-    # Adding duration
+    # Adding plugin simulated duration
     # rand(n) returns a random number between 0 and n-1
     if (defined($self->{option_results}->{min_duration}) && defined($self->{option_results}->{max_duration})) {
         my $sleep_duration = $self->{option_results}->{min_duration} + rand($self->{option_results}->{max_duration} + 1 - $self->{option_results}->{min_duration});
-        use Data::Dumper;
-        print Dumper($sleep_duration);
         sleep($sleep_duration)
     }
 


### PR DESCRIPTION
## Description

Add the posibility to fix a duration in second to this plugin execution with a sleep usage.
This duration is randomly chosen in a range set by the user with min and max duration option.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

<h2> How this pull request can be tested ? </h2>

Duration is a float number that can be set with integer or float values.
```perl centreon_plugins.pl --plugin=apps::centreon::local::plugin --mode=not-so-dummy --status-sequence='up,down,down' --host --output='Not so dummy host' --debug  --min-duration=0.5 --max-duration=10```

Duration needs to set min **and** max value
```perl centreon_plugins.pl --plugin=apps::centreon::local::plugin --mode=not-so-dummy --status-sequence='up,down,down' --host --output='Not so dummy host' --debug  --min-duration=0.5 --max-duration=```

min and max can't be string.
```perl centreon_plugins.pl --plugin=apps::centreon::local::plugin --mode=not-so-dummy --status-sequence='up,down,down' --host --output='Not so dummy host' --debug  --min-duration=0.5 --max-duration="toto"```

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
