### PR TITLE
fix(cpan-libs) build cpan library for arm64 architecture

### DIFF
--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -137,6 +137,8 @@ jobs:
             version: "0.01"
             rpm_dependencies: "zeromq"
 
+
+
     name: package ${{ matrix.distrib }} ${{ matrix.name }}
     container:
       image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:latest
@@ -218,6 +220,83 @@ jobs:
           name: packages-${{ matrix.package_extension }}-${{ matrix.distrib }}-${{ steps.package-name.outputs.name_with_dash }}
           path: ./*.${{ matrix.package_extension }}
           retention-days: 1
+
+  merge-package-rpm-artifacts:
+    needs: [package-rpm]
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        distrib: [el8, el9]
+
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Merging Artifacts
+        uses: ./.github/actions/merge-artifacts
+        with:
+          target_name: packages-rpm-${{ matrix.distrib }}
+          source_paths: packages-rpm-${{ matrix.distrib }}/*.rpm
+          source_name_pattern: packages-rpm-${{ matrix.distrib }}-
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+  sign-rpm:
+    needs: [merge-package-rpm-artifacts]
+
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        distrib: [el8, el9]
+    name: sign rpm ${{ matrix.distrib }}
+    container:
+      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/rpm-signing:ubuntu
+      options: -t
+      credentials:
+        username: ${{ secrets.DOCKER_REGISTRY_ID }}
+        password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}
+
+    steps:
+      - run: apt-get install -y zstd
+        shell: bash
+
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: packages-rpm-${{ matrix.distrib }}
+          path: ./
+
+      - run: echo "HOME=/root" >> $GITHUB_ENV
+        shell: bash
+
+      - run: rpmsign --addsign ./*.rpm
+        shell: bash
+
+      - uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: ./*.rpm
+          key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
+
+  deliver-rpm:
+    needs: [get-environment, sign-rpm]
+    if: ${{ contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) }}
+    runs-on: [self-hosted, common]
+
+    strategy:
+      matrix:
+        distrib: [el8, el9]
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Delivery
+        uses: ./.github/actions/rpm-delivery
+        with:
+          module_name: perl-cpan-libraries
+          distrib: ${{ matrix.distrib }}
+          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
+          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
+          stability: ${{ needs.get-environment.outputs.stability }}
 
   package-deb:
     needs: [get-environment]
@@ -353,23 +432,6 @@ jobs:
           path: ./*.${{ matrix.package_extension }}
           retention-days: 1
 
-  merge-package-rpm-artifacts:
-    needs: [package-rpm]
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        distrib: [el8, el9]
-
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - name: Merging Artifacts
-        uses: ./.github/actions/merge-artifacts
-        with:
-          target_name: packages-rpm-${{ matrix.distrib }}
-          source_paths: packages-rpm-${{ matrix.distrib }}/*.rpm
-          source_name_pattern: packages-rpm-${{ matrix.distrib }}-
-          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   merge-package-deb-artifacts:
     needs: [package-deb]
@@ -389,43 +451,6 @@ jobs:
           source_name_pattern: packages-deb-${{ matrix.distrib }}-
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  sign-rpm:
-    needs: [merge-package-rpm-artifacts]
-
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        distrib: [el8, el9]
-    name: sign rpm ${{ matrix.distrib }}
-    container:
-      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/rpm-signing:ubuntu
-      options: -t
-      credentials:
-        username: ${{ secrets.DOCKER_REGISTRY_ID }}
-        password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}
-
-    steps:
-      - run: apt-get install -y zstd
-        shell: bash
-
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
-        with:
-          name: packages-rpm-${{ matrix.distrib }}
-          path: ./
-
-      - run: echo "HOME=/root" >> $GITHUB_ENV
-        shell: bash
-
-      - run: rpmsign --addsign ./*.rpm
-        shell: bash
-
-      - uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          path: ./*.rpm
-          key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
-
   download-and-cache-deb:
     needs: [merge-package-deb-artifacts]
     runs-on: ubuntu-22.04
@@ -442,28 +467,6 @@ jobs:
         with:
           path: ./*.deb
           key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}
-
-  deliver-rpm:
-    needs: [get-environment, sign-rpm]
-    if: ${{ contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) }}
-    runs-on: [self-hosted, common]
-
-    strategy:
-      matrix:
-        distrib: [el8, el9]
-
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - name: Delivery
-        uses: ./.github/actions/rpm-delivery
-        with:
-          module_name: perl-cpan-libraries
-          distrib: ${{ matrix.distrib }}
-          artifactory_token: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
-          cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
-          stability: ${{ needs.get-environment.outputs.stability }}
 
   deliver-deb:
     needs: [get-environment, download-and-cache-deb]

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -137,8 +137,6 @@ jobs:
             version: "0.01"
             rpm_dependencies: "zeromq"
 
-
-
     name: package ${{ matrix.distrib }} ${{ matrix.name }}
     container:
       image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:latest
@@ -302,11 +300,11 @@ jobs:
     needs: [get-environment]
     if: ${{ needs.get-environment.outputs.stability != 'stable' }}
 
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner_name }}
     strategy:
       fail-fast: false
       matrix:
-        distrib: [bullseye, bookworm, jammy]
+        image: [packaging-plugins-bullseye, packaging-plugins-bookworm, packaging-plugins-jammy, packaging-plugins-bullseye-arm64]
         name:
           [
             "Authen::SCRAM::Client",
@@ -329,6 +327,8 @@ jobs:
             "ZMQ::LibZMQ4"
           ]
         include:
+          - runner_name: ubuntu-22.04
+          - arch: amd64
           - build_distribs: "bullseye,bookworm,jammy"
           - deb_dependencies: ""
           - rpm_provides: ""
@@ -344,6 +344,11 @@ jobs:
           - distrib: jammy
             package_extension: deb
             image: packaging-plugins-jammy
+          - distrib: bullseye
+            package_extension: deb
+            image: packaging-plugins-bullseye-arm64
+            arch: arm64
+            runner_name: ["self-hosted", "collect-arm64"]
           - name: "Paws"
             use_dh_make_perl: "false"
           - name: "Statistics::Regression"
@@ -353,7 +358,7 @@ jobs:
             use_dh_make_perl: "false"
             version: "0.01"
             deb_dependencies: "libzmq5"
-    name: package ${{ matrix.distrib }} ${{ matrix.name }}
+    name: package ${{ matrix.distrib }} ${{ matrix.arch }} ${{ matrix.name }}
     container:
       image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:latest
       credentials:
@@ -405,7 +410,7 @@ jobs:
           cpanm Module::Install
 
           gem install fpm
-          fpm -s cpan -t ${{ matrix.package_extension }} --deb-dist ${{ matrix.distrib }} --iteration ${{ matrix.distrib }} --verbose --cpan-verbose --no-cpan-test -n $PACKAGE_NAME$PACKAGE_DEPENDENCIES -v ${{ steps.package-version.outputs.package_version }} ${{ matrix.name }}
+          fpm -a native -s cpan -t ${{ matrix.package_extension }} --deb-dist ${{ matrix.distrib }} --iteration ${{ matrix.distrib }} --verbose --cpan-verbose --no-cpan-test -n $PACKAGE_NAME$PACKAGE_DEPENDENCIES -v ${{ steps.package-version.outputs.package_version }} ${{ matrix.name }}
         shell: bash
 
       - if: ${{ contains(matrix.build_distribs, matrix.distrib) && matrix.use_dh_make_perl == 'true' }}
@@ -428,7 +433,7 @@ jobs:
       - if: ${{ contains(matrix.build_distribs, matrix.distrib) }}
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: packages-${{ matrix.package_extension }}-${{ matrix.distrib }}-${{ steps.package-name.outputs.name_with_dash}}
+          name: packages-${{ matrix.package_extension }}-${{ matrix.distrib }}-${{ matrix.arch }}-${{ steps.package-name.outputs.name_with_dash}}
           path: ./*.${{ matrix.package_extension }}
           retention-days: 1
 


### PR DESCRIPTION
REF:MON-539

## Description
libzmq-4 is not available for arm architecture. This PR aim to build dependancy created with fpm from cpan in arm architecture
The next PR will add test of plugins on arm architecture, we can't make it on the same pr as lib are pushed to unstable only when merging to develop.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>
try to install centreon-plugin-virtualization-vmware2-connector-plugin, libzmq-libzmq4-perl should be installable (it's a dependancy of this plugin)


## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
