### PR TITLE
fix(colubris-snmp): fix labels to manage 15 minutes average thresholds

### DIFF
--- a/src/network/colubris/snmp/mode/load.pm
+++ b/src/network/colubris/snmp/mode/load.pm
@@ -49,7 +49,7 @@ sub set_counters {
                 ],
             }
         },
-        { label => '1min', set => {
+        { label => '15min', set => {
                 key_values => [ { name => 'load15' } ],
                 output_template => '%s',
                 perfdatas => [
@@ -104,24 +104,38 @@ __END__
 
 =head1 MODE
 
-Check load-average.
+Check average system load.
 
 =over 8
 
 =item B<--filter-counters>
 
 Only display some counters (regexp can be used).
-Example: --filter-counters='15min'
+Example: C<--filter-counters='15min'>
 
-=item B<--warning-*>
+=item B<--warning-1min>
 
-Warning threshold.
-Can be: '1min', '5min', '15min'.
+Thresholds.
 
-=item B<--critical-*>
+=item B<--critical-1min>
 
-Critical threshold.
-Can be: '1min', '5min', '15min'.
+Thresholds.
+
+=item B<--warning-5min>
+
+Thresholds.
+
+=item B<--critical-5min>
+
+Thresholds.
+
+=item B<--warning-15min>
+
+Thresholds.
+
+=item B<--critical-15min>
+
+Thresholds.
 
 =back
 


### PR DESCRIPTION
## Description

Fixed the counter label for 15 minutes average load.
The wrong label caused the plugin to refuse --warning-15min options.

Refs: CTOR-1197

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [x] I have reviewed all the help messages in all the .pm files I have modified.
  - [x] All sentences begin with a capital letter.
  - [x] All sentences end with a period.
  - [x] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
