### PR TITLE
Fix 3com snmp fan/psu check

### DIFF
--- a/src/network/3com/snmp/mode/hardware.pm
+++ b/src/network/3com/snmp/mode/hardware.pm
@@ -32,7 +32,7 @@ sub set_system {
     
     $self->{thresholds} = {        
         default => [
-            ['active', 'OK'],
+            ['^active$', 'OK'],
             ['deactive', 'CRITICAL'],
             ['not-install', 'OK'],
             ['unsupport', 'WARNING']


### PR DESCRIPTION
## Description

On 3com network devices, a fan or psu is reported as "active" when working properly, and "deactive" when failed. The threshold regex for the "OK" status is configured too vaguely: a "deactive" status was considered "active" / "OK" as the string "active" is contained in "deactive". This fix ensures that the "OK" status starts (and ends) with "active".

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Before this patch, a "deactive" fan is considered "OK" (Debug output is redacted for brevity) : 
```
# perl /usr/lib/centreon/plugins/centreon_3com_debug.pl --mode=hardware --hostname=x --snmp-version='3' --authprotocol=sha --privprotocol=aes --snmp-username=x --authpassphrase=x --privpassphrase=x --component=fan --snmp-timeout=20 --debug
`OK: All 12 components are ok [12/12 fans]. | 'count_fan'=12;;;;
.1.3.6.1.4.1.43.45.1.2.23.1.9.1.1.1.1.65536 = 65536
.1.3.6.1.4.1.43.45.1.2.23.1.9.1.1.1.1.196611 = 196611
.1.3.6.1.4.1.43.45.1.2.23.1.9.1.1.1.2.65536 = 1
.1.3.6.1.4.1.43.45.1.2.23.1.9.1.1.1.2.196611 = 2
Checking fans
Fan '65536' status is 'active' [instance: 65536]
Fan '196611' status is 'deactive' [instance: 196611]
```

After patching, the failed fan is correctly reported as failed (Debug output is redacted for brevity) : 

```
perl /usr/lib/centreon/plugins/centreon_3com.pl --mode=hardware --hostname=x --snmp-version='3' --authprotocol=sha --privprotocol=aes --snmp-username=x --authpassphrase=x --privpassphrase=x --component=fan --snmp-timeout=20 --debug
CRITICAL: Fan '196611' status is deactive | 'count_fan'=12;;;;
.1.3.6.1.4.1.43.45.1.2.23.1.9.1.1.1.1.65536 = 65536
.1.3.6.1.4.1.43.45.1.2.23.1.9.1.1.1.1.196611 = 196611
.1.3.6.1.4.1.43.45.1.2.23.1.9.1.1.1.2.65536 = 1
.1.3.6.1.4.1.43.45.1.2.23.1.9.1.1.1.2.196611 = 2
Checking fans
Fan '65536' status is 'active' [instance: 65536]
Fan '196611' status is 'deactive' [instance: 196611]
```


## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (develop).
- [X] I have provide data or shown output displaying the result of this code in the plugin area concerned.