### PR TITLE
CTOR-600-fix-typo-and-missing-wrong-counters-in-plugins-help-documentation 

### DIFF
--- a/src/apps/antivirus/mcafee/webgateway/snmp/mode/httpsstatistics.pm
+++ b/src/apps/antivirus/mcafee/webgateway/snmp/mode/httpsstatistics.pm
@@ -149,16 +149,10 @@ Check HTTPS statistics.
 Only display some counters (regexp can be used).
 (example: --filter-counters='^proxy')
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
-Can be: 'request', 'client-to-proxy', 'server-to-proxy',
-'proxy-to-client', 'proxy-to-server'.
-
-=item B<--critical-*>
-
-Critical threshold.
-Can be: 'request', 'client-to-proxy', 'server-to-proxy',
+Thresholds.
+Can be: 'requests', 'client-to-proxy', 'server-to-proxy',
 'proxy-to-client', 'proxy-to-server'.
 
 =back

--- a/src/apps/antivirus/mcafee/webgateway/snmp/mode/httpstatistics.pm
+++ b/src/apps/antivirus/mcafee/webgateway/snmp/mode/httpstatistics.pm
@@ -150,16 +150,10 @@ Check HTTP statistics.
 Only display some counters (regexp can be used).
 (example: --filter-counters='^proxy')
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
-Can be: 'request', 'client-to-proxy', 'server-to-proxy',
-'proxy-to-client', 'proxy-to-server'.
-
-=item B<--critical-*>
-
-Critical threshold.
-Can be: 'request', 'client-to-proxy', 'server-to-proxy',
+Thresholds.
+Can be: 'requests', 'client-to-proxy', 'server-to-proxy',
 'proxy-to-client', 'proxy-to-server'.
 
 =back

--- a/src/apps/mq/activemq/jmx/mode/brokers.pm
+++ b/src/apps/mq/activemq/jmx/mode/brokers.pm
@@ -370,13 +370,13 @@ You can use the following variables: %{status}, %{name}
 Thresholds.
 Can be: 'store-usage' (%), 'temporary-usage' (%), 'memory-usage' (%),
 'queue-average-enqueue-time' (ms), 'queue-consumers-connected',
-'queue-producers-connected', 'queue-memory-usage' (%), 'queue-size',
+'queue-producers-connected', 'queue-memory-usage' (%), 'queue-size', 
 'queue-messages-enqueued', 'queue-messages-dequeued', 'queue-messages-expired',
-'queue-messages-inflighted',
+'queue-messages-inflighted', 'queue-messages-size-average' (B),
 'topic-average-enqueue-time' (ms), 'topic-consumers-connected',
 'topic-producers-connected', 'topic-memory-usage' (%), 'topic-size',
 'topic-messages-enqueued', 'topic-messages-dequeued', 'topic-messages-expired',
-'topic-messages-inflighted'.
+'topic-messages-inflighted', 'topic-messages-size-average' (B).
 
 =back
 

--- a/src/apps/pineapp/securemail/snmp/mode/system.pm
+++ b/src/apps/pineapp/securemail/snmp/mode/system.pm
@@ -265,7 +265,7 @@ You can use the following variables: %{status}
 
 Thresholds.
 Can be: 'load-1m', 'load-5m', 'load-15m', 
-'messages-priority-high', 'messages-priority-medium', 'messages-priority-low',
+'messages-priority-high', 'messages-priority-normal', 'messages-priority-low',
 'messages-queue-inbound', 'messages-queue-outbound',
 'messages-queue-total'.
 

--- a/src/centreon/common/aruba/snmp/mode/apssidstatistics.pm
+++ b/src/centreon/common/aruba/snmp/mode/apssidstatistics.pm
@@ -242,17 +242,12 @@ Check AP ESSID and BSSID statistics (WLSX-WLAN-MIB, WLSX-SWITCH-MIB).
 
 =over 8
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
-Can be: 'stations-associated' (ESSID and BSSID),
-'channel-noise', 'signal-noise-ratio' (BSSID).
-
-=item B<--critical-*>
-
-Critical threshold.
-Can be: 'stations-associated' (ESSID and BSSID),
-'channel-noise', 'signal-noise-ratio' (BSSID).
+Thresholds.
+Can be: 'stations-associated' (ESSID and BSSID).
+(ESSID) 'essid-stations-associated',
+(BSSID) 'bssid-stations-associated', 'channel-noise', 'signal-noise-ratio'.
 
 =item B<--filter-*>
 

