### PR TITLE
fix(storage::purestorage::flasharray::v2::restapi): fixed wrong option filter-resolution in arrays and volumes mode CTOR-1218

### DIFF
--- a/src/storage/purestorage/flasharray/v2/restapi/mode/arrays.pm
+++ b/src/storage/purestorage/flasharray/v2/restapi/mode/arrays.pm
@@ -262,7 +262,7 @@ Filter arrays by ID (can be a regexp).
 
 Filter arrays by name (can be a regexp).
 
-=item B<--filter-resolution>
+=item B<--perf-resolution>
 
 Time resolution for array performance.
 Can be: 1s, 30s, 5m, 30m, 2h, 8h, 24h (default: 5m).

--- a/src/storage/purestorage/flasharray/v2/restapi/mode/arrays.pm
+++ b/src/storage/purestorage/flasharray/v2/restapi/mode/arrays.pm
@@ -265,7 +265,7 @@ Filter arrays by name (can be a regexp).
 =item B<--perf-resolution>
 
 Time resolution for array performance.
-Can be: 1s, 30s, 5m, 30m, 2h, 8h, 24h (default: 5m).
+Can be: C<1s>, C<30s>, C<5m>, C<30m>, C<2h>, C<8h>, C<24h> (default: C<5m>).
 
 =item B<--warning-*> B<--critical-*>
 

--- a/src/storage/purestorage/flasharray/v2/restapi/mode/volumes.pm
+++ b/src/storage/purestorage/flasharray/v2/restapi/mode/volumes.pm
@@ -248,7 +248,7 @@ Filter volumes by name (can be a regexp).
 =item B<--perf-resolution>
 
 Time resolution for volumes performance.
-Can be: 1s, 30s, 5m, 30m, 2h, 8h, 24h (default: 5m).
+Can be: C<1s>, C<30s>, C<5m>, C<30m>, C<2h>, C<8h>, C<24h> (default: C<5m>).
 
 =item B<--warning-*> B<--critical-*>
 

--- a/src/storage/purestorage/flasharray/v2/restapi/mode/volumes.pm
+++ b/src/storage/purestorage/flasharray/v2/restapi/mode/volumes.pm
@@ -245,9 +245,9 @@ Filter volumes by ID (can be a regexp).
 
 Filter volumes by name (can be a regexp).
 
-=item B<--filter-resolution>
+=item B<--perf-resolution>
 
-Time resolution for array performance.
+Time resolution for volumes performance.
 Can be: 1s, 30s, 5m, 30m, 2h, 8h, 24h (default: 5m).
 
 =item B<--warning-*> B<--critical-*>


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

Quick fixes in options for arrays and volumes modes
CTOR-1218

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

```
perl centreon_plugins.pl --plugin=storage::purestorage::flasharray::v2::restapi::plugin --mode=arrays --hostname=localhost --api-token=toto --perf-resolution='5m'
UNKNOWN: curl perform error : Couldn't connect to server 
```
```
ldubrunfaut@CNTR-PORT-A198:~/centreon-plugins/src$ perl centreon_plugins.pl --plugin=storage::purestorage::flasharray::v2::restapi::plugin --mode=arrays --hostname=localhost --api-token=toto --filter-resolution='5m'
Unknown option: filter-resolution at /home/ldubrunfaut/centreon-plugins/src/centreon/plugins/alternative/Getopt.pm line 81. 
```

## Checklist

- [x ] I have **rebased** my development branch on the base branch (develop).
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
