### PR TITLE
new(plugin): add apache karaf api plugin

### DIFF
--- a/packaging/centreon-plugin-Applications-Apache-Karaf-Api/deb.json
+++ b/packaging/centreon-plugin-Applications-Apache-Karaf-Api/deb.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": []
+}

--- a/packaging/centreon-plugin-Applications-Apache-Karaf-Api/pkg.json
+++ b/packaging/centreon-plugin-Applications-Apache-Karaf-Api/pkg.json
@@ -1,0 +1,9 @@
+{
+    "pkg_name": "centreon-plugin-Applications-Apache-Karaf-Api",
+    "pkg_summary": "Centreon Plugin to monitor Apache Karaf using API throught Jolokia",
+    "plugin_name": "centreon_apache_karaf_api.pl",
+    "files": [
+        "centreon/plugins/script_custom.pm",
+        "apps/apache/karaf/api/"
+    ]
+}

--- a/packaging/centreon-plugin-Applications-Apache-Karaf-Api/rpm.json
+++ b/packaging/centreon-plugin-Applications-Apache-Karaf-Api/rpm.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": []
+}

--- a/src/apps/apache/karaf/api/custom/api.pm
+++ b/src/apps/apache/karaf/api/custom/api.pm
@@ -1,0 +1,199 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::apache::karaf::api::custom::api;
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use JSON::XS;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self  = {};
+    bless $self, $class;
+
+    if (!defined($options{output})) {
+        print "Class Custom: Need to specify 'output' argument.\n";
+        exit 3;
+    }
+    if (!defined($options{options})) {
+        $options{output}->add_option_msg(short_msg => "Class Custom: Need to specify 'options' argument.");
+        $options{output}->option_exit();
+    }
+    
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            'hostname:s'             => { name => 'hostname' },
+            'port:s'                 => { name => 'port' },
+            'proto:s'                => { name => 'proto' },
+            'api-username:s'         => { name => 'api_username' },
+            'api-password:s'         => { name => 'api_password' },
+            'timeout:s'              => { name => 'timeout' },
+            'unknown-http-status:s'  => { name => 'unknown_http_status' },
+            'warning-http-status:s'  => { name => 'warning_http_status' },
+            'critical-http-status:s' => { name => 'critical_http_status' }
+        });
+    }
+    $options{options}->add_help(package => __PACKAGE__, sections => 'API OPTIONS', once => 1);
+
+    $self->{output} = $options{output};
+    $self->{http} = centreon::plugins::http->new(%options, default_backend => 'curl');
+
+    return $self;
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+
+    $self->{option_results} = $options{option_results};
+}
+
+sub set_defaults {}
+
+sub check_options {
+    my ($self, %options) = @_;
+
+    $self->{hostname} = (defined($self->{option_results}->{hostname})) ? $self->{option_results}->{hostname} : '';
+    $self->{port} = (defined($self->{option_results}->{port})) ? $self->{option_results}->{port} : 8181;
+    $self->{proto} = (defined($self->{option_results}->{proto})) ? $self->{option_results}->{proto} : 'https';
+    $self->{timeout} = (defined($self->{option_results}->{timeout})) ? $self->{option_results}->{timeout} : 10;
+    $self->{api_username} = (defined($self->{option_results}->{api_username})) ? $self->{option_results}->{api_username} : '';
+    $self->{api_password} = (defined($self->{option_results}->{api_password})) ? $self->{option_results}->{api_password} : '';
+    $self->{unknown_http_status} = (defined($self->{option_results}->{unknown_http_status})) ? $self->{option_results}->{unknown_http_status} : '%{http_code} < 200 or %{http_code} >= 300';
+    $self->{warning_http_status} = (defined($self->{option_results}->{warning_http_status})) ? $self->{option_results}->{warning_http_status} : '';
+    $self->{critical_http_status} = (defined($self->{option_results}->{critical_http_status})) ? $self->{option_results}->{critical_http_status} : '';
+
+    if ($self->{hostname} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify --hostname option.');
+        $self->{output}->option_exit();
+    }
+
+    return 0;
+}
+
+sub build_options_for_httplib {
+    my ($self, %options) = @_;
+
+    $self->{option_results}->{hostname} = $self->{hostname};
+    $self->{option_results}->{timeout} = $self->{timeout};
+    $self->{option_results}->{port} = $self->{port};
+    $self->{option_results}->{proto} = $self->{proto};
+    $self->{option_results}->{timeout} = $self->{timeout};
+    if ($self->{api_username} ne '') {
+        $self->{option_results}->{credentials} = 1;
+        $self->{option_results}->{basic} = 1;
+        $self->{option_results}->{username} = $self->{api_username};
+        $self->{option_results}->{password} = $self->{api_password};
+    }
+}
+
+sub settings {
+    my ($self, %options) = @_;
+
+    return if (defined($self->{settings_done}));
+    $self->build_options_for_httplib();
+    $self->{http}->add_header(key => 'Accept', value => 'application/json');
+    $self->{http}->add_header(key => 'Content-Type', value => 'application/json');
+    $self->{http}->set_options(%{$self->{option_results}});
+    $self->{settings_done} = 1;
+}
+
+sub get_hostname {
+    my ($self, %options) = @_;
+
+    return $self->{hostname};
+}
+
+sub request_api {
+    my ($self, %options) = @_;
+
+    my $payload = JSON::XS->new->utf8->encode($options{payload});
+
+    $self->settings();
+    my $content = $self->{http}->request(
+        method => $options{method},
+        url_path => $options{endpoint},
+        query_form_post => $payload,
+        unknown_status => $self->{unknown_http_status},
+        warning_status => $self->{warning_http_status},
+        critical_status => $self->{critical_http_status}
+    );
+
+    if (!defined($content) || $content eq '') {
+        $self->{output}->add_option_msg(short_msg => "API returns empty content [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']");
+        $self->{output}->option_exit();
+    }
+
+    my $decoded;
+    eval {
+        $decoded = JSON::XS->new->utf8->decode($content);
+    };
+    if ($@) {
+        $self->{output}->add_option_msg(short_msg => "Cannot decode response (add --debug option to display returned content)");
+        $self->{output}->option_exit();
+    }
+
+    return $decoded;
+}
+
+1;
+
+=head1 NAME
+
+Apache Karaf API
+
+=head1 API OPTIONS
+
+Apache Karaf API
+
+=over 8
+
+=item B<--hostname>
+
+Hostname.
+
+=item B<--port>
+
+Port used (Default: 8181)
+
+=item B<--proto>
+
+Specify https if needed (Default: 'https')
+
+=item B<--api-username>
+
+API username.
+
+=item B<--api-password>
+
+API password.
+
+=item B<--timeout>
+
+Set timeout in seconds (Default: 10).
+
+=back
+
+=head1 DESCRIPTION
+
+B<custom>.
+
+=cut

