### PR TITLE
fix(packaging): advertise that perl-Exporter-Shiny also provides *Tiny

### DIFF
--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -121,6 +121,7 @@ jobs:
             version: "0.026"
           - name: "Exporter::Shiny"
             build_distribs: el8
+            rpm_provides: "perl(Exporter::Shiny) perl(Exporter::Tiny)"
           - name: "FFI::Platypus"
             rpm_provides: "perl(FFI::Platypus::Buffer) perl(FFI::Platypus::Memory)"
           - name: "Net::DHCP"


### PR DESCRIPTION
REFS: CTOR-376

## Description

Attempt to fix the fact that dnf installs the older standard perl-Exporter-Tiny rpm on Alma 8

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

