### PR TITLE
Add --sql-file option to modes sql and sql-string

### DIFF
--- a/src/centreon/common/protocols/sql/mode/sql.pm
+++ b/src/centreon/common/protocols/sql/mode/sql.pm
@@ -24,6 +24,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use centreon::plugins::misc;
 use Time::HiRes qw(gettimeofday tv_interval);
 
 sub custom_value_output {
@@ -76,8 +77,9 @@ sub new {
     my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
 
-    $options{options}->add_options(arguments => { 
+    $options{options}->add_options(arguments => {
         'sql-statement:s' => { name => 'sql_statement' },
+        'sql-file:s'      => { name => 'sql_file' },
         'format:s'        => { name => 'format', default => 'SQL statement result : %i.' },
         'perfdata-unit:s' => { name => 'perfdata_unit', default => '' },
         'perfdata-name:s' => { name => 'perfdata_name', default => 'value' },
@@ -94,10 +96,15 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::check_options(%options);
 
-    if (!defined($self->{option_results}->{sql_statement}) || $self->{option_results}->{sql_statement} eq '') {
-        $self->{output}->add_option_msg(short_msg => "Need to specify '--sql-statement' option.");
-        $self->{output}->option_exit();
+    $self->{query} = $self->{option_results}->{sql_statement};
+    if (!defined($self->{query}) || $self->{query} eq '') {
+        if (!defined($self->{option_results}->{format}) || $self->{option_results}->{format} eq '') {
+            $self->{output}->add_option_msg(short_msg => "Need to specify --sql-statement or --sql-file option.");
+            $self->{output}->option_exit();
+        }
+        $self->{query} = centreon::plugins::misc::slurp_file(output => $self->{output}, file => $self->{option_results}->{sql_file});
     }
+
     if (!defined($self->{option_results}->{format}) || $self->{option_results}->{format} eq '') {
         $self->{output}->add_option_msg(short_msg => "Need to specify '--format' option.");
         $self->{output}->option_exit();
@@ -108,9 +115,9 @@ sub manage_selection {
     my ($self, %options) = @_;
 
     $options{sql}->connect();
-    
+
     my $timing0 = [gettimeofday];
-    $options{sql}->query(query => $self->{option_results}->{sql_statement});
+    $options{sql}->query(query => $self->{query});
     my $value = $options{sql}->fetchrow_array();
     $self->{global} = {
         value => $value,
@@ -133,6 +140,10 @@ Check SQL statement.
 =item B<--sql-statement>
 
 SQL statement that returns a number.
+
+=item B<--sql-file>
+
+Define the file with the SQL request.
 
 =item B<--format>
 

--- a/src/centreon/common/protocols/sql/mode/sqlstring.pm
+++ b/src/centreon/common/protocols/sql/mode/sqlstring.pm
@@ -23,6 +23,7 @@ package centreon::common::protocols::sql::mode::sqlstring;
 use base qw(centreon::plugins::templates::counter);
 use strict;
 use warnings;
+use centreon::plugins::misc;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
 sub set_counters {
@@ -73,6 +74,7 @@ sub new {
 
     $options{options}->add_options(arguments => {
         'sql-statement:s'    => { name => 'sql_statement' },
+        'sql-file:s'         => { name => 'sql_file' },
         'key-column:s'       => { name => 'key_column' },
         'value-column:s'     => { name => 'value_column' },
         'printf-format:s'    => { name => 'printf_format' },
@@ -88,9 +90,13 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::check_options(%options);
 
-    if (!defined($self->{option_results}->{sql_statement}) || $self->{option_results}->{sql_statement} eq '') {
-        $self->{output}->add_option_msg(short_msg => "Need to specify '--sql-statement' option.");
-        $self->{output}->option_exit();
+    $self->{query} = $self->{option_results}->{sql_statement};
+    if (!defined($self->{query}) || $self->{query} eq '') {
+        if (!defined($self->{option_results}->{format}) || $self->{option_results}->{format} eq '') {
+            $self->{output}->add_option_msg(short_msg => "Need to specify --sql-statement or --sql-file option.");
+            $self->{output}->option_exit();
+        }
+        $self->{query} = centreon::plugins::misc::slurp_file(output => $self->{output}, file => $self->{option_results}->{sql_file});
     }
 
     $self->{printf_value} = 'value_field';
@@ -108,7 +114,7 @@ sub manage_selection {
     my ($self, %options) = @_;
 
     $options{sql}->connect();
-    $options{sql}->query(query => $self->{option_results}->{sql_statement});
+    $options{sql}->query(query => $self->{query});
     $self->{rows} = {};
     my $row_count = 0;
 
@@ -155,6 +161,10 @@ Check SQL statement to query string pattern (You cannot have more than to fiels 
 =item B<--sql-statement>
 
 SQL statement that returns a string.
+
+=item B<--sql-file>
+
+Define the file with the SQL request.
 
 =item B<--key-column>
 

--- a/src/database/db2/plugin.pm
+++ b/src/database/db2/plugin.pm
@@ -39,6 +39,8 @@ sub new {
         'database-usage'   => 'database::db2::mode::databaseusage',
         'hadr'             => 'database::db2::mode::hadr',
         'list-tablespaces' => 'database::db2::mode::listtablespaces',
+        'sql'              => 'centreon::common::protocols::sql::mode::sql',
+        'sql-string'       => 'centreon::common::protocols::sql::mode::sqlstring',
         'tablespaces'      => 'database::db2::mode::tablespaces'
     };
 


### PR DESCRIPTION
# Community contributors

## Description

In some case, SQL request can be very complex and we cannot use the argument --sql-statement. So we add the capability to use local file with the sql request. 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

```
centreon_plugins.pl --plugin=database::mysql::plugin --mode=sql --host=127.0.0.1 --username=root --password=xxx --sql-file=test-request.sql --sql-statement=''
```

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.
