### PR TITLE
better compat between map-values and convert-custom-values options

### DIFF
--- a/src/snmp_standard/mode/stringvalue.pm
+++ b/src/snmp_standard/mode/stringvalue.pm
@@ -123,14 +123,17 @@ sub get_change_value {
     
     my $value = $options{value};
     return '' if (!defined($options{value}));
-    if (defined($self->{map_values}->{$options{value}})) {
+    
+    if (defined($self->{option_results}->{convert_custom_values}) && $self->{option_results}->{convert_custom_values} ne '') {
+        eval "\$value = $self->{option_results}->{convert_custom_values}";
+    }
+
+    if (defined($value) && defined($self->{map_values}->{$value})) {
+        $value = $self->{map_values}->{$value}
+    } elsif (defined($self->{map_values}->{$options{value}})) {
         $value = $self->{map_values}->{$options{value}};
     } elsif (defined($self->{option_results}->{map_value_other}) && $self->{option_results}->{map_value_other} ne '') {
         $value = $self->{option_results}->{map_value_other};
-    }
-
-    if (defined($self->{option_results}->{convert_custom_values}) && $self->{option_results}->{convert_custom_values} ne '') {
-        eval "\$value = $self->{option_results}->{convert_custom_values}";
     }
 
     return $value;

--- a/src/snmp_standard/mode/stringvalue.pm
+++ b/src/snmp_standard/mode/stringvalue.pm
@@ -319,9 +319,9 @@ __END__
 
 =head1 MODE
 
-Check SNMP string values (can be a String or an Integer).
+Check SNMP string values (can be a string or an integer).
 
-Check values absent:
+Check absent values:
 centreon_plugins.pl --plugin=snmp_standard::plugin --mode=string-value --hostname=127.0.0.1 --snmp-version=2c --snmp-community=public 
     --oid-table='.1.3.6.1.2.1.25.4.2.1.2' --format-ok='%{filter_rows} processes' --format-critical='processes are absent: %{details_critical}' --critical-absent='centengine' --critical-absent='crond' --filter-table-value='centengine|crond'
 
@@ -395,7 +395,7 @@ Separator uses between values (default: coma).
 =item B<--convert-custom-values>
 
 Custom code to convert values.
-Example to convert octetstring to macaddress: --convert-custom-values='join(":", unpack("(H2)*", $value))'
+Example to convert octet string to MAC address: --convert-custom-values='join(":", unpack("(H2)*", $value))'
 
 =item B<--use-perl-mod>
 


### PR DESCRIPTION
## Description

use case is the following

`SNMPv2-SMI::enterprises.1248.4.1.1.1.9.0 = STRING: "03 0000 0000 T1"`

i want to extract 03 because this is the status code of my projector

therefore, I use the following option in the string-value of the snmp protocol plugin


`--convert-custom-values='my @tanguy = split(/ /, $value); $value=$tanguy[0];'`

03 is a nice value,

`OK: value(s): 03`
but, I want to have a mapping and that's where the problem is

` --map-values='03=>normal'`
this will not work

that's because the mapping is done before the custom values mecanism

therefore, to have it work, I need to put

`--map-values='03 0000 0000 T1=>normal'`
But may be the 0000 0000 T1 is a dynamic value and therefore my mapping won’t work if they change. That’s why I need to be able to do the mapping on the custom value that is generated from the --convert-custom-values option

 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
