### PR TITLE
[CTOR-346] Change the label name to avoid checking the spelling in the github actions

### DIFF
--- a/.github/workflows/spellchecker.yml
+++ b/.github/workflows/spellchecker.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   pod-spell-check:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'do-not-spell-check') }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'do-not-spellcheck') }}
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
## Description

Correct the label use to disable the spell check action
`do-not-spell-check` convert in `do-not-spellcheck`

