### PR TITLE
Fix API endpoint for K8s CronJob

### DIFF
--- a/src/cloud/kubernetes/custom/api.pm
+++ b/src/cloud/kubernetes/custom/api.pm
@@ -192,7 +192,7 @@ sub kubernetes_list_cronjobs {
 
     my $response = $self->request_api_paginate(
         method => 'GET',
-        url_path => $self->{namespace} ne '' ? '/apis/batch/v1beta1/namespaces/' . $self->{namespace} . '/cronjobs' : '/apis/batch/v1beta1/cronjobs'
+        url_path => $self->{namespace} ne '' ? '/apis/batch/v1/namespaces/' . $self->{namespace} . '/cronjobs' : '/apis/batch/v1/cronjobs'
     );
 
     return $response;


### PR DESCRIPTION
**CronJob has moved from batch v1beta to v1 since kube 1.21**

The API endpoint has been updated in this PR to fix the 404 not found error when listing CronJobs using the Kubernetes API plugin in Centreon.
