### PR TITLE
enh(apps::monitoring::iplabel::ekara::restapi): change status match and timeframe option default value CTOR-1387

### DIFF
--- a/src/apps/monitoring/iplabel/ekara/restapi/mode/scenarios.pm
+++ b/src/apps/monitoring/iplabel/ekara/restapi/mode/scenarios.pm
@@ -231,9 +231,13 @@ this value according to the highest check frequency in the scenario.
 Filter by scenario type.
 Can be: 'WEB', 'HTTPR', 'BROWSER PAGE LOAD'
 
+=item B<--unknown-scenario-status>
+Unknown threshold for scenario status (default: '%{status} !~ /(Unknown|No execution)/').
+Syntax: --unknown-scenario-status='%{status} =~ "xxx"'
+
 =item B<--warning-scenario-status>
 
-Warning threshold for scenario status (default: '%{status} !~ "Success"').
+Warning threshold for scenario status (default: '%{status} !~ /(Aborted|Stopped|Excluded|Degraded)/').
 Syntax: --warning-scenario-status='%{status} =~ "xxx"'
 
 =item B<--critical-scenario-status>

--- a/src/apps/monitoring/iplabel/ekara/restapi/mode/scenarios.pm
+++ b/src/apps/monitoring/iplabel/ekara/restapi/mode/scenarios.pm
@@ -222,7 +222,7 @@ Check ip-label Ekara scenarios.
 =item B<--timeframe>
 
 Set timeframe period in seconds. (default: 7500)
-Example: --timeframe='3600' will check the last hour
+Example: C<--timeframe='3600'> will check the last hour.
 Note: If the API/Poller is overloaded, it is preferable to refine
 this value according to the highest check frequency in the scenario.
 

--- a/src/apps/monitoring/iplabel/ekara/restapi/mode/scenarios.pm
+++ b/src/apps/monitoring/iplabel/ekara/restapi/mode/scenarios.pm
@@ -61,8 +61,9 @@ sub set_counters {
     $self->{maps_counters}->{global} = [
         { label => 'scenario-status',
             type => 2,
-            warning_default => '%{status} !~ "Success"',
+            warning_default => '%{status} =~ /(Aborted|Stopped|Excluded|Degraded)/',
             critical_default => '%{status} =~ "Failure"',
+            unknown_default => '%{status} =~ /(Unknown|No execution)/',
             set => {
                 key_values => [ { name => 'status' }, { name => 'num_status' }, { name => 'display' } ],
                 closure_custom_output => $self->can('custom_status_output'),
@@ -133,7 +134,7 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::check_options(%options);
 
-    $self->{timeframe} = defined($self->{option_results}->{timeframe})  && $self->{option_results}->{timeframe} ne '' ? $self->{option_results}->{timeframe} : '900';
+    $self->{timeframe} = defined($self->{option_results}->{timeframe})  && $self->{option_results}->{timeframe} ne '' ? $self->{option_results}->{timeframe} : '7500';
 }
 
 my $status_mapping = {
@@ -220,10 +221,10 @@ Check ip-label Ekara scenarios.
 
 =item B<--timeframe>
 
-Set timeframe period in seconds. (default: 900)
+Set timeframe period in seconds. (default: 7500)
 Example: --timeframe='3600' will check the last hour
-
-
+Note: If the API/Poller is overloaded, it is preferable to refine
+this value according to the highest check frequency in the scenario.
 
 =item B<--filter-type>
 

--- a/src/apps/monitoring/iplabel/ekara/restapi/mode/scenarios.pm
+++ b/src/apps/monitoring/iplabel/ekara/restapi/mode/scenarios.pm
@@ -232,13 +232,13 @@ Filter by scenario type.
 Can be: 'WEB', 'HTTPR', 'BROWSER PAGE LOAD'
 
 =item B<--unknown-scenario-status>
-Unknown threshold for scenario status (default: '%{status} !~ /(Unknown|No execution)/').
-Syntax: --unknown-scenario-status='%{status} =~ "xxx"'
+Unknown threshold for scenario status (default: C<%{status} !~ /(Unknown|No execution)/>).
+Syntax: C<--unknown-scenario-status='%{status} =~ "xxx"'>
 
 =item B<--warning-scenario-status>
 
-Warning threshold for scenario status (default: '%{status} !~ /(Aborted|Stopped|Excluded|Degraded)/').
-Syntax: --warning-scenario-status='%{status} =~ "xxx"'
+Warning threshold for scenario status (default: C<%{status} !~ /(Aborted|Stopped|Excluded|Degraded)/>).
+Syntax: C<--warning-scenario-status='%{status} =~ "xxx"'>
 
 =item B<--critical-scenario-status>
 

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -66,6 +66,7 @@ dfsrevent
 --display-transform-src
 dns-resolve-time
 --dyn-mode
+Ekara
 -EncodedCommand
 env
 ESX


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

CTOR-1387
- Change status match
- Change timeframe option default value

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?
Using internal datas

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] I have reviewed all the help messages in all the .pm files I have modified.
  - [x] All sentences begin with a capital letter.
  - [x] All sentences end with a period.
  - [x] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
