### PR TITLE
new(plugin): add infor ion grid api plugin

### DIFF
--- a/packaging/centreon-plugin-Applications-Infor-Ion-Grid-Api/deb.json
+++ b/packaging/centreon-plugin-Applications-Infor-Ion-Grid-Api/deb.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": []
+}

--- a/packaging/centreon-plugin-Applications-Infor-Ion-Grid-Api/pkg.json
+++ b/packaging/centreon-plugin-Applications-Infor-Ion-Grid-Api/pkg.json
@@ -1,0 +1,9 @@
+{
+    "pkg_name": "centreon-plugin-Applications-Infor-Ion-Grid-Api",
+    "pkg_summary": "Centreon Plugin to monitor ION Grid using API",
+    "plugin_name": "centreon_infor_ion_grid_api.pl",
+    "files": [
+        "centreon/plugins/script_custom.pm",
+        "apps/infor/ion/grid/api"
+    ]
+}

--- a/packaging/centreon-plugin-Applications-Infor-Ion-Grid-Api/rpm.json
+++ b/packaging/centreon-plugin-Applications-Infor-Ion-Grid-Api/rpm.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": []
+}

--- a/src/apps/infor/ion/grid/api/custom/restapi.pm
+++ b/src/apps/infor/ion/grid/api/custom/restapi.pm
@@ -1,0 +1,191 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::ion::grid::api::custom::restapi;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use JSON::XS;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    if (!defined($options{output})) {
+        print "Class Custom: Need to specify 'output' argument.\n";
+        exit 3;
+    }
+    if (!defined($options{options})) {
+        $options{output}->add_option_msg(short_msg => "Class Custom: Need to specify 'options' argument.");
+        $options{output}->option_exit();
+    }
+
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            'hostname:s'             => { name => 'hostname' },
+            'port:s'                 => { name => 'port'},
+            'proto:s'                => { name => 'proto' },
+            'api-username:s'         => { name => 'api_username' },
+            'api-password:s'         => { name => 'api_password' },
+            'timeout:s'              => { name => 'timeout' },
+            'unknown-http-status:s'  => { name => 'unknown_http_status' },
+            'warning-http-status:s'  => { name => 'warning_http_status' },
+            'critical-http-status:s' => { name => 'critical_http_status' }
+        });
+    }
+
+    $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
+
+    $self->{output} = $options{output};
+    $self->{http} = centreon::plugins::http->new(%options, default_backend => 'curl');
+
+    return $self;
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+
+    $self->{option_results} = $options{option_results};
+}
+
+sub set_defaults {}
+
+sub check_options {
+    my ($self, %options) = @_;
+
+    $self->{hostname} = (defined($self->{option_results}->{hostname})) ? $self->{option_results}->{hostname} : '';
+    $self->{port} = (defined($self->{option_results}->{port})) ? $self->{option_results}->{port} : 443;
+    $self->{proto} = (defined($self->{option_results}->{proto})) ? $self->{option_results}->{proto} : 'https';
+    $self->{timeout} = (defined($self->{option_results}->{timeout})) ? $self->{option_results}->{timeout} : 20;
+    $self->{api_username} = (defined($self->{option_results}->{api_username})) ? $self->{option_results}->{api_username} : '';
+    $self->{api_password} = (defined($self->{option_results}->{api_password})) ? $self->{option_results}->{api_password} : '';
+    $self->{unknown_http_status} = (defined($self->{option_results}->{unknown_http_status})) ? $self->{option_results}->{unknown_http_status} : '%{http_code} < 200 or %{http_code} >= 300';
+    $self->{warning_http_status} = (defined($self->{option_results}->{warning_http_status})) ? $self->{option_results}->{warning_http_status} : '';
+    $self->{critical_http_status} = (defined($self->{option_results}->{critical_http_status})) ? $self->{option_results}->{critical_http_status} : '';
+
+    if ($self->{hostname} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --hostname option.");
+        $self->{output}->option_exit();
+    }
+    if ($self->{api_username} ne '' && $self->{api_password} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --api-password option.");
+        $self->{output}->option_exit();
+    }
+    
+    return 0;
+}
+
+sub build_options_for_httplib {
+    my ($self, %options) = @_;
+
+    $self->{option_results}->{hostname} = $self->{hostname};
+    $self->{option_results}->{port} = $self->{port};
+    $self->{option_results}->{proto} = $self->{proto};
+    $self->{option_results}->{timeout} = $self->{timeout};
+    if ($self->{api_username} ne '') {
+        $self->{option_results}->{credentials} = 1;
+        $self->{option_results}->{basic} = 1;
+        $self->{option_results}->{username} = $self->{api_username};
+        $self->{option_results}->{password} = $self->{api_password};
+    }
+}
+
+sub settings {
+    my ($self, %options) = @_;
+
+    return if (defined($self->{settings_done}));
+    $self->build_options_for_httplib();
+    $self->{http}->add_header(key => 'Accept', value => 'application/json');
+    $self->{http}->set_options(%{$self->{option_results}});
+    $self->{settings_done} = 1;
+}
+
+sub request_api {
+    my ($self, %options) = @_;
+
+    $self->settings();
+
+    my $content = $self->{http}->request(
+        %options,
+        unknown_status => $self->{unknown_http_status},
+        warning_status => $self->{warning_http_status},
+        critical_status => $self->{critical_http_status}
+    );
+
+    if (!defined($content) || $content eq '') {
+        $self->{output}->add_option_msg(short_msg => "API returns empty content [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']");
+        $self->{output}->option_exit();
+    }
+
+    my $decoded;
+    eval {
+        $decoded = JSON::XS->new->utf8->decode($content);
+    };
+    if ($@) {
+        $self->{output}->add_option_msg(short_msg => "Cannot decode response (add --debug option to display returned content)");
+        $self->{output}->option_exit();
+    }
+
+    return $decoded;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+ION Grid Rest API
+
+=head1 REST API OPTIONS
+
+=over 8
+
+=item B<--hostname>
+
+Set hostname.
+
+=item B<--port>
+
+Set port (default: '443').
+
+=item B<--proto>
+
+Specify https if needed (default: 'https').
+
+=item B<--api-username>
+
+API username.
+
+=item B<--api-password>
+
+API password.
+
+=item B<--timeout>
+
+Threshold for HTTP timeout (default: '20').
+
+=back
+
+=cut

--- a/src/apps/infor/ion/grid/api/custom/restapi.pm
+++ b/src/apps/infor/ion/grid/api/custom/restapi.pm
@@ -51,7 +51,8 @@ sub new {
             'timeout:s'              => { name => 'timeout' },
             'unknown-http-status:s'  => { name => 'unknown_http_status' },
             'warning-http-status:s'  => { name => 'warning_http_status' },
-            'critical-http-status:s' => { name => 'critical_http_status' }
+            'critical-http-status:s' => { name => 'critical_http_status' },
+            'cookies-file:s'         => { name => 'cookies_file' }
         });
     }
 
