### PR TITLE
CTOR-525-escalation-package-perl-json-path-wrong-version-missing-perl-exporter-easy-for-centreon-repo-23-04-23-10-el-8

### DIFF
--- a/.github/docker/packaging/Dockerfile.packaging-plugins-alma8
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-alma8
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/almalinux:8
 

--- a/.github/docker/packaging/Dockerfile.packaging-plugins-alma9
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-alma9
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/almalinux:9
 

--- a/.github/docker/packaging/Dockerfile.packaging-plugins-bookworm
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-bookworm
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/debian:bookworm
 

--- a/.github/docker/packaging/Dockerfile.packaging-plugins-bullseye
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-bullseye
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/debian:bullseye
 

--- a/.github/docker/packaging/Dockerfile.packaging-plugins-centos7
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-centos7
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/centos:7
 

--- a/.github/docker/packaging/Dockerfile.packaging-plugins-jammy
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-jammy
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/ubuntu:jammy
 

--- a/.github/docker/testing/Dockerfile.testing-plugins-alma8
+++ b/.github/docker/testing/Dockerfile.testing-plugins-alma8
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/almalinux:8
 

--- a/.github/docker/testing/Dockerfile.testing-plugins-alma9
+++ b/.github/docker/testing/Dockerfile.testing-plugins-alma9
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/almalinux:9
 

--- a/.github/docker/testing/Dockerfile.testing-plugins-bookworm
+++ b/.github/docker/testing/Dockerfile.testing-plugins-bookworm
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/debian:bookworm
 

--- a/.github/docker/testing/Dockerfile.testing-plugins-bullseye
+++ b/.github/docker/testing/Dockerfile.testing-plugins-bullseye
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/debian:bullseye
 

--- a/.github/docker/testing/Dockerfile.testing-plugins-jammy
+++ b/.github/docker/testing/Dockerfile.testing-plugins-jammy
@@ -1,4 +1,4 @@
-ARG REGISTRY_URL
+ARG REGISTRY_URL=docker.io
 
 FROM ${REGISTRY_URL}/ubuntu:jammy
 

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -96,7 +96,7 @@ jobs:
             "XML::SAX::Writer",
             "ZMQ::Constants",
             "ZMQ::FFI",
-            "ZMQ::LibZMQ4",
+            "ZMQ::LibZMQ4"
           ]
         include:
           - build_distribs: "el8,el9"

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -53,6 +53,7 @@ jobs:
             "Digest::MD5::File",
             "Digest::SHA1",
             "Email::Send::SMTP::Gmail",
+            "Exporter::Shiny",
             "EV",
             "FFI::CheckLib",
             "FFI::Platypus",
@@ -95,7 +96,7 @@ jobs:
             "XML::SAX::Writer",
             "ZMQ::Constants",
             "ZMQ::FFI",
-            "ZMQ::LibZMQ4"
+            "ZMQ::LibZMQ4",
           ]
         include:
           - build_distribs: "el8,el9"
@@ -121,6 +122,8 @@ jobs:
             version: "0.022"
           - name: "Device::Modbus::TCP::Client"
             version: "0.026"
+          - name: "Exporter::Shiny"
+            build_distribs: el8
           - name: "EV"
           - name: "FFI::CheckLib"
           - name: "FFI::Platypus"
@@ -140,6 +143,7 @@ jobs:
             use_dh_make_perl: "false"
             version: "0.01"
             rpm_dependencies: "zeromq"
+
     name: package ${{ matrix.distrib }} ${{ matrix.name }}
     container:
       image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:latest

--- a/.github/workflows/perl-json-path.yml
+++ b/.github/workflows/perl-json-path.yml
@@ -69,11 +69,8 @@ jobs:
             dnf install -y cpanminus gcc
           fi
 
-          if [ "${{ matrix.distrib }}" = "el8" ]; then
-            cpanm -v -l /tmp JSON::Path@0.5
-          else
-            cpanm -v -l /tmp JSON::Path@1.0.4
-          fi
+          cpanm -v -l /tmp JSON::Path@1.0.4
+
         shell: bash
 
       - name: Set package name and paths according to distrib
@@ -90,7 +87,6 @@ jobs:
           else
             NAME="perl-JSON-Path"
             if [ "${{ matrix.distrib }}" = "el8" ]; then
-              VERSION="0.5" # https://github.com/centreon/centreon-plugins/issues/4540
               PERL_VENDORLIB="/usr/local/share/perl5"
             else
               PERL_VENDORLIB="/usr/local/share/perl5/$PERL_VERSION"


### PR DESCRIPTION
## Description

update JSON::Path library on alma8 to take same version as other OS.
This is a follow up of https://github.com/centreon/centreon-plugins/issues/4540, the root problem was in Exporter::Shiny, updating it to the same version as debian11/alma9 make everything work.

**Fixes** # CTOR-525

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>
install the new library version and launch the plugin 
`/usr/lib/centreon/plugins/centreon_protocol_http.pl  --plugin='apps::protocols::http::plugin' --mode='json-content'`
the plugin should compile correctly.


## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
