### PR TITLE
fix(err-msg): attempt to fix #4703

### DIFF
--- a/src/centreon/plugins/templates/hardware.pm
+++ b/src/centreon/plugins/templates/hardware.pm
@@ -277,6 +277,7 @@ sub display {
     foreach my $comp (sort(keys %{$self->{components}})) {
         # Skipping short msg when no components
         next if (!defined($self->{option_results}->{no_component_count}) && $self->{components}->{$comp}->{total} == 0 && $self->{components}->{$comp}->{skip} == 0);
+        next if (defined($self->{option_results}->{component}) && $comp !~ /$self->{option_results}->{component}/ );
 
         if ($self->{count} == 1) {
             ($exit, $warn, $crit) = $self->get_severity_count(label => $comp, value => $self->{components}->{$comp}->{total});


### PR DESCRIPTION
## Description

Attempt to fix #4703 

Not understanding such a simple thing as "why this value comes undefined" has been vexing me, so I had to look for the truth and tried `perl -d`. What does not kill you makes you stronger, they said :')

Tested with data provided by the issue creator:

```snmpwalk
.1.3.6.1.4.1.318.1.1.10.3.12.11.0 = INTEGER: 1
.1.3.6.1.4.1.318.1.1.10.4.1.2.1.2.0 = STRING: Main Module
.1.3.6.1.4.1.318.1.1.10.4.2.3.1.1.0.1 = INTEGER: 0
.1.3.6.1.4.1.318.1.1.10.4.2.3.1.2.0.1 = INTEGER: 1
.1.3.6.1.4.1.318.1.1.10.4.2.3.1.3.0.1 = STRING: Sonde de temperature
.1.3.6.1.4.1.318.1.1.10.4.2.3.1.4.0.1 = STRING: salle serveur 1
.1.3.6.1.4.1.318.1.1.10.4.2.3.1.5.0.1 = INTEGER: 23
.1.3.6.1.4.1.318.1.1.10.4.2.3.1.6.0.1 = INTEGER: 35
.1.3.6.1.4.1.318.1.1.10.4.2.3.1.7.0.1 = INTEGER: 2
.1.3.6.1.4.1.318.1.1.10.4.2.3.1.8.0.1 = INTEGER: 1
```

### Results without fix (for regression check)

#### All components checked

```
$ perl  centreon_plugins.pl --plugin=hardware::sensors::apc::snmp::plugin --mode=sensors --hostname=192.168.59.1 --snmp-port=8161 --snmp-community=issue_4703 --snmp-version=2c --component '.*' --warning='humidity,.,45:65' --critical='humidity,.,35:70' --verbose
WARNING: Humidity 'Main Module:Sonde de temperature' is 35 % | 'Main Module:Sonde de temperature#hardware.sensor.temperature.celsius'=23C;;;; 'Main Module:Sonde de temperature#hardware.sensor.humidity.percentage'=35%;45:65;35:70;0;100 'hardware.temperature.count'=2;;;;
Checking temperatures
temperature 'Main Module:Sonde de temperature' alarm status is normal [instance: module.0.1] [value: 23] [comm: ok]
Checking humidities
humidity 'Main Module:Sonde de temperature' alarm status is normal [instance: module.0.1] [value: 35] [comm: ok]
Checking fluids
```

#### Only humidity (when the error from #4703 appears)

```
$ perl  centreon_plugins.pl --plugin=hardware::sensors::apc::snmp::plugin --mode=sensors --hostname=192.168.59.1 --snmp-port=8161 --snmp-community=issue_4703 --snmp-version=2c --component 'humidity' --warning='humidity,.,45:65' --critical='humidity,.,35:70' 
Use of uninitialized value in addition (+) at /var/lib/centreon-engine/centreon-plugins/src/centreon/plugins/templates/hardware.pm line 303.
Use of uninitialized value in addition (+) at /var/lib/centreon-engine/centreon-plugins/src/centreon/plugins/templates/hardware.pm line 304.
Use of uninitialized value in concatenation (.) or string at /var/lib/centreon-engine/centreon-plugins/src/centreon/plugins/templates/hardware.pm line 305.
WARNING: Humidity 'Main Module:Sonde de temperature' is 35 % | 'Main Module:Sonde de temperature#hardware.sensor.humidity.percentage'=35%;45:65;35:70;0;100 'hardware.temperature.count'=1;;;;

```

#### Only temperature

```
$ perl  centreon_plugins.pl --plugin=hardware::sensors::apc::snmp::plugin --mode=sensors --hostname=192.168.59.1 --snmp-port=8161 --snmp-community=issue_4703 --snmp-version=2c --component 'temperature' --warning='humidity,.,45:65' --critical='humidity,.,35:70' 
OK: All 1 components are ok [1/1 temperatures]. | 'Main Module:Sonde de temperature#hardware.sensor.temperature.celsius'=23C;;;; 'hardware.temperature.count'=1;;;;

```

### Results with fix

#### All components checked

```
$ perl  centreon_plugins.pl --plugin=hardware::sensors::apc::snmp::plugin --mode=sensors --hostname=192.168.59.1 --snmp-port=8161 --snmp-community=issue_4703 --snmp-version=2c --warning='humidity,.,45:65' --critical='humidity,.,35:70' --verbose
WARNING: Humidity 'Main Module:Sonde de temperature' is 35 % | 'Main Module:Sonde de temperature#hardware.sensor.temperature.celsius'=23C;;;; 'Main Module:Sonde de temperature#hardware.sensor.humidity.percentage'=35%;45:65;35:70;0;100 'hardware.temperature.count'=2;;;;
Checking temperatures
temperature 'Main Module:Sonde de temperature' alarm status is normal [instance: module.0.1] [value: 23] [comm: ok]
Checking humidities
humidity 'Main Module:Sonde de temperature' alarm status is normal [instance: module.0.1] [value: 35] [comm: ok]
Checking fluids
```

NB: the result is the same without the --component option.

#### Only humidity

```
$ perl  centreon_plugins.pl --plugin=hardware::sensors::apc::snmp::plugin --mode=sensors --hostname=192.168.59.1 --snmp-port=8161 --snmp-community=issue_4703 --snmp-version=2c --component 'humidity' --warning='humidity,.,45:65' --critical='humidity,.,35:70' 
WARNING: Humidity 'Main Module:Sonde de temperature' is 35 % | 'Main Module:Sonde de temperature#hardware.sensor.humidity.percentage'=35%;45:65;35:70;0;100
```

#### Only temperature

```
$ perl  centreon_plugins.pl --plugin=hardware::sensors::apc::snmp::plugin --mode=sensors --hostname=192.168.59.1 --snmp-port=8161 --snmp-community=issue_4703 --snmp-version=2c --component 'temperature' --warning='humidity,.,45:65' --critical='humidity,.,35:70' 
OK: All 1 components are ok [1/1 temperatures]. | 'Main Module:Sonde de temperature#hardware.sensor.temperature.celsius'=23C;;;; 'hardware.temperature.count'=1;;;;
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [?] Breaking change (patch or feature) that might cause side effects breaking part of the Software

