### PR TITLE
enh(apps::centreon::sql): added exclude-name option to pollerdelay mode CTOR-1411

### DIFF
--- a/src/apps/centreon/sql/mode/pollerdelay.pm
+++ b/src/apps/centreon/sql/mode/pollerdelay.pm
@@ -57,7 +57,8 @@ sub new {
     bless $self, $class;
     
     $options{options}->add_options(arguments => {
-        "filter-name:s" => { name => 'filter_name' },
+        "filter-name:s"  => { name => 'filter_name' },
+        "exclude-name:s" => { name => 'exclude_name' }
     });
 
     return $self;
@@ -77,6 +78,11 @@ sub manage_selection {
          if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
             $$row[1] !~ /$self->{option_results}->{filter_name}/) {
             $self->{output}->output_add(long_msg => "skipping poller '" . $$row[1] . "': no matching filter.", debug => 1);
+            next;
+        }
+        if (defined($self->{option_results}->{exclude_name}) && $self->{option_results}->{exclude_name} ne '' &&
+            $$row[1] =~ /$self->{option_results}->{exclude_name}/) {
+            $self->{output}->output_add(long_msg => "skipping poller '" . $$row[1] . "': matching exclude filter.", debug => 1);
             next;
         }
         
@@ -108,6 +114,10 @@ The mode should be used with mysql plugin and dyn-mode option.
 =item B<--filter-name>
 
 Filter by poller name (can be a regexp).
+
+=item B<--exclude-name>
+
+Exclude poller name (can be a regexp).
 
 =item B<--warning-delay>
 

--- a/src/apps/centreon/sql/mode/pollerdelay.pm
+++ b/src/apps/centreon/sql/mode/pollerdelay.pm
@@ -107,7 +107,7 @@ __END__
 =head1 MODE
 
 Check the delay of the last update from a poller to the Central server.
-The mode should be used with mysql plugin and dyn-mode option.
+The mode should be used with mysql plugin and --dyn-mode option.
 
 =over 8
 


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

Add option `--exclude-name` 

**Fixes** # (issue)
https://github.com/centreon/centreon-plugins/issues/5446
CTOR-1411

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Using Centreon VM 

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
