### PR TITLE
CTOR-490 - Plugin(os::linux::local) - Mode(process) : Doesn't return the process in some cases

### DIFF
--- a/src/os/linux/local/mode/process.pm
+++ b/src/os/linux/local/mode/process.pm
@@ -199,7 +199,7 @@ sub parse_output {
 
     my ($stdout) = $options{custom}->execute_command(
         command => 'ps',
-        command_options => '-e -o state -o etime -o pid -o ppid -o comm:50 -o %a -w 2>&1'
+        command_options => '-e -o state -o etime:15 -o pid:10 -o ppid:10 -o comm:50 -o %a -w 2>&1'
     );
 
     $self->{global} = { processes => 0 };

--- a/src/os/linux/local/mode/process.pm
+++ b/src/os/linux/local/mode/process.pm
@@ -199,7 +199,7 @@ sub parse_output {
 
     my ($stdout) = $options{custom}->execute_command(
         command => 'ps',
-        command_options => '-e -o state -o etime:15 -o pid:10 -o ppid:10 -o comm:50 -o %a -w 2>&1'
+        command_options => '-e -o state -o etime:15 -o pid:10 -o ppid:10 -o comm:50 -o args -w 2>&1'
     );
 
     $self->{global} = { processes => 0 };

--- a/src/os/linux/local/mode/process.pm
+++ b/src/os/linux/local/mode/process.pm
@@ -394,35 +394,116 @@ Monitor disk I/O.
 
 =item B<--filter-command>
 
-Filter process commands (regexp can be used).
+Define which processes should be included based on the executable’s name.
+This option will be treated as a regular expression.
 
 =item B<--exclude-command>
 
-Exclude process commands (regexp can be used).
+Define which processes should be excluded based on the executable’s name.
+This option will be treated as a regular expression.
 
 =item B<--filter-arg>
 
-Filter process arguments (regexp can be used).
+Define which processes should be included based on the executable’s arguments.
+This option will be treated as a regular expression.
 
 =item B<--exclude-arg>
 
-Exclude process arguments (regexp can be used).
+Define which processes should be excluded based on the executable’s arguments.
+This option will be treated as a regular expression.
 
 =item B<--filter-ppid>
 
-Filter process ppid (regexp can be used).
+Define which processes should be excluded based on the process's parent process ID (PPID).
+This option will be treated as a regular expression.
+
 
 =item B<--filter-state>
 
-Filter process states (regexp can be used).
+Define which processes should be excluded based on the process state.
+This option will be treated as a regular expression.
 You can use: 'zombie', 'dead', 'paging', 'stopped',
 'InterrupibleSleep', 'running', 'UninterrupibleSleep'.
 
-=item B<--warning-*> B<--critical-*>
+=item B<--warning-total>
 
 Thresholds.
-Can be: 'total', 'total-memory-usage', 'total-cpu-utilization', 'total-disks-read',
-'total-disks-write', 'time', 'memory-usage', 'cpu-utilization', 'disks-read', 'disks-write'. 
+
+=item B<--critical-total>
+
+Thresholds.
+
+=item B<--warning-total-memory-usage>
+
+Thresholds.
+
+=item B<--critical-total-memory-usage>
+
+Thresholds.
+
+=item B<--warning-total-cpu-utilization>
+
+Thresholds.
+
+=item B<--critical-total-cpu-utilization>
+
+Thresholds.
+
+=item B<--warning-total-disks-read>
+
+Thresholds.
+
+=item B<--critical-total-disks-read>
+
+Thresholds.
+
+=item B<--warning-total-disks-write>
+
+Thresholds.
+
+=item B<--critical-total-disks-write>
+
+Thresholds.
+
+=item B<--warning-time>
+
+Thresholds.
+
+=item B<--critical-time>
+
+Thresholds.
+
+=item B<--warning-memory-usage>
+
+Thresholds.
+
+=item B<--critical-memory-usage>
+
+Thresholds.
+
+=item B<--warning-cpu-utilization>
+
+Thresholds.
+
+=item B<--critical-cpu-utilization>
+
+Thresholds.
+
+=item B<--warning-disks-read>
+
+Thresholds.
+
+=item B<--critical-disks-read>
+
+Thresholds.
+
+=item B<--warning-disks-write>
+
+Thresholds.
+
+=item B<--critical-disks-write>
+
+Thresholds.
 
 =back
 

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -3,6 +3,8 @@
 3CX
 --3cx-version
 ACS
+--add-cpu
+--add-disk-io
 --add-fc-fe-errors
 --add-qos-limit
 --add-sysdesc
@@ -43,7 +45,9 @@ cpu-utilization-5s
 --critical-backend-congestions
 --critical-backend-outstanding-io
 --critical-bytesallocatedpercentage
+--critical-cpu-utilization
 --critical-na
+--critical-total-cpu-utilization
 Datacore
 datasource
 DC4
@@ -65,6 +69,7 @@ fanspeed
 FCCapacity
 --filter-fs
 --filter-imei
+--filter-ppid
 --filter-vdom
 --filter-vm
 --force-64bits-counters
@@ -89,6 +94,7 @@ in-fcserror
 in-mcast
 -InputFormat
 interface-dsl-name
+InterrupibleSleep
 in-ucast
 IpAddr
 ipv4
@@ -169,6 +175,7 @@ physicaldrive
 PKCS1
 powershell
 powershell.exe
+PPID
 prct
 Primera
 proto
@@ -209,6 +216,7 @@ tower-cli
 TrendMicro
 UCD
 UDP
+UninterrupibleSleep
 uniq
 uptime
 --urlpath
@@ -233,6 +241,8 @@ vSphere
 --warning-backend-congestions
 --warning-backend-outstanding-io
 --warning-bytesallocatedpercentage
+--warning-cpu-utilization
 --warning-na
+--warning-total-cpu-utilization
 WSMAN
 XPath


### PR DESCRIPTION
## Description

In some cases, the process mode (linux local) doesn't return a process.
It's related to the number of characters that compose the etime / pid /ppid.
We can limit them.

**Fixes** # CTOR-490

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences are terminated by a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