--- a/src/apps/apache/karaf/api/mode/bundlestatus.pm
+++ b/src/apps/apache/karaf/api/mode/bundlestatus.pm
@@ -1,0 +1,311 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::apache::karaf::api::mode::bundlestatus;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use Digest::MD5 qw(md5_hex);
+use centreon::plugins::statefile;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "status is '%s' [version: %s] [feature installed: %s, version: %s]",
+        $self->{result_values}->{status},
+        $self->{result_values}->{version},
+        $self->{result_values}->{feature_installed},
+        $self->{result_values}->{feature_version}
+    );
+}
+
+sub prefix_bundle_output {
+    my ($self, %options) = @_;
+
+    return "Bundle '" . $options{instance_value}->{name} . "' ";
+}
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+
+    return 'Number of bundles ';
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        {
+            name => 'global',
+            type => 0,
+            cb_prefix_output => 'prefix_global_output'
+        },
+        {
+            name => 'bundles',
+            type => 1,
+            cb_prefix_output => 'prefix_bundle_output',
+            message_multiple => 'All bundles are ok'
+        },
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'bundles-failed', nlabel => 'bundles.failed.count', set => {
+                key_values => [
+                    { name => 'failed' },
+                    { name => 'total' }
+                ],
+                output_template => 'failed: %s',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 'total' }
+                ]
+            }
+        },
+        { label => 'bundles-active', nlabel => 'bundles.active.count', set => {
+                key_values => [
+                    { name => 'active' },
+                    { name => 'total' }
+                ],
+                output_template => 'active: %s',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 'total' }
+                ]
+            }
+        },
+        { label => 'bundles-resolved', nlabel => 'bundles.resolved.count', set => {
+                key_values => [
+                    { name => 'resolved' },
+                    { name => 'total' }
+                ],
+                output_template => 'resolved: %s',
+                perfdatas => [
+                    { template => '%s', min => 0, max => 'total' }
+                ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{bundles} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '%{status} !~ /^(active|resolved)/i',
+            set => {
+                key_values => [
+                    { name => 'status' },
+                    { name => 'version' },
+                    { name => 'feature_installed' },
+                    { name => 'feature_version' },
+                    { name => 'name' }
+                ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-instance:s'      => { name => 'filter_instance' },
+        'filter-id:s'            => { name => 'filter_id' },
+        'filter-name:s'          => { name => 'filter_name' },
+        'filter-symbolic-name:s' => { name => 'filter_symbolic_name' },
+        'reload-cache-time:s'    => { name => 'reload_cache_time', default => 60 }
+    });
+
+    $self->{statefile_cache} = centreon::plugins::statefile->new(%options);
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    $self->{statefile_cache}->check_options(%options);
+}
+
+sub reload_features_cache {
+    my ($self, %options) = @_;
+
+    my $response = $options{custom}->request_api(
+        method => 'POST',
+        endpoint => '/jolokia/read',
+        payload => {
+            type => 'read',
+            mbean => 'org.apache.karaf:type=feature,name=*'
+        }
+    );
+
+    my $data = { last_timestamp => time() };
+
+    if (defined($response->{value}->{Features})) {
+        $data->{features} = $response->{value}->{Features};
+    } else {
+        my $features = {};
+        foreach my $entry (keys %{$response->{value}}) {
+            $features = { %$features, %{$response->{value}->{$entry}->{Features}} };
+        }
+        $data->{features} = $features;
+    }
+
+    $self->{statefile_cache}->write(data => $data);
+}
+
+sub get_features {
+    my ($self, %options) = @_;
+
+    my $has_cache_file = $self->{statefile_cache}->read(statefile => 'cache_karaf_features_' . md5_hex($self->{option_results}->{hostname}));
+    my $timestamp_cache = $self->{statefile_cache}->get(name => 'last_timestamp');
+    if ($has_cache_file == 0 || !defined($timestamp_cache) ||
+        ((time() - $timestamp_cache) > (($self->{option_results}->{reload_cache_time}) * 60))) {      
+        $self->reload_features_cache(%options);
+        $self->{statefile_cache}->read();
+    }
+
+    return $self->{statefile_cache}->get(name => 'features');
+}
+
+sub get_bundles {
+    my ($self, %options) = @_;
+
+    my $response = $options{custom}->request_api(
+        method => 'POST',
+        endpoint => '/jolokia/read',
+        payload => {
+            type => 'read',
+            mbean => 'org.apache.karaf:type=bundle,name=*'
+        }
+    );
+
+    if (defined($response->{value}->{Bundles})) {
+        return values(%{$response->{value}->{Bundles}});
+    }
+
+    my @values = ();
+    foreach my $entry (keys %{$response->{value}}) {
+        next if ($entry !~ /name=([a-zA-Z]+)/);
+        my $instance = $1;
+        next if (defined($self->{option_results}->{filter_instance}) && $self->{option_results}->{filter_instance} ne ''
+            && $instance !~ /$self->{option_results}->{filter_instance}/);
+        push @values, values(%{$response->{value}->{$entry}->{Bundles}});
+    }
+
+    return @values;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my @bundles = $self->get_bundles(%options);
+    my $features = $self->get_features(%options);
+
+    $self->{global} = { total => 0, failed => 0, active => 0, resolved => 0 };
+    $self->{bundles} = {};
+
+    foreach (@bundles) {
+        my $name = defined($_->{Name}) ? $_->{Name} : $_->{'Symbolic Name'};
+        next if (defined($self->{option_results}->{filter_id}) && $self->{option_results}->{filter_id} ne '' &&
+            $_->{ID} !~ /$self->{option_results}->{filter_id}/);
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
+            $name !~ /$self->{option_results}->{filter_name}/);
+        next if (defined($self->{option_results}->{filter_symbolic_name}) && $self->{option_results}->{filter_symbolic_name} ne '' &&
+            $_->{'Symbolic Name'} !~ /$self->{option_results}->{filter_symbolic_name}/);
+
+        $self->{global}->{failed}++ if ($_->{State} eq 'Failure');
+        $self->{global}->{active}++ if ($_->{State} eq 'Active');
+        $self->{global}->{resolved}++ if ($_->{State} eq 'Resolved');
+        $self->{global}->{total}++;
+
+        my $feature_version = 'n/a';
+        my $feature_installed = 'n/a';
+        if (defined($features->{ $name . '-feature' })) {
+            my @keys = keys %{$features->{ $name . '-feature' }};
+            my $version = shift(@keys);
+            $feature_installed = ($features->{ $name . '-feature' }->{$version}->{Installed} =~ /1|true/i ? 'yes' : 'no');
+            $feature_version = $features->{ $name . '-feature' }->{$version}->{Version};
+        }
+
+        $self->{bundles}->{ $_->{ID} } = {
+            name => $name,
+            status => lc($_->{State}),
+            version => $_->{Version},
+            feature_installed => $feature_installed,
+            feature_version => $feature_version
+        };
+    }
+
+    if (scalar(keys %{$self->{bundles}}) <= 0) {
+        $self->{output}->add_option_msg(short_msg => "No bundles found");
+        $self->{output}->option_exit();
+    }
+}
+
+1;
+
+=head1 MODE
+
+Check bundle status.
+
+=over 8
+
+=item B<--filter-instance>
+
+Filter the Karaf instances by name (can be a regexp).
+
+=item B<--filter-id>
+
+Filter bundles by ID (can be a regexp).
+
+=item B<--filter-name>
+
+Filter bundles by name (can be a regexp).
+
+=item B<--filter-symbolic-name>
+
+Filter bundles by symbolic name (can be a regexp).
+
+=item B<--warning-status>
+
+Set warning threshold for status.
+Can use special variables like: %{status}, %{name}, %{version}, %{feature_installed}, %{feature_version}.
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: '%{status} !~ /^(active|resolved)/i').
+Can use special variables like: %{status}, %{name}, %{version}, %{feature_installed}, %{feature_version}.
+
+=item B<--warning-*> B<--critical-*>
+
+Thresholds.
+Can be: 'bundles-failed', 'bundles-active', 'bundles-resolved'.
+
+=back
+
+=cut

