### PR TITLE
--output-fields added in version 236

### DIFF
--- a/src/os/linux/local/mode/systemdjournal.pm
+++ b/src/os/linux/local/mode/systemdjournal.pm
@@ -69,7 +69,17 @@ sub manage_selection {
         (defined($self->{option_results}->{filter_message}) ? md5_hex($self->{option_results}->{filter_message}) : md5_hex('all')) . '_' .
         (defined($self->{option_results}->{since}) ? md5_hex($self->{option_results}->{since}) : md5_hex('all'));
 
+    my $journalctl_version = $options{custom}->execute_command(
+        command => '/usr/bin/journalctl',
+        command_options => '--version | grep systemd | awk \'{print $2}\'',
+        no_quit => 1
+    );
+
     my $command_options = '--output json --output-fields MESSAGE --no-pager';
+    # --output-field option has been added in version 236
+    if ($journalctl_version < 236) {
+        my $command_options = '--output json --no-pager';
+    };
 
     if (defined($self->{option_results}->{unit}) && $self->{option_results}->{unit} ne '') {
         $command_options .= ' --unit ' . $self->{option_results}->{unit};


### PR DESCRIPTION
## Description

--output-fields has been added in journalctl version 236.
We should remove this option for older versions.

**Fixes** # CTOR-877

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] I have implemented automated tests related to my commits.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences are terminated by a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.