### PR TITLE
CTOR-1264: Doc(hardware-storage-netapp-ontap-restapi): Missing options on hardware mode

### DIFF
--- a/src/storage/netapp/ontap/restapi/mode/hardware.pm
+++ b/src/storage/netapp/ontap/restapi/mode/hardware.pm
@@ -112,6 +112,14 @@ Define the expected status if no components are found (default: critical).
 Use this option to override the status returned by the plugin when the status label matches a regular expression (syntax: section,[instance,]status,regexp).
 Example: --threshold-overload='fru,OK,error'
 
+=item B<--warning-count-*>
+
+Define the warning threshold for the number of components of one type (replace '*' with the component type).
+
+=item B<--critical-count-*>
+
+Define the critical threshold for the number of components of one type (replace '*' with the component type).
+
 =back
 
 =cut


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

Add options missing in hardware mode help section

**Fixes** # (issue)
CTOR-1264