### PR TITLE
Update vpn.pm to add IPSec Tunnel Counter

### DIFF
--- a/src/centreon/common/fortinet/fortigate/snmp/mode/vpn.pm
+++ b/src/centreon/common/fortinet/fortigate/snmp/mode/vpn.pm
@@ -69,6 +69,14 @@ sub set_counters {
                     { label => 'active_tunnels', template => '%d', min => 0, unit => 'tunnels', label_extra_instance => 1 }
                 ]
             }
+        },
+        { label => 'ipsec_tunnels_count', nlabel => 'vpn.ipsec.tunnels.state.count', set => {
+                key_values => [ { name => 'ipsec_tunnels_count' } ],
+                output_template => 'IPSec tunnels state up: %s',
+                perfdatas => [
+                    { label => 'ipsec_tunnels_count', template => '%d', min => 0, unit => 'tunnels', label_extra_instance => 1 }
+                ]
+            }
         }
     ];
 
@@ -128,7 +136,7 @@ sub new {
         'filter-vpn:s'      => { name => 'filter_vpn' },
         'filter-vdomain:s'  => { name => 'filter_vdomain' },
         'warning-status:s'  => { name => 'warning_status', default => '' },
-        'critical-status:s' => { name => 'critical_status', default => '%{state} eq "down"' }
+        'critical-status:s' => { name => 'critical_status', default => '' }
     });
 
     return $self;
@@ -186,6 +194,7 @@ sub manage_selection {
 
     $self->{vd} = {};
     my $duplicated = {};
+    my $ipsec_tunnels_counter = 0;
     foreach my $oid (keys %{$snmp_result->{ $oid_fgVdEntName }}) {
         $oid =~ /^$oid_fgVdEntName\.(.*)$/;
         my $vdom_instance = $1;
@@ -203,7 +212,8 @@ sub manage_selection {
             global => {
                 users => $result->{fgVpnSslStatsLoginUsers},
                 tunnels => $result->{fgVpnSslStatsActiveTunnels},
-                sessions => $result->{fgVpnSslStatsActiveWebSessions}
+                sessions => $result->{fgVpnSslStatsActiveWebSessions},
+		ipsec_tunnels_count => $ipsec_tunnels_counter
             },
             vpn => {},
         };
@@ -238,8 +248,13 @@ sub manage_selection {
                 traffic_in => $result->{fgVpnTunEntInOctets} * 8,
                 traffic_out => $result->{fgVpnTunEntOutOctets} * 8
             };
+            # count tunnels in state up
+            if ($self->{vd}->{$vdomain_name}->{vpn}->{$name}->{state} eq "up") {
+                $ipsec_tunnels_counter++;
+            };
         }
-    }    
+        $self->{vd}->{$vdomain_name}->{global}->{ipsec_tunnels_count} = $ipsec_tunnels_counter;
+     }
 }
 
 1;
@@ -258,11 +273,11 @@ Filter name with regexp. Can be ('vdomain', 'vpn')
 
 =item B<--warning-*>
 
-Warning on counters. Can be ('users', 'sessions', 'tunnels', 'traffic-in', 'traffic-out')
+Warning on counters. Can be ('users', 'sessions', 'tunnels', 'traffic-in', 'traffic-out', 'ipsec_tunnels_count')
 
 =item B<--critical-*>
 
-Warning on counters. Can be ('users', 'sessions', 'tunnels', 'traffic-in', 'traffic-out')
+Warning on counters. Can be ('users', 'sessions', 'tunnels', 'traffic-in', 'traffic-out', 'ipsec_tunnels_down_count', 'ipsec_tunnels_up_count'))
 
 =item B<--warning-status>
 


### PR DESCRIPTION
Add counter for IPSec tunnels and remove default to CRITICAL if one tunnel is down.

# Community contributors

## Description

Add a counter for IPSec tunnels on Fortigate firewalls.
With this counter it is possible to check the current available IPSec tunnels and set the status to WARNING or CRITICAL on the count.

Added to the output **IPSec tunnels state up: 2** in the global sections.
Full output:
`OK: Virtual domain 'root' Logged users: 0, Active web sessions: 0, Active tunnels: 0, IPSec tunnels state up: 2 - All vpn are ok | 'root#vpn.users.logged.count'=0users;;;0; 'root#vpn.websessions.active.count'=0sessions;;;0; 'root#vpn.tunnels.active.count'=0tunnels;;;0; 'root#vpn.ipsec.tunnels.state.count'=2tunnels;@1:1;@0:0;0; 'root~t_hub1-1_111#vpn.traffic.in.bitspersecond'=1077.27b/s;;;0; 'root~t_hub1-1_111#vpn.traffic.out.bitspersecond'=1206.72b/s;;;0; 'root~t_hub2-1_111#vpn.traffic.in.bitspersecond'=1076.06b/s;;;0; 'root~t_hub2-1_111#vpn.traffic.out.bitspersecond'=1205.12b/s;;;0;`

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Run
`
perl src/centreon_plugins.pl --plugin=network::fortinet::fortigate::snmp::plugin \
--mode vpn  \
--hostname firewall-cluster.example.com  \
--snmp-version 3 \
--snmp-username='SNMP-User1' \
--authpassphrase='secret1' \
--authprotocol='SHA' \
--privpassphrase='secret2' \
--privprotocol='AES' \
--warning-ipsec_tunnels_count='@1:1' \
--critical-ipsec_tunnels_count='@0:0' \
--use-new-perfdata \
--filter-vpn='_11'
`

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] I have provide data or shown output displaying the result of this code in the plugin area concerned.