### PR TITLE
CTOR-383-community-pr-handle-variable-path-for-hashicorp-vault-authentication

### DIFF
--- a/src/apps/hashicorp/vault/restapi/custom/api.pm
+++ b/src/apps/hashicorp/vault/restapi/custom/api.pm
@@ -294,7 +294,7 @@ Syntax: --auth-settings='<setting>=<value>'.Example for the 'userpass' method:
 
 =item B<--auth-path>
 
-Authentication path for 'userpass'. Is an optional setting.
+Authentication path for 'userpass' (default: token).
 
 More information here: https://developer.hashicorp.com/vault/docs/auth/userpass#configuration
 

--- a/src/centreon/plugins/passwordmgr/hashicorpvault.pm
+++ b/src/centreon/plugins/passwordmgr/hashicorpvault.pm
@@ -287,7 +287,7 @@ Can be: 'azure', 'cert', 'github', 'ldap', 'okta', 'radius', 'userpass' (default
 
 =item B<--auth-path>
 
-Authentication path for 'userpass'. Is an optional setting.
+Authentication path for 'userpass' (default: token).
 
 More information here: https://developer.hashicorp.com/vault/docs/auth/userpass#configuration
 

--- a/tests/functional/api/storage-datacore-restapi.robot
+++ b/tests/functional/api/storage-datacore-restapi.robot
@@ -10,6 +10,7 @@ Suite Setup         Start Mockoon
 Suite Teardown      Stop Mockoon
 Test Timeout        120s
 
+
 *** Variables ***
 ${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 ${MOCKOON_JSON}         ${CURDIR}${/}..${/}..${/}resources${/}mockoon${/}storage-datacore-restapi.json
@@ -61,6 +62,7 @@ Datacore check status monitor
 
     Examples:    result   --
         ...    CRITICAL: 'State of HostVM2' status : 'Critical', message is 'Connected'
+
 
 *** Keywords ***
 Start Mockoon

--- a/tests/functional/database/database-mysql.robot
+++ b/tests/functional/database/database-mysql.robot
@@ -9,14 +9,14 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS} --plugin=database::mysql::plugin
+${CMD}                  perl ${CENTREON_PLUGINS} --plugin=database::mysql::plugin
 
 &{sql_string_test1}
-...                         result=UNKNOWN: Need to specify data_source arguments.
+...                     result=UNKNOWN: Need to specify data_source arguments.
 @{sql_string_tests}
-...                         &{sql_string_test1}
+...                     &{sql_string_test1}
 
 
 *** Test Cases ***

--- a/tests/functional/linux/os-linux-list-systemdservices.robot
+++ b/tests/functional/linux/os-linux-list-systemdservices.robot
@@ -9,12 +9,13 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS} --plugin=os::linux::local::plugin
-${PERCENT}                  %
+${CMD}                  perl ${CENTREON_PLUGINS} --plugin=os::linux::local::plugin
+${PERCENT}              %
 
-${COND}                     ${PERCENT}\{sub\} =~ /exited/ && ${PERCENT}{display} =~ /network/'
+${COND}                 ${PERCENT}\{sub\} =~ /exited/ && ${PERCENT}{display} =~ /network/'
+
 
 *** Test Cases ***
 List-Systemdservices v219 ${tc}/4

--- a/tests/functional/linux/os-linux-system-sc-status.robot
+++ b/tests/functional/linux/os-linux-system-sc-status.robot
@@ -9,12 +9,13 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS} --plugin=os::linux::local::plugin
+${CMD}                  perl ${CENTREON_PLUGINS} --plugin=os::linux::local::plugin
 # attempt to work around the interpretation of %{} as env variables instead of plugin macros
-#${PERCENT}                  %
-#${COND}                     ${PERCENT}\{sub\} =~ /exited/ && ${PERCENT}{display} =~ /network/'
+# ${PERCENT}    %
+# ${COND}    ${PERCENT}\{sub\} =~ /exited/ && ${PERCENT}{display} =~ /network/'
+
 
 *** Test Cases ***
 Systemd-sc-status v219 ${tc}/15
@@ -59,8 +60,8 @@ Systemd-sc-status v219 ${tc}/15
             ...      14    ${EMPTY}         ${EMPTY}    ${EMPTY}   ${EMPTY}  ${EMPTY}       ${EMPTY}      ${EMPTY}   ${EMPTY}  ${EMPTY}      ${EMPTY}     0           ${EMPTY}     WARNING: Total Failed: 1 | 'total_running'=34;;;0;220 'total_failed'=1;0:0;;0;220 'total_dead'=97;;;0;220 'total_exited'=25;;;0;220
             ...      15    ${EMPTY}         ${EMPTY}    ${EMPTY}   ${EMPTY}  ${EMPTY}       ${EMPTY}      ${EMPTY}   ${EMPTY}  ${EMPTY}      ${EMPTY}     ${EMPTY}     0           CRITICAL: Total Failed: 1 | 'total_running'=34;;;0;220 'total_failed'=1;;0:0;0;220 'total_dead'=97;;;0;220 'total_exited'=25;;;0;220
 # not working atm
-            # ...      6     ${EMPTY}         ${EMPTY}    ${COND}   ${EMPTY}  ${EMPTY}       ${EMPTY}      ${EMPTY}   ${EMPTY}  ${EMPTY}      ${EMPTY}     ${EMPTY}     ${EMPTY}     WARNING
-            # ...      7     ${EMPTY}         ${EMPTY}    ${EMPTY}   ${COND}  ${EMPTY}       ${EMPTY}      ${EMPTY}   ${EMPTY}  ${EMPTY}      ${EMPTY}     ${EMPTY}     ${EMPTY}     CRITICAL
+    # ...    6    ${EMPTY}    ${EMPTY}    ${COND}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    WARNING
+    # ...    7    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${COND}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    CRITICAL
 
 Systemd-sc-status v252 ${tc}/15
     [Documentation]    Systemd version >= 248
@@ -105,6 +106,5 @@ Systemd-sc-status v252 ${tc}/15
             ...      15    ${EMPTY}         ${EMPTY}    ${EMPTY}   ${EMPTY}  ${EMPTY}       ${EMPTY}      ${EMPTY}   ${EMPTY}  ${EMPTY}      ${EMPTY}     ${EMPTY}     2           CRITICAL: Total Failed: 4 | 'total_running'=31;;;0;258 'total_failed'=4;;0:2;0;258 'total_dead'=108;;;0;258 'total_exited'=19;;;0;258
 
 # not working atm
-            # ...      6     ${EMPTY}         ${EMPTY}    ${COND}   ${EMPTY}  ${EMPTY}       ${EMPTY}      ${EMPTY}   ${EMPTY}  ${EMPTY}      ${EMPTY}     ${EMPTY}     ${EMPTY}     WARNING
-            # ...      7     ${EMPTY}         ${EMPTY}    ${EMPTY}   ${COND}  ${EMPTY}       ${EMPTY}      ${EMPTY}   ${EMPTY}  ${EMPTY}      ${EMPTY}     ${EMPTY}     ${EMPTY}     CRITICAL
-
+    # ...    6    ${EMPTY}    ${EMPTY}    ${COND}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    WARNING
+    # ...    7    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${COND}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    ${EMPTY}    CRITICAL

--- a/tests/functional/snmp/apps-protocols-snmp.robot
+++ b/tests/functional/snmp/apps-protocols-snmp.robot
@@ -6,15 +6,16 @@ Library             OperatingSystem
 Library             Process
 Library             String
 
