### PR TITLE
enh(apps::varnish::local): added Transient.g_space in stats mode

### DIFF
--- a/src/apps/varnish/local/mode/stats.pm
+++ b/src/apps/varnish/local/mode/stats.pm
@@ -150,6 +150,7 @@ sub configure_varnish_stats {
         { entry => 'n_wrk_drop', nlabel => 'workers.requests.dropped.count', display_ok => 0, diff => 1 },
         
         { entry => 'Transient.g_space', category => 'SMA', nlabel => 'storage.transient.space.free.bytes', display_ok => 0, custom_output => $self->can('custom_output_scale_bytes') },
+        { entry => 'Transient.g_bytes', category => 'SMA', nlabel => 'storage.transient.space.used.bytes', display_ok => 0, custom_output => $self->can('custom_output_scale_bytes') },
         { entry => 's0.g_space', category => 'SMA', nlabel => 'storage.space.free.bytes', display_ok => 0, custom_output => $self->can('custom_output_scale_bytes') },
     ];
 }

--- a/src/apps/varnish/local/mode/stats.pm
+++ b/src/apps/varnish/local/mode/stats.pm
@@ -148,7 +148,8 @@ sub configure_varnish_stats {
         { entry => 'n_wrk_lqueue', nlabel => 'workers.requests.queue.length.count', display_ok => 0, diff => 1 },
         { entry => 'n_wrk_queued', nlabel => 'workers.requests.queued.count', display_ok => 0, diff => 1 },
         { entry => 'n_wrk_drop', nlabel => 'workers.requests.dropped.count', display_ok => 0, diff => 1 },
-
+        
+        { entry => 'Transient.g_space', category => 'SMA', nlabel => 'storage.transient.space.free.bytes', display_ok => 0, custom_output => $self->can('custom_output_scale_bytes') },
         { entry => 's0.g_space', category => 'SMA', nlabel => 'storage.space.free.bytes', display_ok => 0, custom_output => $self->can('custom_output_scale_bytes') },
     ];
 }


### PR DESCRIPTION
[+] Add Varnish Transient.g_space counter

## Description

These changes add the Transient.g_space counter metric to varnish checks.

**Fixes** (https://github.com/centreon/centreon-plugins/issues/3047)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Here's the command (linux) to run the check on a host:
/var/lib/centreon/plugins/centreon_plugins.pl --plugin=apps::varnish::local::plugin --mode=stats --hostname=HOST_IP --filter-counters Transient.g-space


## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
