### PR TITLE
enh(barracuda): add message mode, enh storage and mails modes

### DIFF
--- a/src/network/barracuda/bma/snmp/mode/load.pm
+++ b/src/network/barracuda/bma/snmp/mode/load.pm
@@ -44,7 +44,6 @@ sub set_counters {
     ];
 }
 
-
 sub new {
     my ($class, %options) = @_;
     my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);

--- a/src/network/barracuda/bma/snmp/mode/message.pm
+++ b/src/network/barracuda/bma/snmp/mode/message.pm
@@ -1,0 +1,118 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package network::barracuda::bma::snmp::mode::message;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use DateTime;
+
+sub set_counters {
+    my ($self, %options) = @_;
+    
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, skipped_code => { -10 => 1 } }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'queued-message', nlabel => 'message.queued.count', set => {
+                key_values => [ { name => 'indexQueueLength' } ],
+                output_template => 'Number of messages in queue: %s',
+                perfdatas => [
+                    { template => '%s', min => 0 }
+                ]
+            }
+        },
+        { label => 'last-archived-message', nlabel => 'message.archived.last.second', set => {
+                key_values => [ { name => 'last_message_archived_seconds' }, { name => 'last_message_archived_human' } ],
+                output_template => 'Last message archived %s ago',
+                output_use => 'last_message_archived_human',
+                threshold_use => 'last_message_archived_seconds',
+                perfdatas => [
+                    { template => '%s', min => 0, unit => 's' }
+                ]
+            }
+        },
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+    
+    $options{options}->add_options(arguments => {});
+
+    return $self;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $oid_indexQueueLength = '.1.3.6.1.4.1.20632.6.6.8'; # indexQueueLength
+    my $oid_lastMessageArchived = '.1.3.6.1.4.1.20632.6.6.9'; # lastMessageArchived
+
+    my $snmp_result = $options{snmp}->get_leef(
+        oids => [ $oid_indexQueueLength, $oid_lastMessageArchived ],
+        nothing_quit => 1
+    );
+
+    # 2023-12-22 12:59:53Z
+    my $tz = centreon::plugins::misc::set_timezone(name => 'UTC');
+    $snmp_result->{$oid_lastMessageArchived} =~ /^(\d{4})-(\d{2})-(\d{2})\s+(\d+):(\d+):(\d+)Z/;
+    my $dt = DateTime->new(
+        year       => $1,
+        month      => $2,
+        day        => $3,
+        hour       => $4,
+        minute     => $5,
+        second     => $6,
+        %$tz
+    );
+    my $last_message_archived_seconds = time() - $dt->epoch;
+    my $last_message_archived_human = centreon::plugins::misc::change_seconds(value => $last_message_archived_seconds);
+
+    $self->{global} = {
+        indexQueueLength => $snmp_result->{$oid_indexQueueLength},
+        last_message_archived_seconds => $last_message_archived_seconds,
+        last_message_archived_human => $last_message_archived_human
+    };
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check messages queued and archived.
+
+=over 8
+
+=item B<--warning-*> B<--critical-*>
+
+Thresholds.
+Can be: 'queued-message', 'last-archived-message' (s)
+
+=back
+
+=cut

