### PR TITLE
CTOR-1294-plugin-hardware-server-cisco-ucs-snmp-mode-equipment-wrong-count-when-using-threshold-overload-option

### DIFF
--- a/src/hardware/server/cisco/ucs/snmp/mode/components/memory.pm
+++ b/src/hardware/server/cisco/ucs/snmp/mode/components/memory.pm
@@ -77,8 +77,10 @@ sub check {
             );
             next;
         }
-        
-        $self->{components}->{memory}->{total}++;
+
+        if($result->{cucsMemoryUnitPresence} eq "equipped") {
+            $self->{components}->{memory}->{total}++;
+        }
 
         $exit = $self->get_severity(section => 'memory.operability', label => 'default.operability', value => $result2->{cucsMemoryUnitOperState});
         if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {

--- a/src/hardware/server/cisco/ucs/snmp/mode/equipment.pm
+++ b/src/hardware/server/cisco/ucs/snmp/mode/equipment.pm
@@ -60,14 +60,14 @@ __END__
 
 =head1 MODE
 
-Check Hardware (Fans, Power supplies, chassis, io cards, blades, fabric extenders).
+Check Hardware (Fans, Power supplies, chassis, io-cards, blades, fabric extenders).
 
 =over 8
 
 =item B<--component>
 
 Which component to check (default: '.*').
-Can be: 'fan', 'psu', 'chassis', 'iocard', 'blade', 'fex', 'cpu', 'memory', 'localdisk'.
+Can be: C<fan>, C<psu>, C<chassis>, C<iocard>, C<blade>, C<fex>, C<cpu>, C<memory>, C<localdisk>.
 
 =item B<--filter>
 

--- a/src/hardware/server/cisco/ucs/snmp/mode/equipment.pm
+++ b/src/hardware/server/cisco/ucs/snmp/mode/equipment.pm
@@ -89,6 +89,9 @@ Use this option to override the status returned by the plugin when the status la
 Example: --threshold-overload='fan.operability,OK,poweredOff|removed' 
 --threshold-overload='presence,OK,missing' 
 --threshold-overload='operability,OK,removed'
+NB: For the memory component you may need to set this option twice if presence status doesn't
+return OK state and you want to override the operability status. Example when memories are missing because of removing.
+--threshold-overload='presence,OK,missing' --threshold-overload='operability,OK,removed'
 
 =back
 

--- a/src/hardware/server/cisco/ucs/snmp/mode/equipment.pm
+++ b/src/hardware/server/cisco/ucs/snmp/mode/equipment.pm
@@ -60,7 +60,7 @@ __END__
 
 =head1 MODE
 
-Check Hardware (Fans, Power supplies, chassis, io-cards, blades, fabric extenders).
+Check Hardware (Fans, Power supplies, chassis, I/O cards, blades, fabric extenders).
 
 =over 8
 

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -109,6 +109,7 @@ in-mcast
 interface-dsl-name
 InterrupibleSleep
 in-ucast
+io-cards
 iops
 IpAddr
 ip-label


### PR DESCRIPTION

## Description
change count of memory unit behaviour


## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Please describe the **procedure** to verify that the goal of the PR is matched. 
Provide clear instructions so that it can be **correctly tested**.
Mention the automated tests included in this FOR (what they test like mode/option combinations).

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
