### PR TITLE
new(monitoring/logs): add common code and plugin to parse logs

### DIFF
--- a/packaging/centreon-plugin-Applications-Monitoring-Logs/deb.json
+++ b/packaging/centreon-plugin-Applications-Monitoring-Logs/deb.json
@@ -1,0 +1,8 @@
+{
+    "dependencies": [
+        "plink",
+        "libssh-session-perl",
+        "libfilesys-smbclient-perl",
+        "libdatetime-perl"
+    ]
+}

--- a/packaging/centreon-plugin-Applications-Monitoring-Logs/pkg.json
+++ b/packaging/centreon-plugin-Applications-Monitoring-Logs/pkg.json
@@ -1,0 +1,14 @@
+{
+    "pkg_name": "centreon-plugin-Applications-Monitoring-Logs",
+    "pkg_summary": "Centreon Plugin to monitor applications or equipments by parsing logs",
+    "plugin_name": "centreon_monitoring_logs.pl",
+    "files": [
+        "centreon/plugins/script_custom.pm",
+        "centreon/plugins/script_custom/cli.pm",
+        "centreon/plugins/backend/ssh/",
+        "centreon/plugins/ssh.pm",
+        "centreon/common/monitoring/logs/",
+        "centreon/common/protocols/cifs/custom/libcifs.pm",
+        "apps/monitoring/logs/"
+    ]
+}

--- a/packaging/centreon-plugin-Applications-Monitoring-Logs/rpm.json
+++ b/packaging/centreon-plugin-Applications-Monitoring-Logs/rpm.json
@@ -1,0 +1,8 @@
+{
+    "dependencies": [
+        "plink",
+        "perl(Libssh::Session)",
+        "perl(Filesys::SmbClient)",
+        "perl(DateTime)"
+    ]
+}

--- a/packaging/centreon-plugin-Applications-Protocol-Cifs/pkg.json
+++ b/packaging/centreon-plugin-Applications-Protocol-Cifs/pkg.json
@@ -1,9 +1,10 @@
 {
     "pkg_name": "centreon-plugin-Applications-Protocol-Cifs",
-    "pkg_summary": "Centreon Plugin",
+    "pkg_summary": "Centreon Plugin to monitor CIFS/Samba shares",
     "plugin_name": "centreon_protocol_cifs.pl",
     "files": [
         "centreon/plugins/script_custom.pm",
+        "centreon/common/protocols/cifs/custom/libcifs.pm",
         "apps/protocols/cifs/"
     ]
 }