@@ -83,6 +84,7 @@ sub check_options {
     $self->{unknown_http_status} = (defined($self->{option_results}->{unknown_http_status})) ? $self->{option_results}->{unknown_http_status} : '%{http_code} < 200 or %{http_code} >= 300';
     $self->{warning_http_status} = (defined($self->{option_results}->{warning_http_status})) ? $self->{option_results}->{warning_http_status} : '';
     $self->{critical_http_status} = (defined($self->{option_results}->{critical_http_status})) ? $self->{option_results}->{critical_http_status} : '';
+    $self->{cookies_file} = (defined($self->{option_results}->{cookies_file})) ? $self->{option_results}->{cookies_file} : '';
 
     if ($self->{hostname} eq '') {
         $self->{output}->add_option_msg(short_msg => "Need to specify --hostname option.");
@@ -109,6 +111,7 @@ sub build_options_for_httplib {
         $self->{option_results}->{username} = $self->{api_username};
         $self->{option_results}->{password} = $self->{api_password};
     }
+    $self->{option_results}->{cookies_file} = $self->{cookies_file};
 }
 
 sub settings {

--- a/src/apps/infor/ion/grid/api/mode/application.pm
+++ b/src/apps/infor/ion/grid/api/mode/application.pm
@@ -1,0 +1,146 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::ion::grid::api::mode::application;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "state is '%s' [online: %s] [started: %s]",
+        $self->{result_values}->{state},
+        $self->{result_values}->{online},
+        $self->{result_values}->{started}
+    );
+}
+
+sub prefix_application_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "Application '%s' [description: %s] ",
+        $options{instance_value}->{name},
+        $options{instance_value}->{description}
+    );
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'applications', type => 1, cb_prefix_output => 'prefix_application_output', message_multiple => 'All applications are ok' },
+    ];
+
+    $self->{maps_counters}->{applications} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '%{online} =~ /true/ && %{state} !~ /^(OK)/i',
+            set => {
+                key_values => [
+                    { name => 'state' }, { name => 'online' }, { name => 'name' },
+                    { name => 'description' }, { name => 'started' }
+                ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s' => { name => 'filter_name' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        method => 'GET',
+        url_path => '/grid/rest/applications'
+    );
+
+    foreach my $entry (@{$result}) {        
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $entry->{name} !~ /$self->{option_results}->{filter_name}/);
+        $self->{applications}->{$entry->{name}} = {
+            name => $entry->{name},
+            description => $entry->{description},
+            online => ($entry->{online}) ? "true" : "false",
+            started => ($entry->{started}) ? "true" : "false",
+            state => $entry->{globalState}->{stateText}
+        }
+    }
+
+    if (scalar(keys %{$self->{applications}}) <= 0) {
+        $self->{output}->add_option_msg(short_msg => "No applications found");
+        $self->{output}->option_exit();
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check application status.
+
+=over 8
+
+=item B<--filter-name>
+
+Filter by name.
+
+=item B<--warning-status>
+
+Set warning threshold for status.
+Can use special variables like: %{state}, %{online}, %{started},
+%{name}, %{description}.
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: "%{online} =~ /true/ && %{state} !~ /^(OK)/i").
+Can use special variables like: %{state}, %{online}, %{started},
+%{name}, %{description}.
+
+=back
+
+=cut

