### PR TITLE
fix(http/collection): infinite loop and json encoding

### DIFF
--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -337,9 +337,11 @@ sub call_http {
         $self->{output}->option_exit();
     }
 
-    my $encoded = JSON::XS->new->utf8->pretty->encode($content);
-    $self->{output}->output_add(long_msg => '======> returned JSON structure:', debug => 1);
-    $self->{output}->output_add(long_msg => "$encoded", debug => 1);
+    if ($self->{output}->is_debug()) {
+        my $encoded = JSON::XS->new->allow_nonref(1)->utf8->pretty->encode($content);
+        $self->{output}->output_add(long_msg => '======> returned JSON structure:', debug => 1);
+        $self->{output}->output_add(long_msg => "$encoded", debug => 1);
+    }
 
     return ($http->get_header(), $content, $http);
 }
@@ -534,14 +536,14 @@ sub collect_http_tables {
             ($headers, $content, $http) = $self->call_http(rq => $options{requests}->[$i], http => $options{http});
             $self->set_builtin();
 
-            next if (!defined($options{requests}->[$i]->{parse}));
-
-            my $local;
-            foreach my $conf (@{$options{requests}->[$i]->{parse}}) {
-                if ($options{requests}->[$i]->{rtype} eq 'txt') {
-                    $local = $self->parse_txt(name => $options{requests}->[$i]->{name}, headers => $headers, content => $content, conf => $conf);
-                } else {
-                    $local = $self->parse_structure(name => $options{requests}->[$i]->{name}, content => $content, conf => $conf);
+            my $local = {};
+			if (defined($options{requests}->[$i]->{parse})) {
+                foreach my $conf (@{$options{requests}->[$i]->{parse}}) {
+                    if ($options{requests}->[$i]->{rtype} eq 'txt') {
+                        $local = $self->parse_txt(name => $options{requests}->[$i]->{name}, headers => $headers, content => $content, conf => $conf);
+                    } else {
+                        $local = $self->parse_structure(name => $options{requests}->[$i]->{name}, content => $content, conf => $conf);
+                    }
                 }
             }
 

--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -438,7 +438,7 @@ sub parse_structure {
     } elsif ($options{rtype} eq 'xml') {
         eval {
             $SIG{__WARN__} = sub {};
-            $content = XMLin($content, ForceArray => $options{force_array}, KeyAttr => []);
+            $content = XMLin($options{content}, ForceArray => $options{force_array}, KeyAttr => []);
         };
     }
     if ($@) {

--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -454,7 +454,7 @@ sub parse_structure {
     }
 
     my $jpath = JSON::Path->new($options{conf}->{path});
-    my @values = $jpath->values($options{content});
+    my @values = $jpath->values($content);
 
     my $local = {};
     my $i = 0;

--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -627,6 +627,11 @@ sub use_local_http_cache {
         }
     }
 
+    my $builtin = $local_http_cache->get(name => 'builtin');
+    foreach my $name (keys %$builtin) {
+        $self->add_builtin(name => $name, value => $builtin->{$name});
+    }
+
     return 1;
 }
 
@@ -639,7 +644,8 @@ sub save_local_http_cache {
                 http_collected => {
                     tables => $options{local},
                     epoch => time()
-                }
+                },
+                builtin => $self->{builtin}
             }
         );
     }

