### PR TITLE
Fix: decode filter_name in os::windows::snmp::plugin to ensure the filter compares with the decoded value

### DIFF
--- a/src/os/windows/snmp/mode/service.pm
+++ b/src/os/windows/snmp/mode/service.pm
@@ -212,6 +212,7 @@ sub manage_selection {
         my $instance = $1 . '.' . $2;
 
         my $name = $self->{output}->decode(join('', map(chr($_), split(/\./, $2))));
+        $self->{option_results}->{filter_name} = $self->{output}->decode($self->{option_results}->{filter_name});
         
         next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
             $name !~ /$self->{option_results}->{filter_name}/);


### PR DESCRIPTION
… value

## Description

When using some German or Italian systems the service names can contain some special language chars. The plugin is working fine because the value receiving from SNMP is UTF-8 decoded (when you don't use --source-encoding UTF-8 is the standard).

The problem is when use a filter to filter only one specific service the filter will not be decoded. So the plugin will filter with a regex that not matches because the filter is not decoded.

The check fails

![image](https://github.com/centreon/centreon-plugins/assets/46994680/37365d8b-26eb-45f9-a840-f99ada3fe14b)

![image](https://github.com/centreon/centreon-plugins/assets/46994680/139847b0-b18e-43c2-a1de-769223444dbe)


**Fixes** # 

decode the filter, too and the check will work fine

![image](https://github.com/centreon/centreon-plugins/assets/46994680/4e5346c4-d857-4219-858e-22e134a6c4d3)

and the check works

![image](https://github.com/centreon/centreon-plugins/assets/46994680/328912ce-ddcc-4233-a5cd-7fb975a82fe4)


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

You can change a Windows Service display name and check it via snmp.
sc config "servicename" displayname= "new displayname"
