### PR TITLE
Citrix psu.pm - wrong psu status mapping

### DIFF
--- a/src/network/citrix/netscaler/snmp/mode/components/psu.pm
+++ b/src/network/citrix/netscaler/snmp/mode/components/psu.pm
@@ -24,10 +24,10 @@ use strict;
 use warnings;
 
 my %map_psu_status = (
-    0 => 'not supported',
+    0 => 'normal',
     1 => 'not present',
     2 => 'failed',
-    3 => 'normal',
+    3 => 'not supported',
 );
 
 my $mapping = {


### PR DESCRIPTION
https://docs.vistanet.jp/about/supported-resources/templates-in-detail/citrix-netscaler-appliance-status-and-performance-g2/

## Wrong status mapping for PSU

According the MIB from Citrix the status mapping is not correct.