### PR TITLE
Ctor 378 fix snmp collections random issue

### DIFF
--- a/src/apps/protocols/snmp/mode/collection.pm
+++ b/src/apps/protocols/snmp/mode/collection.pm
@@ -242,7 +242,7 @@ sub collect_snmp_tables {
         my $used_instance = defined($table->{used_instance}) && $table->{used_instance} ne '' ? $table->{used_instance} : '\.(\d+)$';
         my $snmp_result = $options{snmp}->get_table(oid => $table->{oid});
         foreach (keys %$snmp_result) {
-            /$used_instance/;
+            /$used_instance/ or next;
             next if (defined($self->{snmp_collected}->{tables}->{ $table->{name} }->{$1}));
             my $instance = $1;
     

--- a/src/contrib/collection/snmp/sputnik-environment.json
+++ b/src/contrib/collection/snmp/sputnik-environment.json
@@ -1,0 +1,67 @@
+{
+    "constants": {},
+    "mapping": {},
+    "snmp": {
+        "tables": [
+            {
+                "name": "upsEnvSensors",
+                "oid": ".1.3.6.1.4.1.54661.1.1.1.2.2.1",
+                "used_instance": "\\.2\\.(\\d+)$",
+                "entries": [
+                    {
+                        "name": "temperature",
+                        "oid": ".1.3.6.1.4.1.54661.1.1.1.2.2.1.2"
+                    },
+                    {
+                        "name": "humidity",
+                        "oid": ".1.3.6.1.4.1.54661.1.1.1.2.2.1.3"
+                    }
+                ]
+            }
+        ]
+    },
+    "selection_loop": [
+        {
+            "name": "Sensors",
+            "source": "%(snmp.tables.upsEnvSensors)",
+            "expand_table": {
+                "upsEnvSensors": "%(snmp.tables.upsEnvSensors.[%(upsEnvSensors.instance)])"
+            },
+            "functions": [
+                {
+                   "type": "replace",
+                   "src": "%(upsEnvSensors.temperature)",
+                   "expression": "s/(\\d?\\d)(\\d\\d)/$1.$2/"
+                }
+            ],
+
+            "perfdatas": [
+                {
+                    "nlabel": "environment.temperature.celsius",
+                    "instances": ["%(upsEnvSensors.instance)"],
+                    "value": "%(upsEnvSensors.temperature)",
+                    "critical": "",
+                    "unit": "C"
+                },
+                {
+                    "nlabel": "environment.humidity.percent",
+                    "instances": ["%(upsEnvSensors.instance)"],
+                    "value": "%(upsEnvSensors.humidity)",
+                    "critical": "",
+                    "unit": "%",
+                    "min": 0,
+                    "max": 100
+                }
+            ],
+            "formatting": {
+                "printf_msg": "Sensor '%s' temperature is '%s'°C and humidity is '%s'%%",
+                "printf_var": [
+                    "%(upsEnvSensors.instance)",
+                    "%(upsEnvSensors.temperature)",
+                    "%(upsEnvSensors.humidity)"
+                ],
+                "display_ok": true
+            }
+        }
+    ]
+}

--- a/tests/functional/snmp/snmp-collection-sputnik-snmp.robot
+++ b/tests/functional/snmp/snmp-collection-sputnik-snmp.robot
@@ -1,0 +1,46 @@
+*** Settings ***
+Documentation       Hardware UPS Sputnik SNMP plugin
+
+Library             OperatingSystem
+Library             String
+Library             Examples
+
+Test Timeout        120s
+
+
+*** Variables ***
+${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+
+${CMD}                      perl ${CENTREON_PLUGINS} --plugin=apps::protocols::snmp::plugin
+
+*** Test Cases ***
+SNMP Collection - Sputnik Environment ${tc}/3
+    [Tags]    SNMP Collection
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    --mode=collection
+    ...    --hostname=127.0.0.1
+    ...    --snmp-version=2c
+    ...    --snmp-port=2024
+    ...    --snmp-community=hardware-ups/hardware-ups-sputnik
+    ...    --config=../../../src/contrib/collection/snmp/sputnik-environment.json
+
+    ${output}    Run    ${command}
+    ${output}    Strip String    ${output}
+    Should Be Equal As Strings
+    ...    ${output}
+    ...    ${expected_result}
+    ...    Wrong output result for compliance of ${expected_result}{\n}Command output:{\n}${output}{\n}{\n}{\n}
+
+    Examples:        tc    expected_result    --
+            ...      1     OK: Sensor '1' temperature is '20.06'°C and humidity is '33'% | '1#environment.temperature.celsius'=20.06C;;;; '1#environment.humidity.percent'=33%;;;0;100
+            ...      2     OK: Sensor '1' temperature is '20.06'°C and humidity is '33'% | '1#environment.temperature.celsius'=20.06C;;;; '1#environment.humidity.percent'=33%;;;0;100
+            ...      3     OK: Sensor '1' temperature is '20.06'°C and humidity is '33'% | '1#environment.temperature.celsius'=20.06C;;;; '1#environment.humidity.percent'=33%;;;0;100
+
+*** Keywords ***
+Append Option
+    [Documentation]    Concatenates the first argument (option) with the second (value) after having replaced the value with "" if its content is '_empty_'
+    [Arguments]    ${option}    ${value}
+    ${value}    Set Variable If    '${value}' == '_empty_'    ''    ${value}
+    [return]    ${option}=${value}
+


### PR DESCRIPTION
## Description

I found a random issue that seems to happen when the source of the instances IDs is the same as one of the metrics'.
What I'm proposing here may only be a workaround, but it does not seem harmful to me.
My test performs 3 times the same command. If you run it without the fix, you will almost certainly reproduce this behaviour:

```
$ perl src/centreon_plugins.pl --plugin apps::protocols::snmp::plugin --mode collection --hostname 127.0.0.1 --snmp-port 2024 --snmp-community hardware-ups/hardware-ups-sputnik --config src/contrib/collection/snmp/sputnik-environment.json
Use of uninitialized value $1 in hash element at /home/olivier/projects/centreon-plugins/src/apps/protocols/snmp/mode/collection.pm line 248.
Use of uninitialized value $instance in hash element at /home/olivier/projects/centreon-plugins/src/apps/protocols/snmp/mode/collection.pm line 251.
OK: All selections are ok | '1#environment.temperature.celsius'=20.06C;;;; '1#environment.humidity.percent'=33%;;;0;100
``` 

Instead of this:

```
OK: Sensor '1' temperature is '20.06'°C and humidity is '33'% | '1#environment.temperature.celsius'=20.06C;;;; '1#environment.humidity.percent'=33%;;;0;100
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

