### PR TITLE
add missing swap dependency for aruba cppm

### DIFF
--- a/packaging/centreon-plugin-Network-Aruba-Cppm-Snmp/pkg.json
+++ b/packaging/centreon-plugin-Network-Aruba-Cppm-Snmp/pkg.json
@@ -6,6 +6,7 @@
         "centreon/plugins/script_snmp.pm",
         "centreon/plugins/snmp.pm",
         "snmp_standard/mode/cpu.pm",
+        "snmp_standard/mode/swap.pm",
         "snmp_standard/mode/listinterfaces.pm",
         "snmp_standard/mode/resources/",
         "snmp_standard/mode/interfaces.pm",


### PR DESCRIPTION
# Community contributors

## Description

this patch adds the missing snmp_standard::mode::swap dependency for aruba cppm

