### PR TITLE
new(plugin): add infor m3 monitor api plugin

### DIFF
--- a/packaging/centreon-plugin-Applications-Infor-M3-Monitor-Api/deb.json
+++ b/packaging/centreon-plugin-Applications-Infor-M3-Monitor-Api/deb.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": []
+}

--- a/packaging/centreon-plugin-Applications-Infor-M3-Monitor-Api/pkg.json
+++ b/packaging/centreon-plugin-Applications-Infor-M3-Monitor-Api/pkg.json
@@ -1,0 +1,9 @@
+{
+    "pkg_name": "centreon-plugin-Applications-Infor-M3-Monitor-Api",
+    "pkg_summary": "Centreon Plugin to monitor Infor M3 Monitor using API",
+    "plugin_name": "centreon_infor_m3_monitor_api.pl",
+    "files": [
+        "centreon/plugins/script_custom.pm",
+        "apps/infor/m3/monitor/api"
+    ]
+}

--- a/packaging/centreon-plugin-Applications-Infor-M3-Monitor-Api/rpm.json
+++ b/packaging/centreon-plugin-Applications-Infor-M3-Monitor-Api/rpm.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": []
+}

--- a/src/apps/infor/m3/monitor/api/custom/api.pm
+++ b/src/apps/infor/m3/monitor/api/custom/api.pm
@@ -1,0 +1,190 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::m3::monitor::api::custom::api;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use XML::Simple;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    if (!defined($options{output})) {
+        print "Class Custom: Need to specify 'output' argument.\n";
+        exit 3;
+    }
+    if (!defined($options{options})) {
+        $options{output}->add_option_msg(short_msg => "Class Custom: Need to specify 'options' argument.");
+        $options{output}->option_exit();
+    }
+
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            'hostname:s'             => { name => 'hostname' },
+            'port:s'                 => { name => 'port'},
+            'proto:s'                => { name => 'proto' },
+            'api-username:s'         => { name => 'api_username' },
+            'api-password:s'         => { name => 'api_password' },
+            'timeout:s'              => { name => 'timeout' },
+            'unknown-http-status:s'  => { name => 'unknown_http_status' },
+            'warning-http-status:s'  => { name => 'warning_http_status' },
+            'critical-http-status:s' => { name => 'critical_http_status' }
+        });
+    }
+
+    $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
+
+    $self->{output} = $options{output};
+    $self->{http} = centreon::plugins::http->new(%options, default_backend => 'curl');
+
+    return $self;
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+
+    $self->{option_results} = $options{option_results};
+}
+
+sub set_defaults {}
+
+sub check_options {
+    my ($self, %options) = @_;
+
+    $self->{hostname} = (defined($self->{option_results}->{hostname})) ? $self->{option_results}->{hostname} : '';
+    $self->{port} = (defined($self->{option_results}->{port})) ? $self->{option_results}->{port} : 80;
+    $self->{proto} = (defined($self->{option_results}->{proto})) ? $self->{option_results}->{proto} : 'http';
+    $self->{timeout} = (defined($self->{option_results}->{timeout})) ? $self->{option_results}->{timeout} : 20;
+    $self->{api_username} = (defined($self->{option_results}->{api_username})) ? $self->{option_results}->{api_username} : '';
+    $self->{api_password} = (defined($self->{option_results}->{api_password})) ? $self->{option_results}->{api_password} : '';
+    $self->{unknown_http_status} = (defined($self->{option_results}->{unknown_http_status})) ? $self->{option_results}->{unknown_http_status} : '%{http_code} < 200 or %{http_code} >= 300';
+    $self->{warning_http_status} = (defined($self->{option_results}->{warning_http_status})) ? $self->{option_results}->{warning_http_status} : '';
+    $self->{critical_http_status} = (defined($self->{option_results}->{critical_http_status})) ? $self->{option_results}->{critical_http_status} : '';
+
+    if ($self->{hostname} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --hostname option.");
+        $self->{output}->option_exit();
+    }
+    if ($self->{api_username} ne '' && $self->{api_password} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --api-password option.");
+        $self->{output}->option_exit();
+    }
+    
+    return 0;
+}
+
+sub build_options_for_httplib {
+    my ($self, %options) = @_;
+
+    $self->{option_results}->{hostname} = $self->{hostname};
+    $self->{option_results}->{port} = $self->{port};
+    $self->{option_results}->{proto} = $self->{proto};
+    $self->{option_results}->{timeout} = $self->{timeout};
+    if ($self->{api_username} ne '') {
+        $self->{option_results}->{credentials} = 1;
+        $self->{option_results}->{basic} = 1;
+        $self->{option_results}->{username} = $self->{api_username};
+        $self->{option_results}->{password} = $self->{api_password};
+    }
+}
+
+sub settings {
+    my ($self, %options) = @_;
+
+    return if (defined($self->{settings_done}));
+    $self->build_options_for_httplib();
+    $self->{http}->set_options(%{$self->{option_results}});
+    $self->{settings_done} = 1;
+}
+
+sub request_api {
+    my ($self, %options) = @_;
+
+    $self->settings();
+
+    my $content = $self->{http}->request(
+        %options,
+        unknown_status => $self->{unknown_http_status},
+        warning_status => $self->{warning_http_status},
+        critical_status => $self->{critical_http_status}
+    );
+
+    if (!defined($content) || $content eq '') {
+        $self->{output}->add_option_msg(short_msg => "API returns empty content [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']");
+        $self->{output}->option_exit();
+    }
+
+    my $decoded;
+    eval {
+        $decoded = XMLin($content, ForceArray => $options{force_array}, KeyAttr => []);
+    };
+    if ($@) {
+        $self->{output}->add_option_msg(short_msg => "Cannot decode response (add --debug option to display returned content)");
+        $self->{output}->option_exit();
+    }
+
+    return $decoded;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Infor M3 Monitor
+
+=head1 REST API OPTIONS
+
+=over 8
+
+=item B<--hostname>
+
+Set hostname.
+
+=item B<--port>
+
+Set port (default: '80').
+
+=item B<--proto>
+
+Specify https if needed (default: 'http').
+
+=item B<--api-username>
+
+API username.
+
+=item B<--api-password>
+
+API password.
+
+=item B<--timeout>
+
+Threshold for HTTP timeout (default: '20').
+
+=back
+
+=cut

--- a/src/apps/infor/m3/monitor/api/mode/autojobs.pm
+++ b/src/apps/infor/m3/monitor/api/mode/autojobs.pm
@@ -1,0 +1,168 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::m3::monitor::api::mode::autojobs;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "status is '%s' [thread id: %s, owner: %s]",
+        $self->{result_values}->{status},
+        $self->{result_values}->{thread_id},
+        $self->{result_values}->{owner}
+    );
+}
+
+sub prefix_autojobs_output {
+    my ($self, %options) = @_;
+
+    return "Auto job '" . $options{instance_value}->{name} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0 },
+        { name => 'autojobs', type => 1, cb_prefix_output => 'prefix_autojobs_output', message_multiple => 'All auto jobs are ok' }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'jobs', nlabel => 'jobs.auto.count', set => {
+                key_values => [ { name => 'jobs' } ],
+                output_template => 'Auto jobs : %s',
+                perfdatas => [
+                    { template => '%s', min => 0 }
+                ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{autojobs} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '',
+            set => {
+                key_values => [
+                    { name => 'status' }, { name => 'name' }, { name => 'owner' }, { name => 'thread_id' }, { name => 'jvm_id' }
+                ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        },
+        { label => 'autojob-cpu-usage', nlabel => 'autojob.cpu.usage.percentage', set => {
+                key_values => [ { name => 'cpu_usage' }, { name => 'name' } ],
+                output_template => 'CPU usage: %s %%',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 100, unit => '%',
+                      label_extra_instance => 1, instance_use => 'name' }
+                ]
+            }
+        },
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s' => { name => 'filter_name' },
+        'filter-jvm-id:s' => { name => 'filter_jvm_id' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        method => 'GET',
+        url_path => '/monitor',
+        get_param => ['category=autojobs'],
+        force_array => ['autojobs', 'job']
+    );
+
+    $self->{global}->{jobs} = 0;
+
+    foreach my $entry (@{$result->{category}->{job}}) {
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $entry->{name} !~ /$self->{option_results}->{filter_name}/);
+        next if (defined($self->{option_results}->{filter_jvm_id}) && $self->{option_results}->{filter_jvm_id} ne ''
+            && $entry->{JVMId} !~ /$self->{option_results}->{filter_jvm_id}/);
+        $self->{autojobs}->{$entry->{name}} = {
+            jvm_id => $entry->{JVMId},
+            thread_id => $entry->{threadId},
+            name => $entry->{name},
+            owner => $entry->{owner},
+            status => $entry->{status},
+            cpu_usage => $entry->{cpuUsage}
+        };
+        $self->{global}->{jobs}++;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check auto jobs status.
+
+=over 8
+
+=item B<--filter-name>
+
+Filter by name.
+
+=item B<--filter-jvm-id>
+
+Filter by JVM ID.
+
+=item B<--warning-status>
+
+Set warning threshold for status.
+Can use special variables like: %{status}, %{owner}, %{jvm_id}, %{name}.
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: "").
+Can use special variables like: %{status}, %{owner}, %{jvm_id}, %{name}.
+
+=back
+
+=cut