--- a/src/apps/monitoring/logs/mode/parse.pm
+++ b/src/apps/monitoring/logs/mode/parse.pm
@@ -123,7 +123,9 @@ sub manage_selection {
 
     foreach my $log (@{$data}) {        
         next if (defined($self->{option_results}->{memory}) &&
-            defined($log->{date_parsed}->{timestamp}) && $last_time > $log->{date_parsed}->{timestamp});
+            defined($log->{date_parsed}->{timestamp}) &&
+            defined($last_time) &&
+            $last_time > $log->{date_parsed}->{timestamp});
 
         $self->{logs}->{global}->{log}->{$i}->{message} = $log->{message};
         $i++;

--- a/src/apps/monitoring/logs/mode/parse.pm
+++ b/src/apps/monitoring/logs/mode/parse.pm
@@ -1,0 +1,200 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::monitoring::logs::mode::parse;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::common::monitoring::logs::read;
+use centreon::plugins::misc;
+use centreon::plugins::statefile;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_logs_output {
+    my ($self, %options) = @_;
+
+    my $msg = sprintf("Log message: '%s'", $self->{result_values}->{message});
+
+    return $msg;
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0 },
+        { name => 'logs', type => 2, display_counter_problem => { nlabel => 'logs.problem.count', min => 0 },
+          group => [ { name => 'log', skipped_code => { -11 => 1 } } ] 
+        }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'logs-total', nlabel => 'logs.total.count', set => {
+                key_values => [ { name => 'total' } ],
+                output_template => 'Number of logs: %s',
+                perfdatas => [
+                    { value => 'total', template => '%s', min => 0 },
+                ],
+            }
+        },
+    ];
+
+    $self->{maps_counters}->{log} = [
+        { label => 'status', type => 2, set => {
+                key_values => [ { name => 'message' } ],
+                closure_custom_output => $self->can('custom_logs_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+    
+    $options{options}->add_options(arguments => {
+        "parse-regexp:s"    => { name => 'parse_regexp' },
+        "parse-mapping:s@"  => { name => 'parse_mapping' },
+        "date-regexp:s"     => { name => 'date_regexp' },
+        "date-mapping:s@"   => { name => 'date_mapping' },
+        "memory"            => { name => 'memory' },
+        "timezone:s"        => { name => 'timezone' }
+    });
+
+    $self->{statefile_cache} = centreon::plugins::statefile->new(%options);
+   
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (defined($self->{option_results}->{memory})) {
+        $self->{statefile_cache}->check_options(%options);
+    }
+    
+    $self->{option_results}->{timezone} = 'GMT' if (!defined($self->{option_results}->{timezone}) || $self->{option_results}->{timezone} eq '');
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $last_time = 0;
+    if (defined($self->{option_results}->{memory})) {
+        $self->{statefile_cache}->read(statefile => 'cache_logs_' . $options{custom}->get_uuid());
+        $last_time = $self->{statefile_cache}->get(name => 'last_time');
+    }
+
+    $self->{logs}->{global} = { log => {} };
+
+    my $data = centreon::common::monitoring::logs::read::parse(
+        %options,
+        parse_regexp => $self->{option_results}->{parse_regexp},
+        parse_mapping => $self->{option_results}->{parse_mapping},
+        date_regexp => $self->{option_results}->{date_regexp},
+        date_mapping => $self->{option_results}->{date_mapping},
+        timezone => $self->{option_results}->{timezone}
+    );
+
+    my ($i, $current_time) = (1, time());
+
+    foreach my $log (@{$data}) {        
+        next if (defined($self->{option_results}->{memory}) &&
+            defined($log->{date_parsed}->{timestamp}) && $last_time > $log->{date_parsed}->{timestamp});
+
+        $self->{logs}->{global}->{log}->{$i}->{message} = $log->{message};
+        $i++;
+    }
+
+    $self->{global} = { total => scalar(keys %{$self->{logs}->{global}->{log}}) };
+    
+    if (defined($self->{option_results}->{memory})) {
+        $self->{statefile_cache}->write(data => { last_time => $current_time });
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Parse logs.
+
+To use thresholds, you need to map at least a message key.
+
+Example:
+
+perl centreon_plugins.pl --plugin=apps::monitoring::logs::plugin --mode=parse
+--custommode=file --file='/var/log/centreon-broker/central-broker-master.log'
+--parse-regexp='\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}).*\]\s\[(.*)\]\s\[(.*)\]\s(.*)'
+--parse-mapping='date=$1' --parse-mapping='module=$2' --parse-mapping='level=$3'
+--parse-mapping='message=$4'
+--date-regexp='(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})' 
+--date-mapping='year=$1' --date-mapping='month=$2' --date-mapping='day=$3'
+--date-mapping='hour=$4' --date-mapping='minute=$5' --date-mapping='second=$6'
+--critical-status='%{message} =~ /Duplicate entry/'
+
+=over 8
+
+=item B<--parse-regexp>
+
+Regexp to parse each log.
+
+=item B<--parse-mapping>
+
+Define mapping between variables and captured groups index.
+
+=item B<--date-regexp>
+
+Regexp to parse date retrieve from log parsing.
+
+=item B<--date-mapping>
+
+Define mapping between keys and captured groups index for each part of
+date/time.
+
+=item B<--warning-status>
+
+Define the conditions to match for the status to be WARNING
+You can use the following variables: %{message}
+
+=item B<--critical-status>
+
+Define the conditions to match for the status to be CRITICAL
+You can use the following variables: %{message}
+
+=item B<--timezone>
+
+Timezone if parsing date. Default is 'GMT'.
+
+=item B<--memory>
+
+Only check new logs (based on last timestamp if date is captured).
+
+=back
+
+=cut

--- a/src/apps/monitoring/logs/mode/parse.pm
+++ b/src/apps/monitoring/logs/mode/parse.pm
@@ -92,6 +92,22 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::check_options(%options);
 
+    if (!defined($self->{option_results}->{parse_regexp}) || $self->{option_results}->{parse_regexp} eq '') {
+        $self->{output}->add_option_msg(short_msg => "You need to specify the --parse-regexp option.");
+        $self->{output}->option_exit();
+    }
+
+    if (!defined($self->{option_results}->{parse_mapping}) || $self->{option_results}->{parse_mapping} eq '') {
+        $self->{output}->add_option_msg(short_msg => "You need to specify at least one --parse-mapping option.");
+        $self->{output}->option_exit();
+    }
+    
+    if (defined($self->{option_results}->{date_regexp}) && $self->{option_results}->{date_regexp} ne '' &&
+        (!defined($self->{option_results}->{date_mapping}) || $self->{option_results}->{date_mapping} eq '')) {
+        $self->{output}->add_option_msg(short_msg => "You need to specify at least one --date-mapping option.");
+        $self->{output}->option_exit();
+    }
+
     if (defined($self->{option_results}->{memory})) {
         $self->{statefile_cache}->check_options(%options);
     }

--- a/src/apps/monitoring/logs/plugin.pm
+++ b/src/apps/monitoring/logs/plugin.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package apps::protocols::cifs::plugin;
+package apps::monitoring::logs::plugin;
 
 use strict;
 use warnings;
@@ -30,15 +30,12 @@ sub new {
     bless $self, $class;
 
     $self->{modes} = {
-        'connection'  => 'apps::protocols::cifs::mode::connection',
-        'files'       => 'apps::protocols::cifs::mode::files',
-        'files-count' => 'apps::protocols::cifs::mode::filescount',
-        'files-date'  => 'apps::protocols::cifs::mode::filesdate',
-        'files-size'  => 'apps::protocols::cifs::mode::filessize',
-        'scenario'    => 'apps::protocols::cifs::mode::scenario'
+        'parse' => 'apps::monitoring::logs::mode::parse'
     };
 
-    $self->{custom_modes}->{libcifs} = 'centreon::common::protocols::cifs::custom::libcifs';
+    $self->{custom_modes}->{web} = 'centreon::common::monitoring::logs::custom::web';
+    $self->{custom_modes}->{file} = 'centreon::common::monitoring::logs::custom::file';
+    $self->{custom_modes}->{cifs} = 'centreon::common::monitoring::logs::custom::cifs';
     return $self;
 }
 
@@ -48,8 +45,6 @@ __END__
 
 =head1 PLUGIN DESCRIPTION
 
-Check a CIFS/SMB server.
-
-Need: https://github.com/garnier-quentin/Filesys-SmbClient
+Parse plain text logs in file (local, remote or cifs) or web page.
 
 =cut

--- a/src/centreon/common/monitoring/logs/custom/cifs.pm
+++ b/src/centreon/common/monitoring/logs/custom/cifs.pm
@@ -61,6 +61,11 @@ sub read {
     my ($self, %options) = @_;
 
     my ($rv, $message, $data) =  $self->read_file(file => $self->{option_results}->{file});
+    if ($rv) {
+        $self->{output}->add_option_msg(short_msg => $message);
+        $self->{output}->option_exit();
+    }
+
     return $data;
 }
 

--- a/src/centreon/common/monitoring/logs/custom/cifs.pm
+++ b/src/centreon/common/monitoring/logs/custom/cifs.pm
@@ -1,0 +1,93 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::common::monitoring::logs::custom::cifs;
+
+use base qw(centreon::common::protocols::cifs::custom::libcifs);
+
+use strict;
+use warnings;
+use centreon::plugins::misc;
+use Digest::MD5 qw(md5_hex);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, nohelp => 1);
+    bless $self, $class;
+
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            'file:s' => { name => 'file' }
+        });
+    }
+
+    $options{options}->add_help(package => __PACKAGE__, sections => 'CIFS OPTIONS', once => 1);
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub get_uuid {
+    my ($self, %options) = @_;
+
+    return md5_hex(
+        ((defined($self->{option_results}->{hostname}) && $self->{option_results}->{hostname} ne '') ? $self->{option_results}->{hostname} : 'none') . '_' .
+        ((defined($self->{option_results}->{file}) && $self->{option_results}->{file} ne '') ? $self->{option_results}->{file} : 'none')
+    );
+}
+
+sub read {
+    my ($self, %options) = @_;
+
+    my ($rv, $message, $data) =  $self->read_file(file => $self->{option_results}->{file});
+    return $data;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Logs CIFS
+
+=head1 SYNOPSIS
+
+Logs CIFS custom mode
+
+=head1 CIFS OPTIONS
+
+=over 8
+
+=item B<--file>
+
+Path to the file to read logs from.
+
+=back
+
+=head1 DESCRIPTION
+
+B<custom>.
+
+=cut

--- a/src/centreon/common/monitoring/logs/custom/file.pm
+++ b/src/centreon/common/monitoring/logs/custom/file.pm
@@ -45,6 +45,7 @@ sub new {
 
 sub check_options {
     my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
 
     $self->{option_results}->{command} = 'cat'
         if (!defined($self->{option_results}->{command}) || $self->{option_results}->{command} eq '');

--- a/src/centreon/common/monitoring/logs/custom/file.pm
+++ b/src/centreon/common/monitoring/logs/custom/file.pm
@@ -1,0 +1,116 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::common::monitoring::logs::custom::file;
+
+use base qw(centreon::plugins::script_custom::cli);
+
+use strict;
+use warnings;
+use centreon::plugins::misc;
+use Digest::MD5 qw(md5_hex);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, nohelp => 1);
+    bless $self, $class;
+
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            'file:s' => { name => 'file' }
+        });
+    }
+
+    $options{options}->add_help(package => __PACKAGE__, sections => 'FILE OPTIONS', once => 1);
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+
+    $self->{option_results}->{command} = 'cat'
+        if (!defined($self->{option_results}->{command}) || $self->{option_results}->{command} eq '');
+
+    if (defined($self->{option_results}->{file})) {
+        $self->{option_results}->{command_options} = centreon::plugins::misc::sanitize_command_param(value => $self->{option_results}->{file});
+    }
+
+    centreon::plugins::misc::check_security_command(
+        output => $self->{output},
+        command => $self->{option_results}->{command},
+        command_options => $self->{option_results}->{command_options},
+        command_path => $self->{option_results}->{command_path}
+    );
+
+    return 0;
+}
+
+sub get_uuid {
+    my ($self, %options) = @_;
+
+    return md5_hex(
+        ((defined($self->{option_results}->{hostname}) && $self->{option_results}->{hostname} ne '') ? $self->{option_results}->{hostname} : 'none') . '_' .
+        ((defined($self->{option_results}->{file}) && $self->{option_results}->{file} ne '') ? $self->{option_results}->{file} : 'none')
+    );
+}
+
+sub read {
+    my ($self, %options) = @_;
+
+    my ($stdout) = $self->SUPER::execute_command(%options);
+    return $stdout;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Logs file
+
+=head1 SYNOPSIS
+
+Logs file custom mode
+
+=head1 FILE OPTIONS
+
+=over 8
+
+=item B<--hostname>
+
+Hostname to query (with ssh).
+
+=item B<--command>
+
+Command to get information (default: 'cat').
+
+=item B<--file>
+
+Path to the file to read logs from.
+
+=back
+
+=head1 DESCRIPTION
+
+B<custom>.
+
+=cut

--- a/src/centreon/common/monitoring/logs/custom/web.pm
+++ b/src/centreon/common/monitoring/logs/custom/web.pm
@@ -111,7 +111,7 @@ sub get_uuid {
 
     return md5_hex(
         ((defined($self->{hostname}) && $self->{hostname} ne '') ? $self->{hostname} : 'none') . '_' .
-        ((defined($self->{port}) && $self->{port} ne '') ? $self->{port} : 'none')
+        ((defined($self->{url_path}) && $self->{url_path} ne '') ? $self->{url_path} : 'none')
     );
 }
 

--- a/src/centreon/common/monitoring/logs/custom/web.pm
+++ b/src/centreon/common/monitoring/logs/custom/web.pm
@@ -1,0 +1,182 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::common::monitoring::logs::custom::web;
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use Digest::MD5 qw(md5_hex);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self  = {};
+    bless $self, $class;
+
+    if (!defined($options{output})) {
+        print "Class Custom: Need to specify 'output' argument.\n";
+        exit 3;
+    }
+    if (!defined($options{options})) {
+        $options{output}->add_option_msg(short_msg => "Class Custom: Need to specify 'options' argument.");
+        $options{output}->option_exit();
+    }
+
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            'hostname:s@' => { name => 'hostname' },
+            'port:s@'     => { name => 'port' },
+            'proto:s@'    => { name => 'proto' },
+            'urlpath:s@'  => { name => 'url_path' },
+            'username:s@' => { name => 'username' },
+            'password:s@' => { name => 'password' },
+            'timeout:s@'  => { name => 'timeout' }
+        });
+    }
+    $options{options}->add_help(package => __PACKAGE__, sections => 'WEB OPTIONS', once => 1);
+
+    $self->{output} = $options{output};
+    $self->{http} = centreon::plugins::http->new(%options);
+
+    return $self;
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+
+    $self->{option_results} = $options{option_results};
+}
+
+sub set_defaults {}
+
+sub check_options {
+    my ($self, %options) = @_;
+
+    $self->{hostname} = (defined($self->{option_results}->{hostname})) ? shift(@{$self->{option_results}->{hostname}}) : undef;
+    $self->{port} = (defined($self->{option_results}->{port})) ? shift(@{$self->{option_results}->{port}}) : 80;
+    $self->{proto} = (defined($self->{option_results}->{proto})) ? shift(@{$self->{option_results}->{proto}}) : 'http';
+    $self->{url_path} = (defined($self->{option_results}->{url_path})) ? shift(@{$self->{option_results}->{url_path}}) : '/';
+    $self->{username} = (defined($self->{option_results}->{username})) ? shift(@{$self->{option_results}->{username}}) : '';
+    $self->{password} = (defined($self->{option_results}->{password})) ? shift(@{$self->{option_results}->{password}}) : '';
+    $self->{timeout} = (defined($self->{option_results}->{timeout})) ? shift(@{$self->{option_results}->{timeout}}) : 10;
+
+    if (!defined($self->{hostname})) {
+        $self->{output}->add_option_msg(short_msg => "Need to specify hostname option.");
+        $self->{output}->option_exit();
+    }
+
+    if (!defined($self->{hostname}) ||
+        scalar(@{$self->{option_results}->{hostname}}) == 0) {
+        return 0;
+    }
+    return 1;
+}
+
+sub build_options_for_httplib {
+    my ($self, %options) = @_;
+
+    $self->{option_results}->{hostname} = $self->{hostname};
+    $self->{option_results}->{port} = $self->{port};
+    $self->{option_results}->{proto} = $self->{proto};
+    $self->{option_results}->{url_path} = $self->{url_path};
+    $self->{option_results}->{timeout} = $self->{timeout};
+
+    if (defined($self->{username}) && $self->{username} ne '') {
+        $self->{option_results}->{credentials} = 1;
+        $self->{option_results}->{basic} = 1;
+        $self->{option_results}->{username} = $self->{username};
+        $self->{option_results}->{password} = $self->{password};
+    }
+}
+
+sub get_uuid {
+    my ($self, %options) = @_;
+
+    return md5_hex(
+        ((defined($self->{hostname}) && $self->{hostname} ne '') ? $self->{hostname} : 'none') . '_' .
+        ((defined($self->{port}) && $self->{port} ne '') ? $self->{port} : 'none')
+    );
+}
+
+sub settings {
+    my ($self, %options) = @_;
+
+    $self->build_options_for_httplib();
+    $self->{http}->set_options(%{$self->{option_results}});
+}
+
+sub read {
+    my ($self, %options) = @_;
+
+    $self->settings();
+    return $self->{http}->request(critical_status => '', warning_status => '');
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Logs web
+
+=head1 SYNOPSIS
+
+Logs web custom mode
+
+=head1 WEB OPTIONS
+
+=over 8
+
+=item B<--hostname>
+
+Endpoint hostname.
+
+=item B<--port>
+
+Port used (default: 80)
+
+=item B<--proto>
+
+Specify https if needed (default: 'http')
+
+=item B<--urlpath>
+
+URL to read logs from (default: '/').
+
+=item B<--username>
+
+Endpoint username.
+
+=item B<--password>
+
+Endpoint password.
+
+=item B<--timeout>
+
+Set HTTP timeout (default: 10).
+
+=back
+
+=head1 DESCRIPTION
+
+B<custom>.
+
+=cut

--- a/src/centreon/common/monitoring/logs/read.pm
+++ b/src/centreon/common/monitoring/logs/read.pm
@@ -1,0 +1,173 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::common::monitoring::logs::read;
+
+use strict;
+use warnings;
+use DateTime;
+use centreon::plugins::misc;
+
+sub dump {
+    my (%options) = @_;
+
+    return $options{custom}->read();
+}
+
+sub parse {
+    my (%options) = @_;
+
+    my $parse_mapping;
+    foreach (@{$options{parse_mapping}}) {
+        next if ($_ !~ /(\S+)=\$(\d+)/);
+        $parse_mapping->{'$'.$2} = $1;
+    }
+    my $date_mapping;
+    foreach (@{$options{date_mapping}}) {
+        next if ($_ !~ /(\S+)=\$(\d+)/);
+        $date_mapping->{'$'.$2} = $1;
+    }
+    
+    my $tz = centreon::plugins::misc::set_timezone(name => $options{timezone});
+
+    my $data = $options{custom}->read();
+
+    my $parsed_data;
+
+    foreach my $line (split /\n/, $data) {
+        my $parsed_line;
+        next if ($line !~ $options{parse_regexp});
+        foreach my $match (keys %{$parse_mapping}) {
+            $parsed_line->{$parse_mapping->{$match}} = eval $match;
+
+            if ($parse_mapping->{$match} eq 'date' && defined($options{date_regexp}) && $options{date_regexp} ne '') {
+                my $date;
+                next if ($parsed_line->{date} !~ $options{date_regexp});
+                foreach my $m (keys %{$date_mapping}) {
+                    $date->{$date_mapping->{$m}} = eval $m;
+                }
+                my $dt = DateTime->new(
+                    year => $date->{year},
+                    month => $date->{month},
+                    day => $date->{day},
+                    hour => $date->{hour},
+                    minute => $date->{minute},
+                    second => $date->{second},
+                    %$tz
+                );
+                $parsed_line->{date_parsed} = $date;
+                $parsed_line->{date_parsed}->{timestamp} = $dt->epoch;
+            }
+        }
+
+        push @{$parsed_data}, $parsed_line;
+    }
+
+    return $parsed_data;
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Read and parse logs.
+
+To be used to build modes to retrieve a log file (fashion defined by chosen
+custom mode) and parse it with following options :
+
+parse_regexp: regular expression that will parse each log lines and store
+capturing groups in $x variables.
+
+parse_mapping: map $x variables with a named key in each entries of the resulted
+hash table (can be used multiple times to map all necessary captured groups).
+
+date_regexp: if a date is captured by the first regular expression, this one is
+used to capture each part of the date and time.
+
+date_mapping: like for the mapping of the log line captured groups, this option
+needs to map each of the following key: year, month, day, hour, minute and
+second.
+
+timezone: if the date is captured, one can define its timezone to work with it
+for example to cache the timestamp and use a memory code to only look at the
+newest log.
+
+Utimately, the %options hash needs to be passed for everything that will make
+the custom mode work.
+
+Example:
+
+We want to retrieve 2 values in the last occurrence of a log message. We're not
+parsing the date as we will not use it.
+
+use base qw(centreon::plugins::templates::counter);
+use centreon::common::monitoring::logs::read;
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0 }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'sessions', nlabel => 'sessions.current.count', set => {
+                key_values => [ { name => 'sessions' } ],
+                output_template => 'Current sessions : %d',
+                perfdatas => [
+                    { template => '%d', min => 0 }
+                ]
+            }
+        },
+        { label => 'removed', nlabel => 'sessions.removed.count', set => {
+                key_values => [ { name => 'removed' } ],
+                output_template => 'Removed sessions : %d',
+                perfdatas => [
+                    { template => '%d', min => 0 }
+                ]
+            }
+        }
+    ];
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $data = centreon::common::monitoring::logs::read::parse(
+        %options,
+        parse_regexp => '\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2},\d{3}\s\S{6}\s\{\}\s+\S+\s+\S+\s+(.*)',
+        parse_matching => ['message=$1']
+    );
+
+    foreach my $entry (reverse @{$data}) {
+        next if (defined($entry->{message}) && $entry->{message} ne '' && $entry->{message} !~ /SessionController: checked expiration on (\d+) sessions \(removed (\d+)\)/);
+        $self->{global}->{sessions} = $1 - $2;
+        $self->{global}->{removed} = $2;
+        last;
+    }
+}
+
+=over 8
+
+=back
+
+=cut

