### PR TITLE
fix(stormshield/api): mode interfaces wrong mapped values'

### DIFF
--- a/src/network/stormshield/api/mode/interfaces.pm
+++ b/src/network/stormshield/api/mode/interfaces.pm
@@ -234,7 +234,7 @@ sub set_counters {
             label => 'status',
             type => 2,
             filter => 'add_status',
-            critical_default => "%{state} eq 'enabled' and %{plugged} eq 'unplugged'", set => {
+            critical_default => "%{state} eq 'down'", set => {
                 key_values => [ { name => 'state' }, { name => 'plugged' }, { name => 'real_name' }, { name => 'user_name' } ],
                 closure_custom_output => $self->can('custom_status_output'),
                 closure_custom_perfdata => sub { return 0; },
@@ -344,8 +344,8 @@ sub check_options {
     }
 }
 
-my $map_state = { 0 => 'disabled', 1 => 'enabled' };
-my $map_plugged = { 0 => 'unplugged', 1 => 'plugged' };
+my $map_state = { 0 => 'down', 1 => 'up' };
+my $map_plugged = { 0 => 'passive', 1 => 'active' };
 
 sub manage_selection {
     my ($self, %options) = @_;
@@ -444,7 +444,7 @@ You can use the following variables: %{state}, %{plugged}, %{user_name}, %{real_
 
 =item B<--critical-status>
 
-Define the conditions to match for the status to be CRITICAL (default: "%{state} eq 'enabled' and %{plugged} eq 'unplugged'")
+Define the conditions to match for the status to be CRITICAL (default: "%{state} eq 'down'")
 You can use the following variables: %{state}, %{plugged}, %{user_name}, %{real_name}
 
 =item B<--warning-*> B<--critical-*>


### PR DESCRIPTION
# Community contributors

## Description

Currently values mapped are: 
```
my $map_state = { 0 => 'disabled', 1 => 'enabled' };
my $map_plugged = { 0 => 'unplugged', 1 => 'plugged' };
```

It should be:
```
my $map_state = { 0 => 'down', 1 => 'up' };
my $map_plugged = { 0 => 'passive', 1 => 'active' };
```

https://documentation.stormshield.eu/SNS/v4/en/Content/CLI_Serverd_Commands_reference_Guide_v4/Commands/serverd/MONITOR.INTERFACE.htm

CTOR-743

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.