-Test Timeout        120s
 Suite Setup         Start Mockoon
 Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
 
 *** Variables ***
 ${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 ${MOCKOON_JSON}         ${CURDIR}${/}..${/}..${/}resources${/}mockoon${/}centreon-plugins-passwordmgr-hashicorpvault.json
 
-${CMD}                  perl ${CENTREON_PLUGINS} --plugin apps::protocols::snmp::plugin  --hostname=127.0.0.1
+${CMD}                  perl ${CENTREON_PLUGINS} --plugin apps::protocols::snmp::plugin    --hostname=127.0.0.1
 
 
 *** Test Cases ***
@@ -23,11 +24,22 @@ check hashicorp vault manager${Name}
     [Tags]    snmp    vault
     ${cmd_hashicorp}    Catenate
     ...    ${CMD}
-    ...    --pass-manager hashicorpvault --vault-address='127.0.0.1' --vault-port 3000 --vault-protocol http --auth-method userpass
-    ...    --auth-settings="username=hcvaultuser"  --secret-path="path/of/the/secret" --snmp-port=2024
+    ...    --pass-manager hashicorpvault
+    ...    --vault-address='127.0.0.1'
+    ...    --vault-port 3000
+    ...    --vault-protocol http
+    ...    --auth-method userpass
+    ...    --auth-settings="username=hcvaultuser"
+    ...    --secret-path="path/of/the/secret"
+    ...    --snmp-port=2024
     ...    --map-option="snmp_community=\\%{value_path/of/the/secret}"
-    ...    --mode=string-value  --snmp-version=2c --oid='.1.3.6.1.2.1.1.1.0' ${path-param} --format-ok='current value is: \\%{details_ok}' --format-details-warning='current value is: \\%{details_warning}'  --format-details-critical='current value is: \\%{details_critical}'
-     ${output}    Run
+    ...    --mode=string-value
+    ...    --snmp-version=2c
+    ...    --oid='.1.3.6.1.2.1.1.1.0' ${path-param}
+    ...    --format-ok='current value is: \\%{details_ok}'
+    ...    --format-details-warning='current value is: \\%{details_warning}'
+    ...    --format-details-critical='current value is: \\%{details_critical}'
+    ${output}    Run
     ...    ${cmd_hashicorp}
     ${output}    Strip String    ${output}
     Should Be Equal As Strings
@@ -39,6 +51,7 @@ check hashicorp vault manager${Name}
     ...    default path    --auth-path='' --auth-settings="password=secrethashicorpPassword"    OK: current value is: Linux centreon-devbox 5.10.0-28-amd64 #1 SMP Debian 5.10.209-2 (2024-01-31) x86_64
     ...    wrong path    --auth-path='specific-url' --auth-settings="password=secrethashicorpPassword"    OK: current value is: Linux centreon-devbox 5.10.0-28-amd64 #1 SMP Debian 5.10.209-2 (2024-01-31) x86_64
     ...    wrong password    --auth-path='' --auth-settings="password=WrongPassword"    UNKNOWN: 401 Unauthorized
+
 
 *** Keywords ***
 Start Mockoon

--- a/tests/functional/snmp/apps-protocols-snmp.robot
+++ b/tests/functional/snmp/apps-protocols-snmp.robot
@@ -15,7 +15,7 @@ Test Timeout        120s
 ${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 ${MOCKOON_JSON}         ${CURDIR}${/}..${/}..${/}resources${/}mockoon${/}centreon-plugins-passwordmgr-hashicorpvault.json
 
-${CMD}                  perl ${CENTREON_PLUGINS} --plugin apps::protocols::snmp::plugin    --hostname=127.0.0.1
+${CMD}                  perl ${CENTREON_PLUGINS} --plugin apps::protocols::snmp::plugin --hostname=127.0.0.1
 
 
 *** Test Cases ***
@@ -24,11 +24,11 @@ check hashicorp vault manager${Name}
     [Tags]    snmp    vault
     ${cmd_hashicorp}    Catenate
     ...    ${CMD}
-    ...    --pass-manager hashicorpvault
-    ...    --vault-address='127.0.0.1'
-    ...    --vault-port 3000
-    ...    --vault-protocol http
-    ...    --auth-method userpass
+    ...    --pass-manager=hashicorpvault
+    ...    --vault-address=127.0.0.1
+    ...    --vault-port=3000
+    ...    --vault-protocol=http
+    ...    --auth-method=userpass
     ...    --auth-settings="username=hcvaultuser"
     ...    --secret-path="path/of/the/secret"
     ...    --snmp-port=2024

--- a/tests/functional/snmp/apps-protocols-snmp.robot
+++ b/tests/functional/snmp/apps-protocols-snmp.robot
@@ -35,6 +35,7 @@ check hashicorp vault manager${Name}
     ...    --map-option="snmp_community=\\%{value_path/of/the/secret}"
     ...    --mode=string-value
     ...    --snmp-version=2c
+    ...    --snmp-community=apps/protocols/snmp
     ...    --oid='.1.3.6.1.2.1.1.1.0' ${path-param}
     ...    --format-ok='current value is: \\%{details_ok}'
     ...    --format-details-warning='current value is: \\%{details_warning}'

--- a/tests/functional/snmp/apps-protocols-snmp.robot
+++ b/tests/functional/snmp/apps-protocols-snmp.robot
@@ -1,0 +1,55 @@
+*** Settings ***
+Documentation       OS Linux SNMP plugin
+
+Library             Examples
+Library             OperatingSystem
+Library             Process
+Library             String
+
+Test Timeout        120s
+Suite Setup         Start Mockoon
+Suite Teardown      Stop Mockoon
+
+*** Variables ***
+${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${MOCKOON_JSON}         ${CURDIR}${/}..${/}..${/}resources${/}mockoon${/}centreon-plugins-passwordmgr-hashicorpvault.json
+
+${CMD}                  perl ${CENTREON_PLUGINS} --plugin apps::protocols::snmp::plugin  --hostname=127.0.0.1
+
+
+*** Test Cases ***
+check hashicorp vault manager${Name}
+    [Documentation]    Check hashicorp vaultmanager
+    [Tags]    snmp    vault
+    ${cmd_hashicorp}    Catenate
+    ...    ${CMD}
+    ...    --pass-manager hashicorpvault --vault-address='127.0.0.1' --vault-port 3000 --vault-protocol http --auth-method userpass
+    ...    --auth-settings="username=hcvaultuser"  --secret-path="path/of/the/secret" --snmp-port=2024
+    ...    --map-option="snmp_community=\\%{value_path/of/the/secret}"
+    ...    --mode=string-value  --snmp-version=2c --oid='.1.3.6.1.2.1.1.1.0' ${path-param} --format-ok='current value is: \\%{details_ok}' --format-details-warning='current value is: \\%{details_warning}'  --format-details-critical='current value is: \\%{details_critical}'
+     ${output}    Run
+    ...    ${cmd_hashicorp}
+    ${output}    Strip String    ${output}
+    Should Be Equal As Strings
+    ...    ${output}
+    ...    ${result}
+    ...    Wrong output result for hashicorp auth manager on snmp generic plugin :\n\n ${output} \n\n ${result}\n\n
+
+    Examples:    Name    path-param    result   --
+    ...    default path    --auth-path='' --auth-settings="password=secrethashicorpPassword"    OK: current value is: Linux centreon-devbox 5.10.0-28-amd64 #1 SMP Debian 5.10.209-2 (2024-01-31) x86_64
+    ...    wrong path    --auth-path='specific-url' --auth-settings="password=secrethashicorpPassword"    OK: current value is: Linux centreon-devbox 5.10.0-28-amd64 #1 SMP Debian 5.10.209-2 (2024-01-31) x86_64
+    ...    wrong password    --auth-path='' --auth-settings="password=WrongPassword"    UNKNOWN: 401 Unauthorized
+
+*** Keywords ***
+Start Mockoon
+    ${process}    Start Process
+    ...    mockoon-cli
+    ...    start
+    ...    --data
+    ...    ${MOCKOON_JSON}
+    ...    --port
+    ...    3000
+    Sleep    5s
+
+Stop Mockoon
+    Terminate All Processes

--- a/tests/functional/snmp/hardware-sensors-apc-snmp.robot
+++ b/tests/functional/snmp/hardware-sensors-apc-snmp.robot
@@ -32,7 +32,7 @@ APC Sensors ${tc}/9
     ...    ${output}
     ...    ${expected_result}
     ...    Wrong output result for compliance of ${expected_result}{\n}Command output:{\n}${output}{\n}{\n}{\n}
-#--component 'temperature' --warning='humidity,.,45:65' --critical='humidity,.,35:70' 
+# --component 'temperature' --warning='humidity,.,45:65' --critical='humidity,.,35:70'
     Examples:        tc    component      warning                 critical               expected_result    --
             ...      1     _empty_        _empty_                 _empty_                OK: All 2 components are ok [2/2 temperatures]. | 'Main Module:Sonde de temperature#hardware.sensor.temperature.celsius'=23C;;;; 'Main Module:Sonde de temperature#hardware.sensor.humidity.percentage'=35%;;;0;100 'hardware.temperature.count'=2;;;;
             ...      2     _empty_        humidity,.,45:65        _empty_                WARNING: Humidity 'Main Module:Sonde de temperature' is 35 % | 'Main Module:Sonde de temperature#hardware.sensor.temperature.celsius'=23C;;;; 'Main Module:Sonde de temperature#hardware.sensor.humidity.percentage'=35%;45:65;;0;100 'hardware.temperature.count'=2;;;;

--- a/tests/functional/snmp/hardware-sensors-apc-snmp.robot
+++ b/tests/functional/snmp/hardware-sensors-apc-snmp.robot
@@ -9,22 +9,23 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS} --plugin=hardware::sensors::apc::snmp::plugin --mode=sensors --hostname=127.0.0.1 --snmp-version=2c --snmp-port=2024
+${CMD}                  perl ${CENTREON_PLUGINS} --plugin=hardware::sensors::apc::snmp::plugin --mode=sensors --hostname=127.0.0.1 --snmp-version=2c --snmp-port=2024
+
 
 *** Test Cases ***
 APC Sensors ${tc}/9
-    [Tags]    hardware    Sensors    snmp
+    [Tags]    hardware    sensors    snmp
     ${command}    Catenate
     ...    ${CMD}
     ...    --snmp-community=hardware/sensors/apc/sensors
 
     # Append options to command
-    ${command}    Append Option To Command    ${command}    --warning   ${warning}
-    ${command}    Append Option To Command    ${command}    --critical   ${critical}
-    ${command}    Append Option To Command    ${command}    --component   ${component}
-    
+    ${command}    Append Option To Command    ${command}    --warning    ${warning}
+    ${command}    Append Option To Command    ${command}    --critical    ${critical}
+    ${command}    Append Option To Command    ${command}    --component    ${component}
+
     ${output}    Run    ${command}
     ${output}    Strip String    ${output}
     Should Be Equal As Strings
@@ -43,11 +44,10 @@ APC Sensors ${tc}/9
             ...      8     _empty_        temperature,.,22:25     temperature,.,22:25    OK: All 2 components are ok [2/2 temperatures]. | 'Main Module:Sonde de temperature#hardware.sensor.temperature.celsius'=23C;22:25;22:25;; 'Main Module:Sonde de temperature#hardware.sensor.humidity.percentage'=35%;;;0;100 'hardware.temperature.count'=2;;;;
             ...      9     _empty_        _empty_                 _empty_                OK: All 2 components are ok [2/2 temperatures]. | 'Main Module:Sonde de temperature#hardware.sensor.temperature.celsius'=23C;;;; 'Main Module:Sonde de temperature#hardware.sensor.humidity.percentage'=35%;;;0;100 'hardware.temperature.count'=2;;;;
 
-*** Keywords ***
 
+*** Keywords ***
 Append Option To Command
     [Documentation]    Concatenates the first argument (option) with the second (value) after having replaced the value with "" if its content is '_empty_'
     [Arguments]    ${cmd}    ${option}    ${value}
     ${value}    Set Variable If    '${value}' == '_empty_'    ''    ${value}
-    [return]    ${cmd} ${option}=${value}
-
+    RETURN    ${cmd} ${option}=${value}

--- a/tests/functional/snmp/hardware-ups-socomec-netvision-snmp.robot
+++ b/tests/functional/snmp/hardware-ups-socomec-netvision-snmp.robot
@@ -9,13 +9,14 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS} --plugin=hardware::ups::socomec::netvision::snmp::plugin
+${CMD}                  perl ${CENTREON_PLUGINS} --plugin=hardware::ups::socomec::netvision::snmp::plugin
+
 
 *** Test Cases ***
 Battery ${tc}/4
-    [Tags]    hardware    UPS    snmp
+    [Tags]    hardware    ups    snmp
     ${command}    Catenate
     ...    ${CMD}
     ...    --mode=battery
@@ -25,10 +26,10 @@ Battery ${tc}/4
     ...    --snmp-community=hardware/ups/socomec/netvision/snmp/mode/battery
 
     # Append options to command
-    ${opt}        Append Option    --warning-temperature   ${w_temperature}
-    ${command}    Catenate         ${command}    ${opt}
-    ${opt}        Append Option    --critical-temperature  ${c_temperature}
-    ${command}    Catenate         ${command}    ${opt}
+    ${opt}    Append Option    --warning-temperature    ${w_temperature}
+    ${command}    Catenate    ${command}    ${opt}
+    ${opt}    Append Option    --critical-temperature    ${c_temperature}
+    ${command}    Catenate    ${command}    ${opt}
 
     ${output}    Run    ${command}
     ${output}    Strip String    ${output}
@@ -43,10 +44,10 @@ Battery ${tc}/4
             ...      3     10               20               CRITICAL: temperature: 22 C | 'battery.charge.remaining.percent'=100%;;;0;100 'battery.charge.remaining.minutes'=0;;;0; 'battery.voltage.volt'=339.1V;;;; 'battery.temperature.celsius'=22C;0:10;0:20;;
             ...      4     _empty_          _empty_          OK: battery status is normal - charge remaining: 100% (0 minutes remaining) | 'battery.charge.remaining.percent'=100%;;;0;100 'battery.charge.remaining.minutes'=0;;;0; 'battery.voltage.volt'=339.1V;;;; 'battery.temperature.celsius'=22C;;;;
 
+
 *** Keywords ***
 Append Option
     [Documentation]    Concatenates the first argument (option) with the second (value) after having replaced the value with "" if its content is '_empty_'
     [Arguments]    ${option}    ${value}
     ${value}    Set Variable If    '${value}' == '_empty_'    ''    ${value}
-    [return]    ${option}=${value}
-
+    RETURN    ${option}=${value}

--- a/tests/functional/snmp/hardware-ups-sputnik-snmp.robot
+++ b/tests/functional/snmp/hardware-ups-sputnik-snmp.robot
@@ -9,13 +9,14 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS} --plugin=hardware::ups::inmatics::sputnik::snmp::plugin
+${CMD}                  perl ${CENTREON_PLUGINS} --plugin=hardware::ups::inmatics::sputnik::snmp::plugin
+
 
 *** Test Cases ***
 Sputnik UPS - Environment ${tc}/9
-    [Tags]    hardware    UPS    snmp
+    [Tags]    hardware    ups    snmp
     ${command}    Catenate
     ...    ${CMD}
     ...    --mode=environment
@@ -25,15 +26,15 @@ Sputnik UPS - Environment ${tc}/9
     ...    --snmp-community=hardware-ups/hardware-ups-sputnik
 
     # Append options to command
-    ${opt}    Append Option    --warning-temperature   ${w_temperature}
+    ${opt}    Append Option    --warning-temperature    ${w_temperature}
     ${command}    Catenate    ${command}    ${opt}
-    ${opt}    Append Option    --critical-temperature  ${c_temperature}
+    ${opt}    Append Option    --critical-temperature    ${c_temperature}
     ${command}    Catenate    ${command}    ${opt}
-    ${opt}    Append Option    --warning-humidity      ${w_humidity}
+    ${opt}    Append Option    --warning-humidity    ${w_humidity}
     ${command}    Catenate    ${command}    ${opt}
-    ${opt}    Append Option    --critical-humidity     ${c_humidity}
+    ${opt}    Append Option    --critical-humidity    ${c_humidity}
     ${command}    Catenate    ${command}    ${opt}
-    ${opt}    Append Option    --filter-id             ${filter_id}
+    ${opt}    Append Option    --filter-id    ${filter_id}
     ${command}    Catenate    ${command}    ${opt}
 
     ${output}    Run    ${command}
@@ -54,10 +55,10 @@ Sputnik UPS - Environment ${tc}/9
             ...      8     2            30               50               50            70            UNKNOWN: No sensors found.
             ...      9     1            _empty_          _empty_          _empty_       _empty_       OK: 'Sensor 1': temperature 20.06 C, humidity 33 % | 'Sensor 1#environment.temperature.celsius'=20.06C;;;; 'Sensor 1#environment.humidity.percentage'=33%;;;0;100
 
+
 *** Keywords ***
 Append Option
     [Documentation]    Concatenates the first argument (option) with the second (value) after having replaced the value with "" if its content is '_empty_'
     [Arguments]    ${option}    ${value}
     ${value}    Set Variable If    '${value}' == '_empty_'    ''    ${value}
-    [return]    ${option}=${value}
-
+    RETURN    ${option}=${value}

--- a/tests/functional/snmp/hardware-ups-standard-snmp.robot
+++ b/tests/functional/snmp/hardware-ups-standard-snmp.robot
@@ -8,62 +8,62 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}                                 ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS} --plugin=hardware::ups::standard::rfc1628::snmp::plugin
+${CMD}                                              perl ${CENTREON_PLUGINS} --plugin=hardware::ups::standard::rfc1628::snmp::plugin
 
 &{ups_standard_test_with_values}
-...                         snmpcommunity=hardware-ups/hardware-ups-standard
-...                         warningpower=
-...                         criticalcurrent=
-...                         warningvoltage=
-...                         warningfrequence=
-...                         excludeid=
-...                         result=OK: All input lines are ok | '1#line.input.frequence.hertz'=49.9Hz;;;; '1#line.input.voltage.volt'=233V;;;; '1#line.input.current.ampere'=0A;;;; '1#line.input.power.watt'=0W;;;; '2#line.input.frequence.hertz'=49.9Hz;;;; '2#line.input.voltage.volt'=234V;;;; '2#line.input.current.ampere'=0A;;;; '2#line.input.power.watt'=0W;;;; '3#line.input.frequence.hertz'=49.9Hz;;;; '3#line.input.voltage.volt'=234V;;;; '3#line.input.current.ampere'=0A;;;; '3#line.input.power.watt'=0W;;;;
+...                                                 snmpcommunity=hardware-ups/hardware-ups-standard
+...                                                 warningpower=
+...                                                 criticalcurrent=
+...                                                 warningvoltage=
+...                                                 warningfrequence=
+...                                                 excludeid=
+...                                                 result=OK: All input lines are ok | '1#line.input.frequence.hertz'=49.9Hz;;;; '1#line.input.voltage.volt'=233V;;;; '1#line.input.current.ampere'=0A;;;; '1#line.input.power.watt'=0W;;;; '2#line.input.frequence.hertz'=49.9Hz;;;; '2#line.input.voltage.volt'=234V;;;; '2#line.input.current.ampere'=0A;;;; '2#line.input.power.watt'=0W;;;; '3#line.input.frequence.hertz'=49.9Hz;;;; '3#line.input.voltage.volt'=234V;;;; '3#line.input.current.ampere'=0A;;;; '3#line.input.power.watt'=0W;;;;
 &{ups_standard_test_critical_with_null_values}
