### PR TITLE
fix(vmware-daemon): fix the case-sensitiveness regression on containers

### DIFF
--- a/connectors/vmware/changelog
+++ b/connectors/vmware/changelog
@@ -1,3 +1,7 @@
+2024-10-18 Olivier Mercier <omercier@centreon.com> - 3.3.2
+ * Fix: regression of case sensitiveness for container names fixed
+ * Enhancement: log messages related to the vault have been downgraded from error to info level or explained as safe to ignore if not using the vault
+
 2024-10-10 Olivier Mercier <omercier@centreon.com> - 3.3.1
  * Fix: add missing centreonvault.pm file to packaging
 

--- a/connectors/vmware/src/centreon/script/centreon_vmware.pm
+++ b/connectors/vmware/src/centreon/script/centreon_vmware.pm
@@ -54,7 +54,7 @@ BEGIN {
 
 use base qw(centreon::vmware::script);
 
-my $VERSION = '3.3.1';
+my $VERSION = '3.3.2';
 my %handlers = (TERM => {}, HUP => {}, CHLD => {});
 
 my @load_modules = (
@@ -158,6 +158,13 @@ sub read_configuration {
         our %centreon_vmware_config;
         # loads the .pm configuration (compile time)
         require($self->{opt_extra}) or $self->{logger}->writeLogFatal("There has been an error while requiring file " . $self->{opt_extra});
+        # We want all the keys to be lowercase
+        for my $conf_key (keys %{$centreon_vmware_config{vsphere_server}}) {
+            if ($conf_key ne lc($conf_key)) {
+                $self->{logger}->writeLogDebug("The container $conf_key has capital letters. We convert it to lower case.");
+                $centreon_vmware_config{vsphere_server}->{lc($conf_key)} = delete $centreon_vmware_config{vsphere_server}->{$conf_key};
+            }
+        }
         # Concatenation of the default parameters with the ones from the config file
         $self->{centreon_vmware_config} = {%{$self->{centreon_vmware_default_config}}, %centreon_vmware_config};
     } elsif ($self->{opt_extra} =~ /.*\.json$/i) {

--- a/connectors/vmware/src/centreon/script/centreonvault.pm
+++ b/connectors/vmware/src/centreon/script/centreonvault.pm
@@ -42,7 +42,7 @@ sub new {
 
     if ( !$self->init() ) {
         $self->{enabled} = 0;
-        $self->{logger}->writeLogError("An error occurred in init() method. Centreonvault cannot be used.");
+        $self->{logger}->writeLogInfo("Something happened during init() method that makes Centreonvault not usable. Ignore this if you don't use Centreonvault.");
     }
     return $self;
 }
@@ -86,7 +86,7 @@ sub check_options {
     }
     if ( ! -f $self->{config_file} ) {
         $self->{logger}->writeLogError("The given configuration file " . $self->{config_file}
-            . " does not exist. Centreonvault cannot be used.");
+            . " does not exist. Passwords won't be retrieved from Centreonvault. Ignore this if you don't use Centreonvault.");
         return undef;
     }
 

--- a/connectors/vmware/src/centreon/vmware/common.pm
+++ b/connectors/vmware/src/centreon/vmware/common.pm
@@ -45,7 +45,7 @@ sub init_response {
     my (%options) = @_;
 
     $manager_response->{code} = 0;
-    $manager_response->{vmware_connector_version} = '3.3.0';
+    $manager_response->{vmware_connector_version} = '3.3.2';
     $manager_response->{short_message} = 'OK';
     $manager_response->{extra_message} = '';
     $manager_response->{identity} = $options{identity} if (defined($options{identity}));


### PR DESCRIPTION
## Description

Fixed a regression when container names were declared with capital letters.

Refs: CTOR-1005

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Please describe the **procedure** to verify that the goal of the PR is matched. 
Provide clear instructions so that it can be **correctly tested**.
Mention the automated tests included in this FOR (what they test like mode/option combinations).

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences are terminated by a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
