### PR TITLE
Informix SNMP log-file usage - consider log files with state backedUpButNeeded as free space

### DIFF
--- a/src/database/informix/snmp/mode/logfileusage.pm
+++ b/src/database/informix/snmp/mode/logfileusage.pm
@@ -65,6 +65,7 @@ sub new {
 
 my $mapping = {
     onLogicalLogDbspace         => { oid => '.1.3.6.1.4.1.893.1.1.1.8.1.3' },
+    onLogicalLogStatus          => { oid => '.1.3.6.1.4.1.893.1.1.1.8.1.4' },
     onLogicalLogPagesAllocated  => { oid => '.1.3.6.1.4.1.893.1.1.1.8.1.7' },
     onLogicalLogPagesUsed       => { oid => '.1.3.6.1.4.1.893.1.1.1.8.1.8' },
 };
@@ -76,6 +77,7 @@ sub manage_selection {
     my $snmp_result = $options{snmp}->get_multiple_table(oids => [
             { oid => $oid_applName },
             { oid => $mapping->{onLogicalLogDbspace}->{oid} },
+            { oid => $mapping->{onLogicalLogStatus}->{oid} },
             { oid => $mapping->{onLogicalLogPagesAllocated}->{oid} },
             { oid => $mapping->{onLogicalLogPagesUsed}->{oid} },
         ], return_type => 1, nothing_quit => 1
@@ -103,7 +105,17 @@ sub manage_selection {
         }
         
         $self->{global}->{$name}->{allocated} += $result->{onLogicalLogPagesAllocated};
-        $self->{global}->{$name}->{used} += $result->{onLogicalLogPagesUsed};
+          
+        # Status of the logical-log file:
+        #   newlyAdded (1)
+        #   free (2)
+        #   current (3)
+        #   used (4)
+        #   backedUpButNeeded (5)
+        # consider log files with state backedUpButNeeded as free space
+        if ($result->{onLogicalLogStatus} != 5) {
+            $self->{global}->{$name}->{used} += $result->{onLogicalLogPagesUsed};
+        }
     }
     
     foreach (keys %{$self->{global}}) {


### PR DESCRIPTION
## Description

The informix snmp plugin log file usage adds up all the used space in log files.
Only free or newly created log files are 0% used. When log file is backed up, it's available to be used again, but it only gets cleared before it is converted to current. So in a running environment, log file used space appear to be 99% used all the time, which is misleading.  
If you were going to create an alarm on low log file free space, you wouldn't take into account backed up log files because they can be considered as free space.
This patch takes into account the log file state before adding it as used space. If it is backed up, it considers it as free space, and doesn't add it to used space. 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

<h2> How this pull request can be tested ? </h2>

Using the snmpwalk

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
