### PR TITLE
fix(apps::eclipse::mosquitto::mqtt): fixed perf data options

### DIFF
--- a/src/apps/eclipse/mosquitto/mqtt/mode/numericvalue.pm
+++ b/src/apps/eclipse/mosquitto/mqtt/mode/numericvalue.pm
@@ -69,13 +69,13 @@ sub custom_generic_perfdata {
     my ($self, %options) = @_;
 
     $self->{output}->perfdata_add(
-        label    => $options{option_results}->{perfdata_name},
-        unit     => $options{option_results}->{perfdata_unit},
+        label    => $self->{instance_mode}{option_results}->{perfdata_name},
+        unit     => $self->{instance_mode}{option_results}->{perfdata_unit},
         value    => $self->{result_values}->{numericvalue},
         warning  => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{thlabel}),
         critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{thlabel}),
-        min      => $options{option_results}->{perfdata_min},
-        max      => $options{option_results}->{perfdata_max}
+        min      => $self->{instance_mode}{option_results}->{perfdata_min},
+        max      => $self->{instance_mode}{option_results}->{perfdata_max}
     );
 }
 


### PR DESCRIPTION
# Community contributors

## Description

even i'm giving --perfdata-unit=C --perfdata-name=temp and --perfdata-max=120 the values are not used than in the performance data output. There is NO perfdata label, unit an max value

`/usr/lib/i-vertix/plugins/apps-eclipse-mosquitto-mqtt.pl --hostname=***** --mqtt-port=1883 --mqtt-ca-certificate= --mqtt-ssl-certificate= --mqtt-ssl-key= --mqtt-username= --mqtt-password='' --mqtt-ssl=0 --mqtt-allow-insecure  --plugin=apps::eclipse::mosquitto::mqtt::plugin --mode=numeric-value --topic='****/temperature' --extracted-pattern="\"celsius\":\s*([-+]?\d+(?:\.\d+)?)" --perfdata-unit=C --perfdata-name=temp --perfdata-min= --perfdata-max=120`

**OK: temp is: 19.6 | ''=19.6;;;;**

With the little fix is working fine

`/usr/lib/i-vertix/plugins/apps-eclipse-mosquitto-mqtt.pl --hostname=192.168.40.153 --mqtt-port=1883 --mqtt-ca-certificate= --mqtt-ssl-certificate= --mqtt-ssl-key= --mqtt-username= --mqtt-password='' --mqtt-ssl=0 --mqtt-allow-insecure  --use-new-perfdata --plugin=apps::eclipse::mosquitto::mqtt::plugin --mode=numeric-value --topic='meraki/v1/mt/L_658651445502941862/ble/F8:9E:28:78:4C:4D/temperature' --extracted-pattern="\"celsius\":\s*([-+]?\d+(?:\.\d+)?)"  --perfdata-unit=C --perfdata-name=temp --perfdata-min= --perfdata-max=120`

**OK: temp is: 19.5 | 'temp'=19.5C;;;;120**

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.