### PR TITLE
Ctor 146 escalation microsoft hyperv 2012 add option for powershell module version in node integration service mode

### DIFF
--- a/.github/scripts/pod_spell_check.t
+++ b/.github/scripts/pod_spell_check.t
@@ -5,7 +5,7 @@ use Test::More;
 use Test::Spelling;
 
 if (!@ARGV) {
-    die "Missing perl file to check.";
+    die "Usage: perl pod_spell_check.t module.pm stopwords.t";
 }
 
 my $stopword_filename='tests/resources/spellcheck/stopwords.t';
@@ -14,9 +14,10 @@ if(defined($ARGV[1])){
 }
 open(FILE, "<", $stopword_filename)
     or die "Could not open $stopword_filename";
-printf("stopword file use : ".$stopword_filename." \n");
+printf("Using dictionary: ".$stopword_filename." \n");
 
 add_stopwords(<FILE>);
+close(FILE);
 set_spell_cmd('hunspell -l');
 all_pod_files_spelling_ok($ARGV[0]);
-close(FILE);
+

--- a/src/apps/microsoft/hyperv/2012/local/mode/nodeintegrationservice.pm
+++ b/src/apps/microsoft/hyperv/2012/local/mode/nodeintegrationservice.pm
@@ -235,16 +235,34 @@ sub manage_selection {
         my $services = (ref($node->{services}) eq 'ARRAY') ? $node->{services} : [ $node->{services} ];
 
         foreach my $service (@$services) {
+            my $primary_status;
+            my $secondary_status;
+            if ( defined($service->{primary_operational_status}) ) {
+                if ( defined($node_vm_integration_service_operational_status->{ $service->{primary_operational_status}}) ) {
+                    $primary_status = $node_vm_integration_service_operational_status->{ $service->{primary_operational_status} };
+                } else {
+                    $primary_status = $service->{primary_operational_status};
+                }
+            } else {
+                $primary_status = '-';
+            }
+            if ( defined($service->{secondary_operational_status}) ) {
+                if ( defined($node_vm_integration_service_operational_status->{ $service->{secondary_operational_status}}) ) {
+                    $secondary_status = $node_vm_integration_service_operational_status->{ $service->{secondary_operational_status} };
+                } else {
+                    $secondary_status = $service->{secondary_operational_status};
+                }
+            } else {
+                $secondary_status = '-';
+            }
+
+
             $self->{vm}->{$id}->{service}->{$id2} = {
                 vm => $node->{name},
                 service => $service->{service},
                 enabled => $service->{enabled} =~ /True|1/i ? 1 : 0,
-                primary_status => 
-                    defined($service->{primary_operational_status}) && defined($node_vm_integration_service_operational_status->{ $service->{primary_operational_status} }) ?
-                        $node_vm_integration_service_operational_status->{ $service->{primary_operational_status} } : '-',
-                secondary_status =>
-                    defined($service->{secondary_operational_status}) && defined($node_vm_integration_service_operational_status->{ $service->{secondary_operational_status} }) ?
-                        $node_vm_integration_service_operational_status->{ $service->{secondary_operational_status} } : '-'
+                primary_status => $primary_status,
+                secondary_status => $secondary_status
             };
             $id2++;
         }

--- a/src/apps/microsoft/hyperv/2012/local/mode/nodeintegrationservice.pm
+++ b/src/apps/microsoft/hyperv/2012/local/mode/nodeintegrationservice.pm
@@ -134,6 +134,20 @@ sub check_options {
         if (!defined($self->{option_results}->{command_options}) || $self->{option_results}->{command_options} eq '');
 }
 
+sub determine_operational_status {
+    my ($operational_status) = @_;
+
+    if ( defined($operational_status) ) {
+        if ( defined($node_vm_integration_service_operational_status->{ $operational_status}) ) {
+            return $node_vm_integration_service_operational_status->{ $operational_status };
+        } else {
+            return $operational_status;
+        }
+    } else {
+        return '-';
+    }
+}
+
 sub manage_selection {
     my ($self, %options) = @_;
 
@@ -235,34 +249,13 @@ sub manage_selection {
         my $services = (ref($node->{services}) eq 'ARRAY') ? $node->{services} : [ $node->{services} ];
 
         foreach my $service (@$services) {
-            my $primary_status;
-            my $secondary_status;
-            if ( defined($service->{primary_operational_status}) ) {
-                if ( defined($node_vm_integration_service_operational_status->{ $service->{primary_operational_status}}) ) {
-                    $primary_status = $node_vm_integration_service_operational_status->{ $service->{primary_operational_status} };
-                } else {
-                    $primary_status = $service->{primary_operational_status};
-                }
-            } else {
-                $primary_status = '-';
-            }
-            if ( defined($service->{secondary_operational_status}) ) {
-                if ( defined($node_vm_integration_service_operational_status->{ $service->{secondary_operational_status}}) ) {
-                    $secondary_status = $node_vm_integration_service_operational_status->{ $service->{secondary_operational_status} };
-                } else {
-                    $secondary_status = $service->{secondary_operational_status};
-                }
-            } else {
-                $secondary_status = '-';
-            }
-
 
             $self->{vm}->{$id}->{service}->{$id2} = {
                 vm => $node->{name},
                 service => $service->{service},
                 enabled => $service->{enabled} =~ /True|1/i ? 1 : 0,
-                primary_status => $primary_status,
-                secondary_status => $secondary_status
+                primary_status => determine_operational_status($service->{primary_operational_status}),
+                secondary_status => determine_operational_status($service->{secondary_operational_status})
             };
             $id2++;
         }

--- a/src/apps/trendmicro/iwsva/snmp/plugin.pm
+++ b/src/apps/trendmicro/iwsva/snmp/plugin.pm
@@ -50,6 +50,6 @@ __END__
 
 =head1 PLUGIN DESCRIPTION
 
-Check TendMicro Iwsva equipments in SNMP.
+Check TrendMicro Iwsva equipments in SNMP.
 
 =cut

--- a/src/centreon/common/powershell/hyperv/2012/nodeintegrationservice.pm
+++ b/src/centreon/common/powershell/hyperv/2012/nodeintegrationservice.pm
@@ -35,6 +35,9 @@ $culture = new-object "System.Globalization.CultureInfo" "en-us"
     $ps .= centreon::common::powershell::functions::escape_jsonstring(%options);
     $ps .= centreon::common::powershell::functions::convert_to_json(%options);
 
+    # if the version of HyperV Powershell module is higher than 2.0.0 and not compatible with
+    # the following script, then use this Import-Module instead:
+    # Import-Module -Name "Hyper-V" -MaximumVersion "2.0.0"
     $ps .= '
 $ProgressPreference = "SilentlyContinue"
 
@@ -68,8 +71,19 @@ Try {
 
             $item_service.service = $service.Name
             $item_service.enabled = $service.Enabled
+
+            # this works for sure on v1.1 of HyperV Powershell module
             $item_service.primary_operational_status = $service.PrimaryOperationalStatus.value__
             $item_service.secondary_operational_status = $service.SecondaryOperationalStatus.value__
+
+            # this works for sure on v2.0.0 of HyperV Powershell module
+            if (($vm.PrimaryStatusDescription -ne $null) -and ($vm.PrimaryStatusDescription -ne "")) {
+                $item_service.primary_operational_status = $vm.PrimaryStatusDescription
+            }
+            if (($vm.SecondaryStatusDescription -ne $null) -and ($vm.SecondaryStatusDescription -ne "")) {
+                $item_service.secondary_operational_status = $vm.SecondaryStatusDescription
+            }
+
             $services.Add($item_service)
         }
 

--- a/src/centreon/common/powershell/hyperv/2012/nodeintegrationservice.pm
+++ b/src/centreon/common/powershell/hyperv/2012/nodeintegrationservice.pm
@@ -110,6 +110,6 @@ __END__
 
 =head1 DESCRIPTION
 
-Method to get hyper-v informations.
+Method to get Hyper-V information.
 
 =cut

--- a/src/centreon/common/powershell/hyperv/2012/nodeintegrationservice.pm
+++ b/src/centreon/common/powershell/hyperv/2012/nodeintegrationservice.pm
@@ -77,11 +77,11 @@ Try {
             $item_service.secondary_operational_status = $service.SecondaryOperationalStatus.value__
 
             # this works for sure on v2.0.0 of HyperV Powershell module
-            if (($vm.PrimaryStatusDescription -ne $null) -and ($vm.PrimaryStatusDescription -ne "")) {
-                $item_service.primary_operational_status = $vm.PrimaryStatusDescription
+            if (($service.PrimaryStatusDescription -ne $null) -and ($service.PrimaryStatusDescription -ne "")) {
+                $item_service.primary_operational_status = $service.PrimaryStatusDescription
             }
-            if (($vm.SecondaryStatusDescription -ne $null) -and ($vm.SecondaryStatusDescription -ne "")) {
-                $item_service.secondary_operational_status = $vm.SecondaryStatusDescription
+            if (($service.SecondaryStatusDescription -ne $null) -and ($service.SecondaryStatusDescription -ne "")) {
+                $item_service.secondary_operational_status = $service.SecondaryStatusDescription
             }
 
             $services.Add($item_service)

--- a/tests/resources/spellcheck/stopwords.t
+++ b/tests/resources/spellcheck/stopwords.t
@@ -63,7 +63,6 @@ SNMP
 SSH
 Sansymphony
 SureBackup
-TendMicro
 TrendMicro
 VDSL2
 VM

--- a/tests/resources/spellcheck/stopwords.t
+++ b/tests/resources/spellcheck/stopwords.t
@@ -11,6 +11,7 @@
 --exclude-fs
 --filter-fs
 --filter-vdom
+--filter-vm
 --force-counters32
 --force-counters64
 --force-oid
@@ -34,6 +35,9 @@
 --oid-filter
 --urlpath
 --warning-bytesallocatedpercentage
+-EncodedCommand
+-InputFormat
+-NoLogo
 2c
 ADSL
 Avigilon
@@ -60,7 +64,9 @@ SSH
 Sansymphony
 SureBackup
 TendMicro
+TrendMicro
 VDSL2
+VM
 Veeam
 WSMAN
 XPath
@@ -86,6 +92,7 @@ out-mcast
 out-ucast
 perfdata
 powershell
+powershell.exe
 proto
 psu
 queue-messages-inflighted

--- a/tests/robot/apps/microsoft/hyperv/2012/local/nodeintegrationservice-2022.json
+++ b/tests/robot/apps/microsoft/hyperv/2012/local/nodeintegrationservice-2022.json
@@ -1,0 +1,407 @@
+[
+  {
+    "note": "",
+    "integration_services_state": "",
+    "state": 3,
+    "name": "VSERVER01",
+    "services": [
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Guest Service Interface",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Heartbeat",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Key-Value Pair Exchange",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Shutdown",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Time Synchronization",
+        "enabled": false
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "VSS",
+        "enabled": true
+      }
+    ],
+    "integration_services_version": "0.0"
+  },
+  {
+    "note": "",
+    "integration_services_state": "",
+    "state": 3,
+    "name": "VSERVER02",
+    "services": [
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Guest Service Interface",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Heartbeat",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Key-Value Pair Exchange",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Shutdown",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Time Synchronization",
+        "enabled": false
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "VSS",
+        "enabled": true
+      }
+    ],
+    "integration_services_version": "0.0"
+  },
+  {
+    "note": "",
+    "integration_services_state": "",
+    "state": 3,
+    "name": "VSERVER03",
+    "services": [
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Guest Service Interface",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Heartbeat",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Key-Value Pair Exchange",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Shutdown",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Time Synchronization",
+        "enabled": false
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "VSS",
+        "enabled": true
+      }
+    ],
+    "integration_services_version": "0.0"
+  },
+  {
+    "note": "",
+    "integration_services_state": "",
+    "state": 3,
+    "name": "VSERVER04",
+    "services": [
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Guest Service Interface",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Heartbeat",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Key-Value Pair Exchange",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Shutdown",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Time Synchronization",
+        "enabled": false
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "VSS",
+        "enabled": true
+      }
+    ],
+    "integration_services_version": "0.0"
+  },
+  {
+    "note": "",
+    "integration_services_state": "",
+    "state": 2,
+    "name": "VSERVER05",
+    "services": [
+      {
+        "primary_operational_status": "OK",
+        "secondary_operational_status": null,
+        "service": "Guest Service Interface",
+        "enabled": false
+      },
+      {
+        "primary_operational_status": "OK",
+        "secondary_operational_status": null,
+        "service": "Heartbeat",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": "OK",
+        "secondary_operational_status": null,
+        "service": "Key-Value Pair Exchange",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": "OK",
+        "secondary_operational_status": null,
+        "service": "Shutdown",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": "OK",
+        "secondary_operational_status": null,
+        "service": "Time Synchronization",
+        "enabled": false
+      },
+      {
+        "primary_operational_status": "OK",
+        "secondary_operational_status": null,
+        "service": "VSS",
+        "enabled": false
+      }
+    ],
+    "integration_services_version": "0.0"
+  },
+  {
+    "note": "",
+    "integration_services_state": "",
+    "state": 3,
+    "name": "VSERVER06",
+    "services": [
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Guest Service Interface",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Heartbeat",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Key-Value Pair Exchange",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Shutdown",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Time Synchronization",
+        "enabled": false
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "VSS",
+        "enabled": true
+      }
+    ],
+    "integration_services_version": "0.0"
+  },
+  {
+    "note": "",
+    "integration_services_state": "",
+    "state": 2,
+    "name": "VSERVER07",
+    "services": [
+      {
+        "primary_operational_status": "OK",
+        "secondary_operational_status": null,
+        "service": "Guest Service Interface",
+        "enabled": false
+      },
+      {
+        "primary_operational_status": "Error",
+        "secondary_operational_status": "OK",
+        "service": "Heartbeat",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": "OK",
+        "secondary_operational_status": null,
+        "service": "Key-Value Pair Exchange",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": "OK",
+        "secondary_operational_status": null,
+        "service": "Shutdown",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": "OK",
+        "secondary_operational_status": null,
+        "service": "Time Synchronization",
+        "enabled": false
+      },
+      {
+        "primary_operational_status": "OK",
+        "secondary_operational_status": null,
+        "service": "VSS",
+        "enabled": false
+      }
+    ],
+    "integration_services_version": "0.0"
+  },
+  {
+    "note": "",
+    "integration_services_state": "",
+    "state": 3,
+    "name": "VSERVER07",
+    "services": [
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Guest Service Interface",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Heartbeat",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Key-Value Pair Exchange",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Shutdown",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Time Synchronization",
+        "enabled": false
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "VSS",
+        "enabled": true
+      }
+    ],
+    "integration_services_version": "0.0"
+  },
+  {
+    "note": "",
+    "integration_services_state": "",
+    "state": 3,
+    "name": "VSERVER08",
+    "services": [
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Guest Service Interface",
+        "enabled": false
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Heartbeat",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Key-Value Pair Exchange",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Shutdown",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "Time Synchronization",
+        "enabled": true
+      },
+      {
+        "primary_operational_status": null,
+        "secondary_operational_status": null,
+        "service": "VSS",
+        "enabled": true
+      }
+    ],
+    "integration_services_version": "0.0"
+  }
+]