--- a/src/centreon/common/fortinet/fortigate/snmp/mode/memory.pm
+++ b/src/centreon/common/fortinet/fortigate/snmp/mode/memory.pm
@@ -175,7 +175,7 @@ Check system memory usage (FORTINET-FORTIGATE).
 =item B<--warning-*> B<--critical-*>
 
 Thresholds.
-Can be: 'usage-free', 'usage-prct', 'cluster-usage-prct'.
+Can be: 'usage', 'usage-free', 'usage-prct', 'cluster-usage-prct'.
 
 =item B<--cluster>
 

--- a/src/centreon/common/fortinet/fortigate/snmp/mode/vdomusage.pm
+++ b/src/centreon/common/fortinet/fortigate/snmp/mode/vdomusage.pm
@@ -446,7 +446,7 @@ You can use the following variables: %{op_mode}, %{ha_state}
 =item B<--warning-*> B<--critical-*>
 
 Thresholds.
-Can be: 'cpu-utilization', 'sessions-active', 'session-rate',
+Can be: 'cpu-utilization', 'sessions-active', 'sessions-rate',
 'memory-usage-prct', 'license-usage', 'license-free',
 'license-usage-prct', 'traffic-in', 'traffic-out', 'policies-active'.
 

--- a/src/centreon/common/riverbed/steelhead/snmp/mode/diskutilization.pm
+++ b/src/centreon/common/riverbed/steelhead/snmp/mode/diskutilization.pm
@@ -128,15 +128,9 @@ Check disk utilization : usage, hits and misses.
 
 =over 8
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
-Can be: 'usage' (%), 'hits' (/s), 'misses' (/s).
-
-
-=item B<--critical-usage>
-
-Critical threshold.
+Thresholds.
 Can be: 'usage' (%), 'hits' (/s), 'misses' (/s).
 
 =back

--- a/src/centreon/common/riverbed/steelhead/snmp/mode/loadaverage.pm
+++ b/src/centreon/common/riverbed/steelhead/snmp/mode/loadaverage.pm
@@ -141,14 +141,11 @@ Check system load average.
 
 =over 8
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning thresholds (* can be average, 1m, 5m, 15m).
+Thresholds.
 
-=item B<--critical-*>
-
-Critical thresholds
-Can be --critical-(average|1m|5m|15m)
+Can be: 'average', '1min', '5min', '15min'.
 
 =back
 

--- a/src/centreon/common/xppc/snmp/mode/outputlines.pm
+++ b/src/centreon/common/xppc/snmp/mode/outputlines.pm
@@ -155,7 +155,7 @@ You can use the following variables: %{status}.
 =item B<--warning-*> B<--critical-*>
 
 Thresholds.
-Can be: 'load', 'voltage', 'current', 'power'.
+Can be: 'load', 'voltage', 'current', 'power', 'frequence'.
 
 =back
 

--- a/src/hardware/devices/aeg/acm/snmp/mode/batterystatus.pm
+++ b/src/hardware/devices/aeg/acm/snmp/mode/batterystatus.pm
@@ -245,17 +245,11 @@ You can use the following variables: %{status}
 Define the conditions to match for the status to be CRITICAL (default: '%{status} =~ /disconnected/i || %{status} =~ /shutdown/i').
 You can use the following variables: %{status}
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
+Thresholds.
 Can be: 'voltage', 'current', 'current1', 'current2', 'temperature',
-'temperature2', 'temperature2', 'amphourmeter'.
-
-=item B<--critical-*>
-
-Critical threshold.
-Can be: 'voltage', 'current', 'current1', 'current2', 'temperature',
-'temperature2', 'temperature2', 'amphourmeter'.
+'temperature1', 'temperature2', 'amphourmeter'.
 
 =back
 

