### PR TITLE
fix(protocols/http): mode json-content missing expression

### DIFF
--- a/src/apps/protocols/http/mode/jsoncontent.pm
+++ b/src/apps/protocols/http/mode/jsoncontent.pm
@@ -193,6 +193,8 @@ sub lookup {
 
     $self->decode_json_response();
     foreach my $xpath_find (@{$self->{option_results}->{lookup}}) {
+        next if ($xpath_find eq '');
+
         eval {
             my $jpath = JSON::Path->new($xpath_find);
             @values = $jpath->values($self->{json_response_decoded});


### PR DESCRIPTION
## Description

I have the following error:
```
$ perl centreon_protocol_http.pl --plugin=apps::protocols::http::plugin --mode=json-content --hostname=10.7.9.176 --proto='' --port=''  --urlpath='/api/system/cluster/stats/elasticsearch' --header='Content-Type: text/xml;charset=UTF-8' --data='' --lookup='' --threshold-value='count' --format-ok='%{count} element(s) found' --format-warning='%{count} element(s) found' --format-critical='%{count} element(s) found'  --warning-numeric='' --critical-numeric='' --warning-string='' --critical-string='' --hostname="graylog.svc.ahb" --proto=https --credentials --basic --username='centreon' --password='XXXXX'  --ssl-opt="SSL_verify_mode => SSL_VERIFY_NONE" --lookup='$..store_size' --verbose
UNKNOWN: Cannot lookup: Missing required argument 'expression' in constructor at /usr/share/perl5/JSON/Path.pm line 103.
```

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [X] 22.10.x
- [X] 23.04.x
- [X] 23.10.x
- [X] 24.04.x
- [X] master

<h2> How this pull request can be tested ? </h2>

Test with the same command after the patch.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
