### PR TITLE
If statement added when $total == 0

### DIFF
--- a/src/apps/backup/commvault/commserve/restapi/mode/storagepools.pm
+++ b/src/apps/backup/commvault/commserve/restapi/mode/storagepools.pm
@@ -128,15 +128,28 @@ sub manage_selection {
         }
 
         my ($total, $free) = ($_->{totalCapacity} * 1024 * 1024, $_->{totalFreeSpace} * 1024 * 1024);
-        $self->{sp}->{ $_->{storagePoolEntity}->{storagePoolName} } = {
-            display => $_->{storagePoolEntity}->{storagePoolName},
-            status => defined($map_status_code->{ $_->{statusCode} }) ? $map_status_code->{ $_->{statusCode} } : lc($_->{status}),
-            total_space => $total,
-            used_space => $total - $free,
-            free_space => $free,
-            prct_used_space => 100 - ($free * 100 / $total),
-            prct_free_space => $free * 100 / $total
-        };
+        if ($total == 0) {
+            $self->{sp}->{ $_->{storagePoolEntity}->{storagePoolName} } = {
+                display => $_->{storagePoolEntity}->{storagePoolName},
+                status => defined($map_status_code->{ $_->{statusCode} }) ? $map_status_code->{ $_->{statusCode} } : lc($_->{status}),
+                total_space => 0,
+                used_space => 0 - $free,
+                free_space => $free,
+                prct_used_space => 100 - ($free * 100 / 1),
+                prct_free_space => $free * 100 / 1
+            };
+
+        } else {
+            $self->{sp}->{ $_->{storagePoolEntity}->{storagePoolName} } = {
+                display => $_->{storagePoolEntity}->{storagePoolName},
+                status => defined($map_status_code->{ $_->{statusCode} }) ? $map_status_code->{ $_->{statusCode} } : lc($_->{status}),
+                total_space => $total,
+                used_space => $total - $free,
+                free_space => $free,
+                prct_used_space => 100 - ($free * 100 / $total),
+                prct_free_space => $free * 100 / $total
+            };
+        }
     }
     
     if (scalar(keys %{$self->{sp}}) <= 0) {


### PR DESCRIPTION
# Community contributors

## Description

There are cases when storage-pools with `totalCapacity` property equal to `"0"`. For example, Casette Tape Backup Libraries:

``` xml
<Api_GetStoragePoolListResp>
    <storagePoolList numberOfNodes="1" poolRetentionPeriodDays="365" cloudStorageClassNumber="-1" isArchiveStorage="0" libraryVendorType="0" totalFreeSpace="0" storagePoolType="2" storageSubType="0" totalCapacity="0" wormStoragePoolFlag="0" storageType="4" reserved1="1" status="Online" statusCode="0">
        [... text omited ...]
    </storagePoolList>
</Api_GetStoragePoolListResp>
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Just executing the plugin against a CommServe API when StoragePools with `totalCapacity` property equal to `"0"`.

Without the fix, the return string will be:

``` output
UNKNOWN: Illegal division by zero at /usr/lib/centreon/plugins//centreon_commvault_commserve_restapi.pl line 1547.
```

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [x] I have provide data or shown output displaying the result of this code in the plugin area concerned.
