### PR TITLE
Missing cloudtrail command in event lookup mode

### DIFF
--- a/src/cloud/aws/custom/awscli.pm
+++ b/src/cloud/aws/custom/awscli.pm
@@ -981,7 +981,7 @@ sub cloudtrail_events_set_cmd {
 
     return if (defined($self->{option_results}->{command_options}) && $self->{option_results}->{command_options} ne '');
 
-    my $cmd_options = "lookup-events --region $self->{option_results}->{region} --output json";
+    my $cmd_options = "cloudtrail lookup-events --region $self->{option_results}->{region} --output json";
     if (defined($options{delta})) {
         my $endtime = time();
         my $starttime = $endtime - ($options{delta} * 60);


### PR DESCRIPTION
Missing cloudtrail command.

# Community contributors

## Description

aws cli custom mode is missing cloudtrail command when build aw command.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?
Command fails with aws cli error like 'command error'. 

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.