### PR TITLE
fix(library and packaging): package dependencies for paws cpan library for el8/el9 and package paws without using fpm for debian

### DIFF
--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -318,6 +318,7 @@ jobs:
         image: [packaging-plugins-bullseye, packaging-plugins-bookworm, packaging-plugins-jammy, packaging-plugins-bullseye-arm64]
         name:
           [
+            "Paws",
             "Authen::SCRAM::Client",
             "Convert::EBCDIC",
             "Crypt::Blowfish_PP",
@@ -333,7 +334,6 @@ jobs:
             "Net::HTTPTunnel",
             "Net::MQTT::Simple",
             "Net::SMTP_auth",
-            "Paws",
             "Statistics::Regression",
             "WWW::Selenium",
             "ZMQ::Constants",
@@ -362,8 +362,6 @@ jobs:
             image: packaging-plugins-bullseye-arm64
             arch: arm64
             runner_name: ["self-hosted", "collect-arm64"]
-          - name: "Paws"
-            use_dh_make_perl: "false"
           - name: "Statistics::Regression"
             build_distribs: "bullseye"
             version: "0.53"

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -33,6 +33,7 @@ jobs:
         distrib: [el8, el9]
         name:
           [
+            "ARGV::Struct",
             "Authen::SASL::SASLprep",
             "Authen::SCRAM::Client",
             "boolean",
@@ -42,9 +43,11 @@ jobs:
             "Clone",
             "Clone::Choose",
             "common::sense",
+            "Config::AWS",
             "Convert::Binary::C",
             "Convert::EBCDIC",
             "Crypt::Blowfish_PP",
+            "DataStruct::Flat",
             "DateTime::Format::Duration::ISO8601",
             "DBD::Sybase",
             "Device::Modbus",
@@ -70,6 +73,8 @@ jobs:
             "MIME::Types",
             "Mojo::IOLoop::Signal",
             "MongoDB",
+            "MooseX::ClassAttribute",
+            "Net::Amazon::Signature::V4",
             "Net::DHCP",
             "Net::FTPSSL",
             "Net::HTTPTunnel",
@@ -91,6 +96,7 @@ jobs:
             "URI::Encode",
             "URI::Template",
             "URL::Encode",
+            "URL::Encode::XS",
             "UUID",
             "UUID::URandom",
             "WWW::Selenium",
@@ -130,6 +136,8 @@ jobs:
             rpm_provides: "perl(Net::DHCP::Constants) perl(Net::DHCP::Packet)"
           - name: "Statistics::Regression"
             version: "0.53"
+          - name: "URL::Encode::XS"
+            build_distribs: el9
           - name: "UUID"
             version: "0.31"
           - name: "ZMQ::Constants"

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -318,7 +318,6 @@ jobs:
         image: [packaging-plugins-bullseye, packaging-plugins-bookworm, packaging-plugins-jammy, packaging-plugins-bullseye-arm64]
         name:
           [
-            "Paws",
             "Authen::SCRAM::Client",
             "Convert::EBCDIC",
             "Crypt::Blowfish_PP",
@@ -334,6 +333,7 @@ jobs:
             "Net::HTTPTunnel",
             "Net::MQTT::Simple",
             "Net::SMTP_auth",
+            "Paws",
             "Statistics::Regression",
             "WWW::Selenium",
             "ZMQ::Constants",


### PR DESCRIPTION
# Centreon team

## Description

Add missing dependencies for Paws (el8 & el9)
Build deb package with dh-make-perl instead of fpm

**Fixes** CTOR-472

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] I have implemented automated tests related to my commits.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences are terminated by a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.