### PR TITLE
fix exclude options for backends, hitratio, listdatabases,locks

### DIFF
--- a/src/database/postgres/mode/backends.pm
+++ b/src/database/postgres/mode/backends.pm
@@ -89,7 +89,7 @@ sub run {
     my $result = $options{sql}->fetchall_arrayref();
 
     foreach my $row (@{$result}) {
-        if (defined($self->{option_results}->{exclude}) && $$row[2] !~ /$self->{option_results}->{exclude}/) {
+        if (defined($self->{option_results}->{exclude}) && $self->{option_results}->{exclude} ne '' && $$row[2] =~ /$self->{option_results}->{exclude}/) {
             $self->{output}->output_add(long_msg => "Skipping database '" . $$row[2] . '"');
             next;
         }

--- a/src/database/postgres/mode/hitratio.pm
+++ b/src/database/postgres/mode/hitratio.pm
@@ -87,7 +87,7 @@ sub run {
         $new_datas->{$row->[2] . '_blks_hit'} = $row->[0];
         $new_datas->{$row->[2] . '_blks_read'} = $row->[1];
 
-        if (defined($self->{option_results}->{exclude}) && $row->[2] !~ /$self->{option_results}->{exclude}/) {
+        if (defined($self->{option_results}->{exclude}) && $self->{option_results}->{exclude} ne '' && $row[2] =~ /$self->{option_results}->{exclude}/) {
             $self->{output}->output_add(long_msg => "Skipping database '" . $row->[2] . '"');
             next;
         }

--- a/src/database/postgres/mode/hitratio.pm
+++ b/src/database/postgres/mode/hitratio.pm
@@ -87,7 +87,7 @@ sub run {
         $new_datas->{$row->[2] . '_blks_hit'} = $row->[0];
         $new_datas->{$row->[2] . '_blks_read'} = $row->[1];
 
-        if (defined($self->{option_results}->{exclude}) && $self->{option_results}->{exclude} ne '' && $row[2] =~ /$self->{option_results}->{exclude}/) {
+        if (defined($self->{option_results}->{exclude}) && $self->{option_results}->{exclude} ne '' && $row->[2] =~ /$self->{option_results}->{exclude}/) {
             $self->{output}->output_add(long_msg => "Skipping database '" . $row->[2] . '"');
             next;
         }

--- a/src/database/postgres/mode/listdatabases.pm
+++ b/src/database/postgres/mode/listdatabases.pm
@@ -53,7 +53,7 @@ sub manage_selection {
     );
     $self->{list_db} = [];
     while ((my $row = $self->{sql}->fetchrow_hashref())) {
-        if (defined($self->{option_results}->{exclude}) && $row->{datname} !~ /$self->{option_results}->{exclude}/) {
+        if (defined($self->{option_results}->{exclude}) && $self->{option_results}->{exclude} ne '' && $row->{datname} =~ /$self->{option_results}->{exclude}/) {
             $self->{output}->output_add(long_msg => "Skipping database '" . $row->{datname} . "': no matching filter name");
             next;
         }

--- a/src/database/postgres/mode/locks.pm
+++ b/src/database/postgres/mode/locks.pm
@@ -87,9 +87,7 @@ sub run {
     my $dblocks = {};
     foreach my $row (@{$result}) {        
         my ($granted, $mode, $dbname) = ($$row[0], $$row[1], $$row[2]);
-        if (defined($self->{option_results}->{exclude}) && $dbname !~ /$self->{option_results}->{exclude}/) {
-            next;
-        }
+        next if (defined($self->{option_results}->{exclude}) && $self->{option_results}->{exclude} ne '' && $dbname =~ /$self->{option_results}->{exclude}/);
 
         if (!defined($dblocks->{$dbname})) {
             $dblocks->{$dbname} = {total => 0, waiting => 0};


### PR DESCRIPTION
# Centreon team

## Description

Exclude options is actually including database in place of excluding them (4 modes concerned).
One mode has already been fixed [here](https://github.com/centreon/centreon-plugins/pull/4197).

**Fixes** # CTOR-1019

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
