### PR TITLE
MON-21973-date-problem-on-storage-ibm-storwize-ssh-plugin-eventlog

### DIFF
--- a/packaging/centreon-plugin-Hardware-Storage-Ibm-Storwize-Ssh/deb.json
+++ b/packaging/centreon-plugin-Hardware-Storage-Ibm-Storwize-Ssh/deb.json
@@ -1,6 +1,7 @@
 {
     "dependencies": [
-	"libssh-session-perl",
-        "plink"
+	  "libssh-session-perl",
+      "libtime-piece-perl",
+      "plink"
     ]
 }

--- a/packaging/centreon-plugin-Hardware-Storage-Ibm-Storwize-Ssh/deb.json
+++ b/packaging/centreon-plugin-Hardware-Storage-Ibm-Storwize-Ssh/deb.json
@@ -1,7 +1,7 @@
 {
     "dependencies": [
-	  "libssh-session-perl",
-      "libtime-piece-perl",
-      "plink"
+	"libssh-session-perl",
+    	"libtime-piece-perl",
+    	"plink"
     ]
 }

--- a/packaging/centreon-plugin-Hardware-Storage-Ibm-Storwize-Ssh/deb.json
+++ b/packaging/centreon-plugin-Hardware-Storage-Ibm-Storwize-Ssh/deb.json
@@ -1,7 +1,6 @@
 {
     "dependencies": [
 	"libssh-session-perl",
-    	"libtime-piece-perl",
     	"plink"
     ]
 }

