### PR TITLE
enh(plugin): add Centreon header for Meraki api calls

### DIFF
--- a/src/network/cisco/meraki/cloudcontroller/restapi/custom/api.pm
+++ b/src/network/cisco/meraki/cloudcontroller/restapi/custom/api.pm
@@ -143,6 +143,7 @@ sub build_options_for_httplib {
     $self->{option_results}->{port} = $self->{port};
     $self->{option_results}->{proto} = $self->{proto};
     $self->{http}->add_header(key => 'X-Cisco-Meraki-API-Key', value => $self->{api_token});
+    $self->{http}->add_header(key => 'User-Agent', value => 'CentreonPlugin/1.0 Centreon');
 }
 
 sub settings {


### PR DESCRIPTION
# Centreon team

## Description

Add partner key to Meraki API calls

**Fixes** CTOR-864

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences are terminated by a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