--- a/src/apps/infor/m3/monitor/api/mode/batchjobs.pm
+++ b/src/apps/infor/m3/monitor/api/mode/batchjobs.pm
@@ -1,0 +1,168 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::m3::monitor::api::mode::batchjobs;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "status is '%s' [name: %s, owner: %s]",
+        $self->{result_values}->{status},
+        $self->{result_values}->{name},
+        $self->{result_values}->{owner}
+    );
+}
+
+sub prefix_batchjobs_output {
+    my ($self, %options) = @_;
+
+    return "Batch job '" . $options{instance_value}->{thread_id} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0 },
+        { name => 'batchjobs', type => 1, cb_prefix_output => 'prefix_batchjobs_output', message_multiple => 'All batch jobs are ok' }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'jobs', nlabel => 'jobs.batch.count', set => {
+                key_values => [ { name => 'jobs' } ],
+                output_template => 'Batch jobs : %s',
+                perfdatas => [
+                    { template => '%s', min => 0 }
+                ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{batchjobs} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '',
+            set => {
+                key_values => [
+                    { name => 'status' }, { name => 'name' }, { name => 'owner' }, { name => 'thread_id' }, { name => 'jvm_id' }
+                ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        },
+        { label => 'batchjob-cpu-usage', nlabel => 'batchjob.cpu.usage.percentage', set => {
+                key_values => [ { name => 'cpu_usage' }, { name => 'thread_id' } ],
+                output_template => 'CPU usage: %s %%',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 100, unit => '%',
+                      label_extra_instance => 1, instance_use => 'thread_id' }
+                ]
+            }
+        },
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s' => { name => 'filter_name' },
+        'filter-jvm-id:s' => { name => 'filter_jvm_id' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        method => 'GET',
+        url_path => '/monitor',
+        get_param => ['category=batchjobs'],
+        force_array => ['batchjobs', 'job']
+    );
+
+    $self->{global}->{jobs} = 0;
+
+    foreach my $entry (@{$result->{category}->{job}}) {
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $entry->{name} !~ /$self->{option_results}->{filter_name}/);
+        next if (defined($self->{option_results}->{filter_jvm_id}) && $self->{option_results}->{filter_jvm_id} ne ''
+            && $entry->{JVMId} !~ /$self->{option_results}->{filter_jvm_id}/);
+        $self->{batchjobs}->{$entry->{threadId}} = {
+            jvm_id => $entry->{JVMId},
+            thread_id => $entry->{threadId},
+            name => $entry->{name},
+            owner => $entry->{owner},
+            status => $entry->{status},
+            cpu_usage => $entry->{cpuUsage}
+        };
+        $self->{global}->{jobs}++;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check batch jobs status.
+
+=over 8
+
+=item B<--filter-name>
+
+Filter by name.
+
+=item B<--filter-jvm-id>
+
+Filter by JVM ID.
+
+=item B<--warning-status>
+
+Set warning threshold for status.
+Can use special variables like: %{status}, %{owner}, %{jvm_id}, %{name}.
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: "").
+Can use special variables like: %{status}, %{owner}, %{jvm_id}, %{name}.
+
+=back
+
+=cut