--- a/src/hardware/devices/camera/optelecom/snmp/mode/interfaces.pm
+++ b/src/hardware/devices/camera/optelecom/snmp/mode/interfaces.pm
@@ -94,7 +94,7 @@ You can use the following variables: %{admstatus}, %{opstatus}, %{duplexstatus},
 Thresholds.
 Can be: 'total-port', 'total-admin-up', 'total-admin-down', 'total-oper-up', 'total-oper-down',
 'in-traffic', 'out-traffic', 'in-error', 'in-discard', 'out-error', 'out-discard',
-'in-ucast', 'in-bcast', 'in-mcast', 'out-ucast', 'out-bcast', 'out-mcast',
+'in-ucast', 'in-bcast', 'in-mcast', 'out-ucast', 'out-bcast', 'out-mcast', 'in-volume', 'out-volume',
 'speed' (b/s).
 
 =item B<--units-traffic>

--- a/src/hardware/devices/eltek/enexus/snmp/mode/load.pm
+++ b/src/hardware/devices/eltek/enexus/snmp/mode/load.pm
@@ -213,7 +213,7 @@ You can use the following variables: %{status}
 =item B<--warning-*> B<--critical-*>
 
 Thresholds.
-Can be: 'current', 'power'.
+Can be: 'current', 'power', 'voltage'.
 
 =back
 

--- a/src/hardware/devices/hikvision/nvr/snmp/mode/disks.pm
+++ b/src/hardware/devices/hikvision/nvr/snmp/mode/disks.pm
@@ -210,7 +210,7 @@ Filter disks by name (can be a regexp).
 Define the conditions to match for the status to be UNKNOWN.
 You can use the following variables: %{status}, %{name}
 
-=item B<--warning--status>
+=item B<--warning-status>
 
 Define the conditions to match for the status to be WARNING (default: '%{status} =~ /reparing|formatting/i').
 You can use the following variables: %{status}, %{name}

--- a/src/hardware/devices/hms/ewon/snmp/mode/tags.pm
+++ b/src/hardware/devices/hms/ewon/snmp/mode/tags.pm
@@ -298,6 +298,11 @@ E.g: --tag-output-value='tagNameMatch,remaining: %s%%'
 Set tag value threshold (syntax: [regexp,]threshold).
 E.g: --tag-threshold-warning='tagNameMatch,50' --tag-threshold-critical='tagNameMatch,80'
 
+=item B<--unknown-status>
+
+Define the conditions to match for the status to be UNKNOWN.
+You can use the following variables: %{status}, %{name}
+
 =item B<--warning-status>
 
 Define the conditions to match for the status to be WARNING.
@@ -308,9 +313,9 @@ You can use the following variables: %{status}, %{name}
 Define the conditions to match for the status to be CRITICAL (default: '%{status} =~ /alarm/').
 You can use the following variables: %{status}, %{name}
 
-=item B<--warning-*> B<--critical-*>
+=item B<--unknown-*> B<--warning-*> B<--critical-*>
 
-Warning threshold.
+Thresholds.
 Can be: 'usage' (B), 'usage-free' (B), 'usage-prct' (%).
 
 =back

--- a/src/hardware/pdu/gude/epc/snmp/mode/sppowerchannels.pm
+++ b/src/hardware/pdu/gude/epc/snmp/mode/sppowerchannels.pm
@@ -264,16 +264,11 @@ Warning threshold for for single port status.
 
 Critical threshold for for single port status.
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
+Thresholds.
 Can be: 'active-channels', 'current', 'energy', 'frequency', 'phase-angle', 'power-active',
-'power-apparent', 'power-factor', 'power-reactive', 'voltage'
-
-=item B<--critical-*>
-
-Can be: 'active-channels', 'current', 'energy', 'frequency', 'phase-angle', 'power-active',
-'power-apparent', 'power-factor', 'power-reactive', 'voltage'
+'power-apparent', 'power-factor', 'power-reactive', 'voltage', 'total-singleports'.
 
 =back
 

