### PR TITLE
Add common option --change-output-adv

### DIFF
--- a/src/centreon/plugins/output.pm
+++ b/src/centreon/plugins/output.pm
@@ -523,7 +523,7 @@ sub output_txt_short {
          eval "\$stdout =~ s{$pattern}{$replace}$modifier";
     }
 
-    my $exit = defined($options{exit_litteral}) ? $options{exit_litteral} : $self->{myerrors}->{ $self->{global_status} };
+    my $exit = defined($options{exit_litteral}) ? uc($options{exit_litteral}) : uc($self->{myerrors}->{ $self->{global_status} });
     foreach (@{$self->{change_output_adv}}) {
         if ($self->test_eval(test => $_->{expr}, values => { short_output => $stdout, exit_code => $self->{errors}->{$exit} })) {
             if (defined($_->{short_output}) && $_->{short_output} ne '') {


### PR DESCRIPTION
# Community contributors

## Description

Add a common option to change the short output and the exit code at the same time.

CTOR-820

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

```
--change-output-adv='%(short_output) =~ /No daemon/ and %(exit_code) == 0,OK: no daemon,OK'
```


## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.