--- a/src/apps/apache/karaf/api/mode/datasourcequery.pm
+++ b/src/apps/apache/karaf/api/mode/datasourcequery.pm
@@ -1,0 +1,155 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::apache::karaf::api::mode::datasourcequery;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "Datasource query status is '%s'",
+        $self->{result_values}->{status},
+    );
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        {
+            name => 'global',
+            type => 0
+        }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '%{status} != 200',
+            set => {
+                key_values => [
+                    { name => 'status' }
+                ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'instance:s'   => { name => 'instance' },
+        'datasource:s' => { name => 'datasource' },
+        'query:s'      => { name => 'query' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{instance}) || $self->{option_results}->{instance} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --instance option.");
+        $self->{output}->option_exit();
+    }
+    if (!defined($self->{option_results}->{datasource}) || $self->{option_results}->{datasource} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --datasource option.");
+        $self->{output}->option_exit();
+    }
+    if (!defined($self->{option_results}->{query}) || $self->{option_results}->{query} eq '') {
+        $self->{output}->add_option_msg(short_msg => "Need to specify --query option.");
+        $self->{output}->option_exit();
+    }
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $datasource = $self->{option_results}->{datasource};
+    $datasource  = 'jdbc/' . $datasource if ($datasource !~ /^jdbc\//);
+
+    my $result = $options{custom}->request_api(
+        method => 'POST',
+        endpoint => '/jolokia/exec',
+        payload => {
+            type => 'exec',
+            mbean => 'org.apache.karaf:type=jdbc,name=' . $self->{option_results}->{instance},
+            operation => 'query(java.lang.String,java.lang.String)',
+            arguments => [
+                $datasource,
+                $self->{option_results}->{query}
+            ]
+        }
+    );
+
+    $self->{global} = {
+        status => $result->{status}
+    };
+}
+
+1;
+
+=head1 MODE
+
+Check a datasource query execution status.
+
+=over 8
+
+=item B<--instance>
+
+Set the Karaf instance where the datasource resides.
+
+=item B<--datasource>
+
+Set the datasource on which the query should be executed (Eg.: --datasource='as400ds'
+or --datasource='jdbc/as400ds').
+
+=item B<--query>
+
+Set the SQL query to execute.
+
+=item B<--warning-status>
+
+Set warning threshold for status.
+Can use special variables like: %{status}.
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: '%{status} != 200').
+Can use special variables like: %{status}.
+
+=back
+
+=cut

