### PR TITLE
enh(docker::local): Make compatible with Podman containers

### DIFF
--- a/src/cloud/docker/local/mode/containerstatus.pm
+++ b/src/cloud/docker/local/mode/containerstatus.pm
@@ -79,7 +79,7 @@ sub manage_selection {
 
     shift(@lines);
     foreach my $line (@lines) {
-        next if ($line !~ /^(\S+)\s{3,}(\S+)\s{3,}(.*?)\s{3,}(.*?)\s{3,}(.*?)\s{3,}(.*?)\s{3,}(\S+)$/);
+        next if ($line !~ /^(\S+)\s{2,}(\S+)\s{2,}(.*?)\s{2,}(.*?)\s{2,}(.*?)\s{2,}(.*?)\s{2,}(\S+)$/);
 
         my ($id, $image, $command, $created, $status, $ports, $name) = ($1, $2, $3, $4, $5, $6, $7);
 

--- a/src/cloud/docker/local/mode/containerusage.pm
+++ b/src/cloud/docker/local/mode/containerusage.pm
@@ -206,7 +206,7 @@ sub manage_selection {
 
     shift(@lines);
     foreach my $line (@lines) {
-        next if ($line !~ /^(\S+)\s{3,}(\S+)\s{3,}(\S+)\s{3,}(\S+)\s\/\s(\S+)\s{3,}\S+\s{3,}(\S+)\s\/\s(\S+)\s{3,}(\S+)\s\/\s(\S+).*$/);
+        next if ($line !~ /^(\S+)\s{2,}(\S+)\s{2,}(\S+)\s{2,}(\S+)\s\/\s(\S+)\s{2,}\S+\s{2,}(\S+)\s\/\s(\S+)\s{2,}(\S+)\s\/\s(\S+).*$/);
 
         my ($id, $name, $cpu, $mem_usage, $mem_limit, $net_in, $net_out, $block_in, $block_out) = ($1, $2, $3, $4, $5, $6, $7, $8, $9);
 

--- a/src/cloud/docker/local/mode/listcontainers.pm
+++ b/src/cloud/docker/local/mode/listcontainers.pm
@@ -56,7 +56,7 @@ sub manage_selection {
 
     shift(@lines);
     foreach my $line (@lines) {
-        next if ($line !~ /^(\S+)\s{3,}(\S+)\s{3,}(.*?)\s{3,}(.*?)\s{3,}(.*?)\s{3,}(.*?)\s{3,}(\S+)$/);
+        next if ($line !~ /^(\S+)\s{2,}(\S+)\s{2,}(.*?)\s{2,}(.*?)\s{2,}(.*?)\s{2,}(.*?)\s{2,}(\S+)$/);
 
         my ($id, $image, $command, $created, $status, $ports, $name) = ($1, $2, $3, $4, $5, $6, $7);
 


### PR DESCRIPTION
# Community contributors

## Description

Modify the cloud::docker::local::plugin to be compatible with Podman container engine.

Podman uses two whitespaces at minimum to seperate its cli output colums whereas Docker uses three. This reduces the required whichtespaces in the regex filter of the command output accordingly.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Tested locally on RHEL8 with Icinga, Podman and Docker containers.


## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.