### PR TITLE
Fix cisco umbrella connections threshold name in --help output

### DIFF
--- a/src/network/cisco/umbrella/snmp/mode/connectivity.pm
+++ b/src/network/cisco/umbrella/snmp/mode/connectivity.pm
@@ -116,7 +116,7 @@ Can use special variables like: %{status}, %{display}
 =item B<--critical-*>
 
 Define the conditions to match for the status to be CRITICAL. (default: %{status} =~ /red/).
-Can be: 'dns-connectivity', 'localdns-connectivity', 'cloud-connectivity', 'ad-connectivity'.
+Can be: 'dns-status', 'localdns-status', 'cloud-status', 'ad-status'.
 
 Can use special variables like: %{status}, %{display}
 


### PR DESCRIPTION
# Community contributors

## Description

![image](https://github.com/user-attachments/assets/8f9c9726-d89d-44ba-94d8-5605ccea4091)

in the plugin the variable is "*-status" and not "connectivity"


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software