### PR TITLE
Fix: HTTP status handling & retry on invalid token (firmware upgrade)

### DIFF
--- a/src/storage/hp/primera/restapi/custom/api.pm
+++ b/src/storage/hp/primera/restapi/custom/api.pm
@@ -175,6 +175,21 @@ sub request_api {
         critical_status => ''
     );
 
+    # Maybe token is invalid. so we retry
+    if (!defined($self->{token}) && $self->{http}->get_code() < 200 || $self->{http}->get_code() >= 300) {
+        $self->clean_token();
+        $token = $self->get_token();
+
+        $content = $self->{http}->request(
+            url_path        => $options{endpoint},
+            get_param       => $get_param,
+            header          => [ 'X-HP3PAR-WSAPI-SessionKey: ' . $token ],
+            unknown_status  => $self->{unknown_http_status},
+            warning_status  => $self->{warning_http_status},
+            critical_status => $self->{critical_http_status}
+        );
+    }
+
     if (!defined($content) || $content eq '') {
         $self->{output}->add_option_msg(short_msg => "API returns empty content [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']");
         $self->{output}->option_exit();


### PR DESCRIPTION
# Community contributors

## Description

- The unknown, critical & warning status is not se for the general API HTTP request. They are only set on login. So when token has a valid validation date in the statefile but is not more valid (because retired) the other checks doesn't terminate before validating their data.
- During a firmware upgrade the token saved in the statefile will not be valid anymore even it should by validation date. In this case the user must find the statefile an delete it to force a new login.

**Fixes** # (issue)
 With a simple clean of the token and a retry we can retry ones with a new login. On this retry we can set the http-status parameter so when the retry fails the check will be aborted with a status error.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