-...                         snmpcommunity=hardware-ups/hardware-ups-standard_null_val
-...                         warningpower='215:'
-...                         criticalcurrent='@0:214'
-...                         warningvoltage='@0:214'
-...                         warningfrequence='@0:214'
-...                         excludeid=
-...                         result=CRITICAL: Input Line '1' Frequence : 0.00 Hz, Voltage : 0.00 V, Current : 0.00 A, Power : 0.00 W - Input Line '2' Frequence : 0.00 Hz, Voltage : 0.00 V, Current : 0.00 A, Power : 0.00 W - Input Line '3' Frequence : 0.00 Hz, Voltage : 0.00 V, Current : 0.00 A, Power : 0.00 W | '1#line.input.frequence.hertz'=0Hz;@0:214;;; '1#line.input.voltage.volt'=0V;@0:214;;; '1#line.input.current.ampere'=0A;;@0:214;; '1#line.input.power.watt'=0W;215:;;; '2#line.input.frequence.hertz'=0Hz;@0:214;;; '2#line.input.voltage.volt'=0V;@0:214;;; '2#line.input.current.ampere'=0A;;@0:214;; '2#line.input.power.watt'=0W;215:;;; '3#line.input.frequence.hertz'=0Hz;@0:214;;; '3#line.input.voltage.volt'=0V;@0:214;;; '3#line.input.current.ampere'=0A;;@0:214;; '3#line.input.power.watt'=0W;215:;;;
+...                                                 snmpcommunity=hardware-ups/hardware-ups-standard_null_val
+...                                                 warningpower='215:'
+...                                                 criticalcurrent='@0:214'
+...                                                 warningvoltage='@0:214'
+...                                                 warningfrequence='@0:214'
+...                                                 excludeid=
+...                                                 result=CRITICAL: Input Line '1' Frequence : 0.00 Hz, Voltage : 0.00 V, Current : 0.00 A, Power : 0.00 W - Input Line '2' Frequence : 0.00 Hz, Voltage : 0.00 V, Current : 0.00 A, Power : 0.00 W - Input Line '3' Frequence : 0.00 Hz, Voltage : 0.00 V, Current : 0.00 A, Power : 0.00 W | '1#line.input.frequence.hertz'=0Hz;@0:214;;; '1#line.input.voltage.volt'=0V;@0:214;;; '1#line.input.current.ampere'=0A;;@0:214;; '1#line.input.power.watt'=0W;215:;;; '2#line.input.frequence.hertz'=0Hz;@0:214;;; '2#line.input.voltage.volt'=0V;@0:214;;; '2#line.input.current.ampere'=0A;;@0:214;; '2#line.input.power.watt'=0W;215:;;; '3#line.input.frequence.hertz'=0Hz;@0:214;;; '3#line.input.voltage.volt'=0V;@0:214;;; '3#line.input.current.ampere'=0A;;@0:214;; '3#line.input.power.watt'=0W;215:;;;
 &{ups_standard_test_with_exclude_option_1}
-...                         snmpcommunity=hardware-ups/hardware-ups-standard
-...                         warningpower=
-...                         criticalcurrent=
-...                         warningvoltage=
-...                         warningfrequence=
-...                         excludeid='1,2'
-...                         result=OK: Input Line '3' Frequence : 49.90 Hz, Voltage : 234.00 V, Current : 0.00 A, Power : 0.00 W | '3#line.input.frequence.hertz'=49.9Hz;;;; '3#line.input.voltage.volt'=234V;;;; '3#line.input.current.ampere'=0A;;;; '3#line.input.power.watt'=0W;;;;
+...                                                 snmpcommunity=hardware-ups/hardware-ups-standard
+...                                                 warningpower=
+...                                                 criticalcurrent=
+...                                                 warningvoltage=
+...                                                 warningfrequence=
+...                                                 excludeid='1,2'
+...                                                 result=OK: Input Line '3' Frequence : 49.90 Hz, Voltage : 234.00 V, Current : 0.00 A, Power : 0.00 W | '3#line.input.frequence.hertz'=49.9Hz;;;; '3#line.input.voltage.volt'=234V;;;; '3#line.input.current.ampere'=0A;;;; '3#line.input.power.watt'=0W;;;;
 &{ups_standard_test_with_exclude_option_2}
-...                         snmpcommunity=hardware-ups/hardware-ups-standard
-...                         warningpower=
-...                         criticalcurrent=
-...                         warningvoltage=
-...                         warningfrequence=
-...                         excludeid='1, 2'
-...                         result=OK: Input Line '3' Frequence : 49.90 Hz, Voltage : 234.00 V, Current : 0.00 A, Power : 0.00 W | '3#line.input.frequence.hertz'=49.9Hz;;;; '3#line.input.voltage.volt'=234V;;;; '3#line.input.current.ampere'=0A;;;; '3#line.input.power.watt'=0W;;;;
+...                                                 snmpcommunity=hardware-ups/hardware-ups-standard
+...                                                 warningpower=
+...                                                 criticalcurrent=
+...                                                 warningvoltage=
+...                                                 warningfrequence=
+...                                                 excludeid='1, 2'
+...                                                 result=OK: Input Line '3' Frequence : 49.90 Hz, Voltage : 234.00 V, Current : 0.00 A, Power : 0.00 W | '3#line.input.frequence.hertz'=49.9Hz;;;; '3#line.input.voltage.volt'=234V;;;; '3#line.input.current.ampere'=0A;;;; '3#line.input.power.watt'=0W;;;;
 &{ups_standard_test_with_exclude_option_3}
-...                         snmpcommunity=hardware-ups/hardware-ups-standard
-...                         warningpower=
-...                         criticalcurrent=
-...                         warningvoltage=
-...                         warningfrequence=
-...                         excludeid='1 ,3'
-...                         result=OK: Input Line '2' Frequence : 49.90 Hz, Voltage : 234.00 V, Current : 0.00 A, Power : 0.00 W | '2#line.input.frequence.hertz'=49.9Hz;;;; '2#line.input.voltage.volt'=234V;;;; '2#line.input.current.ampere'=0A;;;; '2#line.input.power.watt'=0W;;;;
+...                                                 snmpcommunity=hardware-ups/hardware-ups-standard
+...                                                 warningpower=
+...                                                 criticalcurrent=
+...                                                 warningvoltage=
+...                                                 warningfrequence=
+...                                                 excludeid='1 ,3'
+...                                                 result=OK: Input Line '2' Frequence : 49.90 Hz, Voltage : 234.00 V, Current : 0.00 A, Power : 0.00 W | '2#line.input.frequence.hertz'=49.9Hz;;;; '2#line.input.voltage.volt'=234V;;;; '2#line.input.current.ampere'=0A;;;; '2#line.input.power.watt'=0W;;;;
 @{ups_standard_tests}
-...                         &{ups_standard_test_with_values}
-...                         &{ups_standard_test_critical_with_null_values}
-...                         &{ups_standard_test_with_exclude_option_1}
-...                         &{ups_standard_test_with_exclude_option_2}
-...                         &{ups_standard_test_with_exclude_option_3}
+...                                                 &{ups_standard_test_with_values}
+...                                                 &{ups_standard_test_critical_with_null_values}
+...                                                 &{ups_standard_test_with_exclude_option_1}
+...                                                 &{ups_standard_test_with_exclude_option_2}
+...                                                 &{ups_standard_test_with_exclude_option_3}
 
 
 *** Test Cases ***
 Hardware UPS Standard SNMP input lines
     [Documentation]    Hardware UPS standard SNMP input lines
-    [Tags]    hardware    UPS    snmp
+    [Tags]    hardware    ups    snmp
     FOR    ${ups_standard_test}    IN    @{ups_standard_tests}
         ${command}    Catenate
         ...    ${CMD}

--- a/tests/functional/snmp/network-aruba-instant-ap-usage.robot
+++ b/tests/functional/snmp/network-aruba-instant-ap-usage.robot
@@ -8,51 +8,51 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS} --plugin=network::aruba::instant::snmp::plugin --mode=ap-usage --hostname=127.0.0.1 --snmp-version=2c --snmp-port=2024
+${CMD}                  perl ${CENTREON_PLUGINS} --plugin=network::aruba::instant::snmp::plugin --mode=ap-usage --hostname=127.0.0.1 --snmp-version=2c --snmp-port=2024
 
 &{ap_usage_test_1}
-...                         documentation=Test AP usage without filters
-...                         snmpcommunity=network-aruba-instant/ap-usage
-...                         filtercounters=
-...                         filtername=
-...                         warningclients=
-...                         criticalclients=
-...                         result=OK: total access points: 5 - All access points are ok | 'accesspoints.total.count'=5;;;0; 'AP Piso 1#clients.current.count'=4;;;0; 'AP Piso 1#cpu.utilization.percentage'=3.00%;;;0;100 'AP Piso 1#memory.usage.bytes'=215711744B;;;0;527028224 'AP Piso 1#memory.free.bytes'=311316480B;;;0;527028224 'AP Piso 1#memory.usage.percentage'=40.93%;;;0;100 'AP Piso 2#clients.current.count'=17;;;0; 'AP Piso 2#cpu.utilization.percentage'=18.00%;;;0;100 'AP Piso 2#memory.usage.bytes'=219455488B;;;0;527028224 'AP Piso 2#memory.free.bytes'=307572736B;;;0;527028224 'AP Piso 2#memory.usage.percentage'=41.64%;;;0;100 'AP Piso 3#clients.current.count'=14;;;0; 'AP Piso 3#cpu.utilization.percentage'=18.00%;;;0;100 'AP Piso 3#memory.usage.bytes'=219185152B;;;0;527028224 'AP Piso 3#memory.free.bytes'=307843072B;;;0;527028224 'AP Piso 3#memory.usage.percentage'=41.59%;;;0;100 'AP Piso 4#clients.current.count'=11;;;0; 'AP Piso 4#cpu.utilization.percentage'=11.00%;;;0;100 'AP Piso 4#memory.usage.bytes'=221700096B;;;0;527028224 'AP Piso 4#memory.free.bytes'=305328128B;;;0;527028224 'AP Piso 4#memory.usage.percentage'=42.07%;;;0;100 'AP Sotano#clients.current.count'=4;;;0; 'AP Sotano#cpu.utilization.percentage'=4.00%;;;0;100 'AP Sotano#memory.usage.bytes'=217473024B;;;0;527028224 'AP Sotano#memory.free.bytes'=309555200B;;;0;527028224 'AP Sotano#memory.usage.percentage'=41.26%;;;0;100
+...                     documentation=Test AP usage without filters
+...                     snmpcommunity=network-aruba-instant/ap-usage
+...                     filtercounters=
+...                     filtername=
+...                     warningclients=
+...                     criticalclients=
+...                     result=OK: total access points: 5 - All access points are ok | 'accesspoints.total.count'=5;;;0; 'AP Piso 1#clients.current.count'=4;;;0; 'AP Piso 1#cpu.utilization.percentage'=3.00%;;;0;100 'AP Piso 1#memory.usage.bytes'=215711744B;;;0;527028224 'AP Piso 1#memory.free.bytes'=311316480B;;;0;527028224 'AP Piso 1#memory.usage.percentage'=40.93%;;;0;100 'AP Piso 2#clients.current.count'=17;;;0; 'AP Piso 2#cpu.utilization.percentage'=18.00%;;;0;100 'AP Piso 2#memory.usage.bytes'=219455488B;;;0;527028224 'AP Piso 2#memory.free.bytes'=307572736B;;;0;527028224 'AP Piso 2#memory.usage.percentage'=41.64%;;;0;100 'AP Piso 3#clients.current.count'=14;;;0; 'AP Piso 3#cpu.utilization.percentage'=18.00%;;;0;100 'AP Piso 3#memory.usage.bytes'=219185152B;;;0;527028224 'AP Piso 3#memory.free.bytes'=307843072B;;;0;527028224 'AP Piso 3#memory.usage.percentage'=41.59%;;;0;100 'AP Piso 4#clients.current.count'=11;;;0; 'AP Piso 4#cpu.utilization.percentage'=11.00%;;;0;100 'AP Piso 4#memory.usage.bytes'=221700096B;;;0;527028224 'AP Piso 4#memory.free.bytes'=305328128B;;;0;527028224 'AP Piso 4#memory.usage.percentage'=42.07%;;;0;100 'AP Sotano#clients.current.count'=4;;;0; 'AP Sotano#cpu.utilization.percentage'=4.00%;;;0;100 'AP Sotano#memory.usage.bytes'=217473024B;;;0;527028224 'AP Sotano#memory.free.bytes'=309555200B;;;0;527028224 'AP Sotano#memory.usage.percentage'=41.26%;;;0;100
 
 &{ap_usage_test_2}
-...                         documentation=Test AP usage with filter on clients
-...                         snmpcommunity=network-aruba-instant/ap-usage
-...                         filtercounters=clients
-...                         filtername=
-...                         warningclients=
-...                         criticalclients=
-...                         result=OK: All access points are ok | 'AP Piso 1#clients.current.count'=4;;;0; 'AP Piso 2#clients.current.count'=17;;;0; 'AP Piso 3#clients.current.count'=14;;;0; 'AP Piso 4#clients.current.count'=11;;;0; 'AP Sotano#clients.current.count'=4;;;0;
+...                     documentation=Test AP usage with filter on clients
+...                     snmpcommunity=network-aruba-instant/ap-usage
+...                     filtercounters=clients
+...                     filtername=
+...                     warningclients=
+...                     criticalclients=
+...                     result=OK: All access points are ok | 'AP Piso 1#clients.current.count'=4;;;0; 'AP Piso 2#clients.current.count'=17;;;0; 'AP Piso 3#clients.current.count'=14;;;0; 'AP Piso 4#clients.current.count'=11;;;0; 'AP Sotano#clients.current.count'=4;;;0;
 
 &{ap_usage_test_3}
-...                         documentation=Test AP usage with filter on clients and filter on name
-...                         snmpcommunity=network-aruba-instant/ap-usage
-...                         filtercounters=clients
-...                         filtername=Piso 4
-...                         warningclients=
-...                         criticalclients=
-...                         result=OK: Access Point 'AP Piso 4' Current Clients: 11 | 'AP Piso 4#clients.current.count'=11;;;0;
+...                     documentation=Test AP usage with filter on clients and filter on name
+...                     snmpcommunity=network-aruba-instant/ap-usage
+...                     filtercounters=clients
+...                     filtername=Piso 4
+...                     warningclients=
+...                     criticalclients=
+...                     result=OK: Access Point 'AP Piso 4' Current Clients: 11 | 'AP Piso 4#clients.current.count'=11;;;0;
 
 &{ap_usage_test_4}