--- a/src/apps/apache/karaf/api/mode/datasourcestatus.pm
+++ b/src/apps/apache/karaf/api/mode/datasourcestatus.pm
@@ -1,0 +1,177 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::apache::karaf::api::mode::datasourcestatus;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "status is '%s'",
+        $self->{result_values}->{status}
+    );
+}
+
+sub prefix_datasource_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "Datasource '%s' [product: %s] [version: %s] ",
+        $options{instance_value}->{name},
+        $options{instance_value}->{product},
+        $options{instance_value}->{version}
+    );
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        {
+            name => 'datasources',
+            type => 1,
+            cb_prefix_output => 'prefix_datasource_output',
+            message_multiple => 'All datasources are ok'
+        },
+    ];
+
+    $self->{maps_counters}->{datasources} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '%{status} !~ /^(OK)/i',
+            set => {
+                key_values => [
+                    { name => 'status' },
+                    { name => 'version' },
+                    { name => 'product' },
+                    { name => 'name' }
+                ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-instance:s' => { name => 'filter_instance' },
+        'filter-name:s'     => { name => 'filter_name' },
+        'filter-product:s'  => { name => 'filter_product' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        method => 'POST',
+        endpoint => '/jolokia/read',
+        payload => {
+            type => 'read',
+            mbean => 'org.apache.karaf:type=jdbc,name=*'
+        }
+    );
+
+    foreach my $entry (keys %{$result->{value}}) {
+        next if ($entry !~ /name=([a-zA-Z]+)/);
+        my $instance = $1;
+        next if (defined($self->{option_results}->{filter_instance}) && $self->{option_results}->{filter_instance} ne ''
+            && $instance !~ /$self->{option_results}->{filter_instance}/);
+        
+        next if (!defined($result->{value}->{$entry}->{Datasources}));
+        
+        foreach my $id (keys %{$result->{value}->{$entry}->{Datasources}}) {
+            my $name = $result->{value}->{$entry}->{Datasources}->{$id}->{name};
+            $name = $1 if ($name =~ /jdbc\/(.*)/);
+
+            next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+                && $name !~ /$self->{option_results}->{filter_name}/);
+            next if (defined($self->{option_results}->{filter_product}) && $self->{option_results}->{filter_product} ne ''
+                && $result->{value}->{$entry}->{Datasources}->{$id}->{product} !~ /$self->{option_results}->{filter_product}/);
+            $self->{datasources}->{$id} = {
+                name => $name,
+                product => $result->{value}->{$entry}->{Datasources}->{$id}->{product},
+                version => $result->{value}->{$entry}->{Datasources}->{$id}->{version},
+                status => $result->{value}->{$entry}->{Datasources}->{$id}->{status}
+            };
+        }
+    }
+
+    if (scalar(keys %{$self->{datasources}}) <= 0) {
+        $self->{output}->add_option_msg(short_msg => "No datasources found");
+        $self->{output}->option_exit();
+    }
+}
+
+1;
+
+=head1 MODE
+
+Check datasource status.
+
+=over 8
+
+=item B<--filter-instance>
+
+Filter the Karaf instances by name (can be a regexp).
+
+=item B<--filter-name>
+
+Filter datasources by name (can be a regexp).
+
+The 'jdbc/' part of the name is removed.
+
+=item B<--filter-product>
+
+Filter datasources by product (can be a regexp).
+
+=item B<--warning-status>
+
+Set warning threshold for status.
+Can use special variables like: %{status}, %{version}, %{product}, %{name}.
+
+=item B<--critical-status>
+
+Set critical threshold for status (Default: '%{status} !~ /^(OK)/i').
+Can use special variables like: %{status}, %{version}, %{product}, %{name}.
+
+=back
+
+=cut

