### PR TITLE
[CTOR-151] Fix for Debian packaging : amd64 and arm64 packages have the same name

### DIFF
--- a/.github/workflows/perl-openwsman.yml
+++ b/.github/workflows/perl-openwsman.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     container:
-      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}
+      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:latest
       credentials:
         username: ${{ secrets.DOCKER_REGISTRY_ID }}
         password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}
@@ -125,13 +125,12 @@ jobs:
         shell: bash
 
       - name: Package
-        uses: ./.github/actions/package
+        uses: ./.github/actions/package-nfpm
         with:
           nfpm_file_pattern: "dependencies/perl-openwsman/perl-openwsman.yaml"
           distrib: ${{ matrix.distrib }}
           package_extension: ${{ matrix.package_extension }}
-          version: ${{ needs.get-environment.outputs.version }}
-          release: ${{ needs.get-environment.outputs.release }}
+          arch: ${{ matrix.arch }}
           commit_hash: ${{ github.sha }}
           cache_key: cache-${{ github.sha }}-${{ matrix.package_extension}}-perl-openwsman-${{ matrix.distrib }}-${{ matrix.arch }}-${{ github.head_ref || github.ref_name }}
           rpm_gpg_key: ${{ secrets.RPM_GPG_SIGNING_KEY }}


### PR DESCRIPTION
## Description

When libopenwsman-perl is installed on bullseye amd64, the package installed is the one for arm64.
The problem is: the packages for bullseye arm64 and bullseye amd64 have the same name (libopenwsman-perl_2.7.2-2_amd64.deb instead of libopenwsman-perl_2.7.2-2_amd64.deb and libopenwsman-perl_2.7.2-2_arm64.deb)