--- a/src/apps/infor/ion/grid/api/mode/listapplications.pm
+++ b/src/apps/infor/ion/grid/api/mode/listapplications.pm
@@ -1,0 +1,117 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::ion::grid::api::mode::listapplications;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {});
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        method => 'GET',
+        url_path => '/grid/rest/applications'
+    );
+    
+    my @applications;
+    foreach my $entry (@{$result}) {        
+        push @applications, {
+            name => $entry->{name},
+            description => $entry->{description},
+            online => ($entry->{online}) ? "true" : "false",
+            started => ($entry->{started}) ? "true" : "false",
+            state => $entry->{globalState}->{stateText}
+        }
+    }
+
+    return \@applications;
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    my $results = $self->manage_selection(%options);
+    foreach (@$results) {
+        $self->{output}->output_add(
+            long_msg => sprintf(
+                '[name: %s][description: %s][online: %s][started: %s][state: %s]',
+                $_->{name},
+                $_->{description},
+                $_->{online},
+                $_->{started},
+                $_->{state}
+            )
+        );
+    }
+
+    $self->{output}->output_add(
+        severity => 'OK',
+        short_msg => 'List applications:'
+    );
+
+    $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+    $self->{output}->exit();
+}
+
+sub disco_format {
+    my ($self, %options) = @_;
+
+    $self->{output}->add_disco_format(elements => ['name', 'description', 'online', 'started', 'state']);
+}
+
+sub disco_show {
+    my ($self, %options) = @_;
+
+    my $results = $self->manage_selection(%options);
+    foreach (@$results) {
+        $self->{output}->add_disco_entry(%$_);
+    }
+}
+
+1;
+
+
+=head1 MODE
+
+List applications.
+
+=over 8
+
+=back
+
+=cut

