### PR TITLE
take into account reserved space

### DIFF
--- a/src/os/linux/local/mode/storage.pm
+++ b/src/os/linux/local/mode/storage.pm
@@ -153,7 +153,7 @@ sub manage_selection {
     my @lines = split /\n/, $stdout;
     foreach my $line (@lines) {
         next if ($line !~ /^(\S+)\s+(\S+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(.*)/);
-        my ($fs, $type, $size, $used, $available, $percent, $mount) = ($1, $2, $3, $4, $5, $6, $7);
+        my ($fs, $type, $size, $available, $percent, $mount) = ($1, $2, $3, $5, $6, $7);
 
         next if (defined($self->{option_results}->{filter_fs}) && $self->{option_results}->{filter_fs} ne '' &&
             $fs !~ /$self->{option_results}->{filter_fs}/);
@@ -171,8 +171,8 @@ sub manage_selection {
             fs => $fs,
             type => $type,
             total => $size * 1024,
-            used => $used * 1024,
-            free => $available * 1024
+            free => $available * 1024,
+            used => ($size - $available) * 1024
         };
     }
 

--- a/src/os/linux/local/mode/storage.pm
+++ b/src/os/linux/local/mode/storage.pm
@@ -153,7 +153,7 @@ sub manage_selection {
     my @lines = split /\n/, $stdout;
     foreach my $line (@lines) {
         next if ($line !~ /^(\S+)\s+(\S+)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\S+)\s+(.*)/);
-        my ($fs, $type, $size, $available, $percent, $mount) = ($1, $2, $3, $5, $6, $7);
+        my ($fs, $type, $used, $available, $percent, $mount) = ($1, $2, $4, $5, $6, $7);
 
         next if (defined($self->{option_results}->{filter_fs}) && $self->{option_results}->{filter_fs} ne '' &&
             $fs !~ /$self->{option_results}->{filter_fs}/);
@@ -170,9 +170,9 @@ sub manage_selection {
             display => $mount,
             fs => $fs,
             type => $type,
-            total => $size * 1024,
+            used => $used * 1024,
             free => $available * 1024,
-            used => ($size - $available) * 1024
+            total => ($used + $available) * 1024
         };
     }
 

--- a/tests/resources/spellcheck/stopwords.t
+++ b/tests/resources/spellcheck/stopwords.t
@@ -15,6 +15,7 @@ ADSL
 Centreon
 Datacore
 deltaps
+df
 eth
 Fortigate
 Fortinet

--- a/tests/resources/spellcheck/stopwords.t
+++ b/tests/resources/spellcheck/stopwords.t
@@ -1,5 +1,7 @@
 --display-transform-dst
 --display-transform-src
+--exclude-fs
+--filter-fs
 --filter-vdom
 --force-counters32
 --force-counters64


### PR DESCRIPTION
## Description

To display the real used space, we need to take into account the reserved space.
If we use the formula `Total = Used + Available` the reserved space is taken into account.

**Fixes** # CTOR-441

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)
