### PR TITLE
enh(protocols::http): mode collection add function boolean2integer

### DIFF
--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -1746,6 +1746,39 @@ sub exec_func_scientific2number {
     }
 }
 
+sub exec_func_boolean2integer {
+    my ($self, %options) = @_;
+
+    #{
+    #    "type": "boolean2integer",
+    #    "src": "%(enabled)",
+    #    "save": "%(enabled)",
+    #}
+    if (!defined($options{src}) || $options{src} eq '') {
+        $self->{output}->add_option_msg(short_msg => "$self->{current_section} please set src attribute");
+        $self->{output}->option_exit();
+    }
+    my $result = $self->parse_special_variable(chars => [split //, $options{src}], start => 0);
+    if ($result->{type} !~ /^(?:0|4)$/) {
+        $self->{output}->add_option_msg(short_msg => $self->{current_section} . " special variable type not allowed in src attribute");
+        $self->{output}->option_exit();
+    } 
+    my $data = $self->get_special_variable_value(%$result);
+
+    if (ref($data) eq 'JSON::PP::Boolean') {
+        $data = $data ? 1 : 0;
+    }
+
+    if (defined($options{save}) && $options{save} ne '') {
+        my $save = $self->parse_special_variable(chars => [split //, $options{save}], start => 0);
+        if ($save->{type} !~ /^(?:0|4)$/) {
+            $self->{output}->add_option_msg(short_msg => $self->{current_section} . " special variable type not allowed in save attribute");
+            $self->{output}->option_exit();
+        }
+        $self->set_special_variable_value(value => $data, %$save);
+    }
+}
+
 sub set_functions {
     my ($self, %options) = @_;
 
@@ -1779,6 +1812,8 @@ sub set_functions {
             $self->exec_func_capture(%$_);
         } elsif (lc($_->{type}) eq 'scientific2number') {
             $self->exec_func_scientific2number(%$_);
+        } elsif (lc($_->{type}) eq 'boolean2integer') {
+            $self->exec_func_boolean2integer(%$_);
         }
     }
 }


### PR DESCRIPTION
# Community contributors

## Description

On legacy centreon system with JSON::XS version < 4.0 (rhel 7 and 8 ), JSON boolean values are of the type ‘JSON::PP::Boolean’. It’s an issue because we can’t manage objects in a Safe Perl object. 

CTOR-957

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

The command to test it:
```
$ perl centreon_plugins.pl --plugin=apps/protocols/http/plugin.pm --mode=collection --config=/root/test-boolean.config --constant='hostname=127.0.0.1'  --constant='port=80' --constant='critical=1' --verbose
CRITICAL: interruptor '2' switch enabled: 1 | '1#interruptor.enabled.count'=0;;;; '2#interruptor.enabled.count'=1;;;;
interruptor '1' switch enabled: 0
interruptor '2' switch enabled: 1
```

JSON file provided by the http server:
```
{ "interruptor": [
        {
            "name": "1",
            "enabled" : false 
        },
        {
            "name": "2",
            "enabled": true
        }
    ]	
}
```

The test-boolean.config file:
```
{
    "mapping": {},
    "constants": {
        "method": "http",
        "port": "80"
    },
    "http": {
        "requests": [
            {
                "name": "interruptor",
                "hostname": "%(constants.hostname)",
                "proto": "%(constants.method)",
                "port": "%(constants.port)",
                "endpoint": "/boolean",
                "headers": ["Accept:application/json", "Content-Type:application/json"],
                "insecure": 1,
                "timeout": 30,
                "backend": "curl",
                "rtype": "json",
                "parse": [
                    {
                        "name": "entry",
                        "path": "..interruptor[*]",
                        "entries": [
                            { "id": "name" },
                            { "id": "enabled" }
                        ]
                    }
                ]
            }
        ]
    },
    "selection_loop": [
        {
            "name": "interruptorValues",
            "source": "%(http.tables.interruptorEntry)",
            "expand_table": {
                "interruptor": "%(http.tables.interruptorEntry.[%(interruptorEntry.instance)])"
            },
            "functions": [
                { "type": "boolean2integer", "src": "%(interruptor.enabled)", "save": "%(interruptor.enabled)" }
            ],
            "critical":  "%(interruptor.enabled) =~ /%(constants.critical)/i",
            "perfdatas": [
                { "nlabel": "interruptor.enabled.count", "value": "%(interruptor.enabled)", "instances": ["%(interruptor.name)"] }
            ],
            "formatting": {
                "printf_msg":"interruptor '%s' switch enabled: %s",
                "printf_var":[
                    "%(interruptor.name)",
                    "%(interruptor.enabled)"
                ]
            }
        }
    ],
    "formatting":{
        "custom_message_global": "interruptor switches are ok",
        "separator": "-"
    }
}

```

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.