--- a/src/apps/infor/ion/grid/api/mode/listnodes.pm
+++ b/src/apps/infor/ion/grid/api/mode/listnodes.pm
@@ -1,0 +1,117 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::ion::grid::api::mode::listnodes;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {});
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        method => 'GET',
+        url_path => '/grid/rest/nodes'
+    );
+    
+    my @nodes;
+    foreach my $entry (@{$result}) {        
+        push @nodes, {
+            type => ucfirst(lc($entry->{entityType})),
+            name => $entry->{name},
+            application_name => $entry->{applicationName},
+            host_name => $entry->{hostName},
+            state => ($entry->{online}) ? "online" : "offline"
+        }
+    }
+
+    return \@nodes;
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    my $results = $self->manage_selection(%options);
+    foreach (@$results) {
+        $self->{output}->output_add(
+            long_msg => sprintf(
+                '[type: %s][name: %s][application_name: %s][host_name: %s][state: %s]',
+                $_->{type},
+                $_->{name},
+                $_->{application_name},
+                $_->{host_name},
+                $_->{state}
+            )
+        );
+    }
+
+    $self->{output}->output_add(
+        severity => 'OK',
+        short_msg => 'List nodes:'
+    );
+
+    $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+    $self->{output}->exit();
+}
+
+sub disco_format {
+    my ($self, %options) = @_;
+
+    $self->{output}->add_disco_format(elements => ['type', 'name', 'application_name', 'host_name', 'state']);
+}
+
+sub disco_show {
+    my ($self, %options) = @_;
+
+    my $results = $self->manage_selection(%options);
+    foreach (@$results) {
+        $self->{output}->add_disco_entry(%$_);
+    }
+}
+
+1;
+
+
+=head1 MODE
+
+List nodes.
+
+=over 8
+
+=back
+
+=cut

