### PR TITLE
enh(plugin): add --since-hours to ansible::tower::mode::jobs

### DIFF
--- a/src/apps/automation/ansible/tower/mode/jobs.pm
+++ b/src/apps/automation/ansible/tower/mode/jobs.pm
@@ -70,6 +70,7 @@ sub new {
 
     $options{options}->add_options(arguments => {
         'filter-name:s'       => { name => 'filter_name' },
+        'since-hours:s'       => { name => 'since_hours' },
         'display-failed-jobs' => { name => 'display_failed_jobs' },
         'memory'              => { name => 'memory' }
     });
@@ -82,13 +83,19 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::check_options(%options);
 
-    if (defined($self->{option_results}->{memory})) {
+    if (defined($self->{option_results}->{memory}) || defined($self->{option_results}->{since_hours})) {
         $self->{statefile_cache}->check_options(%options);
         centreon::plugins::misc::mymodule_load(
             output => $self->{output},
             module => 'Date::Parse',
             error_msg => "Cannot load module 'Date::Parse'."
         );
+    }
+
+    if (defined($self->{option_results}->{since_hours})
+        && !($self->{option_results}->{since_hours} =~ /^\d+$/ && $self->{option_results}->{since_hours} > 0)) {
+        $self->{output}->add_option_msg(short_msg => "--since-hours should be a positive integer to count hours");
+        $self->{output}->option_exit();
     }
 }
 
@@ -111,7 +118,7 @@ sub manage_selection {
         next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' 
             && $job->{name} !~ /$self->{option_results}->{filter_name}/);
 
-        if (defined($self->{option_results}->{memory}) && defined($job->{finished})) {
+        if (defined($job->{finished})) {
             my $finished_time = Date::Parse::str2time($job->{finished});
             if (!defined($finished_time)) {
                 $self->{output}->output_add(
@@ -120,7 +127,15 @@ sub manage_selection {
                 );
                 next;
             }
-            next if (defined($last_time) && $last_time > $finished_time);
+
+            if (defined($self->{option_results}->{memory})) {
+                next if (defined($last_time) && $last_time > $finished_time);
+            }
+
+            if (defined($self->{option_results}->{since_hours})) {
+                my $cutoff_time = $current_time - ($self->{option_results}->{since_hours} * 3600);
+                next if $finished_time < $cutoff_time;
+            }
         }
 
         $self->{global}->{ $job->{status} }++;
@@ -152,6 +167,10 @@ Check jobs.
 =item B<--filter-name>
 
 Filter job name (can use regexp).
+
+=item B<--since-hours>
+
+Only check jobs that finished less than X hours ago
 
 =item B<--display-failed-jobs>
 

--- a/src/apps/automation/ansible/tower/mode/jobs.pm
+++ b/src/apps/automation/ansible/tower/mode/jobs.pm
@@ -118,7 +118,8 @@ sub manage_selection {
         next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' 
             && $job->{name} !~ /$self->{option_results}->{filter_name}/);
 
-        if (defined($job->{finished})) {
+        if ((defined($self->{option_results}->{memory}) || defined($self->{option_results}->{since_hours}))
+            && defined($job->{finished})) {
             my $finished_time = Date::Parse::str2time($job->{finished});
             if (!defined($finished_time)) {
                 $self->{output}->output_add(


### PR DESCRIPTION
## Description

The apps::automation::ansible::tower plugin, in its jobs mode, takes into account all the jobs of Ansible Tower.

In some cases, it's fine to disregard old failed jobs (including those that pass the --filter-name parameter) and only monitor recent ones, which is why a new --since-hours option is proposed here.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Using "--plugin=apps::automation::ansible::tower::plugin --mode=jobs" and other usual settings for this plugin against an Ansible Tower URL, add the --since-hours option with a numeral to check only the jobs that finished less than [numeral] hours ago.

For instance, "--since-hours=24" for the jobs of the past 24 hours.

When the option is omitted, nothing should change.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***) :exclamation: Useless here
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR. :exclamation: Useless here
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
