### PR TITLE
fix(ci): force perl-json-path lib to build when workflow modified

### DIFF
--- a/.github/workflows/perl-json-path.yml
+++ b/.github/workflows/perl-json-path.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     paths:
       - "dependencies/perl-json-path/**"
+      - ".github/workflows/perl-json-path.yml"
   push:
     branches:
       - develop


### PR DESCRIPTION
## Description

force perl-json-path lib to build when workflow modified

**Fixes** CTOR-376 CTOR-525

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