--- a/src/apps/infor/ion/grid/api/mode/node.pm
+++ b/src/apps/infor/ion/grid/api/mode/node.pm
@@ -1,0 +1,237 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::ion::grid::api::mode::node;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::misc;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_heap_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        'Heap usage: %s%s/%s%s (%.2f%%)',
+        $self->{perfdata}->change_bytes(value => $self->{result_values}->{heap_used}),
+        $self->{perfdata}->change_bytes(value => $self->{result_values}->{heap_max}),
+        $self->{result_values}->{heap_percent}
+    );
+}
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "state is '%s'",
+        $self->{result_values}->{state}
+    );
+}
+
+sub prefix_node_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "Node '%s' with PID '%s' from application '%s' on host '%s' ",
+        $options{instance_value}->{name},
+        $options{instance_value}->{pid},
+        $options{instance_value}->{application_name},
+        $options{instance_value}->{host_name}
+    );
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'nodes', type => 1, cb_prefix_output => 'prefix_node_output', message_multiple => 'All nodes are ok' },
+    ];
+
+    $self->{maps_counters}->{nodes} = [
+        {
+            label => 'status',
+            type => 2,
+            warning_default => '%{state} !~ /online/',
+            set => {
+                key_values => [
+                    { name => 'state' }, { name => 'name' }, { name => 'host_name' },
+                    { name => 'application_name' }, { name => 'type' }, { name => 'pid' }
+                ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        },
+        { label => 'log-error', nlabel => 'node.log.error.count', set => {
+                key_values => [ { name => 'logger_error' }, { name => 'pid' } ],
+                output_template => 'Log error: %d',
+                perfdatas => [
+                    { template => '%d', min => 0,
+                      label_extra_instance => 1, instance_use => 'pid' }
+                ]
+            }
+        },
+        { label => 'log-warning', nlabel => 'node.log.warning.count', set => {
+                key_values => [ { name => 'logger_warning' }, { name => 'pid' } ],
+                output_template => 'Log warning: %d',
+                perfdatas => [
+                    { template => '%d', min => 0,
+                      label_extra_instance => 1, instance_use => 'pid' }
+                ]
+            }
+        },
+        { label => 'uptime', nlabel => 'node.uptime.seconds', set => {
+                key_values => [ { name => 'uptime' }, { name => 'uptime_human' } ],
+                output_template => 'Uptime: %s',
+                output_use => 'uptime_human',
+                closure_custom_perfdata => sub { return 0; },
+            }
+        },
+        { label => 'cpu-usage', nlabel => 'node.cpu.usage.percentage', set => {
+                key_values => [ { name => 'cpu_percent' }, { name => 'pid' } ],
+                output_template => 'CPU usage: %.2f%%',
+                perfdatas => [
+                    { template => '%.2f', min => 0, max => 100, unit => '%',
+                      label_extra_instance => 1, instance_use => 'pid' }
+                ]
+            }
+        },
+        { label => 'heap-usage', nlabel => 'node.heap.usage.percentage', set => {
+                key_values => [ { name => 'heap_percent' }, { name => 'heap_used' },
+                                { name => 'heap_max' }, { name => 'pid' } ],
+                closure_custom_output => $self->can('custom_heap_output'),
+                perfdatas => [
+                    { template => '%.2f', min => 0, max => 100, unit => '%',
+                    label_extra_instance => 1, instance_use => 'pid' }
+                ]
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-type:s'             => { name => 'filter_type' },
+        'filter-name:s'             => { name => 'filter_name' },
+        'filter-application-name:s' => { name => 'filter_application_name' },
+        'filter-host-name:s'        => { name => 'filter_host_name' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        method => 'GET',
+        url_path => '/grid/rest/nodes'
+    );
+
+    foreach my $entry (@{$result}) {
+        next if (defined($self->{option_results}->{filter_type}) && $self->{option_results}->{filter_type} ne ''
+            && $entry->{entityType} !~ /$self->{option_results}->{filter_type}/i);
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $entry->{name} !~ /$self->{option_results}->{filter_name}/);
+        next if (defined($self->{option_results}->{filter_host_name}) && $self->{option_results}->{filter_host_name} ne ''
+            && $entry->{hostName} !~ /$self->{option_results}->{filter_host_name}/);
+        next if (defined($self->{option_results}->{filter_application_name}) && $self->{option_results}->{filter_application_name} ne ''
+            && $entry->{applicationName} !~ /$self->{option_results}->{filter_application_name}/);
+        $self->{nodes}->{$entry->{jvmId}} = {
+            type => ucfirst(lc($entry->{entityType})),
+            name => $entry->{name},
+            application_name => $entry->{applicationName},
+            host_name => $entry->{hostName},
+            uptime => ($entry->{upTime} > 0) ? $entry->{upTime} / 1000 : 0,
+            uptime_human => ($entry->{upTime} > 0) ? centreon::plugins::misc::change_seconds(value => $entry->{upTime} / 1000) : 0,
+            logger_error => $entry->{loggerErrorCount},
+            logger_warning => $entry->{loggerWarningCount},
+            heap_used => $entry->{memoryUsed},
+            heap_max => $entry->{memoryMax},
+            heap_percent => $entry->{memoryUsed} / $entry->{memoryMax} * 100,
+            cpu_percent => $entry->{cpuPercent},
+            state => ($entry->{online}) ? "online" : "offline"
+        };
+        $self->{nodes}->{$entry->{jvmId}}->{pid} = $1 if ($entry->{jvmId} =~ /-(\d+)$/); # 10.1.2.3:50156-5152
+    }
+
+    if (scalar(keys %{$self->{nodes}}) <= 0) {
+        $self->{output}->add_option_msg(short_msg => "No nodes found");
+        $self->{output}->option_exit();
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check node status and statistics.
+
+=over 8
+
+=item B<--filter-type>
+
+Filter by node type.
+
+=item B<--filter-name>
+
+Filter by node name.
+
+=item B<--filter-application-name>
+
+Filter by application name.
+
+=item B<--filter-host-name>
+
+Filter by host name.
+
+=item B<--warning-status>
+
+Set warning threshold for status (Default: "%{state} !~ /online/").
+Can use special variables like: %{state}, %{name}, %{host_name},
+%{application_name}, %{type}.
+
+=item B<--critical-status>
+
+Set critical threshold for status.
+Can use special variables like: %{state}, %{name}, %{host_name},
+%{application_name}, %{type}.
+
+=item B<--warning-*> B<--critical-*>
+
+Thresholds.
+Can be: 'log-error', 'log-warning', 'uptime' (s), 'cpu-usage', 'heap-usage' (%).
+
+=back
+
+=cut

--- a/src/apps/infor/ion/grid/api/plugin.pm
+++ b/src/apps/infor/ion/grid/api/plugin.pm
@@ -1,0 +1,49 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::ion::grid::api::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_custom);
+
+sub new {
+    my ( $class, %options ) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{modes} = {
+        'application'       => 'apps::infor::ion::grid::api::mode::application',
+        'list-applications' => 'apps::infor::ion::grid::api::mode::listapplications',
+        'list-nodes'        => 'apps::infor::ion::grid::api::mode::listnodes',
+        'node'              => 'apps::infor::ion::grid::api::mode::node'
+    };
+
+    $self->{custom_modes}->{restapi} = 'apps::infor::ion::grid::api::custom::restapi';
+    return $self;
+}
+
+1;
+
+=head1 PLUGIN DESCRIPTION
+
+Check Infor ION Grid using API.
+
+=cut

--- a/src/centreon/plugins/backend/http/curl.pm
+++ b/src/centreon/plugins/backend/http/curl.pm
@@ -330,6 +330,7 @@ sub request {
     }
     if (defined($options{request}->{cookies_file})) {
         $self->curl_setopt(option => $self->{constant_cb}->(name => 'CURLOPT_COOKIEFILE'), parameter => $options{request}->{cookies_file});
+        $self->curl_setopt(option => $self->{constant_cb}->(name => 'CURLOPT_COOKIEJAR'), parameter => $options{request}->{cookies_file});
     }
 
     $self->curl_setopt(option => $self->{constant_cb}->(name => 'CURLOPT_FOLLOWLOCATION'), parameter => 1);


### PR DESCRIPTION
Adds a new plugin to monitor Infor ION Grid components through its Rest API.

Mode _application_ will look at application status like in Grid UI 'Topology View > Applications' menu:

![image](https://github.com/centreon/centreon-plugins/assets/23257354/e15e4d49-25de-4720-80a6-4b286c81bf38)

```
centreon_plugins.pl --plugin=apps::infor::ion::grid::api::plugin --mode=application --hostname='toto.domain' --port='23456' --proto='https' --api-username='blabla' --api-password='(/ç*/&"*' --filter-name='^M3BE_15.1$' --warning-status='%{online} =~ /true/ && %{state} =~ /^NOT OK$/i' --critical-status='%{online} =~ /false/ || %{state} =~ /^NOT RUNNING$/i'
OK: Application 'M3BE_15.1' [description: System Foundation for M3 BE] state is 'OK' [online: true] [started: true]
```

Mode _node_ will look at node status and statistics link in Grid UI 'Topology View' menu:

![image](https://github.com/centreon/centreon-plugins/assets/23257354/116297f1-7c6f-4257-8651-503473a3f7bb)

```
centreon_plugins.pl --plugin=apps::infor::ion::grid::api::plugin --mode=node --hostname='toto.domain' --port='23456' --proto='https' --api-username='blabla' --api-password='(/ç*/&"*' --filter-name='^Registry$' --filter-application-name='^SYSTEM$' --filter-host-name='^THEHOST$' --warning-status='%{state} !~ /online/' --change-perfdata='.*#(.*),$1'
OK: Node 'Registry' with PID '173' from application 'SYSTEM' on host 'THEHOST' state is 'online', Log error: 0, Log warning: 0, Uptime: 4M 2w 2d 2h 40m, CPU usage: 0.00%, Heap usage: 46.10MB/254.00MB (18.15%) | 'node.log.error.count'=0;;;0; 'node.log.warning.count'=0;;;0; 'node.cpu.usage.percentage'=0.00%;;;0;100 'node.heap.usage.percentage'=18.15%;0:90;;0;100
```

For the node mode, used instance for perfdata is node's PID. For this mode, as for alike modes, I'd recommend to use discovery and filters, in addition to `--change-perfdata` option, to focus on only one node.

_Force pushed to change from M3 to ION_