--- a/src/apps/apache/karaf/api/mode/listbundles.pm
+++ b/src/apps/apache/karaf/api/mode/listbundles.pm
@@ -1,0 +1,175 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::apache::karaf::api::mode::listbundles;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {});
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+}
+
+sub get_bundle_values {
+    my ($self, %options) = @_;
+
+    if (defined($options{bundles}->{value}->{Bundles})) {
+        return values(%{$options{bundles}->{value}->{Bundles}});
+    }
+
+    my @values = ();
+    foreach my $entry (keys %{$options{bundles}->{value}}) {
+        push @values, values(%{$options{bundles}->{value}->{$entry}->{Bundles}});
+    }
+
+    return @values;
+}
+
+sub get_features_list {
+    my ($self, %options) = @_;
+
+    if (defined($options{features}->{value}->{Features})) {
+        return $options{features}->{value}->{Features};
+    }
+
+    my $features = {};
+    foreach my $entry (keys %{$options{features}->{value}}) {
+        $features = { %$features, %{$options{features}->{value}->{$entry}->{Features}} };
+    }
+
+    return $features;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $bundles = $options{custom}->request_api(
+        method => 'POST',
+        endpoint => '/jolokia/read',
+        payload => {
+            type => 'read',
+            mbean => 'org.apache.karaf:type=bundle,name=*'
+        }
+    );
+
+    my $features = $options{custom}->request_api(
+        method => 'POST',
+        endpoint => '/jolokia/read',
+        payload => {
+            type => 'read',
+            mbean => 'org.apache.karaf:type=feature,name=*'
+        }
+    );
+    my $feature_values = $self->get_features_list(features => $features);
+
+    my $results = [];
+    foreach ($self->get_bundle_values(bundles => $bundles)) {
+        my $name = defined($_->{Name}) ? $_->{Name} : $_->{'Symbolic Name'};
+
+        my $feature_version = 'n/a';
+        my $feature_installed = 'n/a';
+        if (defined($feature_values->{ $name . '-feature' })) {
+            my @keys = keys %{$feature_values->{ $name . '-feature' }};
+            my $version = shift(@keys);
+            $feature_installed = ($feature_values->{ $name . '-feature' }->{$version}->{Installed} =~ /1|true/i ? 'yes' : 'no');
+            $feature_version = $feature_values->{ $name . '-feature' }->{$version}->{Version};
+        }
+
+        push @$results, {
+            id => $_->{ID},
+            name => $name,
+            symbolic_name => $_->{'Symbolic Name'},
+            version => $_->{Version},
+            status => lc($_->{State}),
+            feature_installed => $feature_installed,
+            feature_version => $feature_version
+        };
+    }
+
+    return $results;
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    my $results = $self->manage_selection(%options);
+    foreach (@$results) {
+        $self->{output}->output_add(
+            long_msg => sprintf(
+                '[id: %s][name: %s][symbolic_name: %s][version: %s][status: %s][feature_installed: %s][feature_version: %s]',
+                $_->{id},
+                $_->{name},
+                $_->{symbolic_name},
+                $_->{version},
+                $_->{status},
+                $_->{feature_installed},
+                $_->{feature_version}
+            )
+        );
+    }
+
+    $self->{output}->output_add(
+        severity => 'OK',
+        short_msg => 'List bundles:'
+    );
+
+    $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+    $self->{output}->exit();
+}
+
+sub disco_format {
+    my ($self, %options) = @_;
+
+    $self->{output}->add_disco_format(elements => ['id', 'name', 'symbolic_name', 'version', 'status', 'feature_installed', 'feature_version']);
+}
+
+sub disco_show {
+    my ($self, %options) = @_;
+
+    my $results = $self->manage_selection(%options);
+    foreach (@$results) {
+        $self->{output}->add_disco_entry(%$_);
+    }
+}
+
+1;
+
+=head1 MODE
+
+List bundles.
+
+=over 8
+
+=back
+
+=cut

