### PR TITLE
OCD(new mode): (network::fortinet::fortigate::restapi::mode::certificates) mode certificates

### DIFF
--- a/src/network/fortinet/fortigate/restapi/mode/certificates.pm
+++ b/src/network/fortinet/fortigate/restapi/mode/certificates.pm
@@ -1,0 +1,196 @@
+#
+# Copyright 2023 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package network::fortinet::fortigate::restapi::mode::certificates;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+use centreon::plugins::misc;
+use POSIX;
+
+my $unitdiv = { s => 1, w => 604800, d => 86400, h => 3600, m => 60 };
+my $unitdiv_long = { s => 'seconds', w => 'weeks', d => 'days', h => 'hours', m => 'minutes' };
+
+sub custom_expires_perfdata {
+    my ($self, %options) = @_;
+
+    $self->{output}->perfdata_add(
+        nlabel => $self->{nlabel} . '.' . $unitdiv_long->{ $self->{instance_mode}->{option_results}->{unit} },
+        unit => $self->{instance_mode}->{option_results}->{unit},
+        instances => $self->{result_values}->{name},
+        value => floor($self->{result_values}->{expires_seconds} / $unitdiv->{ $self->{instance_mode}->{option_results}->{unit} }),
+        warning => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{thlabel}),
+        critical => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{thlabel}),
+        min => 0
+    );
+}
+
+sub custom_expires_threshold {
+    my ($self, %options) = @_;
+
+    return $self->{perfdata}->threshold_check(
+        value => floor($self->{result_values}->{expires_seconds} / $unitdiv->{ $self->{instance_mode}->{option_results}->{unit} }),
+        threshold => [
+            { label => 'critical-' . $self->{thlabel}, exit_litteral => 'critical' },
+            { label => 'warning-'. $self->{thlabel}, exit_litteral => 'warning' },
+            { label => 'unknown-'. $self->{thlabel}, exit_litteral => 'unknown' }
+        ]
+    );
+}
+
+sub custom_status_output {
+    my ($self, %options) = @_;
+
+    return 'status: ' . $self->{result_values}->{status};
+}
+
+sub prefix_certificate_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "Certificate '%s' ",
+        $options{instance_value}->{name}
+    );
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'certificates', type => 1, cb_prefix_output => 'prefix_certificate_output', message_multiple => 'All certificates are ok', skipped_code => { -10 => 1 } }
+    ];
+
+    $self->{maps_counters}->{certificates} = [
+        { label => 'status', type => 2, critical_default => '%{status} =~ /expired/i', set => {
+                key_values => [ { name => 'name' }, { name => 'status' } ],
+                closure_custom_output => $self->can('custom_status_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        },
+        { label => 'expires', nlabel => 'certificate.expires', set => {
+                key_values      => [ { name => 'expires_seconds' }, { name => 'expires_human' }, { name => 'name' } ],
+                output_template => 'expires in %s',
+                output_use => 'expires_human',
+                closure_custom_perfdata => $self->can('custom_expires_perfdata'),
+                closure_custom_threshold_check => $self->can('custom_expires_threshold')
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s' => { name => 'filter_name' },
+        'unit:s'        => { name => 'unit', default => 's' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if ($self->{option_results}->{unit} eq '' || !defined($unitdiv->{$self->{option_results}->{unit}})) {
+        $self->{option_results}->{unit} = 's';
+    }
+}
+
+sub add_certificate {
+    my ($self, %options) = @_;
+
+    return if (!defined($options{entry}->{status}));
+    return if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
+        $options{name} !~ /$self->{option_results}->{filter_name}/);
+
+    $self->{certificates}->{ $options{name} } = {
+        name => $options{name},
+        status => $options{entry}->{status}
+    };
+    if (defined($options{entry}->{valid_to})) {
+        $self->{certificates}->{ $options{name} }->{expires_seconds} = $options{entry}->{valid_to} - time();
+        $self->{certificates}->{ $options{name} }->{expires_seconds} = 0 if ($self->{certificates}->{ $options{name} }->{expires_seconds} < 0);
+        $self->{certificates}->{ $options{name} }->{expires_human} = centreon::plugins::misc::change_seconds(
+            value => $self->{certificates}->{ $options{name} }->{expires_seconds}
+        );
+    }
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $certificates = $options{custom}->request_api(
+        endpoint => '/api/v2/monitor/system/available-certificates'
+    );
+
+    $self->{certificates} = {};
+
+    foreach my $certificate (@{ $certificates->{results} }) {
+          if (defined($certificate->{name}) and defined($certificate->{valid_to}) and defined($certificate->{status})) {
+                $self->add_certificate(name => $certificate->{name}, entry => $certificate);
+          }
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check certificates.
+
+=over 8
+
+=item B<--filter-name>
+
+Filter certificates by name (can be a regexp).
+
+=item B<--warning-status>
+
+Define the conditions to match for the status to be WARNING.
+You can use the following variables: %{name}, %{status}.
+
+=item B<--critical-status>
+
+Define the conditions to match for the status to be CRITICAL (Default: '%{status} =~ /expired/i').
+You can use the following variables: %{name}, %{status}.
+
+=item B<--unit>
+
+Select the unit for expires threshold. May be 's' for seconds, 'm' for minutes,
+'h' for hours, 'd' for days, 'w' for weeks. Default is seconds.
+
+=item B<--warning-*> B<--critical-*>
+
+Thresholds.
+Can be: 'expires'.
+
+=back
+
+=cut

--- a/src/network/fortinet/fortigate/restapi/plugin.pm
+++ b/src/network/fortinet/fortigate/restapi/plugin.pm
@@ -33,6 +33,7 @@ sub new {
         'ha'       => 'network::fortinet::fortigate::restapi::mode::ha',
         'health'   => 'network::fortinet::fortigate::restapi::mode::health',
         'licenses' => 'network::fortinet::fortigate::restapi::mode::licenses',
+        'certificates' => 'network::fortinet::fortigate::restapi::mode::certificates',
         'system'   => 'network::fortinet::fortigate::restapi::mode::system'
     };
 


### PR DESCRIPTION
**Description:**
New mode to monitor certificate expiration
this works exactly like the licenses mode network::fortinet::fortigate::restapi::mode::licenses

**Mode --help:**
Mode:
    Check certificates.

    --filter-name
            Filter certificates by name (can be a regexp).

    --warning-status
            Define the conditions to match for the status to be WARNING. You
            can use the following variables: %{name}, %{status}.

    --critical-status
            Define the conditions to match for the status to be CRITICAL
            (Default: '%{status} =~ /expired/i'). You can use the following
            variables: %{name}, %{status}.

    --unit  Select the unit for expires threshold. May be 's' for seconds,
            'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks.
            Default is seconds.

    --warning-* --critical-*
            Thresholds. Can be: 'expires'.


**Execution:**
./centreon_plugins.pl --plugin=network::fortinet::fortigate::restapi::plugin --mode certificates --hostname='X.X.X.X' --access-token='REST_API_ACCESS_TOKEN' --port='443' --proto='https'  --warning-expires='60' --critical-expires='30' --unit='d' --curl-opt="CURLOPT_SSL_VERIFYHOST => 0" --curl-opt="CURLOPT_SSL_VERIFYPEER => 0" --filter-name="Fortinet_CA_SSL1" --debug --verbose


**REST API Response format:**
the raw json response follows the following format:
```json
{
    "action": "",
    "build": 1577,
    "http_method": "GET",
    "name": "available-certificates",
    "path": "system",
    "results": [
        {
            "cert_protocol": "none",
            "comments": "This is the default CA certificate the SSL Inspection will use when generating new server certificates.",
            "exists": true,
            "ext": [
                {
                    "critical": false,
                    "data": "CA:TRUE",
                    "name": "X509v3 Basic Constraints"
                }
            ],
            "fingerprint": "F2:79:B7:F6:F2:79:B7:F6",
            "has_valid_cert_key": true,
            "is_built_in": true,
            "is_ca": true,
            "is_deep_inspection_cert": true,
            "is_default_local": false,
            "is_general_allowable_cert": true,
            "is_local_ca_cert": true,
            "is_proxy_ssl_cert": true,
            "is_ssl_client_cert": true,
            "is_ssl_server_cert": true,
            "is_wifi_cert": false,
            "issuer": {
                "C": "US",
                "CN": "FGSNXXXXXXXXXXXX",
                "emailAddress": "support@fortinet.com",
                "L": "Sunnyvale",
                "O": "Fortinet",
                "OU": "Certificate Authority",
                "ST": "California"
            },
            "issuer_raw": "C = US, ST = California, L = Sunnyvale, O = Fortinet, OU = Certificate Authority, CN = FGSNXXXXXXXXXXXX, emailAddress = support@fortinet.com",
            "key_size": 2048,
            "key_type": "RSA",
            "name": "Fortinet_CA_SSL1",
            "q_name": "local",
            "q_path": "vpn.certificate",
            "q_ref": 6,
            "q_static": true,
            "q_type": 168,
            "range": "global",
            "serial_number": "04:66:A8:A8:04:66:A8:A8",
            "signature_algorithm": "SHA256",
            "source": "factory",
            "status": "valid",
            "subject": {
                "C": "US",
                "CN": "FGSNXXXXXXXXXXXX",
                "emailAddress": "support@fortinet.com",
                "L": "Sunnyvale",
                "O": "Fortinet",
                "OU": "Certificate Authority",
                "ST": "California"
            },
            "subject_raw": "C = US, ST = California, L = Sunnyvale, O = Fortinet, OU = Certificate Authority, CN = FGSNXXXXXXXXXXXX, emailAddress = support@fortinet.com",
            "type": "local-ca",
            "valid_from": 1636382833,
            "valid_from_raw": "2021-11-08 14:47:13  GMT",
            "valid_to": 1952002033,
            "valid_to_raw": "2031-11-09 14:47:13  GMT",
            "version": 3
        },
        {
            "cert_protocol": "none",
            "comments": "This is the default CA certificate the SSL Inspection will use when generating new server certificates.",
            "exists": true,
            "ext": [
                {
                    "critical": false,
                    "data": "CA:TRUE",
                    "name": "X509v3 Basic Constraints"
                }
            ],
            "fingerprint": "F2:79:B7:F6:F2:79:B7:F6",
            "has_valid_cert_key": true,
            "is_built_in": true,
            "is_ca": true,
            "is_deep_inspection_cert": true,
            "is_default_local": false,
            "is_general_allowable_cert": true,
            "is_local_ca_cert": true,
            "is_proxy_ssl_cert": true,
            "is_ssl_client_cert": true,
            "is_ssl_server_cert": true,
            "is_wifi_cert": false,
            "issuer": {
                "C": "US",
                "CN": "FGSNXXXXXXXXXXXX",
                "emailAddress": "support@fortinet.com",
                "L": "Sunnyvale",
                "O": "Fortinet",
                "OU": "Certificate Authority",
                "ST": "California"
            },
            "issuer_raw": "C = US, ST = California, L = Sunnyvale, O = Fortinet, OU = Certificate Authority, CN = FGSNXXXXXXXXXXXX, emailAddress = support@fortinet.com",
            "key_size": 2048,
            "key_type": "RSA",
            "name": "Fortinet_CA_SSL",
            "q_name": "local",
            "q_path": "vpn.certificate",
            "q_ref": 6,
            "q_static": true,
            "q_type": 168,
            "range": "global",
            "serial_number": "04:66:A8:A8:04:66:A8:A8",
            "signature_algorithm": "SHA256",
            "source": "factory",
            "status": "valid",
            "subject": {
                "C": "US",
                "CN": "FGSNXXXXXXXXXXXX",
                "emailAddress": "support@fortinet.com",
                "L": "Sunnyvale",
                "O": "Fortinet",
                "OU": "Certificate Authority",
                "ST": "California"
            },
            "subject_raw": "C = US, ST = California, L = Sunnyvale, O = Fortinet, OU = Certificate Authority, CN = FGSNXXXXXXXXXXXX, emailAddress = support@fortinet.com",
            "type": "local-ca",
            "valid_from": 1732824780,
            "valid_from_raw": "2024-11-28 20:13:00  GMT",
            "valid_to": 1804104780,
            "valid_to_raw": "2027-03-03 20:13:00  GMT",
            "version": 3
        },
        {
            "cert_protocol": "none",
            "comments": "This is the default CA certificate the SSL Inspection will use when generating new server certificates.",
            "exists": true,
            "ext": [
                {
                    "critical": false,
                    "data": "CA:TRUE",
                    "name": "X509v3 Basic Constraints"
                }
            ],
            "fingerprint": "F2:79:B7:F6:F2:79:B7:F6",
            "has_valid_cert_key": true,
            "is_built_in": true,
            "is_ca": true,
            "is_deep_inspection_cert": true,
            "is_default_local": false,
            "is_general_allowable_cert": true,
            "is_local_ca_cert": true,
            "is_proxy_ssl_cert": true,
            "is_ssl_client_cert": true,
            "is_ssl_server_cert": true,
            "is_wifi_cert": false,
            "issuer": {
                "C": "US",
                "CN": "FGSNXXXXXXXXXXXX",
                "emailAddress": "support@fortinet.com",
                "L": "Sunnyvale",
                "O": "Fortinet",
                "OU": "Certificate Authority",
                "ST": "California"
            },
            "issuer_raw": "C = US, ST = California, L = Sunnyvale, O = Fortinet, OU = Certificate Authority, CN = FGSNXXXXXXXXXXXX, emailAddress = support@fortinet.com",
            "key_size": 2048,
            "key_type": "RSA",
            "name": "Fortinet_CA_SSL2",
            "q_name": "local",
            "q_path": "vpn.certificate",
            "q_ref": 6,
            "q_static": true,
            "q_type": 168,
            "range": "global",
            "serial_number": "04:66:A8:A8:04:66:A8:A8",
            "signature_algorithm": "SHA256",
            "source": "factory",
            "status": "valid",
            "subject": {
                "C": "US",
                "CN": "FGSNXXXXXXXXXXXX",
                "emailAddress": "support@fortinet.com",
                "L": "Sunnyvale",
                "O": "Fortinet",
                "OU": "Certificate Authority",
                "ST": "California"
            },
            "subject_raw": "C = US, ST = California, L = Sunnyvale, O = Fortinet, OU = Certificate Authority, CN = FGSNXXXXXXXXXXXX, emailAddress = support@fortinet.com",
            "type": "local-ca",
            "valid_from": 1732824775,
            "valid_from_raw": "2024-11-28 20:12:55  GMT",
            "valid_to": 1804104775,
            "valid_to_raw": "2027-03-03 20:12:55  GMT",
            "version": 3
        }
    ],
    "serial": "FGSNXXXXXXXXXXXX",
    "status": "success",
    "vdom": "root",
    "version": "v7.2.0"
}
```

