### PR TITLE
Ctor 1019 plugin centreon plugin applications databases postgresql modes hitratio and backends exclude option is behaving the opposite way more like a filter

### DIFF
--- a/src/database/postgres/mode/backends.pm
+++ b/src/database/postgres/mode/backends.pm
@@ -89,7 +89,7 @@ sub run {
     my $result = $options{sql}->fetchall_arrayref();
 
     foreach my $row (@{$result}) {
-        if (defined($self->{option_results}->{exclude}) && $$row[2] !~ /$self->{option_results}->{exclude}/) {
+        if (defined($self->{option_results}->{exclude}) && $self->{option_results}->{exclude} ne '' && $$row[2] =~ /$self->{option_results}->{exclude}/) {
             $self->{output}->output_add(long_msg => "Skipping database '" . $$row[2] . '"');
             next;
         }

--- a/src/database/postgres/mode/hitratio.pm
+++ b/src/database/postgres/mode/hitratio.pm
@@ -165,7 +165,7 @@ __END__
 
 =head1 MODE
 
-Check hitratio (in buffer cache) for databases.
+Check hit ratio (in buffer cache) for databases.
 
 =over 8
 

--- a/src/database/postgres/mode/hitratio.pm
+++ b/src/database/postgres/mode/hitratio.pm
@@ -87,7 +87,7 @@ sub run {
         $new_datas->{$row->[2] . '_blks_hit'} = $row->[0];
         $new_datas->{$row->[2] . '_blks_read'} = $row->[1];
 
-        if (defined($self->{option_results}->{exclude}) && $row->[2] !~ /$self->{option_results}->{exclude}/) {
+        if (defined($self->{option_results}->{exclude}) && $self->{option_results}->{exclude} ne '' && $row[2] =~ /$self->{option_results}->{exclude}/) {
             $self->{output}->output_add(long_msg => "Skipping database '" . $row->[2] . '"');
             next;
         }

--- a/src/database/postgres/mode/hitratio.pm
+++ b/src/database/postgres/mode/hitratio.pm
@@ -87,7 +87,7 @@ sub run {
         $new_datas->{$row->[2] . '_blks_hit'} = $row->[0];
         $new_datas->{$row->[2] . '_blks_read'} = $row->[1];
 
-        if (defined($self->{option_results}->{exclude}) && $self->{option_results}->{exclude} ne '' && $row[2] =~ /$self->{option_results}->{exclude}/) {
+        if (defined($self->{option_results}->{exclude}) && $self->{option_results}->{exclude} ne '' && $row->[2] =~ /$self->{option_results}->{exclude}/) {
             $self->{output}->output_add(long_msg => "Skipping database '" . $row->[2] . '"');
             next;
         }

--- a/src/database/postgres/mode/listdatabases.pm
+++ b/src/database/postgres/mode/listdatabases.pm
@@ -53,7 +53,7 @@ sub manage_selection {
     );
     $self->{list_db} = [];
     while ((my $row = $self->{sql}->fetchrow_hashref())) {
-        if (defined($self->{option_results}->{exclude}) && $row->{datname} !~ /$self->{option_results}->{exclude}/) {
+        if (defined($self->{option_results}->{exclude}) && $self->{option_results}->{exclude} ne '' && $row->{datname} =~ /$self->{option_results}->{exclude}/) {
             $self->{output}->output_add(long_msg => "Skipping database '" . $row->{datname} . "': no matching filter name");
             next;
         }

--- a/src/database/postgres/mode/listdatabases.pm
+++ b/src/database/postgres/mode/listdatabases.pm
@@ -1,4 +1,4 @@
-    #
+#
 # Copyright 2024 Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets

--- a/src/database/postgres/mode/listdatabases.pm
+++ b/src/database/postgres/mode/listdatabases.pm
@@ -1,4 +1,4 @@
-#
+    #
 # Copyright 2024 Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets

--- a/src/database/postgres/mode/locks.pm
+++ b/src/database/postgres/mode/locks.pm
@@ -153,12 +153,12 @@ Check locks for one or more databases
 =item B<--warning>
 
 Warning threshold. (example: "total=250,waiting=5,exclusive=20")
-'total', 'waiting', or the name of a lock type used by Postgres.
+'total', 'waiting', or the name of a lock type used by PostgreSQL.
 
 =item B<--critical>
 
 Critical threshold. (example: "total=250,waiting=5,exclusive=20")
-'total', 'waiting', or the name of a lock type used by Postgres.
+'total', 'waiting', or the name of a lock type used by PostgreSQL.
 
 =item B<--exclude>
 

--- a/src/database/postgres/mode/locks.pm
+++ b/src/database/postgres/mode/locks.pm
@@ -87,9 +87,7 @@ sub run {
     my $dblocks = {};
     foreach my $row (@{$result}) {        
         my ($granted, $mode, $dbname) = ($$row[0], $$row[1], $$row[2]);
-        if (defined($self->{option_results}->{exclude}) && $dbname !~ /$self->{option_results}->{exclude}/) {
-            next;
-        }
+        next if (defined($self->{option_results}->{exclude}) && $self->{option_results}->{exclude} ne '' && $dbname =~ /$self->{option_results}->{exclude}/);
 
         if (!defined($dblocks->{$dbname})) {
             $dblocks->{$dbname} = {total => 0, waiting => 0};

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -94,6 +94,7 @@ ldap
 --legacy-api-beta
 license-instances-usage-prct
 Loggly
+--lookback
 --lookup-perfdatas-nagios
 machineaccount
 --map-speed-dsl
@@ -130,6 +131,7 @@ Netscaler
 net-snmp
 NLCapacity
 --noeventlog
+--noidle
 -NoLogo
 --nomachineaccount
 --ntlmv2


### PR DESCRIPTION
# Centreon team

## Description

Exclude options is actually including database in place of excluding them (4 modes concerned).
One mode has already been fixed [here](https://github.com/centreon/centreon-plugins/pull/4197).

**Fixes** # CTOR-1019

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