--- a/src/hardware/server/cisco/ucs/snmp/mode/auditlogs.pm
+++ b/src/hardware/server/cisco/ucs/snmp/mode/auditlogs.pm
@@ -229,6 +229,13 @@ Filter on event message. (default: none)
 
 Event older (current time - retention time) is not checked (in seconds).
 
+=item B<--warning-*> B<--critical-*>
+
+Threshold.
+
+Can be: 'audit-total', 'audit-major', 'audit-warning', 'audit-info, 'audit-cleared', 'audit-minor' 'audit-condition', 
+'audit-critical'.
+
 =back
 
 =cut

--- a/src/hardware/ups/ees/snmp/mode/input.pm
+++ b/src/hardware/ups/ees/snmp/mode/input.pm
@@ -106,8 +106,7 @@ Check input lines.
 =item B<--warning-*> B<--critical-*>
 
 Input thresholds in V
-
-Thresholds: line-a, line-c, line-c.
+Can be: 'line-a', 'line-c', 'line-b'.
 
 =back
 

--- a/src/hardware/ups/hp/snmp/mode/outputlines.pm
+++ b/src/hardware/ups/hp/snmp/mode/outputlines.pm
@@ -206,7 +206,7 @@ You can use the following variables: %{source}.
 =item B<--warning-*> B<--critical-*>
 
 Thresholds.
-Can be: 'load', 'voltage', 'current', 'power'.
+Can be: 'load', 'voltage', 'current', 'power', 'frequence'.
 
 =back
 

--- a/src/hardware/ups/powerware/snmp/mode/outputlines.pm
+++ b/src/hardware/ups/powerware/snmp/mode/outputlines.pm
@@ -150,16 +150,10 @@ Check Output lines metrics (load, voltage, current and true power) (XUPS-MIB).
 
 =over 8
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
-Can be: 'load', 'voltage', 'current', 'power'.
-Load is a rate for X phase.
-
-=item B<--critical-*>
-
-Critical threshold.
-Can be: 'load', 'voltage', 'current', 'power'.
+Thresholds.
+Can be: 'load', 'voltage', 'current', 'power', 'frequence'.
 Load is a rate for X phase.
 
 =back

--- a/src/hardware/ups/standard/rfc1628/snmp/mode/outputlines.pm
+++ b/src/hardware/ups/standard/rfc1628/snmp/mode/outputlines.pm
@@ -187,8 +187,8 @@ Ignore counters equals to 0.
 
 =item B<--warning-*> B<--critical-*>
 
-Threshold.
-Can be: 'frequency', 'load', 'voltage', 'current', 'power'.
+Thresholds.
+Can be: 'frequence', 'load', 'voltage', 'current', 'power'.
 
 =item B<--warning-stdev-3phases>
 

--- a/src/network/a10/ax/snmp/mode/globalstats.pm
+++ b/src/network/a10/ax/snmp/mode/globalstats.pm
@@ -111,15 +111,10 @@ Check global statistics.
 Only display some counters (regexp can be used).
 Example: --filter-counters='^current-connections$'
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
-Can be: 'current-connections', 'total-connections'.
-
-=item B<--critical-*>
-
-Critical threshold.
-Can be: 'current-connections', 'total-connections'.
+Thresholds.
+Can be: 'current-connections', 'total-connections', 'total-ssl-connections'.
 
 =back
 

--- a/src/network/acmepacket/snmp/mode/realmusage.pm
+++ b/src/network/acmepacket/snmp/mode/realmusage.pm
@@ -182,18 +182,11 @@ Check realm usage.
 
 =over 8
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
+Thresholds.
 Can be: 'current-in-sessions', 'current-in-sessions-rate', 'total-in-sessions',