--- a/src/apps/apache/karaf/api/mode/listdatasources.pm
+++ b/src/apps/apache/karaf/api/mode/listdatasources.pm
@@ -1,0 +1,130 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::apache::karaf::api::mode::listdatasources;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {});
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        method => 'POST',
+        endpoint => '/jolokia/read',
+        payload => {
+            type => 'read',
+            mbean => 'org.apache.karaf:type=jdbc,name=*'
+        }
+    );
+
+    my @datasources;
+    foreach my $entry (keys %{$result->{value}}) {
+        next if ($entry !~ /name=([a-zA-Z]+)/);
+        my $instance = $1;
+
+        next if (!defined($result->{value}->{$entry}->{Datasources}));
+        
+        foreach my $id (keys %{$result->{value}->{$entry}->{Datasources}}) {
+            my $name = $result->{value}->{$entry}->{Datasources}->{$id}->{name};
+            $name = $1 if ($name =~ /jdbc\/(.*)/);
+
+            push @datasources, { 
+                name => $name,
+                product => $result->{value}->{$entry}->{Datasources}->{$id}->{product},
+                version => $result->{value}->{$entry}->{Datasources}->{$id}->{version},
+                status => $result->{value}->{$entry}->{Datasources}->{$id}->{status},
+                instance => $instance
+            };
+        }
+    }
+
+    return \@datasources;
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    my $results = $self->manage_selection(%options);
+    foreach (@$results) {
+        $self->{output}->output_add(
+            long_msg => sprintf(
+                '[instance: %s][name: %s][product: %s][version: %s][status: %s]',
+                $_->{instance},
+                $_->{name},
+                $_->{product},
+                $_->{version},
+                $_->{status},
+            )
+        );
+    }
+
+    $self->{output}->output_add(
+        severity => 'OK',
+        short_msg => 'List datasources:'
+    );
+
+    $self->{output}->display(nolabel => 1, force_ignore_perfdata => 1, force_long_output => 1);
+    $self->{output}->exit();
+}
+
+sub disco_format {
+    my ($self, %options) = @_;
+
+    $self->{output}->add_disco_format(elements => ['instance', 'name', 'product', 'version', 'status']);
+}
+
+sub disco_show {
+    my ($self, %options) = @_;
+
+    my $results = $self->manage_selection(%options);
+    foreach (@$results) {
+        $self->{output}->add_disco_entry(%$_);
+    }
+}
+
+1;
+
+=head1 MODE
+
+List datasources.
+
+=over 8
+
+=back
+
+=cut

