### PR TITLE
MON-34540-gorgone-fix-perl-mojo-ioloop-signal-v3

### DIFF
--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -149,6 +149,8 @@ jobs:
             rpm_dependencies: "zeromq"
           - name: "Mojo::IOLoop::Signal"
             rpm_dependencies: "perl-Mojolicious"
+            rpm_provides: "perl(Mojo::IOLoop::Signal)"
+            no-auto-depends: true
 
 
     name: package ${{ matrix.distrib }} ${{ matrix.name }}
@@ -188,6 +190,10 @@ jobs:
             for PACKAGE_DEPENDENCY in `echo ${{ matrix.rpm_dependencies }}`; do
               PACKAGE_DEPENDENCIES="$PACKAGE_DEPENDENCIES --depends $PACKAGE_DEPENDENCY"
             done
+          fi
+
+          if [ ! -z "${{ matrix.no-auto-depends }}" ]; then
+            PACKAGE_DEPENDENCIES="$PACKAGE_DEPENDENCIES --no-auto-depends"
           fi
 
           if [ -z "${{ matrix.rpm_provides }}" ]; then


### PR DESCRIPTION
# Centreon team

## Description

Fix again perl Mojo::IOLoop::Signal library to be installable on alma8.

**Fixes** # Refs:MON-34540

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?
once this lib is in unstable, try to install centreon-gorgone from this pr https://github.com/centreon/centreon/pull/4178
installation should work without error

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have implemented automated tests related to my commits.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences are terminated by a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.