### PR TITLE
unique identifier - cloud::aws::cloudwatch::mode::listmetrics

### DIFF
--- a/src/cloud/aws/cloudwatch/mode/listmetrics.pm
+++ b/src/cloud/aws/cloudwatch/mode/listmetrics.pm
@@ -65,6 +65,19 @@ sub get_dimensions_str {
     return $dimensions;
 }
 
+sub get_dimensions_str_short {
+    my ($self, %options) = @_;
+
+    my $dimensions = '';
+    my $append = '';
+    foreach (@{$options{dimensions}}) {
+        $dimensions .= $append . "$_->{Name}:$_->{Value}";
+        $append = ' ';
+    }
+
+    return $dimensions;
+}
+
 sub run {
     my ($self, %options) = @_;
 
@@ -97,6 +110,7 @@ sub disco_show {
             namespace => $_->{Namespace},
             metric => $_->{MetricName},
             dimensions => $self->get_dimensions_str(dimensions => $_->{Dimensions}),
+            dimension_metric => $_->{MetricName} . " " . $self->get_dimensions_str_short(dimensions => $_->{Dimensions})
         );
     }
 }


### PR DESCRIPTION
cloud::aws::cloudwatch::mode::listmetrics  - add combined unique short identifier to better identify the metric

## Description

To use the plugin cloud::aws::cloudwatch::plugin in mode=get-metrics to get a metric value you have to use the metric filter in combination with the dimension filter. It would be nice to have a unique combined field in the mode=list-metrics for faster search in the results.


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)