--- a/src/apps/apache/karaf/api/plugin.pm
+++ b/src/apps/apache/karaf/api/plugin.pm
@@ -1,0 +1,51 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::apache::karaf::api::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_custom);
+
+sub new {
+    my ( $class, %options ) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{modes} = {
+        'bundle-status'     => 'apps::apache::karaf::api::mode::bundlestatus',
+        'datasource-query'  => 'apps::apache::karaf::api::mode::datasourcequery',
+        'datasource-status' => 'apps::apache::karaf::api::mode::datasourcestatus',
+        'list-bundles'      => 'apps::apache::karaf::api::mode::listbundles',
+        'list-datasources'  => 'apps::apache::karaf::api::mode::listdatasources'
+    };
+
+    $self->{custom_modes}->{api} = 'apps::apache::karaf::api::custom::api';
+    return $self;
+}
+
+1;
+
+
+=head1 PLUGIN DESCRIPTION
+
+Check Apache Karaf using API.
+
+=cut


### PR DESCRIPTION
Adds a new plugin to monitor Apache Karaf using API.

```
centreon_plugins.pl --plugin=apps::apache::karaf::api::plugin --mode=bundle-status --hostname='myhost' --api-username='toto' --api-password='*)(ç*)ç(' --filter-symbolic-name='dataexchanges' --filter-counters='bundles'
OK: Number of bundles failed: 2, active: 483, resolved: 0 | 'bundles.failed.count'=2;;;0;485 'bundles.active.count'=483;;;0;485 'bundles.resolved.count'=0;;;0;485
```

```
centreon_plugins.pl --plugin=apps::apache::karaf::api::plugin --mode=bundle-status --hostname='myhost' --api-username='toto' --api-password='*)(ç*)ç(' --filter-name='^theBundle$' --critical-status='%{status} !~ /^(active|resolved)/i' --filter-counters='status'
OK: Bundle 'theBundle' status is 'active' [version: 1.2.0] [feature installed: yes, version: 1.2.0]
```

```
centreon_plugins.pl --plugin=apps::apache::karaf::api::plugin --mode=datasource-query --hostname='myhost' --api-username='toto' --api-password='*)(ç*)ç(' --instance='myInstance' --datasource='thedatasource' --query="SELECT id FROM thebase.dbo.MONITORING" --critical-status='%{status} != 200'
OK: Datasource query status is '200'
```

```
centreon_plugins.pl --plugin=apps::apache::karaf::api::plugin --mode=datasource-status --hostname='myhost' --api-username='toto' --api-password='*)(ç*)ç(' --filter-name='thedatasource' --critical-status='%{status} !~ /^(OK)/i'
OK: Datasource 'thedatasource' [product: Microsoft SQL Server] [version: 15.00.4335] status is 'OK'
```