### PR TITLE
as400 fix previous pending request

### DIFF
--- a/src/os/as400/connector/custom/api.pm
+++ b/src/os/as400/connector/custom/api.pm
@@ -24,6 +24,7 @@ use strict;
 use warnings;
 use centreon::plugins::http;
 use JSON::XS;
+use Digest::MD5 qw(md5_hex);
 
 sub new {
     my ($class, %options) = @_;
@@ -153,7 +154,13 @@ sub request_api {
         password => $self->{as400_password},
         command => $options{command}
     };
-    $post->{args} = $options{args} if (defined($options{args}));
+    if (defined($options{args})) {
+        $post->{args} = $options{args};
+        if (defined($post->{args}->{uuid})) {
+            $post->{args}->{uuid} = md5_hex($post->{args}->{uuid});
+        }
+    }
+    
     my $encoded;
     eval {
         $encoded = encode_json($post);

--- a/src/os/as400/connector/mode/disks.pm
+++ b/src/os/as400/connector/mode/disks.pm
@@ -167,6 +167,18 @@ sub new {
     return $self;
 }
 
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    $self->{uuid} = '';
+    foreach ('filter_counters', 'filter_disk_name') {
+        if (defined($self->{option_results}->{$_}) && $self->{option_results}->{$_} ne '') {
+            $self->{uuid} .= $self->{option_results}->{$_};
+        }
+    }
+}
+
 my $map_disk_status = {
     0 => 'noUnitControl', 1 => 'active', 2 => 'failed',
     3 => 'otherDiskSubFailed', 4 => 'hwFailurePerf', 5 => 'hwFailureOk',
@@ -178,9 +190,12 @@ my $map_disk_status = {
 sub manage_selection {
     my ($self, %options) = @_;
 
-    my %cmd = (command => 'listDisks');
+    my %cmd = (command => 'listDisks', args => {});
     if (defined($self->{option_results}->{disk_name}) && $self->{option_results}->{disk_name} ne '') {
-        $cmd{args} = { diskName => $self->{option_results}->{disk_name} };
+        $cmd{args}->{diskName} = $self->{option_results}->{disk_name};
+    }
+    if ($self->{uuid} ne '') {
+        $cmd{args}->{uuid} = $self->{uuid};
     }
     my $disks = $options{custom}->request_api(%cmd);
 

--- a/src/os/as400/connector/mode/jobs.pm
+++ b/src/os/as400/connector/mode/jobs.pm
@@ -59,10 +59,26 @@ sub new {
     return $self;
 }
 
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    $self->{uuid} = '';
+    foreach ('filter_counters', 'filter_name', 'filter_active_status', 'filter_subsystem') {
+        if (defined($self->{option_results}->{$_}) && $self->{option_results}->{$_} ne '') {
+            $self->{uuid} .= $self->{option_results}->{$_};
+        }
+    }
+}
+
 sub manage_selection {
     my ($self, %options) = @_;
 
-    my $jobs = $options{custom}->request_api(command => 'listJobs');
+    my %cmd = (command => 'listJobs', args => {});
+    if ($self->{uuid} ne '') {
+        $cmd{args}->{uuid} = $self->{uuid};
+    }
+    my $jobs = $options{custom}->request_api(%cmd);
 
     $self->{global} = { total => 0 };
     foreach my $entry (@{$jobs->{result}}) {

--- a/src/os/as400/connector/mode/listdisks.pm
+++ b/src/os/as400/connector/mode/listdisks.pm
@@ -44,7 +44,7 @@ sub check_options {
 sub manage_selection {
     my ($self, %options) = @_;
 
-    return $options{custom}->request_api(command => 'listDisks');
+    return $options{custom}->request_api(command => 'listDisks', args => { uuid => 'svc-discovery' });
 }
 
 my $map_disk_status = {

--- a/src/os/as400/connector/mode/listsubsystems.pm
+++ b/src/os/as400/connector/mode/listsubsystems.pm
@@ -44,7 +44,7 @@ sub check_options {
 sub manage_selection {
     my ($self, %options) = @_;
 
-    return $options{custom}->request_api(command => 'listSubsystems');
+    return $options{custom}->request_api(command => 'listSubsystems', args => { uuid => 'svc-discovery' });
 }
 
 my $map_subsys_status = {

--- a/src/os/as400/connector/mode/subsystems.pm
+++ b/src/os/as400/connector/mode/subsystems.pm
@@ -128,6 +128,18 @@ sub new {
     return $self;
 }
 
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    $self->{uuid} = '';
+    foreach ('filter_counters', 'filter_subsystem_name', 'filter_subsystem_library') {
+        if (defined($self->{option_results}->{$_}) && $self->{option_results}->{$_} ne '') {
+            $self->{uuid} .= $self->{option_results}->{$_};
+        }
+    }
+}
+
 my $map_subsys_status = {
     '*ACTIVE' => 'active', 
     '*ENDING' => 'ending', 
@@ -139,7 +151,11 @@ my $map_subsys_status = {
 sub manage_selection {
     my ($self, %options) = @_;
 
-    my $subsys = $options{custom}->request_api(command => 'listSubsystems');
+    my %cmd = (command => 'listSubsystems', args => {});
+    if ($self->{uuid} ne '') {
+        $cmd{args}->{uuid} = $self->{uuid};
+    }
+    my $subsys = $options{custom}->request_api(%cmd);
 
     $self->{global} = { total => 0, active => 0, ending => 0, inactive => 0, restricted => 0, starting => 0 };
     $self->{subsys} = {};


### PR DESCRIPTION
# Community contributors

## Description

We have the following error:
```
[1735910404] [7068] SERVICE ALERT: VICLOUD-AS400-A1;Job QALERT;UNKNOWN;SOFT;1;UNKNOWN: Previous request pending (started 1013 ms ago). Increase your check interval, and nagios check tyour bandwidth availability
````
There is a mechanism in as400 to avoid the stacking of the same request. I can be useful but there is a bug. So we need to patch it.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

To have the error, you need to execute very quickly the following two requests (example):
```
centreon_plugins.pl --plugin=os::as400::connector::plugin ... --as400-hostname=10.30.2.2 --as400-username=user --as400-password=pass --mode=jobs --filter-name="job1"
centreon_plugins.pl --plugin=os::as400::connector::plugin ... --as400-hostname=10.30.2.2 --as400-username=user --as400-password=pass --mode=jobs --filter-name="job2"
```

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.
