### PR TITLE
enh(database::mssql): mode connected-users, add options to filter

### DIFF
--- a/src/database/mssql/mode/connectedusers.pm
+++ b/src/database/mssql/mode/connectedusers.pm
@@ -90,7 +90,7 @@ Check MSSQL connected users.
 
 Filter connected users by database name (can be a regexp).
 
-=item B<--uniq-name>
+=item B<--uniq-users>
 
 Count users with the same login name once.
 

--- a/src/database/mssql/mode/connectedusers.pm
+++ b/src/database/mssql/mode/connectedusers.pm
@@ -29,7 +29,10 @@ sub new {
     my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
     
-    $options{options}->add_options(arguments => {});
+    $options{options}->add_options(arguments => {
+        'database-name:s' => { name => 'database_name' },
+        'uniq-users'      => { name => 'uniq_users' }
+    });
 
     return $self;
 }
@@ -44,12 +47,12 @@ sub set_counters {
     $self->{maps_counters}->{connected_user} = [
         { label => 'connected-user', nlabel => 'mssql.users.connected.count', set => {
                 key_values => [ { name => 'value' } ],
-                output_template => '%i connected user(s)',
+                output_template => '%s connected user(s)',
                 perfdatas => [
-                    { template => '%i', min => 0 },
-                ],
+                    { template => '%s', min => 0 }
+                ]
             }
-        },
+        }
     ];
 }
 
@@ -57,11 +60,20 @@ sub manage_selection {
     my ($self, %options) = @_;
 
     $options{sql}->connect();
-    $options{sql}->query(query => q{SELECT count(*) FROM master..sysprocesses WHERE spid >= '51'});
+    $options{sql}->query(query => q{SELECT DB_NAME(dbid) as dbname, loginame FROM master..sysprocesses WHERE spid >= '51'});
+    my $results = $options{sql}->fetchall_arrayref();
 
-    my $connected_count = $options{sql}->fetchrow_array();
-    $self->{connected_user}->{value} = $connected_count;
+    $self->{connected_user} = { value => 0 };
+    my %logins = ();
+    foreach my $row (@$results) {
+        $row->[0] = '' if (!defined($row->[0]));
 
+        next if (defined($self->{option_results}->{database_name}) && $self->{option_results}->{database_name} ne '' && 
+            $row->[0] !~ /$self->{option_results}->{database_name}/);
+        next if (defined($self->{option_results}->{uniq_users}) && defined($logins{ $row->[1] }));
+        $logins{ $row->[1] } = 1;
+        $self->{connected_user}->{value}++;
+    }
 }
 
 1;
@@ -73,6 +85,14 @@ __END__
 Check MSSQL connected users.
 
 =over 8
+
+=item B<--database-name>
+
+Filter connected users by database name (can be a regexp).
+
+=item B<--uniq-name>
+
+Count users with the same login name once.
 
 =item B<--warning-connected-user>
 


### PR DESCRIPTION
# Community contributors

## Description

Add options to filter users by database name and add also admin users.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Need a MSSQL database server.

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.

