### PR TITLE
Update alert.pm

### DIFF
--- a/src/notification/email/mode/alert.pm
+++ b/src/notification/email/mode/alert.pm
@@ -829,7 +829,7 @@ Use this option to disable SSL.
 
 =item B<--smtp-debug>
 
-Enable smtp-debug mode.
+Enable debugging of SMTP.
 
 =item B<--to-address>
 

--- a/src/notification/email/mode/alert.pm
+++ b/src/notification/email/mode/alert.pm
@@ -382,7 +382,7 @@ sub service_message {
     ' . $self->{option_results}->{service_output} . '
     ' . $self->{option_results}->{service_longoutput};
 
-    $self->{option_results}->{service_longoutput} =~ s/\\n/<br \/>/g;
+    $self->{option_results}->{service_longoutput} =~ s/\n/<br \/>/g;
     my $output = $self->{option_results}->{service_output} . $line_break . $self->{option_results}->{service_longoutput};
 
     my $background_color= 'white';


### PR DESCRIPTION
Fixing long output wrong parsing

Current long output:
![image](https://github.com/centreon/centreon-plugins/assets/11980015/accbcb55-d55f-4f14-a5a7-b83683e061b2)


Fixed long output:
![image](https://github.com/centreon/centreon-plugins/assets/11980015/a1e2f958-504c-4369-8a1b-27cc425bd5ae)
