### PR TITLE
enh(apache): add requests new-perfdata

### DIFF
--- a/src/apps/apache/serverstatus/mode/requests.pm
+++ b/src/apps/apache/serverstatus/mode/requests.pm
@@ -172,26 +172,26 @@ sub run {
                                                      $rPerSec,
                                                      $bPerReq_value . ' ' . $bPerReq_unit
                                                      ));
-    $self->{output}->perfdata_add(label => "avg_RequestPerSec",
+    $self->{output}->perfdata_add(label => "avg_RequestPerSec", nlabel => "apache.requests.requests.average.persecond",
                                   value => sprintf("%.2f", $rPerSec),
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning'),
                                   critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical'),
                                   min => 0
                                   );
-    $self->{output}->perfdata_add(label => "bytesPerSec", unit => 'B',
+    $self->{output}->perfdata_add(label => "bytesPerSec", nlabel => "apache.requests.bytes.persecond", unit => 'B',
                                   value => sprintf("%.2f", $bPerSec),
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-bytes'),
                                   critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-bytes'),
                                   min => 0);
-    $self->{output}->perfdata_add(label => "avg_bytesPerRequest", unit => 'B',
+    $self->{output}->perfdata_add(label => "avg_bytesPerRequest", nlabel => "apache.requests.request.average.bytes", unit => 'B',
                                   value => $bPerReq,
                                   min => 0
                                   );
-    $self->{output}->perfdata_add(label => "avg_bytesPerSec", unit => 'B',
+    $self->{output}->perfdata_add(label => "avg_bytesPerSec", nlabel => "apache.requests.bytes.average.persecond", unit => 'B',
                                   value => $avg_bPerSec,
                                   min => 0
                                   );
-    $self->{output}->perfdata_add(label => "accessPerSec",
+    $self->{output}->perfdata_add(label => "accessPerSec", nlabel => "apache.requests.accesses.persecond",
                                   value => sprintf("%.2f", $aPerSec),
                                   warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-access'),
                                   critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-access'),

--- a/src/apps/apache/serverstatus/mode/slotstates.pm
+++ b/src/apps/apache/serverstatus/mode/slotstates.pm
@@ -176,7 +176,7 @@ sub set_counters {
                 closure_custom_perfdata => $self->can('custom_value_perfdata'),
             }
         },
-        { label => 'gracefuly-finished', nlabel => 'apache.slot.gracefulyfinished.count', set => {
+        { label => 'gracefully-finishing', nlabel => 'apache.slot.gracefullyfinishing.count', set => {
                 key_values => [ { name => 'gracefuly_finished' }, { name => 'total' } ],
                 closure_custom_calc => $self->can('custom_value_calc'), closure_custom_calc_extra_options => { label_ref => 'gracefuly_finished' },
                 closure_custom_output => $self->can('custom_value_output'),
@@ -315,14 +315,14 @@ Threshold unit (default: '%'. Can be: '%' or 'absolute')
 Warning threshold.
 Can be: 'busy', 'free', 'waiting', 'starting', 'reading',
 'sending', 'keepalive', 'dns-lookup', 'closing',
-'logging', 'gracefuly-finished', 'idle-cleanup-worker'.
+'logging', 'gracefully-finishing', 'idle-cleanup-worker'.
 
 =item B<--critical-*>
 
 Critical threshold.
 Can be: 'busy', 'free', 'waiting', 'starting', 'reading',
 'sending', 'keepalive', 'dns-lookup', 'closing',
-'logging', 'gracefuly-finished', 'idle-cleanup-worker'.
+'logging', 'gracefully-finishing', 'idle-cleanup-worker'.
 
 =over 8)
 


### PR DESCRIPTION
Hi,

## Description

This improves Apache plugin, requests mode, adding new-perfdata labels, which are missing.
While here, fix a label type in slotstates mode.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Use `--use-new-perfdata` option, and look at the new-perfdata labels.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

Thank you 👍 