-...                         documentation=Test AP usage without filters with warning when less than 20 clients
-...                         snmpcommunity=network-aruba-instant/ap-usage
-...                         filtercounters=
-...                         filtername=
-...                         warningclients=20:
-...                         criticalclients=
-...                         result=WARNING: Access Point 'AP Piso 1' Current Clients: 4 - Access Point 'AP Piso 2' Current Clients: 17 - Access Point 'AP Piso 3' Current Clients: 14 - Access Point 'AP Piso 4' Current Clients: 11 - Access Point 'AP Sotano' Current Clients: 4 | 'accesspoints.total.count'=5;;;0; 'AP Piso 1#clients.current.count'=4;20:;;0; 'AP Piso 1#cpu.utilization.percentage'=3.00%;;;0;100 'AP Piso 1#memory.usage.bytes'=215711744B;;;0;527028224 'AP Piso 1#memory.free.bytes'=311316480B;;;0;527028224 'AP Piso 1#memory.usage.percentage'=40.93%;;;0;100 'AP Piso 2#clients.current.count'=17;20:;;0; 'AP Piso 2#cpu.utilization.percentage'=18.00%;;;0;100 'AP Piso 2#memory.usage.bytes'=219455488B;;;0;527028224 'AP Piso 2#memory.free.bytes'=307572736B;;;0;527028224 'AP Piso 2#memory.usage.percentage'=41.64%;;;0;100 'AP Piso 3#clients.current.count'=14;20:;;0; 'AP Piso 3#cpu.utilization.percentage'=18.00%;;;0;100 'AP Piso 3#memory.usage.bytes'=219185152B;;;0;527028224 'AP Piso 3#memory.free.bytes'=307843072B;;;0;527028224 'AP Piso 3#memory.usage.percentage'=41.59%;;;0;100 'AP Piso 4#clients.current.count'=11;20:;;0; 'AP Piso 4#cpu.utilization.percentage'=11.00%;;;0;100 'AP Piso 4#memory.usage.bytes'=221700096B;;;0;527028224 'AP Piso 4#memory.free.bytes'=305328128B;;;0;527028224 'AP Piso 4#memory.usage.percentage'=42.07%;;;0;100 'AP Sotano#clients.current.count'=4;20:;;0; 'AP Sotano#cpu.utilization.percentage'=4.00%;;;0;100 'AP Sotano#memory.usage.bytes'=217473024B;;;0;527028224 'AP Sotano#memory.free.bytes'=309555200B;;;0;527028224 'AP Sotano#memory.usage.percentage'=41.26%;;;0;100
+...                     documentation=Test AP usage without filters with warning when less than 20 clients
+...                     snmpcommunity=network-aruba-instant/ap-usage
+...                     filtercounters=
+...                     filtername=
+...                     warningclients=20:
+...                     criticalclients=
+...                     result=WARNING: Access Point 'AP Piso 1' Current Clients: 4 - Access Point 'AP Piso 2' Current Clients: 17 - Access Point 'AP Piso 3' Current Clients: 14 - Access Point 'AP Piso 4' Current Clients: 11 - Access Point 'AP Sotano' Current Clients: 4 | 'accesspoints.total.count'=5;;;0; 'AP Piso 1#clients.current.count'=4;20:;;0; 'AP Piso 1#cpu.utilization.percentage'=3.00%;;;0;100 'AP Piso 1#memory.usage.bytes'=215711744B;;;0;527028224 'AP Piso 1#memory.free.bytes'=311316480B;;;0;527028224 'AP Piso 1#memory.usage.percentage'=40.93%;;;0;100 'AP Piso 2#clients.current.count'=17;20:;;0; 'AP Piso 2#cpu.utilization.percentage'=18.00%;;;0;100 'AP Piso 2#memory.usage.bytes'=219455488B;;;0;527028224 'AP Piso 2#memory.free.bytes'=307572736B;;;0;527028224 'AP Piso 2#memory.usage.percentage'=41.64%;;;0;100 'AP Piso 3#clients.current.count'=14;20:;;0; 'AP Piso 3#cpu.utilization.percentage'=18.00%;;;0;100 'AP Piso 3#memory.usage.bytes'=219185152B;;;0;527028224 'AP Piso 3#memory.free.bytes'=307843072B;;;0;527028224 'AP Piso 3#memory.usage.percentage'=41.59%;;;0;100 'AP Piso 4#clients.current.count'=11;20:;;0; 'AP Piso 4#cpu.utilization.percentage'=11.00%;;;0;100 'AP Piso 4#memory.usage.bytes'=221700096B;;;0;527028224 'AP Piso 4#memory.free.bytes'=305328128B;;;0;527028224 'AP Piso 4#memory.usage.percentage'=42.07%;;;0;100 'AP Sotano#clients.current.count'=4;20:;;0; 'AP Sotano#cpu.utilization.percentage'=4.00%;;;0;100 'AP Sotano#memory.usage.bytes'=217473024B;;;0;527028224 'AP Sotano#memory.free.bytes'=309555200B;;;0;527028224 'AP Sotano#memory.usage.percentage'=41.26%;;;0;100
 
 @{ap_usage_tests}
-...                         &{ap_usage_test_1}
-...                         &{ap_usage_test_2}
-...                         &{ap_usage_test_3}
-...                         &{ap_usage_test_4}
+...                     &{ap_usage_test_1}
+...                     &{ap_usage_test_2}
+...                     &{ap_usage_test_3}
+...                     &{ap_usage_test_4}
 
 
 *** Test Cases ***
@@ -68,7 +68,7 @@ Network Aruba Instant SNMP plugin
         ...    --critical-clients='${ap_usage_tc.criticalclients}'
         ...    --snmp-community=${ap_usage_tc.snmpcommunity}
 
-        Log To Console      ${ap_usage_tc.documentation}
+        Log To Console    ${ap_usage_tc.documentation}
         ${output}    Run    ${command}
         ${output}    Strip String    ${output}
         Should Be Equal As Strings
@@ -76,4 +76,3 @@ Network Aruba Instant SNMP plugin
         ...    ${ap_usage_tc.result}
         ...    Wrong output result for compliance of ${ap_usage_tc.result}{\n}Command output:{\n}${output}{\n}{\n}{\n}
     END
-

--- a/tests/functional/snmp/network-fortinet-fortigate-snmp.robot
+++ b/tests/functional/snmp/network-fortinet-fortigate-snmp.robot
@@ -8,302 +8,303 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}                             ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS} --plugin=network::fortinet::fortigate::snmp::plugin
+${CMD}                                          perl ${CENTREON_PLUGINS} --plugin=network::fortinet::fortigate::snmp::plugin
 
 # Test simple usage of the linkmonitor mode
 &{fortinet_fortigate_linkmonitor_test1}
-...                         filterid=
-...                         filtername=
-...                         filtervdom=
-...                         customperfdatainstances=
-...                         unknownstatus=
-...                         warningstatus=
-...                         criticalstatus=
-...                         warninglatency=
-...                         criticallatency=
-...                         warningjitter=
-...                         criticaljitter=
-...                         warningpacketloss=
-...                         criticalpacketloss=
-...                         result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
+...                                             filterid=
+...                                             filtername=
+...                                             filtervdom=
+...                                             customperfdatainstances=
+...                                             unknownstatus=
+...                                             warningstatus=
+...                                             criticalstatus=
+...                                             warninglatency=
+...                                             criticallatency=
+...                                             warningjitter=
+...                                             criticaljitter=
+...                                             warningpacketloss=
+...                                             criticalpacketloss=
+...                                             result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
 
 # Test linkmonitor mode with filter-id option set to 3
 &{fortinet_fortigate_linkmonitor_test2}
-...                         filterid=3
-...                         filtername=
-...                         filtervdom=
-...                         customperfdatainstances=
-...                         unknownstatus=
-...                         warningstatus=
-...                         criticalstatus=
-...                         warninglatency=
-...                         criticallatency=
-...                         warningjitter=
-...                         criticaljitter=
-...                         warningpacketloss=
-...                         criticalpacketloss=
-...                         result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead | 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
+...                                             filterid=3
+...                                             filtername=
+...                                             filtervdom=
+...                                             customperfdatainstances=
+...                                             unknownstatus=
+...                                             warningstatus=
+...                                             criticalstatus=
+...                                             warninglatency=
+...                                             criticallatency=
+...                                             warningjitter=
+...                                             criticaljitter=
+...                                             warningpacketloss=
+...                                             criticalpacketloss=
+...                                             result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead | 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
 
 # Test linkmonitor mode with filter-name option set to MonitorWAN1
 &{fortinet_fortigate_linkmonitor_test3}
-...                         filterid=
-...                         filtername='MonitorWAN1'
-...                         filtervdom=
-...                         customperfdatainstances=
-...                         unknownstatus=
-...                         warningstatus=
-...                         criticalstatus=
-...                         warninglatency=
-...                         criticallatency=
-...                         warningjitter=
-...                         criticaljitter=
-...                         warningpacketloss=
-...                         criticalpacketloss=
-...                         result=OK: Link monitor 'MonitorWAN1' [vdom: root] [id: 1] state: alive, latency: 39.739ms, jitter: 0.096ms, packet loss: 0.000% | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0;
+...                                             filterid=
+...                                             filtername='MonitorWAN1'
+...                                             filtervdom=
+...                                             customperfdatainstances=
+...                                             unknownstatus=
+...                                             warningstatus=
+...                                             criticalstatus=
+...                                             warninglatency=
+...                                             criticallatency=
+...                                             warningjitter=
+...                                             criticaljitter=
+...                                             warningpacketloss=
+...                                             criticalpacketloss=
+...                                             result=OK: Link monitor 'MonitorWAN1' [vdom: root] [id: 1] state: alive, latency: 39.739ms, jitter: 0.096ms, packet loss: 0.000% | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0;
 
 # Test linkmonitor mode with filter-vdom option set to 'root'
 &{fortinet_fortigate_linkmonitor_test4}
-...                         filterid=
-...                         filtername=
-...                         filtervdom='root'
-...                         customperfdatainstances=
-...                         unknownstatus=
-...                         warningstatus=
-...                         criticalstatus=
-...                         warninglatency=
-...                         criticallatency=
-...                         warningjitter=
-...                         criticaljitter=
-...                         warningpacketloss=
-...                         criticalpacketloss=
-...                         result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
+...                                             filterid=
+...                                             filtername=
+...                                             filtervdom='root'
+...                                             customperfdatainstances=
+...                                             unknownstatus=
+...                                             warningstatus=
+...                                             criticalstatus=
+...                                             warninglatency=
+...                                             criticallatency=
+...                                             warningjitter=
+...                                             criticaljitter=
+...                                             warningpacketloss=
+...                                             criticalpacketloss=
+...                                             result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
 
 # Test linkmonitor mode with custom-perf-data-instances option set to '%(name) %(id)'
 &{fortinet_fortigate_linkmonitor_test5}
-...                         filterid=
-...                         filtername=
-...                         filtervdom=
-...                         customperfdatainstances='%(name) %(id)'
-...                         unknownstatus=
-...                         warningstatus=
-...                         criticalstatus=
-...                         warninglatency=
-...                         criticallatency=
-...                         warningjitter=
-...                         criticaljitter=
-...                         warningpacketloss=
-...                         criticalpacketloss=
-...                         result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead | 'MonitorWAN1~1#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~1#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~1#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~2#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~2#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~2#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~3#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~3#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~3#linkmonitor.packet.loss.percentage'=100;;;0;
+...                                             filterid=
+...                                             filtername=
+...                                             filtervdom=
+...                                             customperfdatainstances='%(name) %(id)'
+...                                             unknownstatus=
+...                                             warningstatus=
+...                                             criticalstatus=
+...                                             warninglatency=
+...                                             criticallatency=
+...                                             warningjitter=
+...                                             criticaljitter=
+...                                             warningpacketloss=
+...                                             criticalpacketloss=
+...                                             result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead | 'MonitorWAN1~1#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~1#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~1#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~2#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~2#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~2#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~3#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~3#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~3#linkmonitor.packet.loss.percentage'=100;;;0;
 
 # Test linkmonitor mode with unknown-status option set to '%{state} eq "alive"'
 &{fortinet_fortigate_linkmonitor_test6}
-...                         filterid=
-...                         filtername=
-...                         filtervdom=
-...                         customperfdatainstances=
-...                         unknownstatus='\%{state} eq "alive"'
-...                         warningstatus=
-...                         criticalstatus=
-...                         warninglatency=
-...                         criticallatency=
-...                         warningjitter=
-...                         criticaljitter=
-...                         warningpacketloss=
-...                         criticalpacketloss=
-...                         result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead UNKNOWN: Link monitor 'MonitorWAN1' [vdom: root] [id: 1] state: alive - Link monitor 'MonitorWAN2' [vdom: root] [id: 2] state: alive | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
+...                                             filterid=
+...                                             filtername=
+...                                             filtervdom=
+...                                             customperfdatainstances=
+...                                             unknownstatus='\%{state} eq "alive"'
+...                                             warningstatus=
+...                                             criticalstatus=
+...                                             warninglatency=
+...                                             criticallatency=
+...                                             warningjitter=
+...                                             criticaljitter=
+...                                             warningpacketloss=
+...                                             criticalpacketloss=
+...                                             result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead UNKNOWN: Link monitor 'MonitorWAN1' [vdom: root] [id: 1] state: alive - Link monitor 'MonitorWAN2' [vdom: root] [id: 2] state: alive | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
 
 # Test linkmonitor mode with warning-status option set to '%{state} eq "alive"'
 &{fortinet_fortigate_linkmonitor_test7}
-...                         filterid=
-...                         filtername=
-...                         filtervdom=
-...                         customperfdatainstances=
-...                         unknownstatus=
-...                         warningstatus='\%{state} eq "alive"'
-...                         criticalstatus=
-...                         warninglatency=
-...                         criticallatency=
-...                         warningjitter=
-...                         criticaljitter=
-...                         warningpacketloss=
-...                         criticalpacketloss=
-...                         result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead WARNING: Link monitor 'MonitorWAN1' [vdom: root] [id: 1] state: alive - Link monitor 'MonitorWAN2' [vdom: root] [id: 2] state: alive | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
+...                                             filterid=
+...                                             filtername=
+...                                             filtervdom=
+...                                             customperfdatainstances=
+...                                             unknownstatus=
+...                                             warningstatus='\%{state} eq "alive"'
+...                                             criticalstatus=
+...                                             warninglatency=
+...                                             criticallatency=
+...                                             warningjitter=
+...                                             criticaljitter=
+...                                             warningpacketloss=
+...                                             criticalpacketloss=
+...                                             result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead WARNING: Link monitor 'MonitorWAN1' [vdom: root] [id: 1] state: alive - Link monitor 'MonitorWAN2' [vdom: root] [id: 2] state: alive | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
 
 # Test linkmonitor mode with critical-status option set to '%{state} eq "alive"'
 &{fortinet_fortigate_linkmonitor_test8}