--- a/src/apps/infor/m3/monitor/api/mode/interactivejobs.pm
+++ b/src/apps/infor/m3/monitor/api/mode/interactivejobs.pm
@@ -1,0 +1,168 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::m3::monitor::api::mode::interactivejobs;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "status is '%s' [name: %s, owner: %s]",
+        $self->{result_values}->{status},
+        $self->{result_values}->{name},
+        $self->{result_values}->{owner}
+    );
+}
+
+sub prefix_interactivejobs_output {
+    my ($self, %options) = @_;
+
+    return "Interactive job '" . $options{instance_value}->{thread_id} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0 },
+        { name => 'interactivejobs', type => 1, cb_prefix_output => 'prefix_interactivejobs_output', message_multiple => 'All interactive jobs are ok' }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'jobs', nlabel => 'jobs.interactive.count', set => {
+                key_values => [ { name => 'jobs' } ],
+                output_template => 'Interactive jobs : %s',
+                perfdatas => [
+                    { template => '%s', min => 0 }
+                ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{interactivejobs} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '',
+            set => {
+                key_values => [
+                    { name => 'status' }, { name => 'name' }, { name => 'owner' }, { name => 'thread_id' }, { name => 'jvm_id' }
+                ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        },
+        { label => 'interactivejob-cpu-usage', nlabel => 'interactivejob.cpu.usage.percentage', set => {
+                key_values => [ { name => 'cpu_usage' }, { name => 'thread_id' } ],
+                output_template => 'CPU usage: %s %%',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 100, unit => '%',
+                      label_extra_instance => 1, instance_use => 'thread_id' }
+                ]
+            }
+        },
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s' => { name => 'filter_name' },
+        'filter-jvm-id:s' => { name => 'filter_jvm_id' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        method => 'GET',
+        url_path => '/monitor',
+        get_param => ['category=interactivejobs'],
+        force_array => ['interactivejobs', 'job']
+    );
+
+    $self->{global}->{jobs} = 0;
+
+    foreach my $entry (@{$result->{category}->{job}}) {
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $entry->{name} !~ /$self->{option_results}->{filter_name}/);
+        next if (defined($self->{option_results}->{filter_jvm_id}) && $self->{option_results}->{filter_jvm_id} ne ''
+            && $entry->{JVMId} !~ /$self->{option_results}->{filter_jvm_id}/);
+        $self->{interactivejobs}->{$entry->{threadId}} = {
+            jvm_id => $entry->{JVMId},
+            thread_id => $entry->{threadId},
+            name => $entry->{name},
+            owner => $entry->{owner},
+            status => $entry->{status},
+            cpu_usage => $entry->{cpuUsage}
+        };
+        $self->{global}->{jobs}++;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check interactive jobs status.
+
+=over 8
+
+=item B<--filter-name>
+
+Filter by name.
+
+=item B<--filter-jvm-id>
+
+Filter by JVM ID.
+
+=item B<--warning-status>
+
+Set warning threshold for status.
+Can use special variables like: %{status}, %{owner}, %{jvm_id}, %{name}.
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: "").
+Can use special variables like: %{status}, %{owner}, %{jvm_id}, %{name}.
+
+=back
+
+=cut

