### PR TITLE
enh(http/collection): add returned json structure in debug output

### DIFF
--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -337,6 +337,10 @@ sub call_http {
         $self->{output}->option_exit();
     }
 
+    my $encoded = JSON::XS->new->utf8->pretty->encode($content);
+    $self->{output}->output_add(long_msg => '======> returned JSON structure:', debug => 1);
+    $self->{output}->output_add(long_msg => "$encoded", debug => 1);
+
     return ($http->get_header(), $content, $http);
 }
 


### PR DESCRIPTION
Add a pretty JSON structure from the returned body as part of the debug message to help users parse the result with jpath method (very useful when body is actually in XML).

EDIT by @omercier 
REFS: MON-22338