### PR TITLE
(plugin) snmp_standard::mode::uptime - Add 2 decimals to the perfdata

### DIFF
--- a/src/snmp_standard/mode/uptime.pm
+++ b/src/snmp_standard/mode/uptime.pm
@@ -52,7 +52,7 @@ sub custom_uptime_perfdata {
     $self->{output}->perfdata_add(
         label => 'uptime', unit => $self->{instance_mode}->{option_results}->{unit},
         nlabel => 'system.uptime.' . $unitdiv_long->{ $self->{instance_mode}->{option_results}->{unit} },
-        value => floor($self->{result_values}->{uptime} / $unitdiv->{ $self->{instance_mode}->{option_results}->{unit} }),
+        value => sprintf("%.2f", $self->{result_values}->{uptime} / $unitdiv->{ $self->{instance_mode}->{option_results}->{unit} }),
         warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{thlabel}),
         critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{thlabel}),
         min => 0
@@ -63,7 +63,7 @@ sub custom_uptime_threshold {
     my ($self, %options) = @_;
 
     return $self->{perfdata}->threshold_check(
-        value => floor($self->{result_values}->{uptime} / $unitdiv->{ $self->{instance_mode}->{option_results}->{unit} }),
+        value => sprintf("%.2f", $self->{result_values}->{uptime} / $unitdiv->{ $self->{instance_mode}->{option_results}->{unit} }),
         threshold => [
             { label => 'critical-' . $self->{thlabel}, exit_litteral => 'critical' },
             { label => 'warning-'. $self->{thlabel}, exit_litteral => 'warning' },


### PR DESCRIPTION
## Description

Add 2 decimals to the perfdata

**Fixes** # MON-24355

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)