-...                         filterid=
-...                         filtername=
-...                         filtervdom=
-...                         customperfdatainstances=
-...                         unknownstatus=
-...                         warningstatus=
-...                         criticalstatus='\%{state} eq "alive"'
-...                         warninglatency=
-...                         criticallatency=
-...                         warningjitter=
-...                         criticaljitter=
-...                         warningpacketloss=
-...                         criticalpacketloss=
-...                         result=CRITICAL: Link monitor 'MonitorWAN1' [vdom: root] [id: 1] state: alive - Link monitor 'MonitorWAN2' [vdom: root] [id: 2] state: alive | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
+...                                             filterid=
+...                                             filtername=
+...                                             filtervdom=
+...                                             customperfdatainstances=
+...                                             unknownstatus=
+...                                             warningstatus=
+...                                             criticalstatus='\%{state} eq "alive"'
+...                                             warninglatency=
+...                                             criticallatency=
+...                                             warningjitter=
+...                                             criticaljitter=
+...                                             warningpacketloss=
+...                                             criticalpacketloss=
+...                                             result=CRITICAL: Link monitor 'MonitorWAN1' [vdom: root] [id: 1] state: alive - Link monitor 'MonitorWAN2' [vdom: root] [id: 2] state: alive | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
 
 # Test linkmonitor mode with warning-latency option set to 40
 &{fortinet_fortigate_linkmonitor_test9}
-...                         filterid=
-...                         filtername=
-...                         filtervdom=
-...                         customperfdatainstances=
-...                         unknownstatus=
-...                         warningstatus=
-...                         criticalstatus=
-...                         warninglatency=40
-...                         criticallatency=
-...                         warningjitter=
-...                         criticaljitter=
-...                         warningpacketloss=
-...                         criticalpacketloss=
-...                         result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead WARNING: Link monitor 'MonitorWAN2' [vdom: root] [id: 2] latency: 46.446ms | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;0:40;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;0:40;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;0:40;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
+...                                             filterid=
+...                                             filtername=
+...                                             filtervdom=
+...                                             customperfdatainstances=
+...                                             unknownstatus=
+...                                             warningstatus=
+...                                             criticalstatus=
+...                                             warninglatency=40
+...                                             criticallatency=
+...                                             warningjitter=
+...                                             criticaljitter=
+...                                             warningpacketloss=
+...                                             criticalpacketloss=
+...                                             result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead WARNING: Link monitor 'MonitorWAN2' [vdom: root] [id: 2] latency: 46.446ms | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;0:40;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;0:40;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;0:40;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
 
 # Test linkmonitor mode with critical-latency option set to 40
 &{fortinet_fortigate_linkmonitor_test10}
-...                         filterid=
-...                         filtername=
-...                         filtervdom=
-...                         customperfdatainstances=
-...                         unknownstatus=
-...                         warningstatus=
-...                         criticalstatus=
-...                         warninglatency=
-...                         criticallatency=40
-...                         warningjitter=
-...                         criticaljitter=
-...                         warningpacketloss=
-...                         criticalpacketloss=
-...                         result=CRITICAL: Link monitor 'MonitorWAN2' [vdom: root] [id: 2] latency: 46.446ms - Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;0:40;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;0:40;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;0:40;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
+...                                             filterid=
+...                                             filtername=
+...                                             filtervdom=
+...                                             customperfdatainstances=
+...                                             unknownstatus=
+...                                             warningstatus=
+...                                             criticalstatus=
+...                                             warninglatency=
+...                                             criticallatency=40
+...                                             warningjitter=
+...                                             criticaljitter=
+...                                             warningpacketloss=
+...                                             criticalpacketloss=
+...                                             result=CRITICAL: Link monitor 'MonitorWAN2' [vdom: root] [id: 2] latency: 46.446ms - Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;0:40;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;0:40;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;0:40;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
 
 # Test linkmonitor mode with warning-jitter option set to 1
 &{fortinet_fortigate_linkmonitor_test11}
-...                         filterid=
-...                         filtername=
-...                         filtervdom=
-...                         customperfdatainstances=
-...                         unknownstatus=
-...                         warningstatus=
-...                         criticalstatus=
-...                         warninglatency=
-...                         criticallatency=
-...                         warningjitter=1
-...                         criticaljitter=
-...                         warningpacketloss=
-...                         criticalpacketloss=
-...                         result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead WARNING: Link monitor 'MonitorWAN2' [vdom: root] [id: 2] jitter: 1.868ms | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;0:1;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;0:1;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;0:1;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
+...                                             filterid=
+...                                             filtername=
+...                                             filtervdom=
+...                                             customperfdatainstances=
+...                                             unknownstatus=
+...                                             warningstatus=
+...                                             criticalstatus=
+...                                             warninglatency=
+...                                             criticallatency=
+...                                             warningjitter=1
+...                                             criticaljitter=
+...                                             warningpacketloss=
+...                                             criticalpacketloss=
+...                                             result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead WARNING: Link monitor 'MonitorWAN2' [vdom: root] [id: 2] jitter: 1.868ms | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;0:1;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;0:1;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;0:1;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
 
 # Test linkmonitor mode with critical-jitter option set to 1
 &{fortinet_fortigate_linkmonitor_test12}
-...                         filterid=
-...                         filtername=
-...                         filtervdom=
-...                         customperfdatainstances=
-...                         unknownstatus=
-...                         warningstatus=
-...                         criticalstatus=
-...                         warninglatency=
-...                         criticallatency=
-...                         warningjitter=
-...                         criticaljitter=1
-...                         warningpacketloss=
-...                         criticalpacketloss=
-...                         result=CRITICAL: Link monitor 'MonitorWAN2' [vdom: root] [id: 2] jitter: 1.868ms - Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;0:1;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;0:1;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;0:1;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
+...                                             filterid=
+...                                             filtername=
+...                                             filtervdom=
+...                                             customperfdatainstances=
+...                                             unknownstatus=
+...                                             warningstatus=
+...                                             criticalstatus=
+...                                             warninglatency=
+...                                             criticallatency=
+...                                             warningjitter=
+...                                             criticaljitter=1
+...                                             warningpacketloss=
+...                                             criticalpacketloss=
+...                                             result=CRITICAL: Link monitor 'MonitorWAN2' [vdom: root] [id: 2] jitter: 1.868ms - Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;0:1;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;0:1;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;0:1;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;;0;
 
 # Test linkmonitor mode with warning-packetloss option set to 0.5
 &{fortinet_fortigate_linkmonitor_test13}
-...                         filterid=
-...                         filtername=
-...                         filtervdom=
-...                         customperfdatainstances=
-...                         unknownstatus=
-...                         warningstatus=
-...                         criticalstatus=
-...                         warninglatency=
-...                         criticallatency=
-...                         warningjitter=
-...                         criticaljitter=
-...                         warningpacketloss=0.5
-...                         criticalpacketloss=
-...                         result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead, packet loss: 100.000% WARNING: Link monitor 'MonitorWAN2' [vdom: root] [id: 2] packet loss: 1.000% | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;0:0.5;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;0:0.5;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;0:0.5;;0;
+...                                             filterid=
+...                                             filtername=
+...                                             filtervdom=
+...                                             customperfdatainstances=
+...                                             unknownstatus=
+...                                             warningstatus=
+...                                             criticalstatus=
+...                                             warninglatency=
+...                                             criticallatency=
+...                                             warningjitter=
+...                                             criticaljitter=
+...                                             warningpacketloss=0.5
+...                                             criticalpacketloss=
+...                                             result=CRITICAL: Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead, packet loss: 100.000% WARNING: Link monitor 'MonitorWAN2' [vdom: root] [id: 2] packet loss: 1.000% | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;0:0.5;;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;0:0.5;;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;0:0.5;;0;
 
 # Test linkmonitor mode with critical-packetloss option set to 0.5
 &{fortinet_fortigate_linkmonitor_test14}
-...                         filterid=
-...                         filtername=
-...                         filtervdom=
-...                         customperfdatainstances=
-...                         unknownstatus=
-...                         warningstatus=
-...                         criticalstatus=
-...                         warninglatency=
-...                         criticallatency=
-...                         warningjitter=
-...                         criticaljitter=
-...                         warningpacketloss=
-...                         criticalpacketloss=0.5
-...                         result=CRITICAL: Link monitor 'MonitorWAN2' [vdom: root] [id: 2] packet loss: 1.000% - Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead, packet loss: 100.000% | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;0:0.5;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;0:0.5;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;0:0.5;0;
+...                                             filterid=
+...                                             filtername=
+...                                             filtervdom=
+...                                             customperfdatainstances=
+...                                             unknownstatus=
+...                                             warningstatus=
+...                                             criticalstatus=
+...                                             warninglatency=
+...                                             criticallatency=
+...                                             warningjitter=
+...                                             criticaljitter=
+...                                             warningpacketloss=
+...                                             criticalpacketloss=0.5
+...                                             result=CRITICAL: Link monitor 'MonitorWAN2' [vdom: root] [id: 2] packet loss: 1.000% - Link monitor 'MonitorWAN3' [vdom: root] [id: 3] state: dead, packet loss: 100.000% | 'MonitorWAN1~root#linkmonitor.latency.milliseconds'=39.739;;;0; 'MonitorWAN1~root#linkmonitor.jitter.milliseconds'=0.096;;;0; 'MonitorWAN1~root#linkmonitor.packet.loss.percentage'=0;;0:0.5;0; 'MonitorWAN2~root#linkmonitor.latency.milliseconds'=46.446;;;0; 'MonitorWAN2~root#linkmonitor.jitter.milliseconds'=1.868;;;0; 'MonitorWAN2~root#linkmonitor.packet.loss.percentage'=1;;0:0.5;0; 'MonitorWAN3~root#linkmonitor.latency.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.jitter.milliseconds'=0.000;;;0; 'MonitorWAN3~root#linkmonitor.packet.loss.percentage'=100;;0:0.5;0;
 
 @{fortinet_fortigate_linkmonitor_tests}
-...                         &{fortinet_fortigate_linkmonitor_test1}
-...                         &{fortinet_fortigate_linkmonitor_test2}
-...                         &{fortinet_fortigate_linkmonitor_test3}
-...                         &{fortinet_fortigate_linkmonitor_test4}
-...                         &{fortinet_fortigate_linkmonitor_test5}
-...                         &{fortinet_fortigate_linkmonitor_test6}
-...                         &{fortinet_fortigate_linkmonitor_test7}
-...                         &{fortinet_fortigate_linkmonitor_test8}
-...                         &{fortinet_fortigate_linkmonitor_test9}
-...                         &{fortinet_fortigate_linkmonitor_test10}
-...                         &{fortinet_fortigate_linkmonitor_test11}
-...                         &{fortinet_fortigate_linkmonitor_test12}
-...                         &{fortinet_fortigate_linkmonitor_test13}
-...                         &{fortinet_fortigate_linkmonitor_test14}
+...                                             &{fortinet_fortigate_linkmonitor_test1}
+...                                             &{fortinet_fortigate_linkmonitor_test2}
+...                                             &{fortinet_fortigate_linkmonitor_test3}
+...                                             &{fortinet_fortigate_linkmonitor_test4}
+...                                             &{fortinet_fortigate_linkmonitor_test5}
+...                                             &{fortinet_fortigate_linkmonitor_test6}
+...                                             &{fortinet_fortigate_linkmonitor_test7}
+...                                             &{fortinet_fortigate_linkmonitor_test8}
+...                                             &{fortinet_fortigate_linkmonitor_test9}
+...                                             &{fortinet_fortigate_linkmonitor_test10}
+...                                             &{fortinet_fortigate_linkmonitor_test11}
+...                                             &{fortinet_fortigate_linkmonitor_test12}
+...                                             &{fortinet_fortigate_linkmonitor_test13}
+...                                             &{fortinet_fortigate_linkmonitor_test14}
 
 # Test simple usage of the list-linkmonitors mode
 &{fortinet_fortigate_listlinkmonitors_test1}
-...                         filterstate=
-...                         filtername=
-...                         filtervdom=
-...                         result=List link monitors: \n[Name = MonitorWAN1] [Vdom = root] [State = alive]\n[Name = MonitorWAN2] [Vdom = root] [State = alive]\n[Name = MonitorWAN3] [Vdom = root] [State = dead]
+...                                             filterstate=
+...                                             filtername=
+...                                             filtervdom=
+...                                             result=List link monitors: \n[Name = MonitorWAN1] [Vdom = root] [State = alive]\n[Name = MonitorWAN2] [Vdom = root] [State = alive]\n[Name = MonitorWAN3] [Vdom = root] [State = dead]
 
 # Test list-linkmonitors mode with filter-name option set to MonitorWAN1
 &{fortinet_fortigate_listlinkmonitors_test2}
-...                         filterstate=
-...                         filtername='MonitorWAN1'
-...                         filtervdom=
-...                         result=List link monitors: \n[Name = MonitorWAN1] [Vdom = root] [State = alive]
+...                                             filterstate=
+...                                             filtername='MonitorWAN1'
+...                                             filtervdom=
+...                                             result=List link monitors: \n[Name = MonitorWAN1] [Vdom = root] [State = alive]
 
 # Test list-linkmonitors mode with filter-state option set to alive
 &{fortinet_fortigate_listlinkmonitors_test3}
-...                         filterstate='alive'
-...                         filtername=
-...                         filtervdom=
-...                         result=List link monitors: \n[Name = MonitorWAN1] [Vdom = root] [State = alive]\n[Name = MonitorWAN2] [Vdom = root] [State = alive]
+...                                             filterstate='alive'
+...                                             filtername=
+...                                             filtervdom=
+...                                             result=List link monitors: \n[Name = MonitorWAN1] [Vdom = root] [State = alive]\n[Name = MonitorWAN2] [Vdom = root] [State = alive]
 
 # Test list-linkmonitors mode with filter-vdom option set to root
 &{fortinet_fortigate_listlinkmonitors_test4}
