### PR TITLE
Fix authorization header on HPE-Primera-RestAPI

### DIFF
--- a/src/storage/hp/primera/restapi/custom/api.pm
+++ b/src/storage/hp/primera/restapi/custom/api.pm
@@ -169,7 +169,7 @@ sub request_api {
     my ($content) = $self->{http}->request(
         url_path        => $options{endpoint},
         get_param       => $get_param,
-        header          => [ 'Authorization: Bearer ' . $token ],
+        header          => [ 'X-HP3PAR-WSAPI-SessionKey: ' . $token ],
         unknown_status  => '',
         warning_status  => '',
         critical_status => ''


### PR DESCRIPTION
# Community contributors

**Fixes** # (issue)
Every mode returns an error saying that the session key is wrong. With the same user and password the curls are working fine.
The problem is that the plugin uses the wrong Authorization Header.

The Header must be "X-HP3PAR-WSAPI-SessionKey: " and not "Authorization: Bearer".

Correcting this the plugins works fine.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software


## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.