### PR TITLE
CTOR-1216: fix(http-protocol): wrong help message

### DIFF
--- a/src/apps/protocols/http/mode/jsoncontent.pm
+++ b/src/apps/protocols/http/mode/jsoncontent.pm
@@ -459,7 +459,7 @@ Critical threshold (default: on total matching elements)
 =item B<--threshold-value>
 
 Define the scope to which the numeric thresholds apply.
-Possible values for this option: 'value' to check numeric values, 'count' to check the number of values (default: count).
+Possible values for this option: 'values' to check numeric values, 'count' to check the number of values (default: count).
 
 =item B<--warning-string>
 

--- a/src/apps/protocols/http/mode/soapcontent.pm
+++ b/src/apps/protocols/http/mode/soapcontent.pm
@@ -384,7 +384,7 @@ Critical threshold (default: on total matching elements)
 =item B<--threshold-value>
 
 Define the scope to which the numeric thresholds apply.
-Possible values for this option: 'value' to check numeric values, 'count' to check the number of values (default: count).
+Possible values for this option: 'values' to check numeric values, 'count' to check the number of values (default: count).
 
 =item B<--warning-string>
 


### PR DESCRIPTION
# Centreon team

## Description

fix(http-protocol): wrong help message

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Help message

## Checklist

- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences are terminated by a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
