### PR TITLE
enh(delivery): no deliver source and promote on dispatch

### DIFF
--- a/.github/workflows/plugin-delivery.yml
+++ b/.github/workflows/plugin-delivery.yml
@@ -47,6 +47,7 @@ jobs:
           token_download_centreon_com: ${{ secrets.token_download_centreon_com }}
 
   deliver-rpm:
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: [self-hosted, common]
     strategy:
       fail-fast: false
@@ -67,7 +68,7 @@ jobs:
           artifactory_token: ${{ secrets.artifactory_token }}
 
   deliver-rpm-legacy:
-    if: ${{ inputs.stability == 'stable' }}
+    if: ${{ inputs.stability == 'stable' && github.event_name != 'workflow_dispatch' }}
     runs-on: [self-hosted, common]
     strategy:
       fail-fast: false
@@ -90,6 +91,7 @@ jobs:
           artifactory_token: ${{ secrets.artifactory_token }}
 
   deliver-deb:
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: [self-hosted, common]
     strategy:
       fail-fast: false
@@ -110,7 +112,7 @@ jobs:
           artifactory_token: ${{ secrets.artifactory_token }}
 
   deliver-deb-legacy:
-    if: ${{ inputs.stability == 'stable' }}
+    if: ${{ inputs.stability == 'stable' && github.event_name != 'workflow_dispatch' }}
     runs-on: [self-hosted, common]
     strategy:
       fail-fast: false

--- a/.github/workflows/plugin-delivery.yml
+++ b/.github/workflows/plugin-delivery.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   deliver-sources:
     runs-on: [self-hosted, common]
-    if: ${{ contains(fromJson('["stable"]'), inputs.stability) }}
+    if: ${{ contains(fromJson('["stable"]'), inputs.stability) && github.event_name != 'workflow_dispatch' }}
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Description

Avoid triggering promotes and delivery sources if a workflow dispatch event is sent and branch is stable.

Fixes #MON-30965

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
