### PR TITLE
enh(mode): Rubrik RestAPI manage disco empty entries

### DIFF
--- a/src/apps/backup/rubrik/restapi/mode/listjobs.pm
+++ b/src/apps/backup/rubrik/restapi/mode/listjobs.pm
@@ -49,7 +49,9 @@ sub manage_selection {
     );
     my $results = {};
     foreach (@$jobs) {
-        $results->{ $_->{objectId} } = $_;
+        if (defined($_->{objectId})) {
+            $results->{ $_->{objectId} } = $_;
+        }
     }
     return $results;
 }
@@ -63,9 +65,9 @@ sub run {
             long_msg => sprintf(
                 '[jobId: %s][jobName: %s][jobType: %s][locationName: %s]',
                 $_->{objectId},
-                $_->{objectName},
-                $_->{jobType},
-                $_->{locationName}
+                defined($_->{objectName}) ? $_->{objectName} : 'none',
+                defined($_->{jobType}) ? $_->{jobType} : 'none',
+                defined($_->{locationName}) ? $_->{locationName} : 'none'
             )
         );
     }
@@ -91,9 +93,9 @@ sub disco_show {
     foreach (values %$results) {
         $self->{output}->add_disco_entry(
             jobId => $_->{objectId},
-            jobName => $_->{objectName},
-            jobType => $_->{jobType},
-            locationName => $_->{locationName}
+            jobName => defined($_->{objectName}) ? $_->{objectName} : 'none',
+            jobType => defined($_->{jobType}) ? $_->{jobType} : 'none',
+            locationName => defined($_->{locationName}) ? $_->{locationName} : 'none'
         );
     }
 }


### PR DESCRIPTION
## Description

In rubrik Plugin, mode list-jobs, there can be results without id or other fields, leading to "use of uninitialized values" errors in sprintf output and XML errors in disco show output.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

EDIT by @omercier 
REFS: CTOR-96
