### PR TITLE
CTOR-439-datacore-plugin-bad-path-in-pkg-json-source-code-is-not-properly-fatpacked

### DIFF
--- a/packaging/centreon-plugin-Hardware-Storage-DataCore-Sansymphony-Restapi/pkg.json
+++ b/packaging/centreon-plugin-Hardware-Storage-DataCore-Sansymphony-Restapi/pkg.json
@@ -4,6 +4,6 @@
     "plugin_name": "centreon_datacore_api.pl",
     "files": [
         "centreon/plugins/script_custom.pm",
-        "storage/datacore/api/"
+        "storage/datacore/restapi/"
     ]
 }


### PR DESCRIPTION
FIX:CTOR-439

## Description
fatpack configuration didn't include the datacore code

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
