### PR TITLE
[CTOR-96] Rubrik - Enhance jobs and cache modes

### DIFF
--- a/src/apps/backup/rubrik/restapi/custom/api.pm
+++ b/src/apps/backup/rubrik/restapi/custom/api.pm
@@ -404,7 +404,7 @@ sub get_cache_file_response {
 sub cache_jobs_monitoring {
     my ($self, %options) = @_;
 
-    my $datas = $self->get_jobs_monitoring(disable_cache => 1, limit => $options{limit});
+    my $datas = $self->get_jobs_monitoring(disable_cache => 1, get_param => $options{get_param});
     $self->write_cache_file(
         statefile => 'jobs_monitoring',
         response => $datas
@@ -422,7 +422,7 @@ sub get_jobs_monitoring {
     return $self->request_api(
         endpoint => '/api/v1/job_monitoring',
         label => 'jobMonitoringInfoList',
-        get_param => ['limit=' . $options{limit}]
+        get_param => $options{get_param}
     );
 }
 

--- a/src/apps/backup/rubrik/restapi/mode/cache.pm
+++ b/src/apps/backup/rubrik/restapi/mode/cache.pm
@@ -31,7 +31,8 @@ sub new {
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
-        'limit:s' => { name => 'limit' }
+        'filter-job-type:s' => { name => 'filter_job_type' },
+        'limit:s'           => { name => 'limit' }
     });
 
     return $self;
@@ -49,7 +50,12 @@ sub check_options {
 sub manage_selection {
     my ($self, %options) = @_;
 
-    $options{custom}->cache_jobs_monitoring(limit => $self->{option_results}->{limit});
+    my $get_param = [ 'limit=' . $self->{option_results}->{limit} ];
+    if (defined($self->{option_results}->{filter_job_type}) && $self->{option_results}->{filter_job_type} ne '') {
+        push @{$get_param}, 'job_type=' . $self->{option_results}->{filter_job_type};
+    }
+
+    $options{custom}->cache_jobs_monitoring(get_param => $get_param);
 
     $self->{output}->output_add(
         severity => 'OK',
@@ -66,6 +72,10 @@ __END__
 Create cache files (job mode could use it with --cache-use option).
 
 =over 8
+
+=item B<--filter-job-type>
+
+Filter jobs by job type.
 
 =item B<--limit>
 

--- a/src/apps/backup/rubrik/restapi/mode/jobs.pm
+++ b/src/apps/backup/rubrik/restapi/mode/jobs.pm
@@ -220,7 +220,6 @@ sub new {
         'filter-job-type:s'      => { name => 'filter_job_type' },
         'filter-location-name:s' => { name => 'filter_location_name' },
         'filter-object-type:s'   => { name => 'filter_object_type' },
-        'last-job-status'        => { name => 'last_job_status' },
         'unit:s'                 => { name => 'unit', default => 's' },
         'limit:s'                => { name => 'limit' }
     });
@@ -299,7 +298,7 @@ sub manage_selection {
                 $older_running_exec = $_;
             }
             
-            if ($_->{jobStatus} !~ /Scheduled/i) {
+            if ($_->{jobStatus} !~ /Scheduled|Canceled|Canceling|CancelingScheduled/i) {
                 $last_exec = $_;
             }
 

--- a/src/apps/backup/rubrik/restapi/mode/jobs.pm
+++ b/src/apps/backup/rubrik/restapi/mode/jobs.pm
@@ -299,10 +299,7 @@ sub manage_selection {
                 $older_running_exec = $_;
             }
             
-            if ($self->{option_results}->{last_job_status}) {
-                $last_exec = $_;
-            
-            } elsif (!defined($last_exec) && $_->{jobStatus} !~ /Scheduled/i) {
+            if ($_->{jobStatus} !~ /Scheduled/i) {
                 $last_exec = $_;
             }
 
@@ -402,10 +399,6 @@ Filter jobs by object type.
 =item B<--filter-location-name>
 
 Filter jobs by location name.
-
-=item B<--last-job-status>
-
-Select the last job status.
 
 =item B<--unit>
 


### PR DESCRIPTION
## Description

- Added --filter-job-type option to cache mode to filter job type in query.
- Added --filter-object-type option to jobs mode to filter object type on selection.
- Added "locationName" and "objectType" fields to the jobs mode long output.
- Ignore jobs with status "Canceled", "Canceling", ou "CancelingScheduled"
- Take the last completed job status instead of the first one of the list

close https://github.com/centreon/centreon-plugins/issues/4646

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
