### PR TITLE
Ctor 952 plugin deb only centreon plugin applications monitoring speedtest conflict with speedtest and speedtest cli binaries

### DIFF
--- a/packaging/centreon-plugin-Applications-Monitoring-Speedtest/deb.json
+++ b/packaging/centreon-plugin-Applications-Monitoring-Speedtest/deb.json
@@ -1,6 +1,5 @@
 {
     "dependencies": [
-        "libssh-session-perl",
-        "speedtest-cli"
+        "libssh-session-perl"
     ]
 }

--- a/packaging/centreon-plugin-Applications-Monitoring-Speedtest/rpm.json
+++ b/packaging/centreon-plugin-Applications-Monitoring-Speedtest/rpm.json
@@ -1,6 +1,5 @@
 {
     "dependencies": [
-        "perl(Libssh::Session)",
-        "speedtest-cli"
+        "perl(Libssh::Session)"
     ]
 }


### PR DESCRIPTION
# Centreon team

## Description

speedtest-cli isn't used by the plugin.
It only needs speedtest and we ask to download it from the official website.
By the way, speedtest-cli from debian repositories is in conflict with speedtest-cli from the official website.

**Fixes** # CTOR-952

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