-'current-out-sessions', 'current-out-sessions-rate', 'total-out-session',
-'avg-qos-rfactor', 'total-rfactor'.
-
-=item B<--critical-*>
-
-Critical threshold.
-Can be: 'current-in-sessions', 'current-in-sessions-rate', 'total-in-sessions',
-'current-out-sessions', 'current-out-sessions-rate', 'total-out-session',
+'current-out-sessions', 'current-out-sessions-rate', 'total-out-sessions',
 'avg-qos-rfactor', 'total-rfactor'.
 
 =item B<--filter-name>

--- a/src/network/adva/fsp150/snmp/mode/systems.pm
+++ b/src/network/adva/fsp150/snmp/mode/systems.pm
@@ -198,7 +198,7 @@ Check systems.
 
 =over 8
 
-=item B<--filter-network-elemet>
+=item B<--filter-network-element>
 
 Filter by network element name (can be a regexp).
 

--- a/src/network/cambium/cnpilot/snmp/mode/cpu.pm
+++ b/src/network/cambium/cnpilot/snmp/mode/cpu.pm
@@ -116,13 +116,13 @@ Check CPU usage.
 
 Filter on one AP name.
     
-=item B<--warning>
+=item B<--warning-cpu-usage-prct>
 
-Warning threshold for CPU.
+Warning threshold for CPU usage (%).
 
-=item B<--critical>
+=item B<--critical-cpu-usage-prct>
 
-Critical threshold for CPU.
+Critical threshold for CPU usage (%).
 
 =back
 

--- a/src/network/cambium/cnpilot/snmp/mode/memory.pm
+++ b/src/network/cambium/cnpilot/snmp/mode/memory.pm
@@ -126,13 +126,13 @@ Check memory usage.
 
 Filter on one or several AP.
 
-=item B<--warning>
+=item B<--warning-memory-usage-prct>
 
-Warning threshold for Memory.
+Warning threshold for Memory usage (%).
 
-=item B<--critical>
+=item B<--critical-memory-usage-prct>
 
-Critical threshold for Memory.
+Critical threshold for Memory usage (%).
 
 =back
 

--- a/src/network/cisco/WaaS/mode/sessions.pm
+++ b/src/network/cisco/WaaS/mode/sessions.pm
@@ -111,7 +111,7 @@ Check optimized and passthrough sessions on Cisco WAAS equipments against total 
 
 Warning threshold: Percentage value of passthrough sessions resulting in a warning state
 
-=item B<--critical-average>
+=item B<--critical>
 
 Critical threshold: Percentage value of passthrough sessions resulting in a critical state
 

--- a/src/network/cisco/callmanager/snmp/mode/gatewayusage.pm
+++ b/src/network/cisco/callmanager/snmp/mode/gatewayusage.pm
@@ -155,13 +155,9 @@ You can use the following variables: %{status}, %{display}
 Define the conditions to match for the status to be CRITICAL (default: '%{status} !~ /^registered/').
 You can use the following variables: %{status}, %{display}
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
-
-=item B<--critical-*>
-
-Critical threshold.
+Thresholds.
 
 Can be: 'total-registered', 'total-unregistered', 'total-rejected', 
 'total-unknown', 'total-partiallyregistered'.

--- a/src/network/cisco/callmanager/snmp/mode/mediadeviceusage.pm
+++ b/src/network/cisco/callmanager/snmp/mode/mediadeviceusage.pm
@@ -155,13 +155,9 @@ You can use the following variables: %{status}, %{display}
 Define the conditions to match for the status to be CRITICAL (default: '%{status} !~ /^registered/').
 You can use the following variables: %{status}, %{display}
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
-
-=item B<--critical-*>
-
-Critical threshold.
+Thresholds.
 
 Can be: 'total-registered', 'total-unregistered', 'total-rejected', 
 'total-unknown', 'total-partiallyregistered'.

--- a/src/network/cisco/umbrella/snmp/mode/connectivity.pm
+++ b/src/network/cisco/umbrella/snmp/mode/connectivity.pm
@@ -116,7 +116,7 @@ Can use special variables like: %{status}, %{display}
 =item B<--critical-*>
 
 Define the conditions to match for the status to be CRITICAL. (default: %{status} =~ /red/).