--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -1002,7 +1002,7 @@ sub parse_http_tables {
     ($code, $msg_error, $end, $table_label) = $self->parse_forward(
         chars => $options{chars},
         start => $options{start}, 
-        allowed => '[a-zA-Z0-9_]',
+        allowed => '[a-zA-Z0-9_\-]',
         stop => '[).]'
     );
     if ($code) {
@@ -1067,7 +1067,7 @@ sub parse_http_tables {
     ($code, $msg_error, $end, $label) = $self->parse_forward(
         chars => $options{chars},
         start => $end + 2,
-        allowed => '[a-zA-Z0-9_]',
+        allowed => '[a-zA-Z0-9_\-]',
         stop => '[)]'
     );
     if ($code) {
@@ -1107,7 +1107,7 @@ sub parse_special_variable {
         my ($code, $msg_error, $end, $label) = $self->parse_forward(
             chars => $options{chars},
             start => $start + 2, 
-            allowed => '[a-zA-Z0-9\._]',
+            allowed => '[a-zA-Z0-9\._\-]',
             stop => '[)]'
         );
         if ($code) {
@@ -1776,7 +1776,7 @@ sub prepare_variables {
 
     return undef if (!defined($options{value}));
 
-    while ($options{value} =~ /%\(([a-zA-Z0-9\.]+?)\)/g) {
+    while ($options{value} =~ /%\(([a-zA-Z0-9\.\-]+?)\)/g) {
         next if ($1 =~ /^http\./);
         $options{value} =~ s/%\(($1)\)/\$expand->{'$1'}/g;
     }
@@ -1790,7 +1790,7 @@ sub check_filter {
 
     return 0 if (!defined($options{filter}) || $options{filter} eq '');
     our $expand = $options{values};
-    $options{filter} =~ s/%\(([a-zA-Z0-9\._:]+?)\)/\$expand->{'$1'}/g;
+    $options{filter} =~ s/%\(([a-zA-Z0-9\._:\-]+?)\)/\$expand->{'$1'}/g;
     my $result = $self->{safe}->reval("$options{filter}");
     if ($@) {
         $self->{output}->add_option_msg(short_msg => 'Unsafe code evaluation: ' . $@);
@@ -1806,7 +1806,7 @@ sub check_filter2 {
 
     return 0 if (!defined($options{filter}) || $options{filter} eq '');
     our $expand = $options{values};
-    $options{filter} =~ s/%\(([a-zA-Z0-9\._:]+?)\)/\$expand->{'$1'}/g;
+    $options{filter} =~ s/%\(([a-zA-Z0-9\._:\-]+?)\)/\$expand->{'$1'}/g;
     my $result = $self->{safe}->reval("$options{filter}");
     if ($@) {
         $self->{output}->add_option_msg(short_msg => 'Unsafe code evaluation: ' . $@);

--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -537,7 +537,7 @@ sub collect_http_tables {
             $self->set_builtin();
 
             my $local = {};
-			if (defined($options{requests}->[$i]->{parse})) {
+            if (defined($options{requests}->[$i]->{parse})) {
                 foreach my $conf (@{$options{requests}->[$i]->{parse}}) {
                     if ($options{requests}->[$i]->{rtype} eq 'txt') {
                         $local = $self->parse_txt(name => $options{requests}->[$i]->{name}, headers => $headers, content => $content, conf => $conf);

--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -647,6 +647,11 @@ sub use_local_http_cache {
         $self->add_builtin(name => $name, value => $builtin->{$name});
     }
 
+    my $local_vars = $local_http_cache->get(name => 'local_vars');
+    foreach my $name (keys %$local_vars) {
+        $self->set_local_variable(name => $name, value => $local_vars->{$name});
+    }
+
     return 1;
 }
 


### PR DESCRIPTION
## Description

That patch fixes 2 issues and add 2 capabilities:
1. fix infinite loop when the attribute ```parse``` is not defined
2. fix following error: UNKNOWN: hash- or arrayref expected (not a simple scalar, use allow_nonref to allow this) at /usr/lib/centreon/plugins/centreon_protocol_http.pl line 348.
3. add the capability to use attribute ```full_url```
4. add the capability to use attribute ```functions```

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [X] 22.04.x
- [X] 22.10.x
- [X] 23.04.x
- [X] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

The first issue can be tested with following file:
```
{
    "mapping": {},
    "http": {
        "requests": [
            {
                "name": "google",
                "hostname": "www.google.fr",
                "proto": "https",
                "port": "443",
                "endpoint": "/",
                "method": "GET",
                "insecure": 1,
                "timeout": 30,
                "backend": "curl",
                "rtype": "txt"
            }
        ]
    },
    "selection": [
        {
            "name": "google",
            "critical": "defined(%(builtin.httpCode.google)) and %(builtin.httpCode.google) != 200",
            "exit": "defined(%(builtin.httpCode.google)) and %(builtin.httpCode.google) != 200",
            "formatting": {
                "printf_msg":"google failed: %s",
                "printf_var":[
                    "%(builtin.httpCode.google)"
                ],
                "display_ok": true
            }
        }
    ],
    "formatting":{
        "custom_message_global": "login site ok",
        "separator": "-"
    }
}
```

The second issue can be tested with the following file if your ```JSON::XS``` version is lower than 4.0:
```
{
    "mapping": {},
    "http": {
        "requests": [
            {
                "name": "google",
                "hostname": "www.google.fr",
                "proto": "https",
                "port": "443",
                "endpoint": "/",
                "method": "GET",
                "insecure": 1,
                "timeout": 30,
                "backend": "curl",
                "rtype": "txt"
            }
        ]
    },
    "selection": [
        {
            "name": "google",
            "critical": "defined(%(builtin.httpCode.google)) and %(builtin.httpCode.google) != 200",
            "exit": "defined(%(builtin.httpCode.google)) and %(builtin.httpCode.google) != 200",
            "formatting": {
                "printf_msg":"authentication failed: %s",
                "printf_var":[
                    "%(builtin.httpCode.google)"
                ],
                "display_ok": true
            }
        }
    ],
    "formatting":{
        "custom_message_global": "login site ok",
        "separator": "-"
    }
}
```

To test the capabilities:
```
{
    "mapping": {},
    "http": {
        "requests": [
            {
                "name": "google",
                "full_url": "https://www.google.fr/",
                "method": "GET",
                "functions": [
                    {
                        "type": "capture",
                        "src": "%(http.tables.googleLookup.[0].server)",
                        "pattern": "^(.)",
                        "groups": [
                            { "offset": 0, "save": "%(serverFirstChar)" }
                        ]
                    }
                ],
                "insecure": 1,
                "timeout": 30,
                "backend": "curl",
                "rtype": "txt",
                "parse": [
                    {
                        "name": "lookup",
                        "type": "header",
                        "re": "Server\\s*:\\s*(\\S+)",
                        "modifier": "ms",
                        "entries": [
                            { "id": "server", "offset": "1" }
                        ]
                    }
                ]
            }
        ]
    },
    "selection": [
        {
            "name": "google",
            "critical": "defined(%(builtin.httpCode.google)) and %(builtin.httpCode.google) != 200",
            "exit": "defined(%(builtin.httpCode.google)) and %(builtin.httpCode.google) != 200",
            "formatting": {
                "printf_msg":"google check: %s (first server char: %s)",
                "printf_var":[
                    "%(builtin.httpCode.google)",
                    "%(serverFirstChar)"
                ],
                "display_ok": true
            }
        }
    ],
    "formatting":{
        "custom_message_global": "login site ok",
        "separator": "-"
    }
}
```

You should have following output:
```
OK: google check: 200 (first server char: g)
```

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