--- a/tests/robot/apps/microsoft/hyperv/2012/local/nodeintegrationservice.robot
+++ b/tests/robot/apps/microsoft/hyperv/2012/local/nodeintegrationservice.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Documentation       Application Microsoft HyperV 2022
+
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Test Timeout        120s
+
+
+*** Variables ***
+${CMD}      ${CENTREON_PLUGINS}
+...         --plugin=apps::microsoft::hyperv::2012::local::plugin
+...         --mode=node-integration-service
+...         --command=cat
+...         --command-path=/usr/bin
+...         --no-ps
+...         --command-options=nodeintegrationservice-2022.json
+
+*** Test Cases ***
+HyperV 2022 ${tc}/3
+    [Documentation]    Apps Microsoft HyperV 2022
+    [Tags]    applications    microsoft    hyperv    virtualization
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    --filter-vm='${filter_vm}'
+
+    ${output}    Run    ${command}
+    ${output}    Strip String    ${output}
+    Should Be Equal As Strings
+    ...    ${output}
+    ...    ${expected_result}
+    ...    \nWrong output result for command:\n${command}\n\nExpected:\n${expected_result}\nCommand output:\n${output}\n\n
+
+    Examples:        tc    filter_vm       expected_result    --
+            ...      1     ${EMPTY}        CRITICAL: 1 problem(s) detected
+            ...      2     VSERVER05       OK: VM 'VSERVER05' 0 problem(s) detected - VM 'VSERVER05' 0 problem(s) detected
+            ...      3     VSERVER07       CRITICAL: VM 'VSERVER07' 1 problem(s) detected
+


### PR DESCRIPTION
# Centreon team

## Description

REFS: CTOR-146

- Modified the powershell script and the perl code to adapt nodeintegrationservices to Hyperv2022
- Added tests with the result of the powershell script converted to JSON 

**Presumably** fixes #4603 (to be confirmed)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

The provided tests make the perl processing work with the obtained data without the need to have an actual environment.

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have implemented automated tests related to my commits.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences are terminated by a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.