-...                         filterstate=
-...                         filtername=
-...                         filtervdom='root'
-...                         result=List link monitors: \n[Name = MonitorWAN1] [Vdom = root] [State = alive]\n[Name = MonitorWAN2] [Vdom = root] [State = alive]\n[Name = MonitorWAN3] [Vdom = root] [State = dead]
+...                                             filterstate=
+...                                             filtername=
+...                                             filtervdom='root'
+...                                             result=List link monitors: \n[Name = MonitorWAN1] [Vdom = root] [State = alive]\n[Name = MonitorWAN2] [Vdom = root] [State = alive]\n[Name = MonitorWAN3] [Vdom = root] [State = dead]
 
 @{fortinet_fortigate_listlinkmonitors_tests}
-...                         &{fortinet_fortigate_listlinkmonitors_test1}
-...                         &{fortinet_fortigate_listlinkmonitors_test2}
-...                         &{fortinet_fortigate_listlinkmonitors_test3}
-...                         &{fortinet_fortigate_listlinkmonitors_test4}
+...                                             &{fortinet_fortigate_listlinkmonitors_test1}
+...                                             &{fortinet_fortigate_listlinkmonitors_test2}
+...                                             &{fortinet_fortigate_listlinkmonitors_test3}
+...                                             &{fortinet_fortigate_listlinkmonitors_test4}
+
 
 *** Test Cases ***
 Network Fortinet Fortigate SNMP link monitor
     [Documentation]    Network Fortinet Fortigate SNMP link-monitor
-    [Tags]    network    Fortinet    Fortigate    snmp
+    [Tags]    network    fortinet    fortigate    snmp
     FOR    ${fortinet_fortigate_linkmonitor_test}    IN    @{fortinet_fortigate_linkmonitor_tests}
         ${command}    Catenate
         ...    ${CMD}
@@ -326,43 +327,63 @@ Network Fortinet Fortigate SNMP link monitor
         END
         ${length}    Get Length    ${fortinet_fortigate_linkmonitor_test.customperfdatainstances}
         IF    ${length} > 0
-            ${command}    Catenate    ${command}    --custom-perfdata-instances=${fortinet_fortigate_linkmonitor_test.customperfdatainstances}
+            ${command}    Catenate
+            ...    ${command}
+            ...    --custom-perfdata-instances=${fortinet_fortigate_linkmonitor_test.customperfdatainstances}
         END
         ${length}    Get Length    ${fortinet_fortigate_linkmonitor_test.unknownstatus}
         IF    ${length} > 0
-            ${command}    Catenate    ${command}    --unknown-status=${fortinet_fortigate_linkmonitor_test.unknownstatus}
+            ${command}    Catenate
+            ...    ${command}
+            ...    --unknown-status=${fortinet_fortigate_linkmonitor_test.unknownstatus}
         END
         ${length}    Get Length    ${fortinet_fortigate_linkmonitor_test.warningstatus}
         IF    ${length} > 0
-            ${command}    Catenate    ${command}    --warning-status=${fortinet_fortigate_linkmonitor_test.warningstatus}
+            ${command}    Catenate
+            ...    ${command}
+            ...    --warning-status=${fortinet_fortigate_linkmonitor_test.warningstatus}
         END
         ${length}    Get Length    ${fortinet_fortigate_linkmonitor_test.criticalstatus}
         IF    ${length} > 0
-            ${command}    Catenate    ${command}    --critical-status=${fortinet_fortigate_linkmonitor_test.criticalstatus}
+            ${command}    Catenate
+            ...    ${command}
+            ...    --critical-status=${fortinet_fortigate_linkmonitor_test.criticalstatus}
         END
         ${length}    Get Length    ${fortinet_fortigate_linkmonitor_test.warninglatency}
         IF    ${length} > 0
-            ${command}    Catenate    ${command}    --warning-latency=${fortinet_fortigate_linkmonitor_test.warninglatency}
+            ${command}    Catenate
+            ...    ${command}
+            ...    --warning-latency=${fortinet_fortigate_linkmonitor_test.warninglatency}
         END
         ${length}    Get Length    ${fortinet_fortigate_linkmonitor_test.criticallatency}
         IF    ${length} > 0
-            ${command}    Catenate    ${command}    --critical-latency=${fortinet_fortigate_linkmonitor_test.criticallatency}
+            ${command}    Catenate
+            ...    ${command}
+            ...    --critical-latency=${fortinet_fortigate_linkmonitor_test.criticallatency}
         END
-         ${length}    Get Length    ${fortinet_fortigate_linkmonitor_test.warningjitter}
+        ${length}    Get Length    ${fortinet_fortigate_linkmonitor_test.warningjitter}
         IF    ${length} > 0
-            ${command}    Catenate    ${command}    --warning-jitter=${fortinet_fortigate_linkmonitor_test.warningjitter}
+            ${command}    Catenate
+            ...    ${command}
+            ...    --warning-jitter=${fortinet_fortigate_linkmonitor_test.warningjitter}
         END
         ${length}    Get Length    ${fortinet_fortigate_linkmonitor_test.criticaljitter}
         IF    ${length} > 0
-            ${command}    Catenate    ${command}    --critical-jitter=${fortinet_fortigate_linkmonitor_test.criticaljitter}
+            ${command}    Catenate
+            ...    ${command}
+            ...    --critical-jitter=${fortinet_fortigate_linkmonitor_test.criticaljitter}
         END
-         ${length}    Get Length    ${fortinet_fortigate_linkmonitor_test.warningpacketloss}
+        ${length}    Get Length    ${fortinet_fortigate_linkmonitor_test.warningpacketloss}
         IF    ${length} > 0
-            ${command}    Catenate    ${command}    --warning-packet-loss=${fortinet_fortigate_linkmonitor_test.warningpacketloss}
+            ${command}    Catenate
+            ...    ${command}
+            ...    --warning-packet-loss=${fortinet_fortigate_linkmonitor_test.warningpacketloss}
         END
         ${length}    Get Length    ${fortinet_fortigate_linkmonitor_test.criticalpacketloss}
         IF    ${length} > 0
-            ${command}    Catenate    ${command}    --critical-packet-loss=${fortinet_fortigate_linkmonitor_test.criticalpacketloss}
+            ${command}    Catenate
+            ...    ${command}
+            ...    --critical-packet-loss=${fortinet_fortigate_linkmonitor_test.criticalpacketloss}
         END
         ${output}    Run    ${command}
         Log To Console    .    no_newline=true
@@ -376,7 +397,7 @@ Network Fortinet Fortigate SNMP link monitor
 
 Network Fortinet Fortigate SNMP list link monitor
     [Documentation]    Network Fortinet Fortigate SNMP list-linkmonitors
-    [Tags]    network    Fortinet    Fortigate    snmp
+    [Tags]    network    fortinet    fortigate    snmp
     FOR    ${fortinet_fortigate_listlinkmonitors_test}    IN    @{fortinet_fortigate_listlinkmonitors_tests}
         ${command}    Catenate
         ...    ${CMD}
@@ -387,15 +408,21 @@ Network Fortinet Fortigate SNMP list link monitor
         ...    --snmp-community=network-fortinet-fortigate-linkmonitor
         ${length}    Get Length    ${fortinet_fortigate_listlinkmonitors_test.filterstate}
         IF    ${length} > 0
-            ${command}    Catenate    ${command}    --filter-state=${fortinet_fortigate_listlinkmonitors_test.filterstate}
+            ${command}    Catenate
+            ...    ${command}
+            ...    --filter-state=${fortinet_fortigate_listlinkmonitors_test.filterstate}
         END
         ${length}    Get Length    ${fortinet_fortigate_listlinkmonitors_test.filtername}
         IF    ${length} > 0
-            ${command}    Catenate    ${command}    --filter-name=${fortinet_fortigate_listlinkmonitors_test.filtername}
+            ${command}    Catenate
+            ...    ${command}
+            ...    --filter-name=${fortinet_fortigate_listlinkmonitors_test.filtername}
         END
         ${length}    Get Length    ${fortinet_fortigate_listlinkmonitors_test.filtervdom}
         IF    ${length} > 0
-            ${command}    Catenate    ${command}    --filter-vdom=${fortinet_fortigate_listlinkmonitors_test.filtervdom}
+            ${command}    Catenate
+            ...    ${command}
+            ...    --filter-vdom=${fortinet_fortigate_listlinkmonitors_test.filtervdom}
         END
         ${output}    Run    ${command}
         Log To Console    .    no_newline=true

--- a/tests/functional/snmp/network-interfaces.robot
+++ b/tests/functional/snmp/network-interfaces.robot
@@ -9,19 +9,20 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS}
-...                         --plugin=os::linux::snmp::plugin
-...                         --mode=interfaces
-...                         --hostname=127.0.0.1
-...                         --snmp-port=2024
-...                         --snmp-community=network-interfaces
-...                         --statefile-dir=/tmp/
+${CMD}                  perl ${CENTREON_PLUGINS}
+...                     --plugin=os::linux::snmp::plugin
+...                     --mode=interfaces
+...                     --hostname=127.0.0.1
+...                     --snmp-port=2024
+...                     --snmp-community=network-interfaces
+...                     --statefile-dir=/tmp/
 
-${PERCENT}                  %
+${PERCENT}              %
 
-${COND}                     ${PERCENT}\{sub\} =~ /exited/ && ${PERCENT}{display} =~ /network/'
+${COND}                 ${PERCENT}\{sub\} =~ /exited/ && ${PERCENT}{display} =~ /network/'
+
 
 *** Test Cases ***
 Interfaces by id ${tc}/5
@@ -31,7 +32,6 @@ Interfaces by id ${tc}/5
     ...    --interface='${filter}'
     ...    ${extra_options}
 
-
     ${output}    Run    ${command}
     ${output}    Strip String    ${output}
     Should Be Equal As Strings
@@ -39,12 +39,32 @@ Interfaces by id ${tc}/5
     ...    ${expected_result}
     ...    \nWrong output result for command:\n${command}\n\nExpected:\n${expected_result}\nCommand output:\n${output}\n
 
-    Examples:        tc    filter                    extra_options            expected_result    --
-            ...      1     1                         ${EMPTY}                 OK: Interface 'lo' Status : up (admin: up)
-            ...      2     1,3                       --add-traffic                 OK: All interfaces are ok
-            ...      3     1,3                       --add-traffic                 OK: All interfaces are ok | 'traffic_in_lo'=0.00b/s;;;0;10000000 'traffic_out_lo'=0.00b/s;;;0;10000000 'traffic_in_eth1'=0.00b/s;;;0;1000000000 'traffic_out_eth1'=0.00b/s;;;0;1000000000
-            ...      4     2,3,4                     --add-traffic                 OK: All interfaces are ok
-            ...      5     2,3,4                     --add-traffic                 OK: All interfaces are ok | 'traffic_in_eth0'=0.00b/s;;;0;1000000000 'traffic_out_eth0'=0.00b/s;;;0;1000000000 'traffic_in_eth1'=0.00b/s;;;0;1000000000 'traffic_out_eth1'=0.00b/s;;;0;1000000000 'traffic_in_eth2'=0.00b/s;;;0;1000000000 'traffic_out_eth2'=0.00b/s;;;0;1000000000
+    Examples:
+    ...    tc
+    ...    filter
+    ...    extra_options
+    ...    expected_result
+    ...    --
+    ...    1
+    ...    1
+    ...    ${EMPTY}
+    ...    OK: Interface 'lo' Status : up (admin: up)
+    ...    2
+    ...    1,3
+    ...    --add-traffic
+    ...    OK: All interfaces are ok
+    ...    3
+    ...    1,3
+    ...    --add-traffic
+    ...    OK: All interfaces are ok | 'traffic_in_lo'=0.00b/s;;;0;10000000 'traffic_out_lo'=0.00b/s;;;0;10000000 'traffic_in_eth1'=0.00b/s;;;0;1000000000 'traffic_out_eth1'=0.00b/s;;;0;1000000000
+    ...    4
+    ...    2,3,4
+    ...    --add-traffic
+    ...    OK: All interfaces are ok
+    ...    5
+    ...    2,3,4
+    ...    --add-traffic
+    ...    OK: All interfaces are ok | 'traffic_in_eth0'=0.00b/s;;;0;1000000000 'traffic_out_eth0'=0.00b/s;;;0;1000000000 'traffic_in_eth1'=0.00b/s;;;0;1000000000 'traffic_out_eth1'=0.00b/s;;;0;1000000000 'traffic_in_eth2'=0.00b/s;;;0;1000000000 'traffic_out_eth2'=0.00b/s;;;0;1000000000
 
 Interfaces by id regexp ${tc}/6
     [Tags]    os    linux    network    interfaces
@@ -54,7 +74,6 @@ Interfaces by id regexp ${tc}/6
     ...    --regex-id
     ...    ${extra_options}
 
-
     ${output}    Run    ${command}
     ${output}    Strip String    ${output}
     Should Be Equal As Strings
@@ -62,10 +81,33 @@ Interfaces by id regexp ${tc}/6
     ...    ${expected_result}
     ...    \nWrong output result for command:\n${command}\n\nExpected:\n${expected_result}\nCommand output:\n${output}\n
 
