### PR TITLE
new(plugin): add etcd plugins

### DIFF
--- a/packaging/centreon-plugin-Applications-Etcd-Api/deb.json
+++ b/packaging/centreon-plugin-Applications-Etcd-Api/deb.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": []
+}

--- a/packaging/centreon-plugin-Applications-Etcd-Api/pkg.json
+++ b/packaging/centreon-plugin-Applications-Etcd-Api/pkg.json
@@ -1,0 +1,9 @@
+{
+    "pkg_name": "centreon-plugin-Applications-Etcd-Api",
+    "pkg_summary": "Centreon Plugin to monitor etc cluster using API",
+    "plugin_name": "centreon_etcd_api.pl",
+    "files": [
+        "centreon/plugins/script_custom.pm",
+        "apps/etcd/api/"
+    ]
+}

--- a/packaging/centreon-plugin-Applications-Etcd-Api/rpm.json
+++ b/packaging/centreon-plugin-Applications-Etcd-Api/rpm.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": []
+}

--- a/packaging/centreon-plugin-Applications-Etcd-Exporter/deb.json
+++ b/packaging/centreon-plugin-Applications-Etcd-Exporter/deb.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": []
+}

--- a/packaging/centreon-plugin-Applications-Etcd-Exporter/pkg.json
+++ b/packaging/centreon-plugin-Applications-Etcd-Exporter/pkg.json
@@ -1,0 +1,10 @@
+{
+    "pkg_name": "centreon-plugin-Applications-Etcd-Exporter",
+    "pkg_summary": "Centreon Plugin to monitor etc cluster using /metrics exporter's endpoint",
+    "plugin_name": "centreon_etcd_exporter.pl",
+    "files": [
+        "centreon/plugins/script_custom.pm",
+        "centreon/common/monitoring/openmetrics/",
+        "apps/etcd/exporter/"
+    ]
+}

--- a/packaging/centreon-plugin-Applications-Etcd-Exporter/rpm.json
+++ b/packaging/centreon-plugin-Applications-Etcd-Exporter/rpm.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": []
+}

