### PR TITLE
enh(powershell/updates): Substituion of special charactere for Fr, Es,…

### DIFF
--- a/src/centreon/common/powershell/windows/updates.pm
+++ b/src/centreon/common/powershell/windows/updates.pm
@@ -49,7 +49,7 @@ Try {
 
     Foreach ($update in $updates) {
         $item = @{
-            title = $update.Title;
+            title = $update.Title.Normalize([Text.NormalizationForm]::FormD) -replace "\p{M}", "" -replace "\p{Z}", " ";
             isMandatory = $update.IsMandatory;
         }
 


### PR DESCRIPTION
When à, é, ñ, ç , etc. > Replace by a, e, n, c, etc.

Avoid JSON malformed output on WSMAN plugin
Avoid '?' Character output on NSClient++

EDIT by @omercier:
REFS: CTOR-434