-    Examples:        tc    filter         extra_options      expected_result    --
-            ...      1     ^1$            ${EMPTY}           OK: Interface 'lo' Status : up (admin: up)
-            ...      2     1              ${EMPTY}           OK: Interface 'lo' Status : up (admin: up)
-            ...      3     [13]           --add-traffic      OK: All interfaces are ok
-            ...      4     [13]           --add-traffic      OK: All interfaces are ok | 'traffic_in_lo'=0.00b/s;;;0;10000000 'traffic_out_lo'=0.00b/s;;;0;10000000 'traffic_in_eth1'=0.00b/s;;;0;1000000000 'traffic_out_eth1'=0.00b/s;;;0;1000000000
-            ...      5     [234]          --add-traffic      OK: All interfaces are ok
-            ...      6     [234]          --add-traffic      OK: All interfaces are ok | 'traffic_in_eth0'=0.00b/s;;;0;1000000000 'traffic_out_eth0'=0.00b/s;;;0;1000000000 'traffic_in_eth1'=0.00b/s;;;0;1000000000 'traffic_out_eth1'=0.00b/s;;;0;1000000000 'traffic_in_eth2'=0.00b/s;;;0;1000000000 'traffic_out_eth2'=0.00b/s;;;0;1000000000
+    Examples:
+    ...    tc
+    ...    filter
+    ...    extra_options
+    ...    expected_result
+    ...    --
+    ...    1
+    ...    ^1$
+    ...    ${EMPTY}
+    ...    OK: Interface 'lo' Status : up (admin: up)
+    ...    2
+    ...    1
+    ...    ${EMPTY}
+    ...    OK: Interface 'lo' Status : up (admin: up)
+    ...    3
+    ...    [13]
+    ...    --add-traffic
+    ...    OK: All interfaces are ok
+    ...    4
+    ...    [13]
+    ...    --add-traffic
+    ...    OK: All interfaces are ok | 'traffic_in_lo'=0.00b/s;;;0;10000000 'traffic_out_lo'=0.00b/s;;;0;10000000 'traffic_in_eth1'=0.00b/s;;;0;1000000000 'traffic_out_eth1'=0.00b/s;;;0;1000000000
+    ...    5
+    ...    [234]
+    ...    --add-traffic
+    ...    OK: All interfaces are ok
+    ...    6
+    ...    [234]
+    ...    --add-traffic
+    ...    OK: All interfaces are ok | 'traffic_in_eth0'=0.00b/s;;;0;1000000000 'traffic_out_eth0'=0.00b/s;;;0;1000000000 'traffic_in_eth1'=0.00b/s;;;0;1000000000 'traffic_out_eth1'=0.00b/s;;;0;1000000000 'traffic_in_eth2'=0.00b/s;;;0;1000000000 'traffic_out_eth2'=0.00b/s;;;0;1000000000

--- a/tests/functional/snmp/os-linux-snmp.robot
+++ b/tests/functional/snmp/os-linux-snmp.robot
@@ -8,19 +8,19 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS} --plugin=os::linux::snmp::plugin
+${CMD}                  perl ${CENTREON_PLUGINS} --plugin=os::linux::snmp::plugin
 
 &{list_diskio_test1}
-...                         snmpcommunity=os_linux_snmp_plugin
-...                         nbresults=10
+...                     snmpcommunity=os_linux_snmp_plugin
+...                     nbresults=10
 &{list_diskio_test2}
-...                         snmpcommunity=os_linux_snmp_plugin_2
-...                         nbresults=4
+...                     snmpcommunity=os_linux_snmp_plugin_2
+...                     nbresults=4
 @{list_diskio_tests}
-...                         &{list_diskio_test1}
-...                         &{list_diskio_test2}
+...                     &{list_diskio_test1}
+...                     &{list_diskio_test2}
 
 
 *** Test Cases ***

--- a/tests/functional/snmp/os-windows-services.robot
+++ b/tests/functional/snmp/os-windows-services.robot
@@ -9,12 +9,13 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS} --plugin=os::windows::snmp::plugin
-...                         --mode=service
-...                         --hostname=127.0.0.1
-...                         --snmp-port=2024
+${CMD}                  perl ${CENTREON_PLUGINS} --plugin=os::windows::snmp::plugin
+...                     --mode=service
+...                     --hostname=127.0.0.1
+...                     --snmp-port=2024
+
 
 *** Test Cases ***
 Windows Services EN ${tc}/x
@@ -33,13 +34,32 @@ Windows Services EN ${tc}/x
     ...    ${expected_result}
     ...    \nWrong output result for command:\n${command}\n\nExpected:\n${expected_result}\nCommand output:\n${output}\n\n
 
-    Examples:        tc    filter           extra_option            expected_result    --
-            ...      1     ${EMPTY}         ${EMPTY}                OK: All services are ok | 'services.total.count'=168;;;0; 'services.active.count'=168;;;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
-            ...      2     toto             ${EMPTY}                OK: ${SPACE}| 'services.total.count'=0;;;0; 'services.active.count'=0;;;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
-            ...      3     toto             --critical-active=1:    CRITICAL: Number of services active: 0 | 'services.total.count'=0;;;0; 'services.active.count'=0;;1:;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
-            ...      4     ${EMPTY}         --critical-active=1:    OK: All services are ok | 'services.total.count'=168;;;0; 'services.active.count'=168;;1:;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
-            ...      5     ${EMPTY}         --critical-active=1:1   CRITICAL: Number of services active: 168 | 'services.total.count'=168;;;0; 'services.active.count'=168;;1:1;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
-
+    Examples:
+    ...    tc
+    ...    filter
+    ...    extra_option
+    ...    expected_result
+    ...    --
+    ...    1
+    ...    ${EMPTY}
+    ...    ${EMPTY}
+    ...    OK: All services are ok | 'services.total.count'=168;;;0; 'services.active.count'=168;;;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
+    ...    2
+    ...    toto
+    ...    ${EMPTY}
+    ...    OK: ${SPACE}| 'services.total.count'=0;;;0; 'services.active.count'=0;;;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
+    ...    3
+    ...    toto
+    ...    --critical-active=1:
+    ...    CRITICAL: Number of services active: 0 | 'services.total.count'=0;;;0; 'services.active.count'=0;;1:;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
+    ...    4
+    ...    ${EMPTY}
+    ...    --critical-active=1:
+    ...    OK: All services are ok | 'services.total.count'=168;;;0; 'services.active.count'=168;;1:;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
+    ...    5
+    ...    ${EMPTY}
+    ...    --critical-active=1:1
+    ...    CRITICAL: Number of services active: 168 | 'services.total.count'=168;;;0; 'services.active.count'=168;;1:1;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
 
 Windows Services FR ${tc}/x
     [Documentation]    Systemd version < 248
@@ -57,14 +77,41 @@ Windows Services FR ${tc}/x
     ...    ${expected_result}
     ...    \nWrong output result for command:\n${command}\n\nExpected:\n${expected_result}\nCommand output:\n${output}\n\n
 
-    Examples:        tc    filter           extra_option            expected_result    --
-            ...      1     ${EMPTY}         ${EMPTY}                    OK: All services are ok | 'services.total.count'=80;;;0; 'services.active.count'=80;;;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
-            ...      2     toto             ${EMPTY}                    OK: ${SPACE}| 'services.total.count'=0;;;0; 'services.active.count'=0;;;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
-            ...      3     toto             --critical-active=1:        CRITICAL: Number of services active: 0 | 'services.total.count'=0;;;0; 'services.active.count'=0;;1:;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
-            ...      4     ${EMPTY}         --critical-active=1:        OK: All services are ok | 'services.total.count'=80;;;0; 'services.active.count'=80;;1:;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
-            ...      5     ${EMPTY}         --critical-active=1:1       CRITICAL: Number of services active: 80 | 'services.total.count'=80;;;0; 'services.active.count'=80;;1:1;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
-            ...      6     .v.nement        --critical-active=1:        OK: All services are ok | 'services.total.count'=5;;;0; 'services.active.count'=5;;1:;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
-            ...      7     \xe9v\xe9nement  ${EMPTY}                    OK: All services are ok | 'services.total.count'=5;;;0; 'services.active.count'=5;;;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
-            ...      8     SNMP             ${EMPTY}                    OK: Service 'Service SNMP' state is 'active' [installed state: 'installed'] | 'services.total.count'=1;;;0; 'services.active.count'=1;;;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
-
-
+    Examples:
+    ...    tc
+    ...    filter
+    ...    extra_option
+    ...    expected_result
+    ...    --
+    ...    1
+    ...    ${EMPTY}
+    ...    ${EMPTY}
+    ...    OK: All services are ok | 'services.total.count'=80;;;0; 'services.active.count'=80;;;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
+    ...    2
+    ...    toto
+    ...    ${EMPTY}
+    ...    OK: ${SPACE}| 'services.total.count'=0;;;0; 'services.active.count'=0;;;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
+    ...    3
+    ...    toto
+    ...    --critical-active=1:
+    ...    CRITICAL: Number of services active: 0 | 'services.total.count'=0;;;0; 'services.active.count'=0;;1:;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
+    ...    4
+    ...    ${EMPTY}
+    ...    --critical-active=1:
+    ...    OK: All services are ok | 'services.total.count'=80;;;0; 'services.active.count'=80;;1:;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
+    ...    5
+    ...    ${EMPTY}
+    ...    --critical-active=1:1
+    ...    CRITICAL: Number of services active: 80 | 'services.total.count'=80;;;0; 'services.active.count'=80;;1:1;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
+    ...    6
+    ...    .v.nement
+    ...    --critical-active=1:
+    ...    OK: All services are ok | 'services.total.count'=5;;;0; 'services.active.count'=5;;1:;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
+    ...    7
+    ...    \xe9v\xe9nement
+    ...    ${EMPTY}
+    ...    OK: All services are ok | 'services.total.count'=5;;;0; 'services.active.count'=5;;;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;
+    ...    8
+    ...    SNMP
+    ...    ${EMPTY}
+    ...    OK: Service 'Service SNMP' state is 'active' [installed state: 'installed'] | 'services.total.count'=1;;;0; 'services.active.count'=1;;;0; 'services.continue.pending.count'=0;;;0; 'services.pause.pending.count'=0;;;0; 'services.paused.count'=0;;;0;

--- a/tests/functional/snmp/snmp-collection-sputnik-snmp.robot
+++ b/tests/functional/snmp/snmp-collection-sputnik-snmp.robot
@@ -9,13 +9,14 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}     ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS} --plugin=apps::protocols::snmp::plugin
+${CMD}                  perl ${CENTREON_PLUGINS} --plugin=apps::protocols::snmp::plugin
+
 
 *** Test Cases ***
 SNMP Collection - Sputnik Environment ${tc}/3
-    [Tags]    SNMP Collection
+    [Tags]    snmp collection
     ${command}    Catenate
     ...    ${CMD}
     ...    --mode=collection
@@ -32,15 +33,21 @@ SNMP Collection - Sputnik Environment ${tc}/3
     ...    ${expected_result}
     ...    Wrong output result for compliance of ${expected_result}{\n}Command output:{\n}${output}{\n}{\n}{\n}
 
-    Examples:        tc    expected_result    --
-            ...      1     OK: Sensor '1' temperature is '20.06'°C and humidity is '33'% | '1#environment.temperature.celsius'=20.06C;;;; '1#environment.humidity.percent'=33%;;;0;100
-            ...      2     OK: Sensor '1' temperature is '20.06'°C and humidity is '33'% | '1#environment.temperature.celsius'=20.06C;;;; '1#environment.humidity.percent'=33%;;;0;100
-            ...      3     OK: Sensor '1' temperature is '20.06'°C and humidity is '33'% | '1#environment.temperature.celsius'=20.06C;;;; '1#environment.humidity.percent'=33%;;;0;100
+    Examples:
+    ...    tc
+    ...    expected_result
+    ...    --
+    ...    1
+    ...    OK: Sensor '1' temperature is '20.06'°C and humidity is '33'% | '1#environment.temperature.celsius'=20.06C;;;; '1#environment.humidity.percent'=33%;;;0;100
+    ...    2
+    ...    OK: Sensor '1' temperature is '20.06'°C and humidity is '33'% | '1#environment.temperature.celsius'=20.06C;;;; '1#environment.humidity.percent'=33%;;;0;100
+    ...    3
+    ...    OK: Sensor '1' temperature is '20.06'°C and humidity is '33'% | '1#environment.temperature.celsius'=20.06C;;;; '1#environment.humidity.percent'=33%;;;0;100
+
 
 *** Keywords ***
 Append Option
     [Documentation]    Concatenates the first argument (option) with the second (value) after having replaced the value with "" if its content is '_empty_'
     [Arguments]    ${option}    ${value}
     ${value}    Set Variable If    '${value}' == '_empty_'    ''    ${value}
-    [return]    ${option}=${value}
-
+    RETURN    ${option}=${value}

--- a/tests/functional/snmp/storage-synology-snmp.robot
+++ b/tests/functional/snmp/storage-synology-snmp.robot
@@ -8,59 +8,60 @@ Test Timeout        120s
 
 
 *** Variables ***
-${CENTREON_PLUGINS}         ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
+${CENTREON_PLUGINS}             ${CURDIR}${/}..${/}..${/}..${/}src${/}centreon_plugins.pl
 
-${CMD}                      perl ${CENTREON_PLUGINS} --plugin=storage::synology::snmp::plugin
+${CMD}                          perl ${CENTREON_PLUGINS} --plugin=storage::synology::snmp::plugin
 
 &{check_components_test1}
-...                         description=Checking disk components when all disks are ok
-...                         snmpcommunity=synology_component_disk_ok
-...                         expected_output=OK: All 8 components are ok [2/2 disk, 2/2 fan, 1/1 psu, 2/2 raid, 1/1 system]. | 'Disk 1#hardware.disk.bad_sectors.count'=0;;;0; 'Disk 2#hardware.disk.bad_sectors.count'=0;;;0; 'hardware.disk.count'=2;;;; 'hardware.fan.count'=2;;;; 'hardware.psu.count'=1;;;; 'hardware.raid.count'=2;;;; 'hardware.system.count'=1;;;;
+...                             description=Checking disk components when all disks are ok
+...                             snmpcommunity=synology_component_disk_ok
+...                             expected_output=OK: All 8 components are ok [2/2 disk, 2/2 fan, 1/1 psu, 2/2 raid, 1/1 system]. | 'Disk 1#hardware.disk.bad_sectors.count'=0;;;0; 'Disk 2#hardware.disk.bad_sectors.count'=0;;;0; 'hardware.disk.count'=2;;;; 'hardware.fan.count'=2;;;; 'hardware.psu.count'=1;;;; 'hardware.raid.count'=2;;;; 'hardware.system.count'=1;;;;
 &{check_components_test2}
