### PR TITLE
use proper error message

### DIFF
--- a/src/database/mysql/mode/replication.pm
+++ b/src/database/mysql/mode/replication.pm
@@ -222,7 +222,7 @@ sub check_slave {
         $self->{servers}->{ $options{name} }->{thread_io} = {
             display => $options{name},
             running => $running,
-            error_message => defined($result->{Last_Error}) ? $result->{Last_Error} : ''
+            error_message => defined($result->{Last_IO_Error}) ? $result->{Last_IO_Error} : ''
         };
     }
     if (defined($result->{Slave_SQL_Running})) {


### PR DESCRIPTION
# Community contributors

## Description

use the proper mariadb message when checking mysql replication state


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

- have a sql replication running
- on your master do some stupid shit such as 

```sql
CHANGE MASTER TO MASTER_HOST='debian-ha-2', MASTER_USER='wrong_user', MASTER_PASSWORD='centreon', MASTER_LOG_FILE='mysql-bin.000001', MASTER_LOG_POS=328;
START SLAVE;
```

you'll now a failed slave replication thread running on your master server check it with your monitoring plugin and you'll get the following result

```bash
/usr/lib/centreon/plugins/centreon_mysql.pl --plugin=database::mysql::plugin --mode=replication --host=192.168.0.100 --port='3306' --username='centreon_repl' --password='centreon' --multiple --host='192.168.0.101' --port='3306' --username='centreon_repl' --password='centreon'  --unknown-connection-status='' --warning-connection-status='' --critical-connection-status='%{status} ne "ok"' --warning-thread-io-status='' --critical-thread-io-status='' --warning-slaves-running='' --critical-slaves-running='1:1' --warning-slave-latency='' --critical-slave-latency='' --unknown-replication-status='%{replication_status} =~ /configurationIssue/i' --warning-replication-status='%{replication_status} =~ /inProgress/i' --critical-replication-status='%{replication_status} =~ /connectIssueToMaster/i' --warning-thread-sql-status='' --critical-thread-sql-status='%{error_message} !~ //' --verbose
slaves.running.count'=2;;1:1;0;2 'mysql:host=192.168.0.101;port=3306#instance.slave.latency.seconds'=0s;;;;
checking database instance 'mysql:host=192.168.0.100;port=3306'
    connection status: ok
    thread sql running: yes
    thread io running: no [last error message: ]
    replication status: connectIssueToMaster
checking database instance 'mysql:host=192.168.0.101;port=3306'
    connection status: ok
    thread sql running: yes
    thread io running: yes
    slave has 0 seconds latency behind master, replication status: ok
```

with my patch you'll get a much better result

```sql
CRITICAL: number of slave instances running: 2 - database instance 'mysql:host=192.168.0.100;port=3306' replication status: connectIssueToMaster | 'instance.slaves.running.count'=2;;1:1;0;2 'mysql:host=192.168.0.101;port=3306#instance.slave.latency.seconds'=0s;;;;
checking database instance 'mysql:host=192.168.0.100;port=3306'
    connection status: ok
    thread sql running: yes
    thread io running: no [last error message: error connecting to master 'wrong_user@debian-ha-2:3306' - retry-time: 60  maximum-retries: 86400  message: Access denied for user 'wrong_user'@'debian-ha-1' (using password: YES)]
    replication status: connectIssueToMaster
checking database instance 'mysql:host=192.168.0.101;port=3306'
    connection status: ok
    thread sql running: yes
    thread io running: yes
    slave has 0 seconds latency behind master, replication status: ok
```