### PR TITLE
fix(protocol-smtp): fixed chomp on undefined variable

### DIFF
--- a/src/apps/protocols/smtp/lib/smtp.pm
+++ b/src/apps/protocols/smtp/lib/smtp.pm
@@ -127,7 +127,7 @@ sub connect {
         $self->{output}->exit();
     }
     if ($smtp_handle == -1) {
-        chomp $stdout;
+        chomp $stdout if (defined($stdout));
         $self->{output}->output_add(
             severity => $connection_exit,
             short_msg => 'Unable to connect to SMTP: ' . (defined($stdout) ? $stdout : $error_msg)


### PR DESCRIPTION
## Description


Fixed errors popping in automated tests:

```
1) Failed on template: App-Protocol-SMTP-Message - command_name: App-Protocol-SMTP-Message - command_line: /usr/lib/centreon/plugins/centreon_protocol_smtp.pl --plugin=apps::protocols::smtp::plugin --mode=message --hostname= --username='' --password=''  --smtp-from='' --smtp-to='' --warning='' --critical=''  - stderr: Use of uninitialized value $stdout in scalar chomp at /usr/lib/centreon/plugins/centreon_protocol_smtp.pl line 138. - stdout: UNKNOWN: Unable to connect to SMTP: Connection refused 

2) Failed on template: App-Protocol-SMTP-Login - command_name: App-Protocol-SMTP-Login - command_line: /usr/lib/centreon/plugins/centreon_protocol_smtp.pl --plugin=apps::protocols::smtp::plugin --mode=login --hostname= --username='' --password=''  --warning=''  --critical=''  - stderr: Use of uninitialized value $stdout in scalar chomp at /usr/lib/centreon/plugins/centreon_protocol_smtp.pl line 138. - stdout: CRITICAL: Unable to connect to SMTP: Connection refused
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
