### PR TITLE
passwordmgr hashicorp vault: add option to set auth-path

### DIFF
--- a/src/apps/hashicorp/vault/restapi/custom/api.pm
+++ b/src/apps/hashicorp/vault/restapi/custom/api.pm
@@ -157,7 +157,7 @@ sub get_access_token {
         my $login = $self->parse_auth_method(method => $self->{auth_method}, settings => $self->{auth_settings});
         my $post_json = JSON::XS->new->utf8->encode($login);
         if (!defined($self->{auth_path}) || $self->{auth_path} eq '') {
-           $self->{auth_path} = $self->{auth_method};
+            $self->{auth_path} = $self->{auth_method};
         }
         my $url_path = '/' . $self->{api_version} . '/auth/'. $self->{auth_path} . '/login/';
         $url_path .= $self->{auth_settings}->{username} if (defined($self->{auth_settings}->{username}) && $self->{auth_method} =~ 'userpass|login') ;

--- a/src/apps/hashicorp/vault/restapi/custom/api.pm
+++ b/src/apps/hashicorp/vault/restapi/custom/api.pm
@@ -50,6 +50,7 @@ sub new {
             'proto:s'                => { name => 'proto' },
             'warning-http-status:s'  => { name => 'warning_http_status' },
             'auth-method:s'          => { name => 'auth_method', default => 'token' },
+            'auth-path:s'            => { name => 'auth_path' },
             'auth-settings:s%'       => { name => 'auth_settings' },
             'unknown-http-status:s'  => { name => 'unknown_http_status' },
             'vault-token:s'          => { name => 'vault_token'}
@@ -78,6 +79,10 @@ sub check_options {
     if ($self->{option_results}->{auth_method} eq 'token' && (!defined($self->{option_results}->{vault_token}) || $self->{option_results}->{vault_token} eq '')) {
         $self->{output}->add_option_msg(short_msg => "Please set the --vault-token option");
         $self->{output}->option_exit();
+    };
+
+    if (defined($options{option_results}->{auth_path})) {		
+        $self->{auth_path} = lc($options{option_results}->{auth_path});
     };
 
     $self->{hostname} = (defined($self->{option_results}->{hostname})) ? $self->{option_results}->{hostname} : '';
@@ -151,7 +156,10 @@ sub get_access_token {
         my $decoded;
         my $login = $self->parse_auth_method(method => $self->{auth_method}, settings => $self->{auth_settings});
         my $post_json = JSON::XS->new->utf8->encode($login);
-        my $url_path = '/' . $self->{api_version} . '/auth/'. $self->{auth_method} . '/login/';
+        if (!defined($self->{auth_path}) || $self->{auth_path} eq '') {
+           $self->{auth_path} = $self->{auth_method};
+        }
+        my $url_path = '/' . $self->{api_version} . '/auth/'. $self->{auth_path} . '/login/';
         $url_path .= $self->{auth_settings}->{username} if (defined($self->{auth_settings}->{username}) && $self->{auth_method} =~ 'userpass|login') ;
 
         my $content = $self->{http}->request(
@@ -283,6 +291,12 @@ If different from 'token' the "--auth-settings" options must be set.
 Specify the Vault authentication specific settings.
 Syntax: --auth-settings='<setting>=<value>'.Example for the 'userpass' method:
 --auth-method='userpass' --auth-settings='username=my_account' --auth-settings='password=my_password'
+
+=item B<--auth-path>
+
+Authentication path for 'userpass'. Is an optional setting.
+
+More information here: https://developer.hashicorp.com/vault/docs/auth/userpass#configuration
 
 =item B<--timeout>
 

--- a/src/centreon/plugins/passwordmgr/hashicorpvault.pm
+++ b/src/centreon/plugins/passwordmgr/hashicorpvault.pm
@@ -68,7 +68,7 @@ sub get_access_token {
     my $login = $self->parse_auth_method(method => $self->{auth_method}, settings => $self->{auth_settings});
     my $post_json = JSON::XS->new->utf8->encode($login);
     if (!defined($self->{auth_path}) || $self->{auth_path} eq '') {
-       $self->{auth_path} = $self->{auth_method};
+        $self->{auth_path} = $self->{auth_method};
     }
     my $url_path = '/v1/auth/'. $self->{auth_path} . '/login/';
     $url_path .= $self->{auth_settings}->{username} if (defined($self->{auth_settings}->{username}) && $self->{auth_method} =~ 'userpass|login') ;

--- a/src/centreon/plugins/passwordmgr/hashicorpvault.pm
+++ b/src/centreon/plugins/passwordmgr/hashicorpvault.pm
@@ -45,6 +45,7 @@ sub new {
 
     $options{options}->add_options(arguments => {
         'auth-method:s'    => { name => 'auth_method', default => 'token' },
+        'auth-path:s'      => { name => 'auth_path' },
         'auth-settings:s%' => { name => 'auth_settings' },
         'map-option:s@'    => { name => 'map_option' },
         'secret-path:s@'   => { name => 'secret_path' },
@@ -66,7 +67,10 @@ sub get_access_token {
     my $decoded;
     my $login = $self->parse_auth_method(method => $self->{auth_method}, settings => $self->{auth_settings});
     my $post_json = JSON::XS->new->utf8->encode($login);
-    my $url_path = '/v1/auth/'. $self->{auth_method} . '/login/';
+    if (!defined($self->{auth_path}) || $self->{auth_path} eq '') {
+       $self->{auth_path} = $self->{auth_method};
+    }
+    my $url_path = '/v1/auth/'. $self->{auth_path} . '/login/';
     $url_path .= $self->{auth_settings}->{username} if (defined($self->{auth_settings}->{username}) && $self->{auth_method} =~ 'userpass|login') ;
 
     my $content = $self->{http}->request(
@@ -143,6 +147,10 @@ sub settings {
     if (!defined($options{option_results}->{secret_path}) || $options{option_results}->{secret_path} eq '') {
         $self->{output}->add_option_msg(short_msg => "Please set the --secret-path option");
         $self->{output}->option_exit();
+    }
+
+    if (defined($options{option_results}->{auth_path})) {		
+        $self->{auth_path} = lc($options{option_results}->{auth_path});
     }
 
     $self->{auth_method} = lc($options{option_results}->{auth_method});
@@ -276,6 +284,12 @@ Can be: 'http', 'https' (Default: http).
 
 Authentication method to log in against the Vault server.
 Can be: 'azure', 'cert', 'github', 'ldap', 'okta', 'radius', 'userpass' (Default: 'token');
+
+=item B<--auth-path>
+
+Authentication path for 'userpass'. Is an optional setting.
+
+More information here: https://developer.hashicorp.com/vault/docs/auth/userpass#configuration
 
 =item B<--vault-token>
 


### PR DESCRIPTION
## Description

The Authentication path of the method 'userpass' of Hashicorp Vault will be flexible. A different auth path can be defined at Hashicorp Vault [DOCS: HC Vault - Auth: Userpass](https://developer.hashicorp.com/vault/docs/auth/userpass#configuration). 


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Test without the option `--auth-path`, the HashiCorp Login URL is: `/v1/auth/userpass/login/hcvaultuser`

Test with the option `--auth-path=inf-icinga-userpass`, the HashiCorp Login URL is: `/v1/auth/inf-icinga-userpass/login/hcvaultuser`

The command and output of the test: [centreon-plugin_passmanager-hcvault.txt](https://github.com/centreon/centreon-plugins/files/13591980/centreon-plugin_passmanager-hcvault.txt)


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).