### PR TITLE
Extension of the cloud::aws::apigateway::mode::requests and latency plugin with --api-gateway-type option to distinguish between REST, HTTP and WebSocket

### DIFF
--- a/src/cloud/aws/apigateway/mode/requests.pm
+++ b/src/cloud/aws/apigateway/mode/requests.pm
@@ -26,32 +26,32 @@ use strict;
 use warnings;
 
 my %metrics_mapping = (
-    'Count' => {
+    'Count'    => {
         'output' => 'Client Requests',
-        'label' => 'requests-client',
+        'label'  => 'requests-client',
         'nlabel' => 'apigateway.requests.client.count'
     },
     '4XXError' => {
         'output' => 'HTTP 4XX Errors',
-        'label' => 'requests-errors-4xx',
+        'label'  => 'requests-errors-4xx',
         'nlabel' => 'apigateway.requests.errors.4xx.count'
     },
     '5XXError' => {
         'output' => 'HTTP 5XX Errors',
-        'label' => 'requests-errors-5xx',
+        'label'  => 'requests-errors-5xx',
         'nlabel' => 'apigateway.requests.errors.5xx.count'
     },
 );
 
 sub prefix_metric_output {
     my ($self, %options) = @_;
-    
+
     return " '" . $options{instance_value}->{display} . "' ";
 }
 
 sub prefix_statistics_output {
     my ($self, %options) = @_;
-    
+
     return "Statistic '" . $options{instance_value}->{display} . "' Metrics ";
 }
 
@@ -63,26 +63,36 @@ sub long_output {
 
 sub set_counters {
     my ($self, %options) = @_;
-    
+
     $self->{maps_counters_type} = [
-        { name => 'metrics', type => 3, cb_prefix_output => 'prefix_metric_output', cb_long_output => 'long_output',
-          message_multiple => 'All requests metrics are ok', indent_long_output => '    ',
-            group => [
-                { name => 'statistics', display_long => 1, cb_prefix_output => 'prefix_statistics_output',
-                  message_multiple => 'All requests are ok', type => 1, skipped_code => { -10 => 1 } },
-            ]
-        }    
+        {
+            name               => 'metrics',
+            type               => 3,
+            cb_prefix_output   => 'prefix_metric_output',
+            cb_long_output     => 'long_output',
+            message_multiple   => 'All requests metrics are ok',
+            indent_long_output => '    ',
+            group              =>
+                [
+                    { name               => 'statistics',
+                        display_long     => 1,
+                        cb_prefix_output => 'prefix_statistics_output',
+                        message_multiple => 'All requests are ok',
+                        type             => 1,
+                        skipped_code     => { -10 => 1 } },
+                ]
+        }
     ];
 
     foreach my $metric (keys %metrics_mapping) {
         my $entry = {
-            label => $metrics_mapping{$metric}->{label},
+            label  => $metrics_mapping{$metric}->{label},
             nlabel => $metrics_mapping{$metric}->{nlabel},
-            set => {
-                key_values => [ { name => $metric }, { name => 'display' } ],
+            set    => {
+                key_values      => [ { name => $metric }, { name => 'display' } ],
                 output_template => $metrics_mapping{$metric}->{output} . ': %.2f',
-                perfdatas => [
-                    { value => $metric , template => '%.2f', label_extra_instance => 1 }
+                perfdatas       => [
+                    { value => $metric, template => '%.2f', label_extra_instance => 1 }
                 ],
             }
         };
@@ -93,14 +103,15 @@ sub set_counters {
 
 sub new {
     my ($class, %options) = @_;
-    my $self = $class->SUPER::new(package => __PACKAGE__, force_new_perfdata => 1,  %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, force_new_perfdata => 1, %options);
     bless $self, $class;
-    
+
     $options{options}->add_options(arguments => {
-        'api-name:s@'     => { name => 'api_name' },
-        'filter-metric:s' => { name => 'filter_metric' },
+        'api-gateway-type:s' => { name => 'api_gateway_type', default => 'REST' },
+        'dimension-value:s@' => { name => 'dimension_value' },
+        'filter-metric:s'    => { name => 'filter_metric' },
     });
-    
+
     return $self;
 }
 
@@ -108,7 +119,12 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::check_options(%options);
 
-    foreach my $instance (@{$self->{option_results}->{api_name}}) {
+    if ($self->{option_results}->{api_gateway_type} !~ /^(REST|HTTP|WebSocket)$/) {
+        $self->{output}->add_option_msg(short_msg => "Unsupported --api-gateway-type option.");
+        $self->{output}->option_exit();
+    }
+
+    foreach my $instance (@{$self->{option_results}->{dimension_value}}) {
         if ($instance ne '') {
             push @{$self->{aws_instance}}, $instance;
         }
@@ -116,8 +132,8 @@ sub check_options {
 
     $self->{aws_timeframe} = defined($self->{option_results}->{timeframe}) ? $self->{option_results}->{timeframe} : 600;
     $self->{aws_period} = defined($self->{option_results}->{period}) ? $self->{option_results}->{period} : 60;
-    
-    $self->{aws_statistics} = ['Sum'];
+
+    $self->{aws_statistics} = [ 'Sum' ];
     if (defined($self->{option_results}->{statistic})) {
         $self->{aws_statistics} = [];
         foreach my $stat (@{$self->{option_results}->{statistic}}) {
@@ -139,14 +155,16 @@ sub manage_selection {
     my ($self, %options) = @_;
 
     my %metric_results;
+    my $dimension_instance = $self->{option_results}->{api_gateway_type} eq 'REST' ? 'ApiName' : 'ApiId';
+
     foreach my $instance (@{$self->{aws_instance}}) {
         $metric_results{$instance} = $options{custom}->cloudwatch_get_metrics(
-            namespace => 'AWS/ApiGateway',
-            dimensions => [ { Name => 'ApiName', Value => $instance } ],
-            metrics => $self->{aws_metrics},
+            namespace  => 'AWS/ApiGateway',
+            dimensions => [ { Name => $dimension_instance, Value => $instance } ],
+            metrics    => $self->{aws_metrics},
             statistics => $self->{aws_statistics},
-            timeframe => $self->{aws_timeframe},
-            period => $self->{aws_period},
+            timeframe  => $self->{aws_timeframe},
+            period     => $self->{aws_period},
         );
 
         foreach my $metric (@{$self->{aws_metrics}}) {
@@ -158,13 +176,14 @@ sub manage_selection {
                 $self->{metrics}->{$instance}->{statistics}->{lc($statistic)}->{display} = $statistic;
                 $self->{metrics}->{$instance}->{statistics}->{lc($statistic)}->{$metric} =
                     defined($metric_results{$instance}->{$metric}->{lc($statistic)}) ?
-                    $metric_results{$instance}->{$metric}->{lc($statistic)} : 0;
+                        $metric_results{$instance}->{$metric}->{lc($statistic)} : 0;
             }
         }
     }
-    
+
     if (scalar(keys %{$self->{metrics}}) <= 0) {
-        $self->{output}->add_option_msg(short_msg => 'No metrics. Check your options or use --zeroed option to set 0 on undefined values');
+        $self->{output}->add_option_msg(short_msg =>
+            'No metrics. Check your options or use --zeroed option to set 0 on undefined values');
         $self->{output}->option_exit();
     }
 }
@@ -180,18 +199,24 @@ Default statistic: 'sum'
 
 =over 8
 
-=item B<--api-name>
+=item B<--api-gateway-type>
 
-Set the api name (required) (can be defined multiple times).
+The type of the api gateway. Default 'REST'
+(Can be: 'REST', 'HTTP', 'WebSocket'). Used to set the correct dimension instance (ApiName or ApiId)
+
+=item B<--dimension-value>
+
+Can be the APIName or the ApiId value (Required) depending by the --api-gateway-type (can be defined multiple times).
 
 =item B<--filter-metric>
 
-Filter metrics (can be: 'Count', '4XXError', '5XXError') 
+Filter metrics (Can be: 'Count', '4XXError', '5XXError') 
 
 =item B<--warning-*> B<--critical-*>
 
-Warning thresholds (* can be requests-client,
-requests-errors-4xx, requests-errors-5xx).
+Thresholds warning 
+star substitusion possibilities: requests-client,
+requests-errors-4xx, requests-errors-5xx
 
 =back
 


### PR DESCRIPTION
add possibility to change the dimension instance for the Api Gateway type. (REST, HTTP, WebSocket)

## Description

Currently, the ApiGateway plugin always uses --api-name as a parameter. In the code, the dimension is fixed with ApiName.

![image](https://github.com/centreon/centreon-plugins/assets/46994680/48401606-344a-44b9-aa8e-e79be489f81f)

This is working only for ApiGateways of type REST. But there is also HTTP or WebSocket.

Using this two types must be used **ApiId** and not **ApiName** for the dimension instance. Otherwise the plugin returns 0 for the metric (when --zeroed is set) because metric not found.

![image](https://github.com/centreon/centreon-plugins/assets/46994680/93947bc3-9bc9-4431-9f54-5a34e382f4d9)

**Fixes** # (issue)

After my changes the value will be returned correctly.

`perl centreon_plugins.pl --aws-secret-key=*** --aws-access-key=*** --custommode=paws --region=eu-central-1 --plugin=cloud::aws::apigateway::plugin --mode=latency --zeroed --api-gateway-type=HTTP --dimension-value=j5ebxxxx --filter-metric=`

`OK:  'j5ebxxxx' Statistic 'Sum' Metrics HTTP 5XX Errors: 0.00, HTTP 4XX Errors: 0.00, Client Requests: 3.00 | 'j5ebxxxx~sum#apigateway.requests.errors.5xx.count'=0.00;;;; 'j5ebxxxx~sum#apigateway.requests.errors.4xx.count'=0.00;;;; 'j5ebxxxx~sum#apigateway.requests.client.count'=3.00;;;;`

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2>How to test</h2>

Use a AWS ApiGateway of type HTTP and use --api-gateway-type=HTTP and --dimension-value=MyApiId
Use a AWS ApiGateway of type REST and use --api-gateway-type=REST and --dimension-value=MyApiName

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
