### PR TITLE
IBM storewize SSH - new mode vdisk-status

### DIFF
--- a/src/storage/ibm/storwize/ssh/mode/vdiskstatus.pm
+++ b/src/storage/ibm/storwize/ssh/mode/vdiskstatus.pm
@@ -1,0 +1,179 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package storage::ibm::storwize::ssh::mode::vdiskstatus;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub prefix_replication_output {
+    my ($self, %options) = @_;
+
+    my $output = sprintf(
+        'vdisk %s [volume name: %s]',
+        $options{instance_value}->{name},
+        $options{instance_value}->{volume_name}
+    );
+
+    if (defined($options{instance_value}->{rc_name}) && $options{instance_value}->{rc_name}) {
+        $output .= sprintf(
+            ' [RC name: %s - %s (primary: %d)]',
+            $options{instance_value}->{rc_name},
+            $options{instance_value}->{function},
+            $options{instance_value}->{primary}
+        );
+    }
+
+    $output .= " - ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name               =>
+            'vdisks',
+            type             =>
+                1,
+            cb_prefix_output =>
+                'prefix_replication_output',
+            message_multiple =>
+                'All vdisk are ok' }
+    ];
+
+    $self->{maps_counters}->{vdisks} = [
+        {
+            label            => 'status',
+            type             => 2,
+            critical_default => '(%{rc_name} ne "" && %{primary} == 1 || %{rc_name} eq "") && %{status} =~ /offline/i',
+            set              => {
+                key_values                     =>
+                    [ { name => 'status' }, { name => 'primary' }, { name => 'rc_name' } ],
+                output_template                =>
+                    'status: %s',
+                closure_custom_perfdata        =>
+                    sub {return 0;},
+                closure_custom_threshold_check =>
+                    \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-volume-name:s' => { name => 'filter_volume_name' },
+        'filter-rc-name:s'     => { name => 'filter_rc_name' },
+        'filter-function:s'    => { name => 'filter_function' }
+    });
+
+    return $self;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $vd_command = 'lsvdisk -delim :';
+    my $vd_content = $options{custom}->execute_command(command => $vd_command);
+    my $result = $options{custom}->get_hasharray(content => $vd_content, delim => ':');
+
+    my $rel_content = $options{custom}->execute_command(command => 'lsrcrelationship -delim :');
+    my $rel_result = $options{custom}->get_hasharray(content => $rel_content, delim => ':');
+
+    $self->{vdisks} = {};
+    foreach my $vdisk (@$result) {
+        next if (defined($self->{option_results}->{filter_volume_name}) && $self->{option_results}->{filter_volume_name} ne '' &&
+            $vdisk->{volume_name} !~ /$self->{option_results}->{filter_volume_name}/);
+
+        next if (defined($self->{option_results}->{filter_rc_name}) && $self->{option_results}->{filter_rc_name} ne '' &&
+            $vdisk->{RC_name} !~ /$self->{option_results}->{filter_rc_name}/);
+
+        next if (defined($self->{option_results}->{filter_function}) && $self->{option_results}->{filter_function} ne '' &&
+            $vdisk->{function} !~ /$self->{option_results}->{filter_function}/);
+
+        $self->{vdisks}->{ $vdisk->{id} } = {
+            name        => $vdisk->{name},
+            status      => $vdisk->{status},
+            volume_name => $vdisk->{volume_name},
+            rc_name     => $vdisk->{RC_name},
+            function    => $vdisk->{function},
+            primary     => 0
+        };
+
+        if (defined($vdisk->{RC_name}) && length($vdisk->{RC_name}) > 0) {
+            foreach my $item (@$rel_result) {
+                if (defined($item->{primary}) && defined($item->{name})
+                    && $item->{name} eq $vdisk->{RC_name}
+                    && $vdisk->{function} eq $item->{primary}) {
+                    $self->{vdisks}->{ $vdisk->{id} }->{primary} = 1;
+                }
+            }
+        }
+    }
+
+    if (scalar(keys %{$self->{vdisks}}) <= 0) {
+        $self->{output}->add_option_msg(short_msg => 'No volume found.');
+        $self->{output}->option_exit();
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check vdisk & hyperswap status.
+
+=over 8
+
+=item B<--filter-volume-name>
+
+Filter volume name (can be a regexp).
+
+=item B<--filter-rc-name>
+
+Filter RC name (can be a regexp).
+
+=item B<--filter-function>
+
+Filter function name (can be a regexp).
+Can be: master, aux, master_change, aux_change
+
+=item B<--warning-status>
+
+Define the conditions to match for the status to be WARNING (default: '').
+You can use the following variables: %{status}
+
+=item B<--critical-status>
+
+Define the conditions to match for the status to be CRITICAL. (default: '(%{rc_name} ne "" && %{primary} == 1 || %{rc_name} eq "") && %{status} =~ /offline/i').
+You can use the following variables: %{status}, %{rc_name}, %{primary}
+
+=back
+
+=cut

--- a/src/storage/ibm/storwize/ssh/plugin.pm
+++ b/src/storage/ibm/storwize/ssh/plugin.pm
@@ -30,10 +30,11 @@ sub new {
     bless $self, $class;
 
     $self->{modes} = {
-        'components'  => 'storage::ibm::storwize::ssh::mode::hardware',
-        'eventlog'    => 'storage::ibm::storwize::ssh::mode::eventlog',
-        'pool-usage'  => 'storage::ibm::storwize::ssh::mode::poolusage',
-        'replication' => 'storage::ibm::storwize::ssh::mode::replication'
+        'components'   => 'storage::ibm::storwize::ssh::mode::hardware',
+        'eventlog'     => 'storage::ibm::storwize::ssh::mode::eventlog',
+        'pool-usage'   => 'storage::ibm::storwize::ssh::mode::poolusage',
+        'replication'  => 'storage::ibm::storwize::ssh::mode::replication',
+        'vdisk-status' => 'storage::ibm::storwize::ssh::mode::vdiskstatus'
     };
 
     $self->{custom_modes}{api} = 'storage::ibm::storwize::ssh::custom::api';


### PR DESCRIPTION
# Community contributors

## Description

if a Hyperswap configuration seem's actually not really supported and the returned data are not interpreted in the correct way. Teh components "vdisk" check has not enough filter possibilities and not the possibility to override the critical status with the needed variables. So i created a new vdisk-status mode to handle the status in correct way for all needs.

For the hyperswap configuration from 4 disk 1 disk is always offline:

```
id  name                             status  RC_name  volume_name                      function      
380 IBMi_P3_xx             online  rcrel95  IBMi_P3_xx             master        
381 vdisk286                         offline rcrel95  IBMi_P3_xx             aux           
382 vdisk287                         online  rcrel95  IBMi_P3_xx             master_change 
383 vdisk288                         online  rcrel95  IBMi_P3_xx             aux_change    
```
A hyperswap configuration can be identified when the column RC_name is not empty and has a value like rcrelXX.

The right logic to monitor this configuration should be:

every disk with function master_change or aux_change must be online, otherwise should be a error
one of the disks with function master or aux is allways offline, the other one is online
to indentify which of this 2 disks should be online you need to launch the **lsrcrelationship** command.

It's much more faster to call it generally once wihout rc_name (lsrcrelationship rcrel95 ) as 100 times with rc_name.

So this case is OK because the offline ones is not the primary vdisk of the RC

![image](https://github.com/user-attachments/assets/f3540679-da96-4a16-b5e0-932a075fa3c3)

default critical status

(%{rc_name} ne "" && %{primary} == 1 || %{rc_name} eq "") && %{status} =~ /offline/i

so this means the "primary" is only checked fore RC's. for single vdsisk only the status will be checked.

The vsidk component check can be removed

Linked PR:

https://github.com/centreon/centreon-plugins/issues/5106

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

All data are still the same. So use the test since yet.