### PR TITLE
fix(packaging): various issues + migration to JSON config file

### DIFF
--- a/connectors/vmware/changelog
+++ b/connectors/vmware/changelog
@@ -1,3 +1,11 @@
+2024-12-05 Olivier Mercier <omercier@centreon.com> - 3.4.0
+ * Enhancement: systemd service now takes its options from
+ /etc/(default|sysconfig)/centreon_vmware.
+ * Enhancement: the existing .pm config file is converted into a .json file
+ during upgrade.
+ * Breaking: the default config file is now the JSON one.
+ * Fix: added the 'perl(Text::Template)' missing dependency for AlmaLinux.
+
 2024-10-18 Olivier Mercier <omercier@centreon.com> - 3.3.2
  * Fix: regression of case sensitiveness for container names fixed
  * Enhancement: log messages related to the vault have been downgraded from error to info level or explained as safe to ignore if not using the vault

--- a/connectors/vmware/packaging/centreon-plugin-virtualization-vmware-daemon.yaml
+++ b/connectors/vmware/packaging/centreon-plugin-virtualization-vmware-daemon.yaml
@@ -69,18 +69,16 @@ contents:
 
   - src: "redhat/centreon_vmware-sysconfig"
     dst: "/etc/sysconfig/centreon_vmware"
+    type: config|noreplace
     packager: rpm
   - src: "debian/centreon_vmware-default"
     dst: "/etc/default/centreon_vmware"
+    type: config|noreplace
     packager: deb
 
-  - src: "config/centreon_vmware-conf.pm"
-    dst: "/etc/centreon/centreon_vmware.pm"
+  - src: "config/centreon_vmware-conf.json"
+    dst: "/etc/centreon/centreon_vmware.json"
     type: config|noreplace
-    packager: rpm
-  - src: "config/centreon_vmware-conf.pm"
-    dst: "/etc/centreon/centreon_vmware.pm.new"
-    packager: deb
 
 scripts:
   postinstall: ./scripts/postinstall.sh
@@ -92,6 +90,7 @@ overrides:
       - perl(IO::Socket::INET6)
       - perl(JSON::XS)
       - perl(LWP::Protocol::https)
+      - perl(Text::Template)
       - perl(ZMQ::Constants)
       - perl(ZMQ::LibZMQ4)
       - perl-Net-Curl

--- a/connectors/vmware/packaging/debian/centreon_vmware-default
+++ b/connectors/vmware/packaging/debian/centreon_vmware-default
@@ -1,2 +1,2 @@
 # centreon_vmware command line options
-OPTIONS="--logfile=/var/log/centreon_vmware.log --severity=error"
+OPTIONS="--config-extra=/etc/centreon/centreon_vmware.json --logfile=/var/log/centreon/centreon_vmware.log --severity=info"

--- a/connectors/vmware/packaging/debian/centreon_vmware-systemd
+++ b/connectors/vmware/packaging/debian/centreon_vmware-systemd
@@ -19,7 +19,8 @@
 Description=Centreon VMWare
 
 [Service]
-ExecStart=/usr/bin/perl /usr/bin/centreon_vmware.pl --logfile=/var/log/centreon/centreon_vmware.log --severity=error
+EnvironmentFile=-/etc/default/centreon_vmware
+ExecStart=/usr/bin/perl /usr/bin/centreon_vmware.pl $OPTIONS
 Type=simple
 User=centreon
 

--- a/connectors/vmware/packaging/redhat/centreon_vmware-sysconfig
+++ b/connectors/vmware/packaging/redhat/centreon_vmware-sysconfig
@@ -1,2 +1,2 @@
 # centreon_vmware command line options
-OPTIONS="--logfile=/var/log/centreon/centreon_vmware.log --severity=error"
+OPTIONS="--config-extra=/etc/centreon/centreon_vmware.json --logfile=/var/log/centreon/centreon_vmware.log --severity=info"

--- a/connectors/vmware/packaging/redhat/centreon_vmware-systemd
+++ b/connectors/vmware/packaging/redhat/centreon_vmware-systemd
@@ -19,7 +19,8 @@
 Description=Centreon VMWare
 
 [Service]
-ExecStart=/usr/bin/perl /usr/bin/centreon_vmware.pl --logfile=/var/log/centreon/centreon_vmware.log --severity=error
+EnvironmentFile=-/etc/sysconfig/centreon_vmware
+ExecStart=/usr/bin/perl /usr/bin/centreon_vmware.pl $OPTIONS
 Type=simple
 User=centreon
 

--- a/connectors/vmware/packaging/scripts/postinstall.sh
+++ b/connectors/vmware/packaging/scripts/postinstall.sh
@@ -1,7 +1,49 @@
-#!/bin/sh
+#!/bin/bash
 
