### PR TITLE
fix(cloud::azure::custom): fixed azurecost

### DIFF
--- a/src/cloud/azure/custom/api.pm
+++ b/src/cloud/azure/custom/api.pm
@@ -930,7 +930,7 @@ sub azure_get_usagedetails_set_url {
     my $url = $self->{management_endpoint} . "/subscriptions/" . $self->{subscription};
     $url .= "/resourceGroups/" . $options{resource_group} if (defined($options{resource_group}) && $options{resource_group} ne '');
     $url .= "/providers/Microsoft.Consumption/usageDetails?\$filter=properties%2FusageStart ge %27" . $options{usage_start} . "%27 and properties%2FusageEnd le %27" . $options{usage_end} . "%27";
-    $url .= "&metric=actualcost";
+    $url .= "&metric=amortized";
     $url .= "&api-version=" . $self->{api_version};
     return $url;
 }


### PR DESCRIPTION
## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
Change call to API with amortized metric instead of actualcost allows to avoid unwanted costs spikes due to instance reservations and/or savings plans.

**Fixes** # (issue)

## Type of change

- [X ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [X ] 22.04.x
- [X ] 22.10.x
- [X ] 23.04.x
- [X ] 23.10.x
- [X ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>
use the cost plugin / mode budgets:
--plugin=cloud::azure::management::costs::plugin --custommode='api' --mode='budgets'
and usual parameters

## Checklist
