### PR TITLE
enh(vmware-daemon): prepare release of version 3.3.0 with 24.10 connector release

### DIFF
--- a/connectors/vmware/changelog
+++ b/connectors/vmware/changelog
@@ -1,3 +1,8 @@
+2024-10-10 Olivier Mercier <omercier@centreon.com> - 3.3.0
+ * Enhancement: add ability to read configuration from JSON file
+ * Enhancement: add ability to get the VMware credentials from a Centreon
+ flavoured Hashicorp vault
+
 2022-08-09 Quentin Garnier <qgarnier@centreon.com> - 3.2.5
  * Enhancement: add tags in discovery
 

--- a/connectors/vmware/src/centreon/script/centreon_vmware.pm
+++ b/connectors/vmware/src/centreon/script/centreon_vmware.pm
@@ -54,7 +54,7 @@ BEGIN {
 
 use base qw(centreon::vmware::script);
 
-my $VERSION = '3.2.6';
+my $VERSION = '3.3.0';
 my %handlers = (TERM => {}, HUP => {}, CHLD => {});
 
 my @load_modules = (

--- a/connectors/vmware/src/centreon/vmware/common.pm
+++ b/connectors/vmware/src/centreon/vmware/common.pm
@@ -45,7 +45,7 @@ sub init_response {
     my (%options) = @_;
 
     $manager_response->{code} = 0;
-    $manager_response->{vmware_connector_version} = '3.2.6';
+    $manager_response->{vmware_connector_version} = '3.3.0';
     $manager_response->{short_message} = 'OK';
     $manager_response->{extra_message} = '';
     $manager_response->{identity} = $options{identity} if (defined($options{identity}));


### PR DESCRIPTION
## Description

Increment version `3.2.6` ➡️  `3.3.0` for next release.

* Enhancement: add ability to read configuration from JSON file
* Enhancement: add ability to get the VMware credentials from a Centreon flavoured Hashicorp vault

