### PR TITLE
fix(eclipse-mosquitto-mqtt): fix stringvalue mode regexp threshold

### DIFF
--- a/src/apps/eclipse/mosquitto/mqtt/mode/stringvalue.pm
+++ b/src/apps/eclipse/mosquitto/mqtt/mode/stringvalue.pm
@@ -30,7 +30,7 @@ use POSIX qw(floor);
 
 sub new {
     my ($class, %options) = @_;
-    my $self              = $class->SUPER::new(package => __PACKAGE__, %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
@@ -70,12 +70,14 @@ sub custom_stringvalue_threshold {
     my ($self, %options) = @_;
 
     my $severity = 'ok';
+    my $value = $self->{result_values}->{stringvalue};
+    my $option_results = $self->{instance_mode}->{option_results};
     foreach my $check_severity (('critical', 'warning', 'unknown')) {
-        next if (centreon::plugins::misc::is_empty($self->{option_results}->{$check_severity . '_regexp'}));
-        my $regexp = $self->{option_results}->{$check_severity . '_regexp'};
-        if (defined($self->{option_results}->{use_iregexp}) && $options{value} =~ /$regexp/i) {
+        next if (centreon::plugins::misc::is_empty($option_results->{$check_severity . '_regexp'}));
+        my $regexp = $option_results->{$check_severity . '_regexp'};
+        if (defined($option_results->{use_iregexp}) && $value =~ /$regexp/i) {
             $severity = $check_severity;
-        } elsif (!defined($self->{option_results}->{use_iregexp}) && $options{value} =~ /$regexp/) {
+        } elsif (!defined($option_results->{use_iregexp}) && $value =~ /$regexp/) {
             $severity = $check_severity;
         }
     }
@@ -93,7 +95,7 @@ sub set_counters {
     $self->{maps_counters}->{global} = [
         { label => 'generic',
           set   => {
-              key_values                     => [{ name => 'stringvalue' }],
+              key_values                     => [ { name => 'stringvalue' } ],
               closure_custom_output          => $self->can('custom_stringvalue_output'),
               closure_custom_threshold_check => \&custom_stringvalue_threshold
           }


### PR DESCRIPTION
## Description

Problème avec les options warning-regrexp et critical-regexp dans le mode string-value

**Fixes** CTOR-789

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
- [x] I have reviewed all the help messages in all the .pm files I have modified.
  - [x] All sentences begin with a capital letter.
  - [x] All sentences are terminated by a period.
  - [x] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