-Can be: 'dns-connectivity', 'localdns-connectivity', 'cloud-connectivity', 'ad-connectivity'.
+Can be: 'dns-status', 'localdns-status', 'cloud-status', 'ad-status'.
 
 Can use special variables like: %{status}, %{display}
 

--- a/src/network/efficientip/snmp/mode/dnsusage.pm
+++ b/src/network/efficientip/snmp/mode/dnsusage.pm
@@ -111,13 +111,9 @@ Check dhcp usage.
 Only display some counters (regexp can be used).
 Example: --filter-counters='^requestv4$'
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
-
-=item B<--critical-*>
-
-Critical threshold.
+Thresholds.
 
 General name server statistics: 'udp', 'tcp', 'requestv4', 'requestv6', 'recursion', 'response',
 'recurserej', 'duplicate', 'dropped', 'res-queryv4', 'res-queryv6', 'res-retry',

--- a/src/network/f5/bigip/snmp/mode/trunks.pm
+++ b/src/network/f5/bigip/snmp/mode/trunks.pm
@@ -508,7 +508,7 @@ You can use the following variables: %{status}, %{display}
 Thresholds.
 Can be: 'traffic-in', 'traffic-out', 'packets-error-in' (%),
 'packets-error-out' (%), 'packets-drop-in' (%), 'packets-drop-out' (%),
-'total-interfaces'.
+'interfaces-total'.
 
 =back
 

--- a/src/network/fortinet/fortiauthenticator/snmp/mode/ha.pm
+++ b/src/network/fortinet/fortiauthenticator/snmp/mode/ha.pm
@@ -108,12 +108,17 @@ Check high-availability status.
 
 =over 8
 
-=item B<--warning-status>
+=item B<--unknown-ha-status>
 
 Define the conditions to match for the status to be WARNING.
 You can use the following variables: %{ha_status}, %{ha_status_last}
 
-=item B<--critical-status>
+=item B<--warning-ha-status>
+
+Define the conditions to match for the status to be WARNING.
+You can use the following variables: %{ha_status}, %{ha_status_last}
+
+=item B<--critical-ha-status>
 
 Define the conditions to match for the status to be CRITICAL (default: '%{ha_status} ne %{ha_status_last}').
 You can use the following variables: %{ha_status}, %{ha_status_last}

--- a/src/network/infoblox/snmp/mode/dnsusage.pm
+++ b/src/network/infoblox/snmp/mode/dnsusage.pm
@@ -277,15 +277,9 @@ Use cache file to store dns zone.
 
 Time in minutes before reloading cache file (default: 180).
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
-Can be: 'total-query-rate', 'total-hit-ratio', 'success-count', 'referral-count', 'nxrrset-count', 
-'failure-count'.
-
-=item B<--critical-*>
-
-Critical threshold.
+Thresholds.
 Can be: 'total-query-rate', 'total-hit-ratio',
 'success-count', 'referral-count', 'nxrrset-count', 'failure-count',
 'aa-latency-1m', 'aa-latency-5m', 'aa-latency-15m',

--- a/src/network/moxa/switch/snmp/mode/cpu.pm
+++ b/src/network/moxa/switch/snmp/mode/cpu.pm
@@ -141,7 +141,7 @@ Example: --filter-counters='1m|5m'
 =item B<--warning-*> B<--critical-*>
 
 Thresholds.
-Can be: 'cpu-utilization-1s', 'cpu-utilization-1m', 'cpu-utilization-5m'.
+Can be: 'cpu-utilization-5s', 'cpu-utilization-1m', 'cpu-utilization-5m'.
 
 =back
 

--- a/src/network/oneaccess/snmp/mode/rttprobes.pm
+++ b/src/network/oneaccess/snmp/mode/rttprobes.pm
@@ -193,7 +193,7 @@ Filter probes by name.
 Define the conditions to match for the status to be UNKNOWN.
 You can use the following variables: %{adminStatus}, %{status}, %{type}, %{tag}
 
