### PR TITLE
fix(docker/local): fix cache name to prevent conflict

### DIFF
--- a/src/cloud/docker/local/mode/containerusage.pm
+++ b/src/cloud/docker/local/mode/containerusage.pm
@@ -232,7 +232,7 @@ sub manage_selection {
         $self->{output}->option_exit();
     }
     
-    $self->{cache_name} = 'docker_' . $self->{mode} . '_' .
+    $self->{cache_name} = 'docker_local_' . $self->{mode} . '_' . $self->{option_results}->{hostname} . '_' .
         (defined($self->{option_results}->{filter_counters}) ? md5_hex($self->{option_results}->{filter_counters}) : md5_hex('all')) . '_' .
         (defined($self->{option_results}->{filter_name}) ? md5_hex($self->{option_results}->{filter_name}) : md5_hex('all')). '_' .
         (defined($self->{option_results}->{filter_id}) ? md5_hex($self->{option_results}->{filter_id}) : md5_hex('all'));


### PR DESCRIPTION
Fix the cache name to prevent conflict between containers with same being check from different hosts.

EDIT by @omercier 
REFS: MON-22340