--- a/src/storage/ibm/storwize/ssh/mode/eventlog.pm
+++ b/src/storage/ibm/storwize/ssh/mode/eventlog.pm
@@ -57,8 +57,10 @@ sub check_options {
 
     my $last_timestamp = '';
     if (defined($self->{option_results}->{retention}) && $self->{option_results}->{retention} =~ /^\d+$/) {
+        my $epoch = time();
+        $retention_epoch = $epoch - $self->{option_results}->{retention};
         # by default UTC timezone used
-        my $dt = DateTime->from_epoch(epoch => time() - $self->{option_results}->{retention});
+        my $dt = DateTime->from_epoch(epoch => $retention_epoch);
         my $dt_format = sprintf("%d%02d%02d%02d%02d%02d", substr($dt->year(), 2), $dt->month(), $dt->day(), $dt->hour(), $dt->minute(), $dt->second());
         $last_timestamp = 'last_timestamp>=' . $dt_format . ":";
     }
@@ -88,7 +90,7 @@ sub run {
         $self->{output}->output_add(
             long_msg => sprintf(
                 '%s : %s - %s', 
-                scalar(localtime($_->{last_timestamp})),
+                scalar(localtime($_->{retention_epoch})),
                 $_->{event_id}, $_->{description}
             )
         );

--- a/src/storage/ibm/storwize/ssh/mode/eventlog.pm
+++ b/src/storage/ibm/storwize/ssh/mode/eventlog.pm
@@ -25,6 +25,7 @@ use base qw(centreon::plugins::mode);
 use strict;
 use warnings;
 use DateTime;
+use Time::Piece;
 
 sub new {
     my ($class, %options) = @_;
@@ -88,7 +89,7 @@ sub run {
         $self->{output}->output_add(
             long_msg => sprintf(
                 '%s : %s - %s', 
-                scalar(localtime($_->{last_timestamp})),
+                scalar(localtime(Time::Piece->strptime($_->{last_timestamp}, '%y%m%d%H%M%S'))),
                 $_->{event_id}, $_->{description}
             )
         );

--- a/src/storage/ibm/storwize/ssh/mode/eventlog.pm
+++ b/src/storage/ibm/storwize/ssh/mode/eventlog.pm
@@ -31,12 +31,12 @@ sub new {
     my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
 
-    $options{options}->add_options(arguments => { 
-        'warning:s'           => { name => 'warning', },
-        'critical:s'          => { name => 'critical', },
-        'filter-event-id:s'   => { name => 'filter_event_id'  },
-        'filter-message:s'    => { name => 'filter_message' },
-        'retention:s'         => { name => 'retention' }
+    $options{options}->add_options(arguments => {
+        'warning:s'         => { name => 'warning', },
+        'critical:s'        => { name => 'critical', },
+        'filter-event-id:s' => { name => 'filter_event_id' },
+        'filter-message:s'  => { name => 'filter_message' },
+        'retention:s'       => { name => 'retention' }
     });
 
     return $self;
@@ -85,16 +85,16 @@ sub run {
             next;
         }
 
-    my @array = ( $event->{last_timestamp} =~ m/../g ); # format expected is YYMMDDHHMMSS
-    my $date = DateTime->new(
-	    "year"      => "20" . $array[0], # DateTime expect 4 digit year, as this is log the chance of decade old data is slim.
-	    "month"     => $array[1],
-        "day"       => $array[2],
-        "hour"      => $array[3],
-        "minute"    => $array[4],
-        "second"    => $array[5],
+        my @array = ($event->{last_timestamp} =~ m/../g); # format expected is YYMMDDHHMMSS
+        my $date = DateTime->new(
+            "year"   => "20" . $array[0], # DateTime expect 4 digit year, as this is log the chance of decade old data is slim.
+            "month"  => $array[1],
+            "day"    => $array[2],
+            "hour"   => $array[3],
+            "minute" => $array[4],
+            "second" => $array[5],
 
-);
+        );
 
         $self->{output}->output_add(
             long_msg => sprintf(
@@ -109,16 +109,16 @@ sub run {
     $self->{output}->output_add(long_msg => sprintf("Number of message checked: %s", $num_eventlog_checked));
     my $exit = $self->{perfdata}->threshold_check(value => $num_errors, threshold => [ { label => 'critical', exit_litteral => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
     $self->{output}->output_add(
-        severity => $exit,
+        severity  => $exit,
         short_msg => sprintf("%d problem detected (use verbose for more details)", $num_errors)
     );
 
     $self->{output}->perfdata_add(
-        nlabel => 'eventlogs.problems.count',
-        value => $num_errors,
-        warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning'),
+        nlabel   => 'eventlogs.problems.count',
+        value    => $num_errors,
+        warning  => $self->{perfdata}->get_perfdata_for_output(label => 'warning'),
         critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical'),
-        min => 0
+        min      => 0
     );
 
     $self->{output}->display();

--- a/src/storage/ibm/storwize/ssh/mode/eventlog.pm
+++ b/src/storage/ibm/storwize/ssh/mode/eventlog.pm
@@ -57,10 +57,8 @@ sub check_options {
 
     my $last_timestamp = '';
     if (defined($self->{option_results}->{retention}) && $self->{option_results}->{retention} =~ /^\d+$/) {
-        my $epoch = time();
-        $retention_epoch = $epoch - $self->{option_results}->{retention};
         # by default UTC timezone used
-        my $dt = DateTime->from_epoch(epoch => $retention_epoch);
+        my $dt = DateTime->from_epoch(epoch => time() - $self->{option_results}->{retention});
         my $dt_format = sprintf("%d%02d%02d%02d%02d%02d", substr($dt->year(), 2), $dt->month(), $dt->day(), $dt->hour(), $dt->minute(), $dt->second());
         $last_timestamp = 'last_timestamp>=' . $dt_format . ":";
     }
@@ -90,7 +88,7 @@ sub run {
         $self->{output}->output_add(
             long_msg => sprintf(
                 '%s : %s - %s', 
-                scalar(localtime($_->{retention_epoch})),
+                scalar(localtime($_->{last_timestamp})),
                 $_->{event_id}, $_->{description}
             )
         );

--- a/src/storage/ibm/storwize/ssh/mode/eventlog.pm
+++ b/src/storage/ibm/storwize/ssh/mode/eventlog.pm
@@ -25,7 +25,6 @@ use base qw(centreon::plugins::mode);
 use strict;
 use warnings;
 use DateTime;
-use Time::Piece;
 
 sub new {
     my ($class, %options) = @_;
@@ -73,24 +72,35 @@ sub run {
     my $result = $options{custom}->get_hasharray(content => $content, delim => ':');
 
     my ($num_eventlog_checked, $num_errors) = (0, 0);
-    foreach (@$result) {
+    foreach my $event (@$result) {
         $num_eventlog_checked++;
         if (defined($self->{option_results}->{filter_message}) && $self->{option_results}->{filter_message} ne '' &&
-            $_->{description} !~ /$self->{option_results}->{filter_message}/) {
-            $self->{output}->output_add(long_msg => "skipping '" . $_->{description} . "': no matching filter description.", debug => 1);
+            $event->{description} !~ /$self->{option_results}->{filter_message}/) {
+            $self->{output}->output_add(long_msg => "skipping '" . $event->{description} . "': no matching filter description.", debug => 1);
             next;
         }
         if (defined($self->{option_results}->{filter_event_id}) && $self->{option_results}->{filter_event_id} ne '' &&
-            $_->{event_id} !~ /$self->{option_results}->{filter_event_id}/) {
-            $self->{output}->output_add(long_msg => "skipping '" . $_->{event_id} . "': no matching filter event id.", debug => 1);
+            $event->{event_id} !~ /$self->{option_results}->{filter_event_id}/) {
+            $self->{output}->output_add(long_msg => "skipping '" . $event->{event_id} . "': no matching filter event id.", debug => 1);
             next;
         }
 
+    my @array = ( $event->{last_timestamp} =~ m/../g ); # format expected is YYMMDDHHMMSS
+    my $date = DateTime->new(
+	    "year"      => "20" . $array[0], # DateTime expect 4 digit year, as this is log the chance of decade old data is slim.
+	    "month"     => $array[1],
+        "day"       => $array[2],
+        "hour"      => $array[3],
+        "minute"    => $array[4],
+        "second"    => $array[5],
+
+);
+
         $self->{output}->output_add(
             long_msg => sprintf(
-                '%s : %s - %s', 
-                scalar(localtime(Time::Piece->strptime($_->{last_timestamp}, '%y%m%d%H%M%S'))),
-                $_->{event_id}, $_->{description}
+                '%s : %s - %s',
+                $date->strftime("%a %b %d %T %Y"),
+                $event->{event_id}, $event->{description}
             )
         );
         $num_errors++;


### PR DESCRIPTION
fix: Converting from epoch to normal date, format was not valid for `localtime()`

## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

`/usr/lib/centreon/plugins//centreon_ibm_storwize_ssh.pl --plugin=storage::ibm::storwize::ssh::plugin --mode=eventlog --hostname='SAN_V7000_CE_CED1' --ssh-backend='sshcli' --ssh-username='nagios.adm' --verbose --retention=3600`

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