-=item B<--warning-probe-estatus>
+=item B<--warning-probe-status>
 
 Define the conditions to match for the status to be WARNING.
 You can use the following variables: %{adminStatus}, %{status}, %{type}, %{tag}

--- a/src/network/oracle/infiniband/snmp/mode/infinibandusage.pm
+++ b/src/network/oracle/infiniband/snmp/mode/infinibandusage.pm
@@ -352,15 +352,10 @@ You can use the following variables: %{status}, %{display}
 Set critical threshold for ib status (default: '%{status} !~ /up/i').
 You can use the following variables: %{status}, %{display}
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
-Can be: 'in', 'out'.
-
-=item B<--critical-*>
-
-Critical threshold.
-Can be: 'in', 'out'.
+Thresholds.
+Can be: 'in', 'out', 'ib-status', ibgw-status.
 
 =back
 

--- a/src/network/peplink/pepwave/snmp/mode/wanusage.pm
+++ b/src/network/peplink/pepwave/snmp/mode/wanusage.pm
@@ -203,15 +203,10 @@ You can use the following variables: %{health_status}, %{display}
 Define the conditions to match for the status to be CRITICAL (default: '%{health_status} =~ /fail/').
 You can use the following variables: %{health_status}, %{display}
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
-Can be: 'traffic-in', 'traffic-out'.
-
-=item B<--critical-*>
-
-Critical threshold.
-Can be: Can be: 'traffic-in', 'traffic-out'.
+Thresholds.
+Can be: Can be: 'traffic-in', 'traffic-out', 'signal'.
 
 =back
 

--- a/src/network/ruckus/scg/snmp/mode/systemstats.pm
+++ b/src/network/ruckus/scg/snmp/mode/systemstats.pm
@@ -188,18 +188,11 @@ Check system statistics.
 
 =over 8
 
-=item B<--warning-*>
+=item B<--warning-*> B<--critical-*>
 
-Warning threshold.
+Thresholds.
 Can be: 'aps-count', 'users-count', 'total-traffic-in', 'total-traffic-out', 'total-packets-in',
-'total-mcast-packets-in', 'total-packets-out', 'total-mcast-packets-out', 'total-fail-packets-in',
-'total-retry-packets-out'.
-
-=item B<--critical-*>
-
-Critical threshold.
-Can be: 'aps-count', 'users-count', 'total-traffic-in', 'total-traffic-out', 'total-packets-in',
-'total-mcast-packets-in', 'total-packets-out', 'total-mcast-packets-out', 'total-fail-packets-in',
+'total-packets-out', 'total-mcast-packets-in', 'total-packets-out', 'total-mcast-packets-out', 'total-fail-packets-out',
 'total-retry-packets-out'.
 
 =back

--- a/src/network/stonesoft/snmp/mode/clusterload.pm
+++ b/src/network/stonesoft/snmp/mode/clusterload.pm
@@ -86,6 +86,14 @@ __END__
 
 Check load of cluster in percent.
 
+=item B<--warning>
+
+Warning threshold in percent.
+
+=item B<--critical>
+
+Critical threshold in percent.
+
 =over 8
 
 =back

--- a/src/network/stonesoft/snmp/mode/memory.pm
+++ b/src/network/stonesoft/snmp/mode/memory.pm
@@ -179,7 +179,7 @@ Warning threshold in percent.
 
 Critical threshold in percent.
 
-=item B<-swap>
+=item B<--swap>
 
 Check swap also.
 

--- a/src/network/versa/snmp/mode/bgppeers.pm
+++ b/src/network/versa/snmp/mode/bgppeers.pm
@@ -194,13 +194,9 @@ Filter based on local IP:PORT of peers (regexp allowed)
 
 Filter based on remote IP:PORT of peers (regexp allowed)
 
-=item B<--warning-updates>
+=item B<--warning-update-last> B<--critical-update-last>
 
-Warning threshold on last update (seconds)
-
-=item B<--critical-updates>
-
-Critical threshold on last update (seconds)
+Thresholds on last update (seconds)
 
 =item B<--unknown-status>
 

