### PR TITLE
enh(custommode): add support of 3CX v18 and higher

### DIFF
--- a/src/apps/voip/3cx/restapi/plugin.pm
+++ b/src/apps/voip/3cx/restapi/plugin.pm
@@ -46,7 +46,7 @@ __END__
 
 =head1 PLUGIN DESCRIPTION
 
-Check 3CX ressources through its HTTPS remote API.
+Monitor 3CX resources through its HTTPS API.
 
 Requirements: at least 3CX 15.5.
 

--- a/tests/resources/spellcheck/stopwords.t
+++ b/tests/resources/spellcheck/stopwords.t
@@ -1,7 +1,9 @@
+--3cx-version
 --add-sysdesc
 --api-filter-orgs
 --api-password
 --api-token
+--api-username
 --api-version
 --cacert-file
 --cert-pkcs12
@@ -44,6 +46,7 @@
 -InputFormat
 -NoLogo
 2c
+3CX
 ADSL
 ASAM
 Alcatel
@@ -79,8 +82,8 @@ TrendMicro
 UCD
 VDSL2
 VM
-Veeam
 VPN
+Veeam
 WSMAN
 XPath
 api.meraki.com


### PR DESCRIPTION
## Description

REFS: CTOR-360

Attempt to take advantage of PR #4757 and keep compatibility with older versions.

**Fixes**: #4083 #4608 

## How to use

### 3CX version 18 update 5 or higher

As usual:

```bash
perl src/centreon_plugins.pl --plugin=apps::voip::3cx::restapi::plugin --mode system  --hostname=XXXXX --api-username=XXXXX --api-password=XXXXX
```

or with the version of your 3CX:

```bash
perl src/centreon_plugins.pl --plugin=apps::voip::3cx::restapi::plugin --mode system  --hostname=XXXXX --api-username=XXXXX --api-password=XXXXX --3cx-version 18.0.9.20
```

### 3CX older than version 18 update 5

Specify your 3CX version:

```bash
perl src/centreon_plugins.pl --plugin=apps::voip::3cx::restapi::plugin --mode system  --hostname=XXXXX --api-username=XXXXX --api-password=XXXXX --3cx-version 18.0.4.1
```

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Please describe the **procedure** to verify that the goal of the PR is matched. 
Provide clear instructions so that it can be **correctly tested**.
Mention the automated tests included in this FOR (what they test like mode/option combinations).

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] I have implemented automated tests related to my commits.
- [x] I have reviewed all the help messages in all the .pm files I have modified.
  - [x] All sentences begin with a capital letter.
  - [x] All sentences are terminated by a period.
  - [x] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.