### PR TITLE
as400: add ssl connection

### DIFF
--- a/as400/connector.as400/.gitignore
+++ b/as400/connector.as400/.gitignore
@@ -1,2 +1,2 @@
 .vscode
-/target
+target/

--- a/as400/connector.as400/.gitignore
+++ b/as400/connector.as400/.gitignore
@@ -1,2 +1,2 @@
 .vscode
-target/
+/target

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/AbstractHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/AbstractHandler.java
@@ -26,6 +26,7 @@ import java.text.NumberFormat;
 import java.util.Locale;
 
 import com.ibm.as400.access.AS400;
+import com.ibm.as400.access.SecureAS400;
 import com.ibm.as400.access.AS400SecurityException;
 import com.ibm.as400.access.ConnectionEvent;
 import com.ibm.as400.access.ConnectionListener;
@@ -45,10 +46,11 @@ public abstract class AbstractHandler {
     protected String login = null;
     protected String password = null;
 
-    public AbstractHandler(final String host, final String login, final String password) {
+    public AbstractHandler(final String host, final String login, final String password, final Integer ssl) {
         this.host = host;
         this.login = login;
         this.password = password;
+        this.ssl = ssl;
     }
 
     static {
@@ -77,7 +79,11 @@ public abstract class AbstractHandler {
         properties.setLoginTimeout(Conf.as400LoginTimeout);
         properties.setSoTimeout(Conf.as400ReadTimeout);
 
-        final AS400 system = new AS400(this.host, this.login, this.password);
+        if (this.ssl == 1) {
+            final SecureAS400 system = new SecureAS400(this.host, this.login, this.password);
+        } else {
+            final AS400 system = new AS400(this.host, this.login, this.password);
+        }
         system.setSocketProperties(properties);
         system.addConnectionListener(new ConnectionListener() {
             @Override

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/CommandHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/CommandHandler.java
@@ -34,8 +34,8 @@ import com.centreon.connector.as400.dispatcher.check.ResponseData;
  */
 public class CommandHandler extends AbstractHandler implements ICommandHandler {
 
-    public CommandHandler(final String host, final String login, final String password) {
-        super(host, login, password);
+    public CommandHandler(final String host, final String login, final String password, final Integer ssl) {
+        super(host, login, password, ssl);
     }
 
     @Override

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/DiskHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/DiskHandler.java
@@ -38,10 +38,10 @@ public class DiskHandler extends AbstractHandler implements IDiskHandler {
 
     private QyaspolYasp0300PcmlHandler qyaspolPcmlHandler = null;
 
-    public DiskHandler(final String host, final String login, final String password)
+    public DiskHandler(final String host, final String login, final String password, final Integer ssl)
             throws AS400SecurityException, IOException {
         super(host, login, password);
-        this.qyaspolPcmlHandler = new QyaspolYasp0300PcmlHandler(host, login, password);
+        this.qyaspolPcmlHandler = new QyaspolYasp0300PcmlHandler(host, login, password, ssl);
     }
 
     @Override

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/DiskHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/DiskHandler.java
@@ -40,7 +40,7 @@ public class DiskHandler extends AbstractHandler implements IDiskHandler {
 
     public DiskHandler(final String host, final String login, final String password, final Integer ssl)
             throws AS400SecurityException, IOException {
-        super(host, login, password);
+        super(host, login, password, ssl);
         this.qyaspolPcmlHandler = new QyaspolYasp0300PcmlHandler(host, login, password, ssl);
     }
 

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/JobHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/JobHandler.java
@@ -37,8 +37,8 @@ import com.centreon.connector.as400.dispatcher.check.ResponseData;
 public class JobHandler extends AbstractHandler implements IJobHandler {
     private final JobCache jobCache;
 
-    public JobHandler(final String host, final String login, final String password) {
-        super(host, login, password);
+    public JobHandler(final String host, final String login, final String password, final Integer ssl) {
+        super(host, login, password, ssl);
         this.jobCache = new JobCache(this);
     }
 

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/JobQueueHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/JobQueueHandler.java
@@ -37,8 +37,8 @@ import com.centreon.connector.as400.dispatcher.check.ResponseData;
  */
 public class JobQueueHandler extends AbstractHandler implements IJobQueueHandler {
 
-    public JobQueueHandler(final String host, final String login, final String password) {
-        super(host, login, password);
+    public JobQueueHandler(final String host, final String login, final String password, final Integer ssl) {
+        super(host, login, password, ssl);
     }
 
     @Override

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/SubSystemHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/SubSystemHandler.java
@@ -42,9 +42,9 @@ import com.centreon.connector.as400.dispatcher.check.ResponseData;
  */
 public class SubSystemHandler extends AbstractHandler implements ISubSystemHandler {
 
-    public SubSystemHandler(final String host, final String login, final String password)
+    public SubSystemHandler(final String host, final String login, final String password, final Integer ssl)
             throws AS400SecurityException, IOException {
-        super(host, login, password);
+        super(host, login, password, ssl);
     }
 
     @Override

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/SystemHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/SystemHandler.java
@@ -45,14 +45,14 @@ import com.centreon.connector.as400.dispatcher.check.ResponseData;
 public class SystemHandler extends AbstractHandler implements ISystemHandler {
     private SystemStatus status = null;
 
-    public SystemHandler(final String host, final String login, final String password)
+    public SystemHandler(final String host, final String login, final String password, final Integer ssl)
             throws AS400SecurityException, IOException {
-        this(host, login, password, null);
+        this(host, login, password, null, ssl);
     }
 
-    public SystemHandler(final String host, final String login, final String password, SystemStatus as400Status)
+    public SystemHandler(final String host, final String login, final String password, SystemStatus as400Status, final Integer ssl)
             throws AS400SecurityException, IOException {
-        super(host, login, password);
+        super(host, login, password, ssl);
         this.status = as400Status == null ? new SystemStatus(getNewAs400()) : as400Status;
     }
 

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/disk/QyaspolYasp0300PcmlHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/disk/QyaspolYasp0300PcmlHandler.java
@@ -241,7 +241,27 @@ public class QyaspolYasp0300PcmlHandler {
         properties.setLoginTimeout(Conf.as400LoginTimeout);
         properties.setSoTimeout(Conf.as400ReadTimeout);
 
-        final AS400 system = new AS400(this.host, this.login, this.password);
+        if (this.ssl == 1) {
+            SecureAS400 system = new SecureAS400(this.host, this.login, this.password);
+            system.setSocketProperties(properties);
+            system.addConnectionListener(new ConnectionListener() {
+                @Override
+                public void connected(final ConnectionEvent event) {
+                    ConnectorLogger.getInstance().getLogger().debug("Connect event service : " + event.getService());
+                }
+
+                @Override
+                public void disconnected(final ConnectionEvent event) {
+                    ConnectorLogger.getInstance().getLogger().debug("Disconnect event service : " + event.getService());
+                }
+            });
+
+            system.validateSignon();
+
+            return (AS400)system;
+        }
+
+        AS400 system = new AS400(this.host, this.login, this.password);
         system.setSocketProperties(properties);
         system.addConnectionListener(new ConnectionListener() {
             @Override

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/disk/QyaspolYasp0300PcmlHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/impl/disk/QyaspolYasp0300PcmlHandler.java
@@ -26,6 +26,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import com.ibm.as400.access.AS400;
+import com.ibm.as400.access.SecureAS400;
 import com.ibm.as400.access.AS400Message;
 import com.ibm.as400.access.AS400SecurityException;
 import com.ibm.as400.access.ConnectionEvent;
@@ -61,11 +62,13 @@ public class QyaspolYasp0300PcmlHandler {
     String host = null;
     String login = null;
     String password = null;
+    Integer ssl = 0;
 
-    public QyaspolYasp0300PcmlHandler(final String host, final String login, final String password) {
+    public QyaspolYasp0300PcmlHandler(final String host, final String login, final String password, final Integer ssl) {
         this.host = host;
         this.login = login;
         this.password = password;
+        this.ssl = ssl;
     }
 
     public void addYasp0300Data(final Yasp0300Data data) {

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/msgqueue/CachedMessageQueueHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/msgqueue/CachedMessageQueueHandler.java
@@ -102,8 +102,8 @@ public class CachedMessageQueueHandler extends AbstractHandler implements ICache
         return sb.toString();
     }
 
-    public CachedMessageQueueHandler(final String host, final String login, final String password) {
-        super(host, login, password);
+    public CachedMessageQueueHandler(final String host, final String login, final String password, final Integer ssl) {
+        super(host, login, password, ssl);
     }
 
     @Override

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/msgqueue/MessageQueueHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/msgqueue/MessageQueueHandler.java
@@ -42,8 +42,8 @@ import com.centreon.connector.as400.dispatcher.check.ResponseData;
  */
 public class MessageQueueHandler extends AbstractHandler implements IMessageQueueHandler {
 
-    public MessageQueueHandler(final String host, final String login, final String password) {
-        super(host, login, password);
+    public MessageQueueHandler(final String host, final String login, final String password, final Integer ssl) {
+        super(host, login, password, ssl);
     }
 
     @Override

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/wrkprb/WorkWithProblemHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/wrkprb/WorkWithProblemHandler.java
@@ -69,8 +69,8 @@ public class WorkWithProblemHandler extends AbstractHandler {
     private final boolean SSL = false;
     private final String logPrefix;
 
-    public WorkWithProblemHandler(final String host, final String login, final String password) {
-        super(host, login, password);
+    public WorkWithProblemHandler(final String host, final String login, final String password, final Integer ssl) {
+        super(host, login, password, ssl);
         this.logPrefix = "[" + WorkWithProblemHandler.INSTANCE_ID++ + "]";
     }
 

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/client/IClient.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/client/IClient.java
@@ -40,5 +40,7 @@ public interface IClient {
 
     String getAs400CheckType();
 
+    Integer getAs400Ssl();
+
     Object getAs400Arg(String key);
 }

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/client/impl/AbstractClient.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/client/impl/AbstractClient.java
@@ -42,6 +42,7 @@ abstract class AbstractClient implements IClient {
     private String as400Password = null;
     private String as400CheckType = null;
     private String as400Args = null;
+    private Integer as400Ssl = 0;
     private List<Map<String, String>> argList = new ArrayList<Map<String, String>>();
 
     @Override
@@ -75,6 +76,11 @@ abstract class AbstractClient implements IClient {
     @Override
     public Object getAs400Arg(String key) {
         return this.input.getArg(key);
+    }
+
+    @Override
+    public Integer getAs400Ssl() {
+        return this.input.getSsl();
     }
 
     public List<Map<String , String>> getAs400ArgList(String key) {

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/dispatcher/check/CheckDispatcher.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/dispatcher/check/CheckDispatcher.java
@@ -87,6 +87,7 @@ public class CheckDispatcher {
     private String host = null;
     private String login = null;
     private String password = null;
+    private Integer ssl = 0;
 
     private volatile ConcurrentHashMap<String, Long> filter = new ConcurrentHashMap<String, Long>();
 
@@ -135,10 +136,11 @@ public class CheckDispatcher {
         }
     }
 
-    public CheckDispatcher(final String host, final String login, final String password) {
+    public CheckDispatcher(final String host, final String login, final String password, final Integer ssl) {
         this.host = host;
         this.login = login;
         this.password = password;
+        this.ssl = ssl;
 
         this.executorGlobal = new ThreadPoolExecutorPostFilter(5, 10, Conf.workerQueueTimeout, TimeUnit.MILLISECONDS,
                 new LinkedBlockingQueue<Runnable>());
@@ -163,6 +165,10 @@ public class CheckDispatcher {
 
     public String getPassword() {
         return this.password;
+    }
+
+    public Integer getSsl() {
+        return this.ssl;
     }
 
     public synchronized void dispatch(final NetworkClient client) {
@@ -190,52 +196,52 @@ public class CheckDispatcher {
 
     public ICommandHandler getCommandHandler() throws AS400SecurityException, IOException {
         if (this.commandHandler == null) {
-            this.commandHandler = new CommandHandler(this.host, this.login, this.password);
+            this.commandHandler = new CommandHandler(this.host, this.login, this.password, this.ssl);
         }
         return this.commandHandler;
     }
 
     public IDiskHandler getDiskHandler() throws AS400SecurityException, IOException {
         if (this.diskHandler == null) {
-            this.diskHandler = new DiskHandler(this.host, this.login, this.password);
+            this.diskHandler = new DiskHandler(this.host, this.login, this.password, this.ssl);
         }
         return this.diskHandler;
     }
 
     public IJobHandler getJobHandler() throws AS400SecurityException, IOException {
         if (this.jobHandler == null) {
-            this.jobHandler = new JobHandler(this.host, this.login, this.password);
+            this.jobHandler = new JobHandler(this.host, this.login, this.password, this.ssl);
         }
         return this.jobHandler;
     }
 
     public ISubSystemHandler getSubSystemHandler() throws AS400SecurityException, IOException {
         if (this.subSystemHandler == null) {
-            this.subSystemHandler = new SubSystemHandler(this.host, this.login, this.password);
+            this.subSystemHandler = new SubSystemHandler(this.host, this.login, this.password, this.ssl);
         }
         return this.subSystemHandler;
     }
 
     public ISystemHandler getSystemHandler() throws AS400SecurityException, IOException {
         if (this.systemHandler == null) {
-            this.systemHandler = new SystemHandler(this.host, this.login, this.password);
+            this.systemHandler = new SystemHandler(this.host, this.login, this.password, this.ssl);
         }
         return this.systemHandler;
     }
 
     public ICachedMessageQueueHandler getCachedMessageQueueHandler() throws AS400SecurityException, IOException {
-        return new CachedMessageQueueHandler(this.host, this.login, this.password);
+        return new CachedMessageQueueHandler(this.host, this.login, this.password, this.ssl);
     }
 
     public IMessageQueueHandler getMessageQueueHandler() throws AS400SecurityException, IOException {
-        return new MessageQueueHandler(this.host, this.login, this.password);
+        return new MessageQueueHandler(this.host, this.login, this.password, this.ssl);
     }
 
     public IJobQueueHandler getJobQueueHandler() throws AS400SecurityException, IOException {
-        return new JobQueueHandler(this.host, this.login, this.password);
+        return new JobQueueHandler(this.host, this.login, this.password, this.ssl);
     }
 
     public WorkWithProblemHandler getWrkPrbHandler() throws AS400SecurityException, IOException {
-        return new WorkWithProblemHandler(this.host, this.login, this.password);
+        return new WorkWithProblemHandler(this.host, this.login, this.password, this.ssl);
     }
 }

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/dispatcher/check/InputData.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/dispatcher/check/InputData.java
@@ -31,6 +31,7 @@ public class InputData {
 	private String password = null;
     private String host = null;
     private String command = null;
+    private Integer ssl = null;
     Map<String, Object> args = null;
 
 	public InputData() {
@@ -42,6 +43,13 @@ public class InputData {
 
     public String getPassword() {
         return this.password;
+	}
+
+    public Integer getSsl() {
+        if (this.ssl == null || this.ssl == 0) {
+            return 0;
+        }
+        return 1;
 	}
 
     public String getHost() {

--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/dispatcher/client/impl/ClientDispatcherImpl.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/dispatcher/client/impl/ClientDispatcherImpl.java
@@ -52,37 +52,37 @@ public class ClientDispatcherImpl implements ClientDispatcher {
     }
 
     private synchronized CheckDispatcher createNewCheckDispatcher(final String host, final String login,
-            final String password) throws AS400SecurityException, IOException, DelayedConnectionException, Exception {
+            final String password, final Integer ssl) throws AS400SecurityException, IOException, DelayedConnectionException, Exception {
 
         ConnectorLogger.getInstance().info("create new As400 : " + host);
 
         CheckDispatcher resource = null;
-        resource = new CheckDispatcher(host, login, password);
+        resource = new CheckDispatcher(host, login, password, ssl);
 
         this.pool.put(resource, System.currentTimeMillis());
 
         return resource;
     }
 
-    private CheckDispatcher getAs400(final String host, final String login, final String password)
+    private CheckDispatcher getAs400(final String host, final String login, final String password, final Integer ssl)
             throws AS400SecurityException, IOException, DelayedConnectionException, Exception {
 
         for (final CheckDispatcher resource : this.pool.keySet()) {
             if (resource.getHost().equalsIgnoreCase(host) && resource.getLogin().equalsIgnoreCase(login)
-                    && resource.getPassword().equalsIgnoreCase(password)) {
+                    && resource.getPassword().equalsIgnoreCase(password) && resource.getSsl() == ssl) {
                 this.pool.put(resource, System.currentTimeMillis());
                 return resource;
             }
         }
 
-        return this.createNewCheckDispatcher(host, login, password);
+        return this.createNewCheckDispatcher(host, login, password, ssl);
     }
 
     @Override
     public synchronized void dispatch(final NetworkClient client)
             throws AS400SecurityException, IOException, DelayedConnectionException, Exception {
         final CheckDispatcher checkDispatcher = this.getAs400(client.getAs400Host(), client.getAs400Login(),
-                client.getAs400Password());
+                client.getAs400Password(), client.getAs400Ssl());
         checkDispatcher.dispatch(client);
     }
 }

--- a/as400/connector.as400/src/test/java/com/centreon/connector/as400/check/handler/impl/SystemHandlerTest.java
+++ b/as400/connector.as400/src/test/java/com/centreon/connector/as400/check/handler/impl/SystemHandlerTest.java
@@ -35,7 +35,7 @@ public class SystemHandlerTest {
     try {
       SystemStatus as400 = mock(SystemStatus.class);
       when(as400.getSystemPools()).thenReturn(new Vector<Object>().elements());
-      SystemHandler sh = new SystemHandler(null, null, null, as400);
+      SystemHandler sh = new SystemHandler(null, null, null, as400, null);
       sh.dumpSystem();
     } finally {
       System.setOut(originalOut);

--- a/src/os/as400/connector/custom/api.pm
+++ b/src/os/as400/connector/custom/api.pm
@@ -52,7 +52,8 @@ sub new {
             'critical-http-status:s'   => { name => 'critical_http_status' },
             'as400-hostname:s'         => { name => 'as400_hostname' },
             'as400-username:s'         => { name => 'as400_username' },
-            'as400-password:s'         => { name => 'as400_password' }
+            'as400-password:s'         => { name => 'as400_password' },
+            'as400-ssl'                => { name => 'as400_ssl' }
         });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -86,6 +87,7 @@ sub check_options {
     $self->{as400_hostname} = (defined($self->{option_results}->{as400_hostname})) ? $self->{option_results}->{as400_hostname} : '';
     $self->{as400_username} = (defined($self->{option_results}->{as400_username})) ? $self->{option_results}->{as400_username} : '';
     $self->{as400_password} = (defined($self->{option_results}->{as400_password})) ? $self->{option_results}->{as400_password} : '';
+    $self->{as400_ssl} = (defined($self->{option_results}->{as400_ssl})) ? 1 : 0;
 
     if ($self->{connector_hostname} eq '') {
         $self->{output}->add_option_msg(short_msg => "Need to specify --connector-hostname option.");
@@ -151,6 +153,7 @@ sub request_api {
         host => $self->{as400_hostname},
         login => $self->{as400_username},
         password => $self->{as400_password},
+        ssl => $self->{as400_ssl},
         command => $options{command}
     };
     $post->{args} = $options{args} if (defined($options{args}));
@@ -239,6 +242,10 @@ AS/400 username (required)
 =item B<--as400-password>
 
 AS/400 password (required)
+
+=item B<--as400-ssl>
+
+Use SSL connection (port: 9475)
 
 =back
 


### PR DESCRIPTION
# Community contributors

## Description

Add capability to use AS400 SSL connection.
The plugin has a new option: ```--ssl```.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

For the SSL connection, the port 9475 must be opened from the poller. If you check it, you surely have the error:
```
UNKNOWN: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
```

You need to import the target AS400 certificate on your poller. How could do that ?

Get the certificate (change the IP with your AS400 IP):
```
openssl s_client -showcerts -connect 192.168.23.13:9475
....
-----BEGIN CERTIFICATE-----
MIIBzTCCAXKgAwIBAgIHZ2AwVwa86DAKBggqhkjOPQQDAjBBMQswCQYDVQQGEwJJ
VDEMMAoGA1UECBMDSVRBMQswCQYDVQQKEwJBNDEXMBUGA1UEAxMOYTQuaG9yc2Eu
bG9jYWwwHhcNMjQxMjE1MTM1MTE5WhcNMjUxMjE2MTM1MTE5WjBEMQswCQYDVQQG
EwJJVDEMMAoGA1UECBMDSVRBMQ4wDAYDVQQKEwVob3JzYTEXMBUGA1UEAxMOYTQu
aG9yc2EubG9jYWwwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATqCX0phiFrLWO4
DIQPgia3tUWDR3AhG9bj1nJZGH18DzdFo3Vmkw7OIXd8Hb4h/SPU9RW4UJP2mkye
fQ7KYjT3o1IwUDAdBgNVHQ4EFgQUbXG2MgF61atRpOPk8bqE00sTtWwwHwYDVR0j
BBgwFoAUA2TweBcnGgh+RoLcNFzlncglz/MwDgYDVR0PAQH/BAQDAgPoMAoGCCqG
SM49BAMCA0kAMEYCIQC/vW+MKDb+qmS2z2bHhmXL9hBdxlWneU3IMvQyz/bGtQIh
ALikXP2MyNN79k/CTewYI929gPQ19GAohyXWkAjq8LoC
-----END CERTIFICATE-----
...
```

Create a file ```as400_192.168.23.13.crt``` with the BEGIN and END certificate section from previous command.
Import the certificate (the path is for centos 7):
```
# keytool -importcert -keystore /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.412.b08-1.el7_9.x86_64/jre/lib/security/cacerts -storepass changeit -file as400_192.168.23.13.crt -alias " as400_192.168.23.13"
...
Trust this certificate? [no]:  yes
Certificate was added to keystore
```

Now it should work with option ```--ssl```.

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.
