### PR TITLE
enh(http/collection): move json parsing outside http call

### DIFF
--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -658,7 +658,7 @@ sub save_local_http_cache {
                     tables => $options{local},
                     epoch => time()
                 },
-                builtin => $self->{builtin}
+                builtin => $options{builtin}
             }
         );
     }

--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -566,7 +566,11 @@ sub collect_http_tables {
                     }
                 }
 
-                $self->save_local_http_cache(local_http_cache => $local_http_cache, local => $local);
+                $self->save_local_http_cache(
+                    local_http_cache => $local_http_cache,
+                    local => $local,
+                    builtin => $self->{builtin}
+                );
             }
         }
 
@@ -637,6 +641,9 @@ sub use_local_http_cache {
             $self->{http_collected}->{tables}->{$name}->{$instance} = $self->{local_http_collected}->{tables}->{$name}->{$instance};
         }
     }
+    
+    $self->{builtin} = $local_http_cache->get(name => 'builtin');
+    $self->set_builtin();
 
     return 1;
 }
@@ -650,7 +657,8 @@ sub save_local_http_cache {
                 http_collected => {
                     tables => $options{local},
                     epoch => time()
-                }
+                },
+                builtin => $self->{builtin}
             }
         );
     }


### PR DESCRIPTION
This PR moves JSON (and XML) parsing outside the call_http function so we can actually use the scenario_stopped directive if we don't do recursive requests (only one request, which must be most use cases).

It was not possible before because the parsing bit was stopping the scenario for JSON decoding problem before HTTP metrics were used (through check_filter2 function).

Now, for example we can look at HTTP returned code before parsing a content, so we can exit the scenario in case of non-2xx.

This example adds a "test" selection that shows the returned code and message that can handle, in addition to the "scenario_stopped" directive, the cases where the API does not respond as expected. That way, we don't have "Cannot decode ..." unknown output when the API actually doesn't work.

```
{
    "http": {
        "requests": [
            {
                "name": "ping",
                ...
                "endpoint": "/toto",
                "method": "GET",
                ...
                "insecure": 0,
                "timeout": 30,
                ...
                "backend": "curl",
                "scenario_stopped": "%(builtin.httpCode.ping) != 200",
                "rtype": "xml",
                "parse": [
                    {
                        "name": "result",
                        "path": "$..PingResponse.PingResult",
                        "entries": [
                            {
                                "id": "ElapsedMilliseconds"
                            }
                        ]
                    }
                ]
            }
        ]
    },
    "selection": [
        {
            "name": "test",
            "critical": "%(builtin.httpCode.ping) != 200",
            "exit": "%(builtin.httpCode.ping) != 200",
            "formatting": {
                "printf_msg":"API returned HTTP code '%s' with message '%s'",
                "printf_var":[
                    "%(builtin.httpCode.ping)",
                    "%(builtin.httpMessage.ping)"
                ],
                "display_ok": true
            }
        },
        {
            "name": "status",
            "formatting": {
                "printf_msg": "Worker ping returned in %s ms",
                "printf_var": [
                    "%(http.tables.pingResult.[0].ElapsedMilliseconds)"
                ],
                "display_ok": true
            },
            "perfdatas": [
                {
                    "nlabel": "worker.ping.milliseconds",
                    "value": "%(http.tables.pingResult.[0].ElapsedMilliseconds)",
                    "min": 0,
                    "unit": "ms"
                }
            ]
        }
    ],
    "formatting": {
        "custom_message_global": "Saas platform returned calls successfully",
        "separator": "-"
    }
}
```