### PR TITLE
fix(gorgone) correctly handle gorgone pullwss module shutdown

### DIFF
--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -68,6 +68,7 @@ jobs:
             "JSON::WebToken",
             "LV",
             "MIME::Types",
+            "Mojo::IOLoop::Signal",
             "MongoDB",
             "Net::DHCP",
             "Net::FTPSSL",
@@ -160,7 +161,7 @@ jobs:
           yum install -y yum-utils epel-release git
           yum config-manager --set-enabled crb || true # alma 9
           yum config-manager --set-enabled powertools || true # alma 8
-          yum install -y cpanminus rpm-build libcurl-devel libssh-devel expat-devel gcc libuuid-devel zeromq-devel libxml2-devel libffi-devel perl-DBI perl-Net-Pcap freetds freetds-devel
+          yum install -y cpanminus rpm-build libcurl-devel libssh-devel expat-devel gcc libuuid-devel zeromq-devel libxml2-devel libffi-devel perl-DBI perl-Net-Pcap freetds freetds-devel perl-Module-Build-Tiny
 
           dnf module reset -y ruby
           dnf module enable -y ruby:3.1
@@ -247,6 +248,7 @@ jobs:
             "Hash::Ordered",
             "HTTP::ProxyPAC",
             "JMX::Jmx4Perl",
+            "Mojo::IOLoop::Signal",
             "Net::FTPSSL",
             "Net::HTTPTunnel",
             "Net::SMTP_auth",
@@ -335,7 +337,8 @@ jobs:
 
       - if: ${{ contains(matrix.build_distribs, matrix.distrib) && matrix.use_dh_make_perl == 'true' }}
         run: |
-          apt-get install -y libcurl4-openssl-dev dh-make-perl libssh-dev uuid-dev libczmq-dev libmodule-install-perl
+          apt-get install -y libcurl4-openssl-dev dh-make-perl libssh-dev uuid-dev libczmq-dev libmodule-install-perl libmodule-build-tiny-perl
+          # module-build-tiny is required for Mojo::IOLoop::Signal build.
 
           DEB_BUILD_OPTIONS="nocheck nodocs notest" dh-make-perl make --dist ${{ matrix.distrib }} --build --version ${{ steps.package-version.outputs.package_version }}-${{ matrix.distrib }} --cpan ${{ matrix.name }}
         shell: bash


### PR DESCRIPTION


## Description
This PR add Mojo::IOLoop::Signal library to be built from cpan to a deb/rpm installable packet.
This lib will be required by gorgone pullwss module to correctly handle unix signal (sigterm/sighup).
as centreon-plugins release every month and gorgone twice a year the lib will be available for gorgone next release (24.10).

**Fixes** # (MON-34540)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] master

<h2> How this pull request can be tested ? </h2>
The Mojo::IOLoop::Signal library should be installable from centreon repository in all OS version currenctly supported by centreon.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