--- a/src/centreon/common/protocols/cifs/custom/libcifs.pm
+++ b/src/centreon/common/protocols/cifs/custom/libcifs.pm
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-package apps::protocols::cifs::custom::libcifs;
+package centreon::common::protocols::cifs::custom::libcifs;
 
 use strict;
 use warnings;
@@ -69,7 +69,7 @@ sub check_options {
 
     $self->{hostname} = (defined($self->{option_results}->{hostname})) ? $self->{option_results}->{hostname} : '';
     $self->{port} = (defined($self->{option_results}->{port})) ? $self->{option_results}->{port} : 139;
-    $self->{timeout} = (defined($self->{option_results}->{timeout})) && $self->{option_results}->{timeout} =~ /^\d+$/? $self->{option_results}->{timeout} : 30;
+    $self->{timeout} = (defined($self->{option_results}->{timeout})) && $self->{option_results}->{timeout} =~ /^\d+$/ ? $self->{option_results}->{timeout} : 30;
     $self->{cifs_username} = (defined($self->{option_results}->{cifs_username})) ? $self->{option_results}->{cifs_username} : '';
     $self->{cifs_password} = (defined($self->{option_results}->{cifs_password})) ? $self->{option_results}->{cifs_password} : '';
     $self->{workgroup} = (defined($self->{option_results}->{workgroup})) ? $self->{option_results}->{workgroup} : '';


### PR DESCRIPTION
Adds a plugin to parse a log file locally, through SSH or on a CIFS/Samba share, or a web page.
This plugin is really simple and awaits contributions to give it more features. It is not made to replace check_logfiles though (or is it?).
The more important thing is the common code that can be used by anyone to build their own modes that will parse exotic logs.
It moves the cifs lib binding, hence the plugin and packaging modifications.