### PR TITLE
fix(library-and-packaging): adding missing libraries for bookworm

### DIFF
--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -316,6 +316,8 @@ jobs:
             "DataStruct::Flat",
             "DateTime::Format::Duration::ISO8601",
             "Device::Modbus",
+            "Device::Modbus::RTU::Client",
+            "Device::Modbus::TCP::Client",
             "Digest::SHA1",
             "Email::Send::SMTP::Gmail",
             "Hash::Ordered",
@@ -356,6 +358,10 @@ jobs:
             image: packaging-plugins-bullseye-arm64
             arch: arm64
             runner_name: ["self-hosted", "collect-arm64"]
+          - name: "Device::Modbus::RTU::Client"
+            build_distribs: "bookworm"
+          - name: "Device::Modbus::TCP::Client"
+            build_distribs: "bookworm"
           - name: "Net::Amazon::Signature::V4"
             build_distribs: ["bullseye", "jammy"]
           - name: "Net::MQTT::Simple"


### PR DESCRIPTION
## Description

Adding 2 missing perl libraries for Debian Bookworm : `Device::Modbus::RTU::Client` and `Device::Modbus::TCP::Client`


**Fixes** CTOR-1230

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist
- [x] I have **rebased** my development branch on the base branch (develop).
