### PR TITLE
fix(packaging): do not package rpm for perl dependency common::sense

### DIFF
--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -42,7 +42,6 @@ jobs:
             "Carp::Assert",
             "Clone",
             "Clone::Choose",
-            "common::sense",
             "Config::AWS",
             "Convert::Binary::C",
             "Convert::EBCDIC",


### PR DESCRIPTION
## Description

fix(packaging): do not package rpm for perl dependency common::sense
already available on crb and powertools repositories

**Fixes** MON-152660