### PR TITLE
Ctor 264 plugin database mysql mode databasesize change the way we calculate the fragmentation rate

### DIFF
--- a/src/database/mysql/mode/databasessize.pm
+++ b/src/database/mysql/mode/databasessize.pm
@@ -243,7 +243,7 @@ __END__
 
 =head1 MODE
 
-Check MySQL databases size and tables.
+Check MySQL/MariaDB databases and tables sizes.
 
 =over 8
 
@@ -253,7 +253,7 @@ Filter the databases to monitor with a regular expression.
 
 =item B<--filter-table>
 
-Filter table name (can be a regexp).
+Filter tables by name (can be a regexp).
 
 =item B<--warning-*> B<--critical-*>
 

--- a/src/database/mysql/mode/databasessize.pm
+++ b/src/database/mysql/mode/databasessize.pm
@@ -179,7 +179,7 @@ sub manage_selection {
                 engine,
                 data_free,
                 data_length + index_length as data_used,
-                (DATA_FREE / (DATA_LENGTH+INDEX_LENGTH)) as TAUX_FRAG
+                DATA_FREE / (DATA_LENGTH + INDEX_LENGTH + DATA_FREE) as TAUX_FRAG
             FROM
                 information_schema.tables
             WHERE

--- a/src/database/mysql/mode/databasessize.pm
+++ b/src/database/mysql/mode/databasessize.pm
@@ -172,7 +172,20 @@ sub manage_selection {
     $innodb_per_table = 1 if ($value =~ /on/i);
 
     $options{sql}->query(
-        query => q{SELECT table_schema, table_name, engine, data_free, data_length+index_length as data_used, (DATA_FREE / (DATA_LENGTH+INDEX_LENGTH)) as TAUX_FRAG FROM information_schema.tables WHERE table_type = 'BASE TABLE' AND engine IN ('InnoDB', 'MyISAM')}
+        query => q{
+            SELECT
+                table_schema,
+                table_name,
+                engine,
+                data_free,
+                data_length + index_length as data_used,
+                (DATA_FREE / (DATA_LENGTH+INDEX_LENGTH)) as TAUX_FRAG
+            FROM
+                information_schema.tables
+            WHERE
+                table_type = 'BASE TABLE'
+                AND engine IN ('InnoDB', 'MyISAM')
+        }
     );
     my $result = $options{sql}->fetchall_arrayref();
 


### PR DESCRIPTION
## Description

REFS: CTOR-264

Enhanced the way the fragmentation is calculated.

**Fixes** #4761 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

On a Centreon server:

```bash
/usr/lib/centreon/plugins//centreon_mysql.pl --plugin=database::mysql::plugin  --host=127.0.0.1 --username='centreon' --password='centreon' --port=''  --mode=databases-size --filter-database='^(?!(information_schema|performance_schema|test))' --filter-perfdata='database' --verbose --warning-table-frag=1
```

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] I have implemented automated tests related to my commits.
- [x] I have reviewed all the help messages in all the .pm files I have modified.
  - [x] All sentences begin with a capital letter.
  - [x] All sentences are terminated by a period.
  - [x] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.