### PR TITLE
enh(passwordmgr): handle different kind of options (string, arrays and hashes)

### DIFF
--- a/src/centreon/plugins/passwordmgr/environment.pm
+++ b/src/centreon/plugins/passwordmgr/environment.pm
@@ -56,8 +56,18 @@ sub manage_options {
         next if (! /^(.+?)=(.+)$/);
         my ($option, $map) = ($1, $2);
 
-        $option =~ s/-/_/g;
         $options{option_results}->{$option} = defined($ENV{$map}) ? $ENV{$map} : '';
+        
+        $option =~ s/-/_/g;
+        if ($option =~ /\@(.*)/) {
+            push @{$options{option_results}->{$1}}, $ENV{$map} if (defined($ENV{$map}));
+        } elsif ($option =~ /\%(.*)/) {
+            my $opt = $1;
+            next if ($map !~ /^(.+?)=(.+)$/);
+            $options{option_results}->{$opt}->{$1} = $ENV{$2} if (defined($ENV{$2}));
+        } else {
+            $options{option_results}->{$option} = defined($ENV{$map}) ? $ENV{$map} : '';
+        }
     }
 }
 
@@ -80,8 +90,17 @@ environment class
 =item B<--environment-map-option>
 
 Overload plugin option.
-Example:
+
+Examples:
+
+For simple options:
 --environment-map-option="snmp-community=SNMPCOMMUNITY"
+
+For options that can be set multiple times (ex Jolokia plugins):
+--environment-map-option="@username=THEUSERNAME"
+
+For options that are used to set key/value couple (ex Collection plugins):
+--environment-map-option="%constant=password=THEPASSWORD"
 
 =back
 

--- a/src/centreon/plugins/passwordmgr/keepass.pm
+++ b/src/centreon/plugins/passwordmgr/keepass.pm
@@ -121,6 +121,7 @@ sub do_map {
     my ($self, %options) = @_;
     
     return if (!defined($options{option_results}->{keepass_map_option}));
+    
     foreach (@{$options{option_results}->{keepass_map_option}}) {
         next if (! /^(.+?)=(.+)$/);
         my ($option, $map) = ($1, $2);
@@ -129,11 +130,19 @@ sub do_map {
         while ($map =~ /\%\{(.*?)\}/g) {
             my $sub = '';
             $sub = $self->{lookup_values}->{$1} if (defined($self->{lookup_values}->{$1}));
-            $map =~ s/\%\{$1\}/$sub/g
+            $map =~ s/\%\{$1\}/$sub/g;
         }
 
         $option =~ s/-/_/g;
-        $options{option_results}->{$option} = $map;
+        if ($option =~ /\@(.*)/) {
+            push @{$options{option_results}->{$1}}, $map;
+        } elsif ($option =~ /\%(.*)/) {
+            my $opt = $1;
+            next if ($map !~ /^(.+?)=(.+)$/);
+            $options{option_results}->{$opt}->{$1} = $2;
+        } else {
+            $options{option_results}->{$option} = $map;
+        }
     }
 }
 
@@ -198,9 +207,18 @@ Example:
 =item B<--keepass-map-option>
 
 Overload plugin option.
-Example:
+
+Examples:
+
+For simple options:
 --keepass-map-option="password=%{password}"
 --keepass-map-option="username=%{username}"
+
+For options that can be set multiple times (ex Jolokia plugins):
+--keepass-map-option="@username=%{username}"
+
+For options that are used to set key/value couple (ex Collection plugins):
+--keepass-map-option="%constant=password=%{password}"
 
 =back
 


### PR DESCRIPTION
Adds support for the different kinds of options that a user can provide depending on the plugin/mode.
For examples Jolokia plugins are expecting arrays, Collections plugins are expecting key/value hash for constant options.