### PR TITLE
fix(Plugin(video::axis): wrong psu status oid

### DIFF
--- a/src/hardware/devices/video/axis/snmp/mode/components/fan.pm
+++ b/src/hardware/devices/video/axis/snmp/mode/components/fan.pm
@@ -24,8 +24,8 @@ use strict;
 use warnings;
 
 my %map_fan_status = (
-    0 => 'ok',
-    1 => 'failure',
+    1=> 'ok',
+    2 => 'failure',
 );
 
 my $mapping = {

--- a/src/hardware/devices/video/axis/snmp/mode/components/fan.pm
+++ b/src/hardware/devices/video/axis/snmp/mode/components/fan.pm
@@ -25,7 +25,7 @@ use warnings;
 
 my %map_fan_status = (
     0 => 'ok',
-    1 => 'failed',
+    1 => 'failure',
 );
 
 my $mapping = {

--- a/src/hardware/devices/video/axis/snmp/mode/components/psu.pm
+++ b/src/hardware/devices/video/axis/snmp/mode/components/psu.pm
@@ -24,12 +24,12 @@ use strict;
 use warnings;
 
 my %map_psu_status = (
-    1 => 'ok',
-    2 => 'failure',
+    0 => 'ok',
+    1 => 'failure',
 );
 
 my $mapping = {
-    axisPsState => { oid => '.1.3.6.1.4.1.368.4.1.2.1.3', map => \%map_psu_status },
+    axisPsState => { oid => '.1.3.6.1.4.1.368.4.1.1.1.3', map => \%map_psu_status },
 };
 
 sub load {

--- a/src/hardware/devices/video/axis/snmp/mode/components/psu.pm
+++ b/src/hardware/devices/video/axis/snmp/mode/components/psu.pm
@@ -24,8 +24,8 @@ use strict;
 use warnings;
 
 my %map_psu_status = (
-    0 => 'ok',
-    1 => 'failure',
+    1 => 'ok',
+    2 => 'failure',
 );
 
 my $mapping = {


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

OID duplicate in axis video SNMP plugin : 
[.1.3.6.1.4.1.368.4.1.2.1.3](https://github.com/search?q=repo%3Acentreon%2Fcentreon-plugins+path%3A%2F%5Esrc%5C%2Fhardware%5C%2Fdevices%5C%2Fvideo%5C%2Faxis%5C%2Fsnmp%5C%2Fmode%5C%2Fcomponents%5C%2F%2F+.1.3.6.1.4.1.368.4.1.2.1.3&type=code) 


The rights OIDs and mappings seems to be this ones : 
[1.3.6.1.4.1.368.4.1.2.1.3](https://oid-rep.orange-labs.fr/get/1.3.6.1.4.1.368.4.1.2.1.3  )

```
1.3.6.1.4.1.368.4.1.2.1.3
fanStatus OBJECT-TYPE
SYNTAX INTEGER { ok(1), failure(2) }
MAX-ACCESS read-only
STATUS current
DESCRIPTION
"The status of a fan."
```

[1.3.6.1.4.1.368.4.1.1.1.3](https://oid-rep.orange-labs.fr/get/1.3.6.1.4.1.368.4.1.1.1.3  )

```
1.3.6.1.4.1.368.4.1.1.1.3
powerSupplyStatus OBJECT-TYPE
SYNTAX INTEGER { ok(1), failure(2) }
MAX-ACCESS read-only
STATUS current
DESCRIPTION
"The status of a power supply."
```

**Fixes** # (issue)
CTPR-1252

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Creating a fake SNMPWalk with the duplicate OID and compare with one with two OIDs separated.

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
