### PR TITLE
enh(interfaces) Allow a regex to be used when looking for ids

### DIFF
--- a/src/snmp_standard/mode/interfaces.pm
+++ b/src/snmp_standard/mode/interfaces.pm
@@ -1208,10 +1208,9 @@ sub get_selection {
     if (!defined($self->{option_results}->{use_name}) && defined($self->{option_results}->{interface}) 
         && $self->{no_interfaceid_options} == 0) {
         my $regex = $self->{option_results}->{interface};
-        foreach (@{$all_ids}) {
-            my $id = $_;
+        for my $id (@{$all_ids}) {
             if ($id =~ /(^|\s|,)$regex(\s*,|$)/) {
-                $self->add_selected_interface(id => $_);
+                $self->add_selected_interface(id => $id);
             }
         }
     } else {

--- a/src/snmp_standard/mode/interfaces.pm
+++ b/src/snmp_standard/mode/interfaces.pm
@@ -1207,8 +1207,10 @@ sub get_selection {
     my $all_ids = $self->{statefile_cache}->get(name => 'all_ids');
     if (!defined($self->{option_results}->{use_name}) && defined($self->{option_results}->{interface}) 
         && $self->{no_interfaceid_options} == 0) {
+        my $regex = $self->{option_results}->{interface};
         foreach (@{$all_ids}) {
-            if ($self->{option_results}->{interface} =~ /(^|\s|,)$_(\s*,|$)/) {
+            my $id = $_;
+            if ($id =~ /(^|\s|,)$regex(\s*,|$)/) {
                 $self->add_selected_interface(id => $_);
             }
         }


### PR DESCRIPTION
## Description

Allow a regex to be used when looking for a more than of ids to be able to use i.e --interface='1048[0-9]*'.

Before :

```
./centreon_plugins.pl --plugin=network::dell::sseries::snmp::plugin --mode=interfaces --hostname=xxxx --snmp-version='2c' --snmp-community='dell_s_series' --add-traffic --interface='1048[0-9]*' --warning-in-traffic='80' --critical-in-traffic='90' --warning-out-traffic='80' --critical-out-traffic='90' --snmp-autoreduce
UNKNOWN: No entry found (maybe you should reload cache file) 
```

After :

```
./centreon_plugins.pl --plugin=network::dell::sseries::snmp::plugin --mode=interfaces --hostname=xxx --snmp-version='2c' --snmp-community='dell_s_series'  --add-traffic --interface='1048[0-9]*' --warning-in-traffic='80' --critical-in-traffic='90' --warning-out-traffic='80' --critical-out-traffic='90' --snmp-autoreduce
OK: All interfaces are ok | 'traffic_in_TenGigabitEthernet 0/0'=0.00b/s;0:8000000000;0:9000000000;0;10000000000 'traffic_out_TenGigabitEthernet 0/0'=0.00b/s;0:8000000000;0:9000000000;0;10000000000 'traffic_in_TenGigabitEthernet 0/1'=0.00b/s;0:8000000000;0:9000000000;0;10000000000 'traffic_out_TenGigabitEthernet 0/1'=0.00b/s;0:8000000000;0:9000000000;0;10000000000 'traffic_in_TenGigabitEthernet 0/2'=0.00b/s;0:8000000000;0:9000000000;0;10000000000 'traffic_out_TenGigabitEthernet 0/2'=0.00b/s;0:8000000000;0:9000000000;0;10000000000 'traffic_in_TenGigabitEthernet 0/3'=0.00b/s;0:8000000000;0:9000000000;0;10000000000 'traffic_out_TenGigabitEthernet 0/3'=0.00b/s;0:8000000000;0:9000000000;0;10000000000
```

**Fixes** # MON-34949

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

