### PR TITLE
fix(primera-restapi): retry authentication when the token is invalid

### DIFF
--- a/src/storage/hp/primera/restapi/custom/api.pm
+++ b/src/storage/hp/primera/restapi/custom/api.pm
@@ -176,7 +176,7 @@ sub request_api {
     );
 
     # Maybe token is invalid. so we retry
-    if (!defined($self->{token}) && $self->{http}->get_code() < 200 || $self->{http}->get_code() >= 300) {
+    if (!defined($token) || $self->{http}->get_code() >= 400) {
         $self->clean_token();
         $token = $self->get_token();
 

--- a/src/storage/hp/primera/restapi/custom/api.pm
+++ b/src/storage/hp/primera/restapi/custom/api.pm
@@ -175,6 +175,21 @@ sub request_api {
         critical_status => ''
     );
 
+    # Maybe token is invalid. so we retry
+    if (!defined($self->{token}) && $self->{http}->get_code() < 200 || $self->{http}->get_code() >= 300) {
+        $self->clean_token();
+        $token = $self->get_token();
+
+        $content = $self->{http}->request(
+            url_path        => $options{endpoint},
+            get_param       => $get_param,
+            header          => [ 'X-HP3PAR-WSAPI-SessionKey: ' . $token ],
+            unknown_status  => $self->{unknown_http_status},
+            warning_status  => $self->{warning_http_status},
+            critical_status => $self->{critical_http_status}
+        );
+    }
+
     if (!defined($content) || $content eq '') {
         $self->{output}->add_option_msg(short_msg => "API returns empty content [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']");
         $self->{output}->option_exit();


### PR DESCRIPTION
## Description

**Source** #5256 
Refs: CTOR-1032

PS: Thanks @rmorandell-pgum!

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Robot tests still working.

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] In case of a new plugin, I have created the new packaging directory accordingly.
- [x] I have implemented automated tests related to my commits.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences are terminated by a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