--- a/src/network/barracuda/bma/snmp/mode/storage.pm
+++ b/src/network/barracuda/bma/snmp/mode/storage.pm
@@ -24,6 +24,19 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use Digest::MD5 qw(md5_hex);
+
+sub prefix_effective_output {
+    my ($self, %options) = @_;
+
+    return 'Effective size ';
+}
+
+sub prefix_ondisk_output {
+    my ($self, %options) = @_;
+
+    return 'On disk size ';
+}
 
 sub prefix_global_output {
     my ($self, %options) = @_;
@@ -35,12 +48,14 @@ sub set_counters {
     my ($self, %options) = @_;
     
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output', skipped_code => { -10 => 1 } }
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output', skipped_code => { -10 => 1 } },
+        { name => 'effective', type => 0, cb_prefix_output => 'prefix_effective_output', skipped_code => { -10 => 1 } },
+        { name => 'ondisk', type => 0, cb_prefix_output => 'prefix_ondisk_output', skipped_code => { -10 => 1 } }
     ];
 
     $self->{maps_counters}->{global} = [
         { label => 'firmware-space', nlabel => 'storage.firmware.space.usage.percentage', set => {
-                key_values => [ { name => 'firmware_used' } ],
+                key_values => [ { name => 'firmwareStorage' } ],
                 output_template => 'firmware used: %.2f%%',
                 perfdatas => [
                     { template => '%.2f', min => 0, max => 100, unit => '%' }
@@ -48,7 +63,7 @@ sub set_counters {
             }
         },
         { label => 'maillog-space', nlabel => 'storage.maillog.space.usage.percentage', set => {
-                key_values => [ { name => 'maillog_used' } ],
+                key_values => [ { name => 'mailLogStorage' } ],
                 output_template => 'mail and logs used: %.2f%%',
                 perfdatas => [
                     { template => '%.2f', min => 0, max => 100, unit => '%' }
@@ -56,12 +71,71 @@ sub set_counters {
             }
         }
     ];
-}
 
+    $self->{maps_counters}->{effective} = [
+        { label => 'effective-hourly', nlabel => 'storage.effective.hourly.bytes', set => {
+                key_values => [ { name => 'effectiveHour' } ],
+                output_template => 'hourly: %s %s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    { template => '%s', min => 0, unit => 'B' }
+                ]
+            }
+        },
+        { label => 'effective-daily', nlabel => 'storage.effective.daily.bytes', set => {
+                key_values => [ { name => 'effectiveDay' } ],
+                output_template => 'daily: %s %s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    { template => '%s', min => 0, unit => 'B' }
+                ]
+            }
+        },
+        { label => 'effective-delta', nlabel => 'storage.effective.delta.bytespersecond', set => {
+                key_values => [ { name => 'effectiveTotal', per_second => 1 } ],
+                output_template => 'delta: %s %s/s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    { template => '%s', min => 0, unit => 'B/s' }
+                ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{ondisk} = [
+        { label => 'ondisk-hourly', nlabel => 'storage.ondisk.hourly.bytes', set => {
+                key_values => [ { name => 'onDiskSizeHour' } ],
+                output_template => 'hourly: %s %s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    { template => '%s', min => 0, unit => 'B' }
+                ]
+            }
+        },
+        { label => 'ondisk-daily', nlabel => 'storage.ondisk.daily.bytes', set => {
+                key_values => [ { name => 'onDiskSizeDay' } ],
+                output_template => 'daily: %s %s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    { template => '%s', min => 0, unit => 'B' }
+                ]
+            }
+        },
+        { label => 'ondisk-delta', nlabel => 'storage.ondisk.delta.bytespersecond', set => {
+                key_values => [ { name => 'onDiskSizeTotal', per_second => 1 } ],
+                output_template => 'delta: %s %s/s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    { template => '%s', min => 0, unit => 'B/s' }
+                ]
+            }
+        }
+    ];
+}
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1, statefile => 1);
     bless $self, $class;
     
     $options{options}->add_options(arguments => {});
@@ -69,20 +143,33 @@ sub new {
     return $self;
 }
 
+my $mapping = {
+    firmwareStorage => { oid => '.1.3.6.1.4.1.20632.6.6.5' }, 
+    mailLogStorage  => { oid => '.1.3.6.1.4.1.20632.6.6.6' }, 
+    effectiveHour   => { oid => '.1.3.6.1.4.1.20632.6.8.1' }, 
+    effectiveDay    => { oid => '.1.3.6.1.4.1.20632.6.8.2' },
+    effectiveTotal  => { oid => '.1.3.6.1.4.1.20632.6.8.3' },
+    onDiskSizeHour  => { oid => '.1.3.6.1.4.1.20632.6.8.4' },
+    onDiskSizeDay   => { oid => '.1.3.6.1.4.1.20632.6.8.5' },
+    onDiskSizeTotal => { oid => '.1.3.6.1.4.1.20632.6.8.6' }
+};
+
 sub manage_selection {
     my ($self, %options) = @_;
 
-    my $oid_firmware = '.1.3.6.1.4.1.20632.6.6.5'; # firmwareStorage
-    my $oid_maillog = '.1.3.6.1.4.1.20632.6.6.6'; # mailLogStorage
     my $snmp_result = $options{snmp}->get_leef(
-        oids => [$oid_firmware, $oid_maillog],
+        oids => [ map($_->{oid}, values(%$mapping)) ],
         nothing_quit => 1
     );
 
-    $self->{global} = {
-        firmware_used => $snmp_result->{$oid_firmware},
-        maillog_used => $snmp_result->{$oid_maillog}
-    };
+    my $result = $options{snmp}->map_instance(mapping => $mapping, results => $snmp_result);
+
+    $self->{global} = $result;
+    $self->{effective} = $result;
+    $self->{ondisk} = $result;
+
+    $self->{cache_name} = 'barracuda_bma_' . $options{snmp}->get_hostname()  . '_' . $options{snmp}->get_port() . '_' . $self->{mode} . '_' .
+        (defined($self->{option_results}->{filter_counters}) ? md5_hex($self->{option_results}->{filter_counters}) : md5_hex('all'));
 }
 
 1;