-...                         description=Checking disk components when one disks is warning
-...                         snmpcommunity=synology_component_disk_warning
-...                         expected_output=WARNING: Disk 'Disk 2' health is warning | 'Disk 1#hardware.disk.bad_sectors.count'=0;;;0; 'Disk 2#hardware.disk.bad_sectors.count'=0;;;0; 'hardware.disk.count'=2;;;; 'hardware.fan.count'=2;;;; 'hardware.psu.count'=1;;;; 'hardware.raid.count'=2;;;; 'hardware.system.count'=1;;;;
+...                             description=Checking disk components when one disks is warning
+...                             snmpcommunity=synology_component_disk_warning
+...                             expected_output=WARNING: Disk 'Disk 2' health is warning | 'Disk 1#hardware.disk.bad_sectors.count'=0;;;0; 'Disk 2#hardware.disk.bad_sectors.count'=0;;;0; 'hardware.disk.count'=2;;;; 'hardware.fan.count'=2;;;; 'hardware.psu.count'=1;;;; 'hardware.raid.count'=2;;;; 'hardware.system.count'=1;;;;
 &{check_components_test3}
-...                         description=Checking disk components when one disks is critical
-...                         snmpcommunity=synology_component_disk_critical
-...                         expected_output=CRITICAL: Disk 'Disk 2' health is critical | 'Disk 1#hardware.disk.bad_sectors.count'=0;;;0; 'Disk 2#hardware.disk.bad_sectors.count'=0;;;0; 'hardware.disk.count'=2;;;; 'hardware.fan.count'=2;;;; 'hardware.psu.count'=1;;;; 'hardware.raid.count'=2;;;; 'hardware.system.count'=1;;;;
+...                             description=Checking disk components when one disks is critical
+...                             snmpcommunity=synology_component_disk_critical
+...                             expected_output=CRITICAL: Disk 'Disk 2' health is critical | 'Disk 1#hardware.disk.bad_sectors.count'=0;;;0; 'Disk 2#hardware.disk.bad_sectors.count'=0;;;0; 'hardware.disk.count'=2;;;; 'hardware.fan.count'=2;;;; 'hardware.psu.count'=1;;;; 'hardware.raid.count'=2;;;; 'hardware.system.count'=1;;;;
 &{check_components_test4}
-...                         description=Checking disk components when one disks is failing
-...                         snmpcommunity=synology_component_disk_failing
-...                         expected_output=CRITICAL: Disk 'Disk 2' health is failing | 'Disk 1#hardware.disk.bad_sectors.count'=0;;;0; 'Disk 2#hardware.disk.bad_sectors.count'=0;;;0; 'hardware.disk.count'=2;;;; 'hardware.fan.count'=2;;;; 'hardware.psu.count'=1;;;; 'hardware.raid.count'=2;;;; 'hardware.system.count'=1;;;;
+...                             description=Checking disk components when one disks is failing
+...                             snmpcommunity=synology_component_disk_failing
+...                             expected_output=CRITICAL: Disk 'Disk 2' health is failing | 'Disk 1#hardware.disk.bad_sectors.count'=0;;;0; 'Disk 2#hardware.disk.bad_sectors.count'=0;;;0; 'hardware.disk.count'=2;;;; 'hardware.fan.count'=2;;;; 'hardware.psu.count'=1;;;; 'hardware.raid.count'=2;;;; 'hardware.system.count'=1;;;;
 @{check_components_tests}
-...                         &{check_components_test1}
-...                         &{check_components_test2}
-...                         &{check_components_test3}
-...                         &{check_components_test4}
+...                             &{check_components_test1}
+...                             &{check_components_test2}
+...                             &{check_components_test3}
+...                             &{check_components_test4}
 
 &{uptime_t1}
-...                         description=Uptime check expected to be OK
-...                         snmpcommunity=synology_component_disk_ok
-...                         warning=
-...                         critical=
-...                         expected_output=OK: System uptime is: 46m 5s | 'uptime'=2765.00s;;;0;
+...                             description=Uptime check expected to be OK
+...                             snmpcommunity=synology_component_disk_ok
+...                             warning=
+...                             critical=
+...                             expected_output=OK: System uptime is: 46m 5s | 'uptime'=2765.00s;;;0;
 &{uptime_t2}
-...                         description=Uptime check expected to be warning
-...                         snmpcommunity=synology_component_disk_ok
-...                         warning=10
-...                         critical=
-...                         expected_output=WARNING: System uptime is: 46m 5s | 'uptime'=2765.00s;0:10;;0;
+...                             description=Uptime check expected to be warning
+...                             snmpcommunity=synology_component_disk_ok
+...                             warning=10
+...                             critical=
+...                             expected_output=WARNING: System uptime is: 46m 5s | 'uptime'=2765.00s;0:10;;0;
 &{uptime_t3}
-...                         description=Uptime check expected to be critical
-...                         snmpcommunity=synology_component_disk_ok
-...                         warning=
-...                         critical=10
-...                         expected_output=CRITICAL: System uptime is: 46m 5s | 'uptime'=2765.00s;;0:10;0;
+...                             description=Uptime check expected to be critical
+...                             snmpcommunity=synology_component_disk_ok
+...                             warning=
+...                             critical=10
+...                             expected_output=CRITICAL: System uptime is: 46m 5s | 'uptime'=2765.00s;;0:10;0;
 
 @{uptime_tests}
-...                         &{uptime_t1}
-...                         &{uptime_t2}
-...                         &{uptime_t3}
+...                             &{uptime_t1}
+...                             &{uptime_t2}
+...                             &{uptime_t3}
+
 
 *** Test Cases ***
 Components
-    [Tags]    storage   synology    snmp
+    [Tags]    storage    synology    snmp
     FOR    ${check_components_test}    IN    @{check_components_tests}
         ${command}    Catenate
         ...    ${CMD}
@@ -78,7 +79,7 @@ Components
     END
 
 Uptime
-    [Tags]    storage   synology    snmp
+    [Tags]    storage    synology    snmp
     FOR    ${test_item}    IN    @{uptime_tests}
         ${command}    Catenate
         ...    ${CMD}

--- a/tests/resources/mockoon/centreon-plugins-passwordmgr-hashicorpvault.json
+++ b/tests/resources/mockoon/centreon-plugins-passwordmgr-hashicorpvault.json
@@ -1,0 +1,238 @@
+{
+  "uuid": "98b9aab1-da6e-46a5-a2c2-5c001be49806",
+  "lastMigration": 27,
+  "name": "Apps hashicorp vault",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3000,
+  "hostname": "",
+  "folders": [],
+  "routes": [
+    {
+      "uuid": "6b8dd80b-3ea0-48c0-8e9d-609d618e980e",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "v1/auth/userpass/login/hcvaultuser",
+      "responses": [
+        {
+          "uuid": "edc924ee-c73b-44e9-8402-d3d75a514083",
+          "body": "{\r\n    \"request_id\":\r\n    \"9a423954-2109-1e23-b0e4-f694d557031f\", \"lease_id\":\r\n    \"\", \"renewable\":\r\n    false, \"lease_duration\":\r\n    0, \"data\":\r\n    null, \"wrap_info\":\r\n    null, \"warnings\":\r\n    [ \"Endpoint replaced the value of these parameters with the values captured from the endpoint's path: [username]\" ], \"auth\":\r\n    {\r\n        \"client_token\":\r\n        \"hvs.CAESIHR511IiIwmAXLTrXQnLJ0Pq-NHQYgfiv4m1ZYVQHVt_Gh4KHGh2cy5HRTZidHZ0b0s3NzE5UG41cE10aUtrQjg\", \"accessor\":\r\n        \"fYX782sU7MPQH2Xhf8q0BfSP\", \"policies\":\r\n        [ \"default\", \"inf-icinga.ro\" ], \"token_policies\":\r\n        [ \"default\", \"inf-icinga.ro\" ], \"metadata\":\r\n        {\r\n            \"username\":\r\n            \"hcvaultuser\"\r\n        }, \"lease_duration\":\r\n        604800, \"renewable\":\r\n        true, \"entity_id\":\r\n        \"cc0f1543-6838-46d1-c97e-d61a5899fc9b\", \"token_type\":\r\n        \"service\", \"orphan\":\r\n        true, \"mfa_requirement\":\r\n        null, \"num_uses\":\r\n        0\r\n    }\r\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "if password ok",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "password",
+              "value": "secrethashicorpPassword",
+              "invert": false,
+              "operator": "equals"
+            },
+            {
+              "target": "body",
+              "modifier": "username",
+              "value": "hcvaultuser",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "AND",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false
+        },
+        {
+          "uuid": "fc4cc190-618b-480d-ae22-296248292297",
+          "body": "{\r\n  \"errors\": [\r\n    \"wrong user/password\"\r\n  ]\r\n}",
+          "latency": 0,
+          "statusCode": 401,
+          "label": "error",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    },
+    {
+      "uuid": "8fdb70c1-a874-40eb-8b9f-542dca268992",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "v1/path/of/the/secret",
+      "responses": [
+        {
+          "uuid": "2dec61d5-f84d-4223-b993-a91d127e0e71",
+          "body": "{\r\n   \"request_id\":\"76aa492b-acc0-52dc-1f2c-3e2f959a5dfd\",\r\n   \"lease_id\":\"\",\r\n   \"renewable\":false,\r\n   \"lease_duration\":0,\r\n   \"data\":{\r\n      \"data\":{\r\n         \"monitor\":\"snmp\"\r\n      },\r\n      \"metadata\":{\r\n         \"created_time\":\"2023-11-17T13:46:39.240097987Z\",\r\n         \"custom_metadata\":null,\r\n         \"deletion_time\":\"\",\r\n         \"destroyed\":false,\r\n         \"version\":1\r\n      }\r\n   },\r\n   \"wrap_info\":null,\r\n   \"warnings\":null,\r\n   \"auth\":null\r\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    },
+    {
+      "uuid": "8ef8c935-ff40-4817-8211-52cc1d0c64b4",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "v1/otherPath",
+      "responses": [
+        {
+          "uuid": "894d68aa-3f3b-463c-a1dd-cf9dd3565d7c",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    },
+    {
+      "uuid": "2686745a-9783-4b64-9376-068c159aa725",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "v1/auth/specific-url/login/hcvaultuser",
+      "responses": [
+        {
+          "uuid": "400e5fea-c3f3-4abc-bc24-73afa75111c6",
+          "body": "{\r\n    \"request_id\":\r\n    \"9a423954-2109-1e23-b0e4-f694d557031f\", \"lease_id\":\r\n    \"\", \"renewable\":\r\n    false, \"lease_duration\":\r\n    0, \"data\":\r\n    null, \"wrap_info\":\r\n    null, \"warnings\":\r\n    [ \"Endpoint replaced the value of these parameters with the values captured from the endpoint's path: [username]\" ], \"auth\":\r\n    {\r\n        \"client_token\":\r\n        \"hvs.CAESIHR511IiIwmAXLTrXQnLJ0Pq-NHQYgfiv4m1ZYVQHVt_Gh4KHGh2cy5HRTZidHZ0b0s3NzE5UG41cE10aUtrQjg\", \"accessor\":\r\n        \"fYX782sU7MPQH2Xhf8q0BfSP\", \"policies\":\r\n        [ \"default\", \"inf-icinga.ro\" ], \"token_policies\":\r\n        [ \"default\", \"inf-icinga.ro\" ], \"metadata\":\r\n        {\r\n            \"username\":\r\n            \"hcvaultuser\"\r\n        }, \"lease_duration\":\r\n        604800, \"renewable\":\r\n        true, \"entity_id\":\r\n        \"cc0f1543-6838-46d1-c97e-d61a5899fc9b\", \"token_type\":\r\n        \"service\", \"orphan\":\r\n        true, \"mfa_requirement\":\r\n        null, \"num_uses\":\r\n        0\r\n    }\r\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "if password ok",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "password",
+              "value": "secrethashicorpPassword",
+              "invert": false,
+              "operator": "equals"
+            },
+            {
+              "target": "body",
+              "modifier": "username",
+              "value": "hcvaultuser",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "AND",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false
+        },
+        {
+          "uuid": "21593d10-e496-4a39-ac84-0ef9e0de6bbf",
+          "body": "{\r\n  \"errors\": [\r\n    \"wrong user/password\"\r\n  ]\r\n}",
+          "latency": 0,
+          "statusCode": 401,
+          "label": "error",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true
+        }
+      ],
+      "enabled": true,
+      "responseMode": null
+    }
+  ],
+  "rootChildren": [
+    {
+      "type": "route",
+      "uuid": "6b8dd80b-3ea0-48c0-8e9d-609d618e980e"
+    },
+    {
+      "type": "route",
+      "uuid": "8fdb70c1-a874-40eb-8b9f-542dca268992"
+    },
+    {
+      "type": "route",
+      "uuid": "8ef8c935-ff40-4817-8211-52cc1d0c64b4"
+    },
+    {
+      "type": "route",
+      "uuid": "2686745a-9783-4b64-9376-068c159aa725"
+    }
+  ],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "application/json"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": []
+}

--- a/tests/resources/snmp/apps/protocols/snmp.snmpwalk
+++ b/tests/resources/snmp/apps/protocols/snmp.snmpwalk
@@ -1,0 +1,1 @@
+.1.3.6.1.2.1.1.1.0 = STRING: "Linux centreon-devbox 5.10.0-28-amd64 #1 SMP Debian 5.10.209-2 (2024-01-31) x86_64"

--- a/tests/resources/spellcheck/stopwords.t
+++ b/tests/resources/spellcheck/stopwords.t
@@ -1,3 +1,4 @@
+--api-version
 --display-transform-dst
 --display-transform-src
 --filter-vdom
@@ -16,6 +17,7 @@ deltaps
 eth
 Fortigate
 Fortinet
+HashiCorp
 ifAlias
 ifDesc
 ifName

--- a/tests/resources/spellcheck/stopwords.t
+++ b/tests/resources/spellcheck/stopwords.t
@@ -26,6 +26,7 @@ in-mcast
 in-ucast
 interface-dsl-name
 IpAddr
+'ldap'
 license-instances-usage-prct
 MBean
 NagVis


### PR DESCRIPTION
## Description

contribution of lugg1 from https://github.com/centreon/centreon-plugins/pull/4764.
for hashicorp vault product, when authentication is user/pass method, this modification allow to configure the url to query, a new feature of Vault : https://developer.hashicorp.com/vault/docs/auth/userpass#configuration


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

see automated tests provided, this new parameter by default don't change anything.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