--- a/src/apps/infor/m3/monitor/api/mode/jvms.pm
+++ b/src/apps/infor/m3/monitor/api/mode/jvms.pm
@@ -1,0 +1,308 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::m3::monitor::api::mode::jvms;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+use centreon::plugins::misc;
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "status is '%s' [type: %s, system: %s]",
+        $self->{result_values}->{status},
+        $self->{result_values}->{type},
+        $self->{result_values}->{system},
+    );
+}
+
+sub prefix_jvm_output {
+    my ($self, %options) = @_;
+
+    return "JVM '" . $options{instance_value}->{id} . "' ";
+}
+
+sub prefix_status_output {
+    my ($self, %options) = @_;
+
+    return 'JVMs statuses ';
+}
+
+sub prefix_type_output {
+    my ($self, %options) = @_;
+
+    return 'JVMs types ';
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'statuses', type => 0, cb_prefix_output => 'prefix_status_output' },
+        { name => 'types', type => 0, cb_prefix_output => 'prefix_type_output' },
+        { name => 'jvms', type => 1, cb_prefix_output => 'prefix_jvm_output', message_multiple => 'All JVMs are ok' }
+    ];
+
+    $self->{maps_counters}->{statuses} = [
+        { label => 'status-normal', nlabel => 'jvms.status.normal.count', set => {
+                key_values => [ { name => 'normal' }, { name => 'total' } ],
+                output_template => 'normal: %s',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 'total' }
+                ]
+            }
+        },
+        { label => 'status-offline', nlabel => 'jvms.status.offline.count', set => {
+                key_values => [ { name => 'offline' }, { name => 'total' } ],
+                output_template => 'offline: %s',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 'total' }
+                ]
+            }
+        },
+        { label => 'status-started', nlabel => 'jvms.status.started.count', set => {
+                key_values => [ { name => 'started' }, { name => 'total' } ],
+                output_template => 'started: %s',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 'total' }
+                ]
+            }
+        },
+        { label => 'status-locked', nlabel => 'jvms.status.locked.count', set => {
+                key_values => [ { name => 'locked' }, { name => 'total' } ],
+                output_template => 'locked: %s',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 'total' }
+                ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{types} = [
+        { label => 'type-autojobs', nlabel => 'jvms.type.autojobs.count', set => {
+                key_values => [ { name => 'autojobs' }, { name => 'total' } ],
+                output_template => 'autojobs: %s',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 'total' }
+                ]
+            }
+        },
+        { label => 'type-interactivejobs', nlabel => 'jvms.type.interactivejobs.count', set => {
+                key_values => [ { name => 'interactivejobs' }, { name => 'total' } ],
+                output_template => 'interactivejobs: %s',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 'total' }
+                ]
+            }
+        },
+        { label => 'type-batchjobs', nlabel => 'jvms.type.batchjobs.count', set => {
+                key_values => [ { name => 'batchjobs' }, { name => 'total' } ],
+                output_template => 'batchjobs: %s',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 'total' }
+                ]
+            }
+        },
+        { label => 'type-mijobs', nlabel => 'jvms.type.mijobs.count', set => {
+                key_values => [ { name => 'mijobs' }, { name => 'total' } ],
+                output_template => 'mijobs: %s',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 'total' }
+                ]
+            }
+        },
+        { label => 'type-m3coordinator', nlabel => 'jvms.type.m3coordinator.count', set => {
+                key_values => [ { name => 'm3coordinator' }, { name => 'total' } ],
+                output_template => 'm3coordinator: %s',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 'total' }
+                ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{jvms} = [
+        {
+            label => 'jvm-status',
+            type => 2,
+            critical_default => '%{status} =~ /locked/',
+            set => {
+                key_values => [
+                    { name => 'id' },
+                    { name => 'type' },
+                    { name => 'system' },
+                    { name => 'status' },
+                    { name => 'cpu_usage' },
+                    { name => 'heap_size' },
+                    { name => 'uptime' }
+                ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        },
+        { label => 'jvm-cpu-usage', nlabel => 'jvm.cpu.usage.percentage', set => {
+                key_values => [ { name => 'cpu_usage' }, { name => 'id' } ],
+                output_template => 'CPU usage: %s %%',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 100, unit => '%',
+                      label_extra_instance => 1, instance_use => 'id' }
+                ]
+            }
+        },
+        { label => 'jvm-jobs', nlabel => 'jvm.jobs.count', set => {
+                key_values => [ { name => 'job_count' }, { name => 'id' } ],
+                output_template => 'Jobs: %s',
+                perfdatas => [
+                    { template => '%s', min => 0,
+                      label_extra_instance => 1, instance_use => 'id' }
+                ]
+            }
+        },
+        { label => 'jvm-threads', nlabel => 'jvm.threads.count', set => {
+                key_values => [ { name => 'threads' }, { name => 'id' } ],
+                output_template => 'Threads: %s',
+                perfdatas => [
+                    { template => '%s', min => 0,
+                      label_extra_instance => 1, instance_use => 'id' }
+                ]
+            }
+        },
+        { label => 'jvm-heap-size', nlabel => 'jvm.heap_size.bytes', set => {
+                key_values => [ { name => 'heap_size' }, { name => 'id' } ],
+                output_template => 'Heap Size: %s %s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    { template => '%s', min => 0, unit => 'B',
+                      label_extra_instance => 1, instance_use => 'id' }
+                ]
+            }
+        },
+        { label => 'jvm-uptime', nlabel => 'jvm.uptime.seconds', set => {
+                key_values => [ { name => 'uptime' }, { name => 'uptime_human' }, { name => 'id' } ],
+                output_template => 'Uptime: %s',
+                output_use => 'uptime_human',
+                closure_custom_perfdata => sub { return 0; },
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-id:s' => { name => 'filter_id' },
+        'filter-type:s' => { name => 'filter_type' },
+        'filter-system:s' => { name => 'filter_system' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        method => 'GET',
+        url_path => '/monitor',
+        get_param => ['category=jvms'],
+        force_array => ['jvms', 'jvm']
+    );
+
+    $self->{statuses} = { total => 0, normal => 0, offline => 0, started => 0, locked => 0 };
+    $self->{types} = { total => 0, autojobs => 0, interactivejobs => 0, batchjobs => 0, mijobs => 0, m3coordinator => 0 };
+
+    foreach my $entry (@{$result->{category}->{jvm}}) {
+        next if (defined($self->{option_results}->{filter_id}) && $self->{option_results}->{filter_id} ne ''
+            && $entry->{JVMId} !~ /$self->{option_results}->{filter_id}/);
+        next if (defined($self->{option_results}->{filter_type}) && $self->{option_results}->{filter_type} ne ''
+            && $entry->{type} !~ /$self->{option_results}->{filter_type}/);
+        next if (defined($self->{option_results}->{filter_system}) && $self->{option_results}->{filter_system} ne ''
+            && $entry->{systemConfiguration} !~ /$self->{option_results}->{filter_system}/);
+
+        $self->{jvms}->{$entry->{JVMId}} = {
+            id => $entry->{JVMId},
+            type => $entry->{type},
+            system => ($entry->{systemConfiguration}) ne "" ? $entry->{systemConfiguration} : "-",
+            cpu_usage => $entry->{processCpuUsage},
+            job_count => (defined($entry->{jobCount})) ? $entry->{jobCount} : 0,
+            threads => $entry->{threads},
+            heap_size => $entry->{heapSizeKB} * 1024,
+            uptime => ($entry->{upTimeMS} > 0) ? $entry->{upTimeMS} / 1000 : 0,
+            uptime_human => ($entry->{upTimeMS} > 0) ? centreon::plugins::misc::change_seconds(value => $entry->{upTimeMS} / 1000) : 0,
+            status => $entry->{status}
+        };
+
+        $self->{statuses}->{lc($entry->{status})}++;
+        $self->{statuses}->{total}++;
+        $self->{types}->{lc($entry->{type})}++;
+        $self->{types}->{total}++;
+    }
+
+    if (scalar(keys %{$self->{jvms}}) <= 0) {
+        $self->{output}->add_option_msg(short_msg => "No JVMs found");
+        $self->{output}->option_exit();
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check JVMs status.
+
+=over 8
+
+=item B<--filter-type>
+
+Filter by type.
+
+=item B<--filter-system>
+
+Filter by system.
+
+=item B<--warning-jvm-status>
+
+Set warning threshold for status.
+Can use special variables like: %{status}, %{id}, %{type}, %{system}.
+
+=item B<--critical-jvm-status>
+
+Set critical threshold for status (Default: "%{status} =~ /locked/").
+Can use special variables like: %{status}, %{id}, %{type}, %{system}.
+
+=back
+
+=cut

--- a/src/apps/infor/m3/monitor/api/mode/mijobs.pm
+++ b/src/apps/infor/m3/monitor/api/mode/mijobs.pm
@@ -1,0 +1,168 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::m3::monitor::api::mode::mijobs;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "status is '%s' [name: %s, owner: %s]",
+        $self->{result_values}->{status},
+        $self->{result_values}->{name},
+        $self->{result_values}->{owner}
+    );
+}
+
+sub prefix_mijobs_output {
+    my ($self, %options) = @_;
+
+    return "MI job '" . $options{instance_value}->{thread_id} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0 },
+        { name => 'mijobs', type => 1, cb_prefix_output => 'prefix_mijobs_output', message_multiple => 'All MI jobs are ok' }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'jobs', nlabel => 'jobs.mi.count', set => {
+                key_values => [ { name => 'jobs' } ],
+                output_template => 'MI jobs : %s',
+                perfdatas => [
+                    { template => '%s', min => 0 }
+                ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{mijobs} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '',
+            set => {
+                key_values => [
+                    { name => 'status' }, { name => 'name' }, { name => 'owner' }, { name => 'thread_id' }, { name => 'jvm_id' }
+                ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        },
+        { label => 'mijob-cpu-usage', nlabel => 'mijob.cpu.usage.percentage', set => {
+                key_values => [ { name => 'cpu_usage' }, { name => 'thread_id' } ],
+                output_template => 'CPU usage: %s %%',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 100, unit => '%',
+                      label_extra_instance => 1, instance_use => 'thread_id' }
+                ]
+            }
+        },
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s' => { name => 'filter_name' },
+        'filter-jvm-id:s' => { name => 'filter_jvm_id' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        method => 'GET',
+        url_path => '/monitor',
+        get_param => ['category=mijobs'],
+        force_array => ['mijobs', 'job']
+    );
+
+    $self->{global}->{jobs} = 0;
+
+    foreach my $entry (@{$result->{category}->{job}}) {
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $entry->{name} !~ /$self->{option_results}->{filter_name}/);
+        next if (defined($self->{option_results}->{filter_jvm_id}) && $self->{option_results}->{filter_jvm_id} ne ''
+            && $entry->{JVMId} !~ /$self->{option_results}->{filter_jvm_id}/);
+        $self->{mijobs}->{$entry->{threadId}} = {
+            jvm_id => $entry->{JVMId},
+            thread_id => $entry->{threadId},
+            name => $entry->{name},
+            owner => $entry->{owner},
+            status => $entry->{status},
+            cpu_usage => $entry->{cpuUsage}
+        };
+        $self->{global}->{jobs}++;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check MI jobs status.
+
+=over 8
+
+=item B<--filter-name>
+
+Filter by name.
+
+=item B<--filter-jvm-id>
+
+Filter by JVM ID.
+
+=item B<--warning-status>
+
+Set warning threshold for status.
+Can use special variables like: %{status}, %{owner}, %{jvm_id}, %{name}.
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: "").
+Can use special variables like: %{status}, %{owner}, %{jvm_id}, %{name}.
+
+=back
+
+=cut

--- a/src/apps/infor/m3/monitor/api/mode/news.pm
+++ b/src/apps/infor/m3/monitor/api/mode/news.pm
@@ -1,0 +1,179 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::m3::monitor::api::mode::news;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use DateTime;
+use centreon::plugins::misc;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        'news [severity: %s] [count: %s] [first seen: %s] [last seen: %s] %s',
+        $self->{result_values}->{severity},
+        $self->{result_values}->{count},
+        $self->{result_values}->{first_seen},
+        $self->{result_values}->{last_seen},
+        $self->{result_values}->{message}
+    );
+}
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+
+    return 'News ';
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output', },
+        { name => 'news', type => 2, message_multiple => '0 problem(s) detected', display_counter_problem => { nlabel => 'news.problems.current.count', min => 0 },
+          group => [ { name => 'entry', skipped_code => { -11 => 1 } } ]
+        }
+    ];
+
+    foreach (0, 1, 2, 3, 4) {
+        push @{$self->{maps_counters}->{global}},
+            { label => 'news-severity-' . $_, nlabel => 'news.severity.' . $_ . '.count', display_ok => 0, set => {
+                    key_values => [ { name => $_ }, { name => 'total' } ],
+                    output_template => 'severity ' . $_ . ': %s',
+                    perfdatas => [
+                        { template => '%s', min => 0, max => 'total' }
+                    ]
+                }
+            };
+    }
+
+    $self->{maps_counters}->{entry} = [
+        {
+            label => 'status',
+            type => 2,
+            warning_default => '',
+            critical_default => '%{severity} <= 2 || %{message} =~ /Job may be looping/i',
+            set => {
+                key_values => [
+                    { name => 'message' }, { name => 'severity' },
+                    { name => 'count' }, { name => 'first_seen' }, { name => 'last_seen' }
+                ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-message:s' => { name => 'filter_message' },
+        'retention:s'      => { name => 'retention' },
+        'timezone:s'       => { name => 'timezone', default => 'UTC' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        method => 'GET',
+        url_path => '/monitor',
+        get_param => ['category=news'],
+        force_array => ['news']
+    );
+
+    $self->{news} = { global => { entry => {} } };
+    $self->{global} = {
+        0 => 0, 1 => 0, 2 => 0, 3 => 0, 4 => 0
+    };
+
+    my ($i, $current_time) = (1, time());
+    my $tz = centreon::plugins::misc::set_timezone(name => $self->{option_results}->{timezone});
+
+    foreach my $entry (@{$result->{category}->{news}}) {        
+        $entry->{lastSeen} =~ /^(\d+)-(\d+)-(\d+)T(\d+):(\d+):(\d+)/;
+        my $dt = DateTime->new(year => $1, month => $2, day => $3, hour => $4, minute => $5, second => $6, %$tz);
+        my $last_seen = $dt->epoch();
+
+        if (defined($self->{option_results}->{retention})) {
+            next if ($current_time - $last_seen > $self->{option_results}->{retention});
+        }
+
+        $self->{global}->{total}++;
+
+        next if (defined($self->{option_results}->{filter_message}) && $self->{option_results}->{filter_message} ne '' && $entry->{message} !~ /$self->{option_results}->{filter_message}/);
+
+        $self->{news}->{global}->{entry}->{$i} = {
+            message => $entry->{message},
+            severity => $entry->{severity},
+            count => $entry->{count},
+            first_seen => $entry->{firstSeen},
+            last_seen => $entry->{lastSeen}
+        };
+        $self->{global}->{ $entry->{severity} }++;
+        $i++;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check news.
+
+=over 8
+
+=item B<--filter-message>
+
+Exclude message not matching expression.
+
+=item B<--warning-status>
+
+Set warning threshold for status.
+Can use special variables like: %{status}, %{name}, %{description}.
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: "%{status} !~ /up/").
+Can use special variables like: %{status}, %{name}, %{description}.
+
+=back
+
+=cut

--- a/src/apps/infor/m3/monitor/api/mode/services.pm
+++ b/src/apps/infor/m3/monitor/api/mode/services.pm
@@ -1,0 +1,138 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::m3::monitor::api::mode::services;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "status is '%s' [description: %s]",
+        $self->{result_values}->{status},
+        $self->{result_values}->{description}
+    );
+}
+
+sub prefix_service_output {
+    my ($self, %options) = @_;
+
+    return "Service '" . $options{instance_value}->{name} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'services', type => 1, cb_prefix_output => 'prefix_service_output', message_multiple => 'All services are ok' }
+    ];
+
+    $self->{maps_counters}->{services} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '%{status} !~ /up/',
+            set => {
+                key_values => [
+                    { name => 'description' }, { name => 'status' }, { name => 'name' }
+                ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s' => { name => 'filter_name' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        method => 'GET',
+        url_path => '/monitor',
+        get_param => ['category=services'],
+        force_array => ['services', 'service']
+    );
+
+    foreach my $entry (@{$result->{category}->{service}}) {
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $entry->{name} !~ /$self->{option_results}->{filter_name}/);
+        $self->{services}->{$entry->{name}} = {
+            name => $entry->{name},
+            description => $entry->{description},
+            status => (defined($entry->{'port-status'})) ? $entry->{'port-status'} : $entry->{'thread-status'}
+        }
+    }
+
+    if (scalar(keys %{$self->{services}}) <= 0) {
+        $self->{output}->add_option_msg(short_msg => "No services found");
+        $self->{output}->option_exit();
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check service status.
+
+=over 8
+
+=item B<--filter-name>
+
+Filter by name.
+
+=item B<--warning-status>
+
+Set warning threshold for status.
+Can use special variables like: %{status}, %{name}, %{description}.
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: "%{status} !~ /up/").
+Can use special variables like: %{status}, %{name}, %{description}.
+
+=back
+
+=cut

--- a/src/apps/infor/m3/monitor/api/plugin.pm
+++ b/src/apps/infor/m3/monitor/api/plugin.pm
@@ -1,0 +1,53 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::infor::m3::monitor::api::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_custom);
+
+sub new {
+    my ( $class, %options ) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{modes} = {
+        'autojobs'        => 'apps::infor::m3::monitor::api::mode::autojobs',
+        'batchjobs'       => 'apps::infor::m3::monitor::api::mode::batchjobs',
+        'interactivejobs' => 'apps::infor::m3::monitor::api::mode::interactivejobs',
+        'jvms'            => 'apps::infor::m3::monitor::api::mode::jvms',
+        'mijobs'          => 'apps::infor::m3::monitor::api::mode::mijobs',
+        'news'            => 'apps::infor::m3::monitor::api::mode::news',
+        'services'        => 'apps::infor::m3::monitor::api::mode::services'
+    };
+
+    $self->{custom_modes}->{api} = 'apps::infor::m3::monitor::api::custom::api';
+    return $self;
+}
+
+1;
+
+
+=head1 PLUGIN DESCRIPTION
+
+Check Infor M3 Monitor using API.
+
+=cut