--- a/src/snmp_standard/mode/interfaces.pm
+++ b/src/snmp_standard/mode/interfaces.pm
@@ -1673,7 +1673,7 @@ You can use the following variables: %{admstatus}, %{opstatus}, %{duplexstatus},
 Thresholds.
 Can be: 'total-port', 'total-admin-up', 'total-admin-down', 'total-oper-up', 'total-oper-down',
 'in-traffic', 'out-traffic', 'in-error', 'in-discard', 'out-error', 'out-discard',
-'in-ucast', 'in-bcast', 'in-mcast', 'out-ucast', 'out-bcast', 'out-mcast',
+'in-ucast', 'in-bcast', 'in-mcast', 'out-ucast', 'out-bcast', 'out-mcast', 'in-volume', 'out-volume',
 'speed' (b/s).
 
 =item B<--units-traffic>

--- a/src/snmp_standard/mode/storage.pm
+++ b/src/snmp_standard/mode/storage.pm
@@ -604,17 +604,16 @@ __END__
 
 =over 8
 
-=item B<--warning-usage>
 
-Warning threshold.
+=item B<--warning-*> B<--critical-*>
 
-=item B<--critical-usage>
+Thresholds.
 
-Critical threshold.
+Can be: 'count', 'usage'.
 
 =item B<--warning-access>
 
-Warning threshold. 
+Warning threshold.
 
 =item B<--critical-access>
 

--- a/src/storage/dell/equallogic/snmp/mode/diskusage.pm
+++ b/src/storage/dell/equallogic/snmp/mode/diskusage.pm
@@ -207,7 +207,7 @@ You can use the following variables: %{health}, %{status}, %{display}
 =item B<--warning-*> B<--critical-*>
 
 Thresholds.
-Can be:  'busy-time' (s), 'read-iops' (iops), 'write-iops' (iops).
+Can be: 'busy-time' (s), 'read', 'write'.
 
 =back
 

--- a/src/storage/hitachi/hcp/snmp/mode/volumes.pm
+++ b/src/storage/hitachi/hcp/snmp/mode/volumes.pm
@@ -229,6 +229,10 @@ Check volumes.
 
 Filter volumes by node ID (can be a regexp).
 
+=item B<--filter-label>
+
+Filter volumes by channel unit (can be a regexp).
+
 =item B<--unknown-volume-status>
 
 Define the conditions to match for the status to be UNKNOWN.

--- a/src/storage/huawei/oceanstor/snmp/mode/luns.pm
+++ b/src/storage/huawei/oceanstor/snmp/mode/luns.pm
@@ -197,7 +197,7 @@ Include LUN not exposed to an iniator, usually LUN snapshots.
 =item B<--warning-*> B<--critical-*>
 
 Thresholds.
-Can be: 'space-usage', 'space-usage-free', 'space-usage-prct'.
+Can be: 'space-usage', 'space-usage-free', 'space-usage-prct', 'space-usage-prot'.
 
 =back
 

--- a/src/storage/synology/snmp/mode/ups.pm
+++ b/src/storage/synology/snmp/mode/ups.pm
@@ -104,8 +104,8 @@ Check ups (SYNOLOGY-UPS-MIB).
 
 =item B<--warning-*> B<--critical-*> 
 
-Thresholds
-Can be: 'charge-remaining' (%), 'lifetime-remaining' (s)
+Thresholds.
+Can be: 'charge-remaining' (%), 'lifetime-remaining' (s), 'load' (%).
 
 =back
 


### PR DESCRIPTION
## Description

A small number of plugins have some typos in their help documentation or some missing or wrong counters.

Example:

- apps::antivirus::mcafee::webgateway::snmp::mode::httpsstatistics → ‘request’ instead of 'requests'
- apps::mq::activemq::jmx::mode::brokers → ‘queue-messages-size-average’ is missing
- apps::pineapp::securemail::snmp::mode::system → ‘messages-priority-medium' instead of 'messages-priority-normal’
...


Among other things, this allows the missing macro descriptions in the relevant connector documentation to be resolved.




## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
