### PR TITLE
enh(network::hp::standard::snmp): added vrrp-status mode

### DIFF
--- a/src/network/hp/standard/snmp/plugin.pm
+++ b/src/network/hp/standard/snmp/plugin.pm
@@ -39,6 +39,7 @@ sub new {
         'memory'               => 'centreon::common::h3c::snmp::mode::memory',
         'spanning-tree'        => 'snmp_standard::mode::spanningtree',
         'uptime'               => 'snmp_standard::mode::uptime',
+        'vrrp-status'          => 'snmp_standard::mode::vrrp'
     );
 
     return $self;


### PR DESCRIPTION
please refer to #4841

This will add the vrrp-status mode. We have tested this on a HPE 5900AF-48XG which is using the standard vrrp mibs