### PR DESCRIPTION
Adds a new plugin to monitor Infor M3 throught the /monitor endpoint.

```
centreon_plugins.pl --plugin=apps::infor::m3::monitor::api::plugin --mode=services --hostname='toto.domain' --port='12345' --proto='http'  --filter-name='.*' --critical-status='%{status} !~ /up/' --verbose
OK: All services are ok
Service 'BCIDispatcher' status is 'up' [description: M3 Foundation LWS connections dispatcher]
Service 'MIDispatcher' status is 'up' [description: M3 Foundation MI jobs dispatcher]
Service 'Transaction Server' status is 'up' [description: M3 Foundation locks and transactions server]
```

```
centreon_plugins.pl --plugin=apps::infor::m3::monitor::api::plugin --mode=jvms --hostname='toto.domain' --port='12345' --proto='http' --filter-id='.*' --filter-type='^((?!M3Coordinator).)*$' --filter-system='.*' --critical-jvm-status='%{status} =~ /locked/' --warning-jvm-cpu-usage='75' --filter-counters='^((?!m3coordinator).)*$' --filter-perfdata='jvms' --verbose
OK: JVMs statuses normal: 46, offline: 2, started: 0, locked: 0 - JVMs types autojobs: 6, interactivejobs: 5, batchjobs: 18, mijobs: 19 - All JVMs are ok | 'jvms.status.normal.count'=46;;;0;48 'jvms.status.offline.count'=2;;;0;48 'jvms.status.started.count'=0;;;0;48 'jvms.status.locked.count'=0;;;0;48 'jvms.type.autojobs.count'=6;;;0;48 'jvms.type.interactivejobs.count'=5;;;0;48 'jvms.type.batchjobs.count'=18;;;0;48 'jvms.type.mijobs.count'=19;;;0;48
JVM '10.120.8.22:10611-228872' status is 'normal' [type: mijobs, system: SYS1], CPU usage: 0 %, Jobs: 0, Threads: 88, Heap Size: 31.21 MB, Uptime: 5h 58m 1s
JVM '10.120.8.22:14631-228633' status is 'normal' [type: mijobs, system: SYS2], CPU usage: 0 %, Jobs: 0, Threads: 88, Heap Size: 28.24 MB, Uptime: 6h 26m 35s
JVM '10.120.8.22:14990-228423' status is 'normal' [type: batchjobs, system: SYS2], CPU usage: 0 %, Jobs: 0, Threads: 89, Heap Size: 28.81 MB, Uptime: 13h 43m 1s
...
```

```
centreon_plugins.pl --plugin=apps::infor::m3::monitor::api::plugin --mode=autojobs --hostname='toto.domain' --port='12345' --proto='http' --filter-name='.*' --filter-jvm-id='.*' --warning-autojob-cpu-usage='75' --filter-perfdata=jobs
OK: Auto jobs : 76 - All auto jobs are ok | 'jobs.auto.count'=76;;;0;
```