### PR TITLE
Plugin(cloud::aws) - Custom(Awscli): Missing cloudtrail command in event lookup mode

### DIFF
--- a/src/cloud/aws/custom/awscli.pm
+++ b/src/cloud/aws/custom/awscli.pm
@@ -1078,7 +1078,7 @@ Set AWS session token.
 
 =item B<--aws-role-arn>
 
-Set arn of the role to be assumed.
+Set Amazon Resource Name of the role to be assumed.
 
 =item B<--aws-profile>
 
@@ -1102,7 +1102,7 @@ Set timeframe in seconds.
 
 =item B<--statistic>
 
-Set cloudwatch statistics (can be: 'minimum', 'maximum', 'average', 'sum').
+Set CloudWatch statistics (can be: 'minimum', 'maximum', 'average', 'sum').
 
 =item B<--zeroed>
 
@@ -1139,7 +1139,7 @@ Proxy URL if any
 
 Avoid certificate issuer verification. Useful when AWS resources are hosted by a third party. 
 
-Note that it strips all stderr from the command result. Debug will only display CLI instead of evreything.
+Note that it strips all stderr from the command result. Debug will only display CLI instead of everything.
 
 =back
 

--- a/src/cloud/aws/custom/awscli.pm
+++ b/src/cloud/aws/custom/awscli.pm
@@ -981,7 +981,7 @@ sub cloudtrail_events_set_cmd {
 
     return if (defined($self->{option_results}->{command_options}) && $self->{option_results}->{command_options} ne '');
 
-    my $cmd_options = "lookup-events --region $self->{option_results}->{region} --output json";
+    my $cmd_options = "cloudtrail lookup-events --region $self->{option_results}->{region} --output json";
     if (defined($options{delta})) {
         my $endtime = time();
         my $starttime = $endtime - ($options{delta} * 60);

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -17,12 +17,16 @@ api.meraki.com
 --api-version
 ASAM
 Avigilon
+aws
+AWSCLI
+--aws-role-arn
 Backbox
 --cacert-file
 cardtemperature
 Centreon
 --cert-pkcs12
 --cert-pwd
+CloudWatch
 connections-dhcp
 connections-dns
 cpu-utilization-1m
@@ -155,6 +159,7 @@ powershell.exe
 prct
 Primera
 proto
+--proxyurl
 psu
 QoS
 queue-messages-inflighted
@@ -164,6 +169,7 @@ RRDCached
 Sansymphony
 --scope-datacenter
 sfp.temperature
+--skip-ssl-check
 SNMP
 space-usage-prct
 --sql-errors-exit


### PR DESCRIPTION
# Centreon team

## Description

CTOR-958
enh(plugin): add cloudtrail in awscli custom command option
Community contribution https://github.com/centreon/centreon-plugins/pull/5086

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

//

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences are terminated by a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
