### PR TITLE
CTOR-729-plugin-apps-backup-rubrik-restapi-custom-api-token-not-clean-and-renewed

### DIFF
--- a/src/apps/backup/rubrik/restapi/custom/api.pm
+++ b/src/apps/backup/rubrik/restapi/custom/api.pm
@@ -313,8 +313,7 @@ sub request_api_paginate {
         );
 
         if (!defined($content) || $content eq '') {
-            $self->{output}->add_option_msg(short_msg => "API returns empty content [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']");
-            $self->{output}->option_exit();
+            return ; # If the content is empty, it means that the request failed. caller can try to get a new token and retry.
         }
 
         my $decoded;


### PR DESCRIPTION
Refs:CTOR-729

# Centreon team

## Description

fix rubrik rest api to retry getting the data from the api if the token is not valid anymore.


**Fixes** CTOR-729

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

waiting from community for test data to make an automated test.

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (develop).
- [X] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
- [X] I have reviewed all the help messages in all the .pm files I have modified.
  - [X] All sentences begin with a capital letter.
  - [X] All sentences are terminated by a period.
  - [X] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
