### PR TITLE
enh (storage::purestorage::flasharray::v2::restapi::plugin) : Add the flag attribute to the alert filter

### DIFF
--- a/src/storage/purestorage/flasharray/v2/restapi/mode/alerts.pm
+++ b/src/storage/purestorage/flasharray/v2/restapi/mode/alerts.pm
@@ -58,7 +58,7 @@ sub set_counters {
                 key_values => [
                     { name => 'category' }, { name => 'code' },
                     { name => 'severity' }, { name => 'opened' }, { name => 'state' },
-                    { name => 'component_name' }, { name => 'issue' }
+                    { name => 'component_name' }, { name => 'issue' }, { name => 'flagged' }
                 ],
                 closure_custom_output => $self->can('custom_status_output'),
                 closure_custom_perfdata => sub { return 0; },
@@ -166,12 +166,12 @@ Filter by category name (can be a regexp).
 =item B<--warning-status>
 
 Define the conditions to match for the status to be WARNING (default: '%{state} ne "closed" and %{severity} =~ /warning/i')
-You can use the following variables: %{category}, %{code}, %{severity}, %{opened}, %{state}, %{issue}, %{component_name}
+You can use the following variables: %{category}, %{code}, %{severity}, %{opened}, %{state}, %{issue}, %{component_name}, %{flagged}
 
 =item B<--critical-status>
 
 Define the conditions to match for the status to be CRITICAL (default: '%{state} ne "closed" and %{severity} =~ /critical/i').
-You can use the following variables: %{category}, %{code}, %{severity}, %{opened}, %{state}, %{issue}, %{component_name}
+You can use the following variables: %{category}, %{code}, %{severity}, %{opened}, %{state}, %{issue}, %{component_name}, %{flagged}
 
 =item B<--memory>
 


### PR DESCRIPTION
# Community contributors

## Description

Plugin : storage::purestorage::flasharray::v2::restapi::plugin
Mode : storage::purestorage::flasharray::v2::restapi::mode::alerts

At the moment, it is possible to filter alerts by : category, code, severity, opened, state, component_name, issue.

The goal of this pull request is to be able to also filter the alerts by the flag attribute.

**Fixes** # (issue)
Non applicable.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

For example : 
To avoid alerts, of severity "warning" which have been manualy unflagged, to be catch by the service,  modify the default value of the warning-status by adding the flag filter : 
`--warning-status='%{state} ne "closed" and %{severity} =~ /warning/i and %{flagged}'`

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] I have provide data or shown output displaying the result of this code in the plugin area concerned.

