### PR TITLE
Plugin network::cisco::meraki::cloudcontroller::restapi::plugin - Add filter for discovery mode

### DIFF
--- a/src/network/cisco/meraki/cloudcontroller/restapi/mode/discovery.pm
+++ b/src/network/cisco/meraki/cloudcontroller/restapi/mode/discovery.pm
@@ -37,6 +37,7 @@ sub new {
         'filter-network-id:s'        => { name => 'filter_network_id' },
         'filter-organization-name:s' => { name => 'filter_organization_name' },
         'filter-organization-id:s'   => { name => 'filter_organization_id' },
+        'filter-model:s'             => { name => 'filter_model' },
         'filter-tags:s'              => { name => 'filter_tags' }
     });
 
@@ -70,6 +71,8 @@ sub discovery_devices {
 
     my @results;
     foreach (values %$devices) {
+        next if (defined($self->{option_results}->{filter_model}) && $self->{option_results}->{filter_model} ne '' &&
+            $_->{model} !~ /$self->{option_results}->{filter_model}/);
         next if (defined($self->{option_results}->{filter_network_id}) && $self->{option_results}->{filter_network_id} ne '' &&
             $_->{networkId} !~ /$self->{option_results}->{filter_network_id}/);
         next if (defined($self->{option_results}->{filter_tags}) && $self->{option_results}->{filter_tags} ne '' &&
@@ -205,6 +208,10 @@ Prettify JSON output.
 =item B<--resource-type>
 
 Choose the type of resources to discover (can be: 'device', 'network').
+
+=item B<--filter-model>
+
+Filter by model (can be a regexp).
 
 =item B<--filter-network-id>
 


### PR DESCRIPTION
## Description
Add a filter to allow to filter by model for the meraki api plugin (mode discovery)

## How this pull request can be tested ?
./centreon_plugins.pl --plugin=network::cisco::meraki::cloudcontroller::restapi::plugin --mode="discovery" --hostname='api.meraki.com' --port='443' --proto='https' --http-backend='curl' --api-token=$MERAKI_DASHBOARD_API_KEY --ignore-permission-errors --ignore-orgs-api-disabled --api-filter-orgs=${ORG_REGEX} --verbose --resource-type=device --prettify --filter-model="z3c"
