### PR TITLE
 hardware::devices::video::axis::snmp::mode::components::fan - Fix map fan status - false positive

### DIFF
--- a/src/hardware/devices/video/axis/snmp/mode/components/fan.pm
+++ b/src/hardware/devices/video/axis/snmp/mode/components/fan.pm
@@ -24,8 +24,8 @@ use strict;
 use warnings;
 
 my %map_fan_status = (
-    0 => 'ok',
-    1 => 'failed',
+    1 => 'ok',
+    2 => 'failed',
 );
 
 my $mapping = {


### PR DESCRIPTION
# Community contributors

## Description

The fan status mapping is not correct. Correct working cameras shows wrong fan status failed.

![image](https://github.com/user-attachments/assets/1725df7d-2f86-45e4-a736-ad0e8f8488b0)

status 1 should be OK and not failed. Here is the MIB file description

![image](https://github.com/user-attachments/assets/0523c77a-ba93-4905-b460-ff69661fe793)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

[AXIS-ROOT-MIB.txt](https://github.com/user-attachments/files/18153766/AXIS-ROOT-MIB.txt)
[AXIS-VIDEO-MIB.txt](https://github.com/user-attachments/files/18153767/AXIS-VIDEO-MIB.txt)

Attached the MIB files

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.