### PR TITLE
enh(windows/local): add storage mode, update list-storages powershell

### DIFF
--- a/src/centreon/common/powershell/windows/liststorages.pm
+++ b/src/centreon/common/powershell/windows/liststorages.pm
@@ -41,21 +41,20 @@ $ProgressPreference = "SilentlyContinue"
 Try {
     $ErrorActionPreference = "Stop"
 
-    $disks = Get-CimInstance Win32_LogicalDisk
+    $disks = Get-CimInstance Win32_Volume
     $items = New-Object System.Collections.Generic.List[Hashtable];
 
     Foreach ($disk in $disks) {
         $item = @{
-            name = $disk.DeviceID;
+            name = $disk.Name;
+            desc = $disk.Label;
             type = $disk.DriveType;
-            providername = $disk.ProviderName;
-            desc = $disk.VolumeName;
             size = $null;
             freespace = $null;
         }
 
-        if ($disk.Size -ne $null) {
-            $item.size = $disk.Size.toString()
+        if ($disk.Capacity -ne $null) {
+            $item.size = $disk.Capacity.toString()
         }
         if ($disk.FreeSpace -ne $null) {
             $item.freespace = $disk.FreeSpace.toString()
@@ -82,6 +81,6 @@ __END__
 
 =head1 DESCRIPTION
 
-Method to list Windows Disks.
+Method to list Windows disks (including mount points).
 
 =cut

--- a/src/centreon/common/powershell/windows/liststorages.pm
+++ b/src/centreon/common/powershell/windows/liststorages.pm
@@ -46,13 +46,16 @@ Try {
 
     Foreach ($disk in $disks) {
         $item = @{
-            name = $disk.Name;
+            name = $disk.DriveLetter;
             desc = $disk.Label;
             type = $disk.DriveType;
             size = $null;
             freespace = $null;
         }
 
+        if ($disk.DriveLetter -eq $null) {
+            $item.name = $disk.Name
+        }
         if ($disk.Capacity -ne $null) {
             $item.size = $disk.Capacity.toString()
         }

--- a/src/os/windows/local/mode/storage.pm
+++ b/src/os/windows/local/mode/storage.pm
@@ -1,0 +1,297 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package os::windows::local::mode::storage;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::common::powershell::windows::liststorages;
+use centreon::plugins::misc;
+use JSON::XS;
+
+my %storage_types = (
+    0 => 'unknown',
+    1 => 'noRootDirectory',
+    2 => 'removableDisk',
+    3 => 'localDisk',
+    4 => 'networkDrive',
+    5 => 'compactDisc',
+    6 => 'ramDisk'
+);
+
+sub custom_usage_perfdata {
+    my ($self, %options) = @_;
+
+    my ($label, $nlabel) = ('used', $self->{nlabel});
+    my $value_perf = $self->{result_values}->{used};
+    if (defined($self->{instance_mode}->{option_results}->{free})) {
+        ($label, $nlabel) = ('free', 'storage.space.free.bytes');
+        $value_perf = $self->{result_values}->{free};
+    }
+
+    my %total_options = ();
+    if ($self->{instance_mode}->{option_results}->{units} eq '%') {
+        $total_options{total} = $self->{result_values}->{total};
+        $total_options{cast_int} = 1;
+    }
+
+    $self->{output}->perfdata_add(
+        label => $label, unit => 'B',
+        instances => $self->use_instances(extra_instance => $options{extra_instance}) ? $self->{result_values}->{display} : undef,
+        nlabel => $nlabel,
+        value => $value_perf,
+        warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{thlabel}, %total_options),
+        critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{thlabel}, %total_options),
+        min => 0, max => $self->{result_values}->{total}
+    );
+}
+
+sub custom_usage_threshold {
+    my ($self, %options) = @_;
+
+    my ($exit, $threshold_value);
+    $threshold_value = $self->{result_values}->{used};
+    $threshold_value = $self->{result_values}->{free} if (defined($self->{instance_mode}->{option_results}->{free}));
+    if ($self->{instance_mode}->{option_results}->{units} eq '%') {
+        $threshold_value = $self->{result_values}->{prct_used};
+        $threshold_value = $self->{result_values}->{prct_free} if (defined($self->{instance_mode}->{option_results}->{free}));
+    }
+    $exit = $self->{perfdata}->threshold_check(
+        value => $threshold_value,
+        threshold => [
+            { label => 'critical-' . $self->{thlabel}, exit_litteral => 'critical' },
+            { label => 'warning-'. $self->{thlabel}, exit_litteral => 'warning' }
+        ]
+    );
+    return $exit;
+}
+
+sub custom_usage_output {
+    my ($self, %options) = @_;
+
+    my ($total_size_value, $total_size_unit) = $self->{perfdata}->change_bytes(value => $self->{result_values}->{total});
+    my ($total_used_value, $total_used_unit) = $self->{perfdata}->change_bytes(value => $self->{result_values}->{used});
+    my ($total_free_value, $total_free_unit) = $self->{perfdata}->change_bytes(value => $self->{result_values}->{free});
+    return sprintf(
+        'Usage Total: %s Used: %s (%.2f%%) Free: %s (%.2f%%)',
+        $total_size_value . " " . $total_size_unit,
+        $total_used_value . " " . $total_used_unit, $self->{result_values}->{prct_used},
+        $total_free_value . " " . $total_free_unit, $self->{result_values}->{prct_free}
+    );
+}
+
+sub custom_usage_calc {
+    my ($self, %options) = @_;
+
+    $self->{result_values}->{display} = $options{new_datas}->{$self->{instance} . '_display'};
+    $self->{result_values}->{total} = $options{new_datas}->{$self->{instance} . '_size'};
+    $self->{result_values}->{free} = $options{new_datas}->{$self->{instance} . '_free'};
+    $self->{result_values}->{used} = $self->{result_values}->{total} - $self->{result_values}->{free};
+    $self->{result_values}->{prct_used} = $self->{result_values}->{used} * 100 / $self->{result_values}->{total};
+    $self->{result_values}->{prct_free} = 100 - $self->{result_values}->{prct_used};
+    
+    # limit to 100. Better output.
+    if ($self->{result_values}->{prct_used} > 100) {
+        $self->{result_values}->{free} = 0;
+        $self->{result_values}->{prct_used} = 100;
+        $self->{result_values}->{prct_free} = 0;
+    }
+
+    return 0;
+}
+
+sub prefix_storage_output {
+    my ($self, %options) = @_;
+
+    return "Storage '" . $options{instance_value}->{display} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0 },
+        { name => 'storage', type => 1, cb_prefix_output => 'prefix_storage_output', message_multiple => 'All storages are ok', skipped_code => { -10 => 1 } }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'count', nlabel => 'storage.partitions.count', display_ok => 0, set => {
+                key_values => [ { name => 'count' } ],
+                output_template => 'Partitions count: %d',
+                perfdatas => [
+                    { label => 'count', template => '%d', min => 0 }
+                ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{storage} = [
+        { label => 'usage', nlabel => 'storage.space.usage.bytes', set => {
+                key_values => [ { name => 'display' }, { name => 'free' }, { name => 'size' } ],
+                closure_custom_calc => $self->can('custom_usage_calc'),
+                closure_custom_output => $self->can('custom_usage_output'),
+                closure_custom_perfdata => $self->can('custom_usage_perfdata'),
+                closure_custom_threshold_check => $self->can('custom_usage_threshold')
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'timeout:s'               => { name => 'timeout', default => 50 },
+        'command:s'               => { name => 'command', default => 'powershell.exe' },
+        'command-path:s'          => { name => 'command_path' },
+        'command-options:s'       => { name => 'command_options', default => '-InputFormat none -NoLogo -EncodedCommand' },
+        'no-ps'                   => { name => 'no_ps' },
+        'ps-exec-only'            => { name => 'ps_exec_only' },
+        'ps-display'              => { name => 'ps_display' },
+        'filter-name:s'           => { name => 'filter_name' },
+        'filter-description:s'    => { name => 'filter_description' },
+        'filter-type:s'           => { name => 'filter_type', default => '^(localDisk|networkDrive)$' },
+        'units:s'                 => { name => 'units', default => '%' },
+        'free'                    => { name => 'free' },
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    if (!defined($self->{option_results}->{no_ps})) {
+        my $ps = centreon::common::powershell::windows::liststorages::get_powershell();
+        if (defined($self->{option_results}->{ps_display})) {
+            $self->{output}->output_add(
+                severity => 'OK',
+                short_msg => $ps
+            );
+            $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+            $self->{output}->exit();
+        }
+
+        $self->{option_results}->{command_options} .= " " . centreon::plugins::misc::powershell_encoded($ps);
+    }
+
+    my ($stdout) = centreon::plugins::misc::execute(
+        output => $self->{output},
+        options => $self->{option_results},
+        command => $self->{option_results}->{command},
+        command_path => $self->{option_results}->{command_path},
+        command_options => $self->{option_results}->{command_options}
+    );
+    if (defined($self->{option_results}->{ps_exec_only})) {
+        $self->{output}->output_add(
+            severity => 'OK',
+            short_msg => $stdout
+        );
+        $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+        $self->{output}->exit();
+    }
+
+    my $decoded;
+    eval {
+        $decoded = JSON::XS->new->utf8->decode($stdout);
+    };
+    if ($@) {
+        $self->{output}->add_option_msg(short_msg => "Cannot decode json response: $@");
+        $self->{output}->option_exit();
+    }
+
+    $self->{global}->{count} = 0;
+    $self->{storage} = {};
+
+    foreach (@$decoded) {
+        my $name = $_->{name};
+        $name = $1 if ($name =~ /([A-Z]:)\\$/);
+
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
+           $name !~ /$self->{option_results}->{filter_name}/);
+        next if (defined($self->{option_results}->{filter_description}) && $self->{option_results}->{filter_description} ne '' &&
+            $_->{desc} !~ /$self->{option_results}->{filter_description}/);
+        next if (defined($self->{option_results}->{filter_type}) && $self->{option_results}->{filter_type} ne '' &&
+            $storage_types{$_->{type}} !~ /$self->{option_results}->{filter_type}/);
+
+        $self->{storage}->{$name} = {
+            display => $name,
+            size => $_->{size},
+            free => $_->{freespace},
+        };
+        $self->{global}->{count}++;
+    }
+
+    if (scalar(keys %{$self->{storage}}) <= 0) {
+        $self->{output}->add_option_msg(short_msg => 'Issue with storage information (see details)');
+        $self->{output}->option_exit();
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check storages usage (including mount points).
+
+=over 8
+
+=item B<--filter-name>
+
+Filter on storage name (can use regexp).
+
+=item B<--filter-description>
+
+Filter on storage description (can use regexp).
+
+=item B<--warning-usage>
+
+Warning threshold.
+
+=item B<--critical-usage>
+
+Critical threshold.
+
+=item B<--units>
+
+Units of thresholds (default: '%') ('%', 'B').
+
+=item B<--free>
+
+Thresholds are on free space left.
+
+=item B<--filter-type>
+
+Filter storage types with a regexp (default: '^(localDisk|networkDrive)$').
+
+=back
+
+=cut

--- a/src/os/windows/local/mode/storage.pm
+++ b/src/os/windows/local/mode/storage.pm
@@ -230,18 +230,15 @@ sub manage_selection {
     $self->{storage} = {};
 
     foreach (@$decoded) {
-        my $name = $_->{name};
-        $name = $1 if ($name =~ /([A-Z]:)\\$/);
-
         next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
-           $name !~ /$self->{option_results}->{filter_name}/);
+           $_->{name} !~ /$self->{option_results}->{filter_name}/);
         next if (defined($self->{option_results}->{filter_description}) && $self->{option_results}->{filter_description} ne '' &&
             $_->{desc} !~ /$self->{option_results}->{filter_description}/);
         next if (defined($self->{option_results}->{filter_type}) && $self->{option_results}->{filter_type} ne '' &&
             $storage_types{$_->{type}} !~ /$self->{option_results}->{filter_type}/);
 
-        $self->{storage}->{$name} = {
-            display => $name,
+        $self->{storage}->{$_->{name}} = {
+            display => $_->{name},
             size => $_->{size},
             free => $_->{freespace},
         };

--- a/src/os/windows/local/plugin.pm
+++ b/src/os/windows/local/plugin.pm
@@ -37,6 +37,7 @@ sub new {
          'pending-reboot'    => 'os::windows::local::mode::pendingreboot',
          'sessions'          => 'os::windows::local::mode::sessions',
          'time'              => 'os::windows::local::mode::ntp',
+         'storage'           => 'os::windows::local::mode::storage',
          'updates'           => 'os::windows::local::mode::updates'
     };
 


### PR DESCRIPTION
Adds a new local mode for Windows for storages check.
Moreover, it changes the powershell code to use Win32_Volume instead of Win32_LogicalDisk to list the mount points in addition to the disks.
```
perl centreon_plugins.pl --plugin=os::windows::local::plugin --mode=storage --filter-counters='usage' --verbose
OK: All storages are ok | 'C:#storage.space.usage.bytes'=126149279744B;;;0;192746090496 'C:\mountpoints\toto\#storage.space.usage.bytes'=28842065920B;;;0;85864677376 'D:#storage.space.usage.bytes'=1192564555776B;;;0;2254722498560 
Storage 'C:' Usage Total: 179.51 GB Used: 117.49 GB (65.45%) Free: 62.02 GB (34.55%)
Storage 'C:\mountpoints\toto\' Usage Total: 79.97 GB Used: 26.86 GB (33.59%) Free: 53.11 GB (66.41%)
Storage 'D:' Usage Total: 2.05 TB Used: 1.08 TB (52.89%) Free: 989.21 GB (47.11%)
```