### PR TITLE
HPE Primera API OPTIONS not shown in --help

### DIFF
--- a/src/storage/hp/primera/restapi/custom/api.pm
+++ b/src/storage/hp/primera/restapi/custom/api.pm
@@ -54,7 +54,7 @@ sub new {
             'critical-http-status:s' => { name => 'critical_http_status' }
         });
     }
-    $options{options}->add_help(package => __PACKAGE__, sections => 'HPE PRIMERA API OPTIONS', once => 1);
+    $options{options}->add_help(package => __PACKAGE__, sections => 'HPE Primera API OPTIONS', once => 1);
 
     $self->{output} = $options{output};
     $self->{http}   = centreon::plugins::http->new(%options, default_backend => 'curl');


### PR DESCRIPTION
# Community contributors

## Description

The custom API options (like --hostname or --api-username) are not shown during --help on a mode of the plugin.

This happens because the section name in add_help function must be case sensitive.