--- a/src/apps/etcd/api/mode/statistics.pm
+++ b/src/apps/etcd/api/mode/statistics.pm
@@ -1,0 +1,289 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::etcd::api::mode::statistics;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "Node state is '%s' [id: %s]",
+            $self->{result_values}->{state},
+            $self->{result_values}->{id}
+    );
+}
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+
+    return 'Members ';
+}
+
+sub prefix_member_output {
+    my ($self, %options) = @_;
+
+    return "Member '" . $options{instance_value}->{id} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        {
+            name => 'node',
+            type => 0,
+            skipped_code => { -10 => 1 }
+        },
+        {
+            name => 'global',
+            type => 0,
+            cb_prefix_output => 'prefix_global_output',
+            skipped_code => { -10 => 1 }
+        },
+        {
+            name => 'members',
+            type => 1,
+            cb_prefix_output => 'prefix_member_output',
+            message_multiple => 'All members are ok'
+        }
+    ];
+
+    $self->{maps_counters}->{node} = [
+        {
+            label => 'status',
+            type => 2,
+            set => {
+                key_values => [
+                    { name => 'state' },
+                    { name => 'id' },
+                    { name => 'name' }
+                ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        },
+        {
+            label => 'requests-sent-bandwidth',
+            nlabel => 'requests.sent.bandwidth.bytespersecond',
+            set => {
+                key_values => [
+                    { name => 'sendBandwidthRate' }
+                ],
+                output_template => 'requests sent bandwidth: %.2f %s/s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    { template => '%.2f', unit => 'B/s', min => 0 }
+                ]
+            }
+        },
+        {
+            label => 'requests-sent',
+            nlabel => 'requests.sent.persecond',
+            set => {
+                key_values => [
+                    { name => 'sendPkgRate' }
+                ],
+                output_template => 'requests sent: %.2f/s',
+                perfdatas => [
+                    { template => '%.2f', unit => 'requests/s', min => 0 }
+                ]
+            }
+        },
+        {
+            label => 'requests-received-bandwidth',
+            nlabel => 'requests.received.bandwidth.bytespersecond',
+            set => {
+                key_values => [
+                    { name => 'recvBandwidthRate' }
+                ],
+                output_template => 'requests received bandwidth: %.2f %s/s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    { template => '%.2f', unit => 'B/s', min => 0 }
+                ]
+            }
+        },
+        {
+            label => 'requests-received',
+            nlabel => 'requests.received.persecond',
+            set => {
+                key_values => [
+                    { name => 'recvPkgRate' }
+                ],
+                output_template => 'requests received: %.2f/s',
+                perfdatas => [
+                    { template => '%.2f', unit => 'requests/s', min => 0 }
+                ]
+            }
+        }
+    ];
+        
+    $self->{maps_counters}->{global} = [
+        {
+            label => 'total',
+            nlabel => 'cluster.members.total.count',
+            display_ok => 0,
+            set => {
+                key_values => [
+                    { name => 'total' }
+                ],
+                output_template => 'total: %d',
+                perfdatas => [
+                    { template => '%d', min => 0 }
+                ]
+            }
+        },
+        {
+            label => 'leader',
+            nlabel => 'cluster.members.leader.count',
+            display_ok => 0,
+            set => {
+                key_values => [
+                    { name => 'leader' }
+                ],
+                output_template => 'leader: %d',
+                perfdatas => [
+                    { template => '%d', min => 0 }
+                ]
+            }
+        },
+        {
+            label => 'follower',
+            nlabel => 'cluster.members.follower.count',
+            display_ok => 0,
+            set => {
+                key_values => [
+                    { name => 'follower' }
+                ],
+                output_template => 'follower: %d',
+                perfdatas => [
+                    { template => '%d', min => 0 }
+                ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{members} = [
+        {
+            label => 'latency',
+            nlabel => 'member.latency.milliseconds',
+            set => {
+                key_values => [
+                    { name => 'latency' },
+                    { name => 'id' }
+                ],
+                output_template => 'Latency: %.3f ms',
+                perfdatas => [
+                    {
+                        template => '%.3f',
+                        unit => 'ms',
+                        min => 0,
+                        label_extra_instance => 1,
+                        instance_use => 'id'
+                    }
+                ]
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {});
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+    
+    my $self_result = $options{custom}->get_self_statistics;
+
+    $self->{node} = {
+        name => $self_result->{name},
+        id => $self_result->{id},
+        state => $self_result->{state},
+        recvBandwidthRate => defined($self_result->{recvBandwidthRate}) ? $self_result->{recvBandwidthRate} : 0,
+        recvPkgRate => defined($self_result->{recvPkgRate}) ? $self_result->{recvPkgRate} : 0,
+        sendBandwidthRate => defined($self_result->{sendBandwidthRate}) ? $self_result->{sendBandwidthRate} : 0,
+        sendPkgRate => defined($self_result->{sendPkgRate}) ? $self_result->{sendPkgRate} : 0
+    };
+    
+    if (defined($self_result->{state}) && $self_result->{state} =~ /StateLeader/) {
+        $self->{global}->{total} = 1;
+        $self->{global}->{leader} = 1;
+        $self->{global}->{follower} = 0;
+
+        my $leader_result = $options{custom}->get_leader_statistics;
+
+        foreach my $entry (keys %{$leader_result->{followers}}) {
+            $self->{members}->{$entry} = {
+                id => $entry,
+                latency => $leader_result->{followers}->{$entry}->{latency}->{average} * 1000
+            };
+            $self->{global}->{total}++;
+            $self->{global}->{follower}++;
+        }
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check member status in a cluster.
+
+=over 8
+
+=item B<--warning-status>
+
+Set warning threshold for status.
+Can use special variables like: %{state}, %{id}, %{name}.
+
+=item B<--critical-status>
+
+Set critical threshold for status.
+Can use special variables like: %{state}, %{id}, %{name}.
+
+=item B<--warning-*> B<--critical-*>
+
+Thresholds.
+Can be: 'total', 'leader', 'followe', 'latency' (ms).
+
+=back
+
+=cut

--- a/src/apps/etcd/api/plugin.pm
+++ b/src/apps/etcd/api/plugin.pm
@@ -1,0 +1,46 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::etcd::api::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_custom);
+
+sub new {
+    my ( $class, %options ) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{modes} = {
+        'statistics' => 'apps::etcd::api::mode::statistics'
+    };
+
+    $self->{custom_modes}->{restapi} = 'apps::etcd::api::custom::restapi';
+    return $self;
+}
+
+1;
+
+=head1 PLUGIN DESCRIPTION
+
+Check etcd using API.
+
+=cut

--- a/src/apps/etcd/exporter/mode/databasesize.pm
+++ b/src/apps/etcd/exporter/mode/databasesize.pm
@@ -1,0 +1,105 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::etcd::exporter::mode::databasesize;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::common::monitoring::openmetrics::scrape;
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        {
+            name => 'global',
+            type => 0,
+        }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        {
+            label => 'size',
+            nlabel => 'database.size.bytes',
+            set => {
+                key_values => [
+                    { name => 'size' }
+                ],
+                output_template => 'Database size: %s %s',
+                output_change_bytes => 1,
+                perfdatas => [
+                    {
+                        template => '%s',
+                        unit => 'B',
+                        min => 0
+                    }
+                ]
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {});
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+    
+    my $raw_metrics = centreon::common::monitoring::openmetrics::scrape::parse(
+        filter_metrics => 'etcd_mvcc_db_total_size_in_bytes',
+        %options
+    );
+
+    # etcd_mvcc_db_total_size_in_bytes 1.1362304e+07
+    
+    $self->{global}->{size} = int($raw_metrics->{etcd_mvcc_db_total_size_in_bytes}->{data}[0]->{value});
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check database size.
+
+=over 8
+
+=item B<--warning-size> B<--critical-size>
+
+Thresholds on database size (in bytes).
+
+=back
+
+=cut

--- a/src/apps/etcd/exporter/plugin.pm
+++ b/src/apps/etcd/exporter/plugin.pm
@@ -1,0 +1,47 @@
+#
+# Copyright 2020 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::etcd::exporter::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_custom);
+
+sub new {
+    my ( $class, %options ) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{modes} = {
+        'database-size' => 'apps::etcd::exporter::mode::databasesize'
+    };
+
+    $self->{custom_modes}->{web} = 'centreon::common::monitoring::openmetrics::custom::web';
+
+    return $self;
+}
+
+1;
+
+=head1 PLUGIN DESCRIPTION
+
+Check etcd using /metrics exporter's endpoint.
+
+=cut


### PR DESCRIPTION
Adds 2 plugins to monitor etcd, one using the API, one using /metrics exporter's endpoint.
 
```
$ centreon_plugins.pl --plugin=apps::etcd::api::plugin --mode=statistics --hostname='10.1.2.3' --port='2379' --proto='http' --verbose
OK: Node state is 'StateLeader' [id: 234bb185487f53a2], requests sent bandwidth: 0.00 B/s, requests sent: 0.00/s, requests received bandwidth: 0.00 B/s, requests received: 0.00/s - All members are ok | 'requests.sent.bandwidth.bytespersecond'=0.00B/s;;;0; 'requests.sent.persecond'=0.00requests/s;;;0; 'requests.received.bandwidth.bytespersecond'=0.00B/s;;;0; 'requests.received.persecond'=0.00requests/s;;;0; 'cluster.members.total.count'=3;;;0; 'cluster.members.leader.count'=1;;;0; 'cluster.members.follower.count'=2;;;0; '7d91e5f5234c9ff6#member.latency.milliseconds'=1.467ms;;;0; 'ea5a6f62346782a2#member.latency.milliseconds'=1.438ms;;;0;
Member '7d91e5f5234c9ff6' Latency: 1.467 ms
Member 'ea5a6f62346782a2' Latency: 1.438 ms
```

```
$ centreon_plugins.pl --plugin=apps::etcd::exporter::plugin --mode=database-size --hostname='10.1.2.3' --port='2379' --proto='http' --urlpath='/metrics'
OK: Database size: 11.34 MB | 'database.size.bytes'=11890688B;;;0;
```

This PR uses commit 3d29d9cde1802b845e3a35f95259db6c649aeb37 from PR https://github.com/centreon/centreon-plugins/pull/4968 (so it can be removed from this one if the other is merged before in next few months or years).