@@ -98,7 +185,9 @@ Check storage usage.
 =item B<--warning-*> B<--critical-*>
 
 Thresholds.
-Can be: 'firmware-space', 'maillog-space'.
+Can be: 'firmware-space', 'maillog-space', 'effective-hourly',
+'effective-daily', 'effective-delta', 'ondisk-hourly',
+'ondisk-daily', 'ondisk-delta',
 
 =back
 

--- a/src/network/barracuda/bma/snmp/plugin.pm
+++ b/src/network/barracuda/bma/snmp/plugin.pm
@@ -32,6 +32,7 @@ sub new {
     $self->{modes} = {
         'load'    => 'network::barracuda::bma::snmp::mode::load',
         'mails'   => 'network::barracuda::bma::snmp::mode::mails',
+        'message' => 'network::barracuda::bma::snmp::mode::message',
         'storage' => 'network::barracuda::bma::snmp::mode::storage'
     };
 


### PR DESCRIPTION
Adds a new message mode that check the number of queued messages.
```
perl centreon_plugins.pl --plugin=network::barracuda::bma::snmp::plugin --mode=message --hostname=10.1.2.3 --subsetleef=1
OK: Number of messages in queue: 6, Last message archived 3s ago | 'message.queued.count'=6;;;0; 'message.archived.last.second'=3s;;;0;
```

Enhance the storage mode to add effective and on disk size of message per hour, day and total (delta per seconds).
```
perl centreon_plugins.pl --plugin=network::barracuda::bma::snmp::plugin --mode=storage --hostname=10.1.2.3 --subsetleef=1
OK: Storage space firmware used: 71.00%, mail and logs used: 89.00% - Effective size hourly: 820.00 B, daily: 18.27 KB, delta: 0.00 B/s - On disk size hourly: 483.00 B, daily: 11.30 KB, delta: 0.00 B/s | 'storage.firmware.space.usage.percentage'=71.00%;;;0;100 'storage.maillog.space.usage.percentage'=89.00%;;;0;100 'storage.effective.hourly.bytes'=820B;;;0; 'storage.effective.daily.bytes'=18706B;;;0; 'storage.effective.delta.bytespersecond'=0B/s;;;0; 'storage.ondisk.hourly.bytes'=483B;;;0; 'storage.ondisk.daily.bytes'=11573B;;;0; 'storage.ondisk.delta.bytespersecond'=0B/s;;;0;
```

Change mails mode to output delta per seconds volume of emails instead of delta (named total).
```
perl centreon_plugins.pl --plugin=network::barracuda::bma::snmp::plugin --mode=mails --hostname=10.1.2.3 --subsetleef=1
OK: Number of inbound mails hourly: 9049, daily: 77853, delta: 2.20/s - Number of outbound mails hourly: 0, daily: 36, delta: 0.00/s - Number of internal mails hourly: 0, daily: 0, delta: 0.00/s | 'mails.inbound.hourly.count'=9049;;;0; 'mails.inbound.daily.count'=77853;;;0; 'mails.inbound.delta.persecond'=2.20/s;;;0; 'mails.outbound.hourly.count'=0;;;0; 'mails.outbound.daily.count'=36;;;0; 'mails.outbound.delta.persecond'=0.00/s;;;0; 'mails.internal.hourly.count'=0;;;0; 'mails.internal.daily.count'=0;;;0; 'mails.internal.delta.persecond'=0.00/s;;;0;
```