-if  [ "$1" = "configure" ]; then # deb
-  if [ ! -f "/etc/centreon/centreon_vmware.pm" ]; then
-    mv /etc/centreon/centreon_vmware.pm.new /etc/centreon/centreon_vmware.pm
-  fi
+json_config_file_path='/etc/centreon/centreon_vmware.json'
+perl_config_file_path='/etc/centreon/centreon_vmware.pm'
+
+function migrateConfigFromPmToJson() {
+    # If the legacy config file exists, we migrate it into a JSON config file
+    if [[ -f "$perl_config_file_path" ]] ; then
+        /usr/bin/centreon_vmware_convert_config_file "$perl_config_file_path" > "$json_config_file_path"
+        mv "$perl_config_file_path" "${perl_config_file_path}.deprecated"
+    fi
+    chown centreon: "$json_config_file_path"
+    chmod 640 "$json_config_file_path"
+}
+
+function applyToSystemD() {
+    systemctl daemon-reload
+    systemctl restart centreon_vmware.service
+}
+
+action="$1"
+version="$2"
+
+if  [[ "$1" == "configure" ]]; then # deb
+    if  [[ -z "$version" ]]; then
+        # Alpine linux does not pass args, and deb passes $1=configure
+        action="install"
+    elif [[ -n "$version" ]]; then
+        # deb passes $1=configure $2=<current version>
+        action="upgrade"
+    fi
 fi
+
+
+case "$action" in
+  "1" | "install")
+    migrateConfigFromPmToJson
+    applyToSystemD
+    ;;
+  "2" | "upgrade")
+    migrateConfigFromPmToJson
+    applyToSystemD
+    ;;
+  *)
+    # $1 == version being installed
+    applyToSystemD
+    ;;
+esac
+

--- a/connectors/vmware/src/centreon/script/centreon_vmware.pm
+++ b/connectors/vmware/src/centreon/script/centreon_vmware.pm
@@ -54,7 +54,7 @@ BEGIN {
 
 use base qw(centreon::vmware::script);
 
-my $VERSION = '3.3.2';
+my $VERSION = '3.4.0';
 my %handlers = (TERM => {}, HUP => {}, CHLD => {});
 
 my @load_modules = (

--- a/connectors/vmware/src/centreon/script/centreon_vmware_convert_config_file
+++ b/connectors/vmware/src/centreon/script/centreon_vmware_convert_config_file
@@ -19,7 +19,7 @@
 
 use strict;
 use warnings FATAL => 'all';
-use JSON::XS;
+use JSON;
 use Data::Dumper;
 
 die "Usage: centreon_vmware_convert_config_file /etc/centreon/centreon_vmware.pm > /etc/centreon/centreon_vmware.json" if (scalar(@ARGV) < 1);
@@ -34,7 +34,6 @@ my $new_config_structure = {
     vsphere_server => []
 };
 
-
 for my $config_entry_key (keys %centreon_vmware_config){
     if ($config_entry_key eq 'vsphere_server') {
         for my $server_config_entry_key (keys %{$centreon_vmware_config{vsphere_server}}) {
@@ -45,11 +44,11 @@ for my $config_entry_key (keys %centreon_vmware_config){
     } else {
         $new_config_structure->{$config_entry_key} = $centreon_vmware_config{$config_entry_key};
     }
-
-
 }
 
-my $new_json_config = encode_json($new_config_structure) or die "Unable to convert this object to JSON:\n" . Dumper($new_config_structure);
+my $new_json_config = JSON->new->utf8(1)->pretty(1)->encode($new_config_structure) or die "Unable to convert this object to JSON:\n" . Dumper($new_config_structure);
+
 print($new_json_config);
 
 exit(0);
+

--- a/connectors/vmware/src/centreon/vmware/common.pm
+++ b/connectors/vmware/src/centreon/vmware/common.pm
@@ -45,7 +45,7 @@ sub init_response {
     my (%options) = @_;
 
     $manager_response->{code} = 0;
-    $manager_response->{vmware_connector_version} = '3.3.2';
+    $manager_response->{vmware_connector_version} = '3.4.0';
     $manager_response->{short_message} = 'OK';
     $manager_response->{extra_message} = '';
     $manager_response->{identity} = $options{identity} if (defined($options{identity}));


### PR DESCRIPTION
## Description

- missing dependency on AlmaLinux
- /etc/(default|sysconfig)/centreon_vmware was ignored
- migrate the config file from .pm to .json

Refs: CTOR-1079

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Try:
- a fresh install 
- an upgrade from a version using the legacy .pm config file
- an upgrade from a version using the .json config file

In every scenario, the result must be centroen_vmware running on the .json file and no .pm file must remain.

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences are terminated by a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
