### PR TITLE
fix UNKNOWN: Can't call method "map_instance"

### DIFF
--- a/src/network/sonus/sbc/snmp/mode/dspstats.pm
+++ b/src/network/sonus/sbc/snmp/mode/dspstats.pm
@@ -106,7 +106,7 @@ sub manage_selection {
     foreach my $oid (keys %$snmp_result) {
         next if($oid !~ /^$mapping->{uxDSPServiceStatus}->{oid}\.(.*)$/);
         my $instance = $1;
-        my $result = $self->{snmp}->map_instance(mapping => $mapping, results => $snmp_result, instance => $instance);
+        my $result = $options{snmp}->map_instance(mapping => $mapping, results => $snmp_result, instance => $instance);
 
         next if ($result->{uxDSPIsPresent} eq '0');
 


### PR DESCRIPTION
# Community contributors

## Description

fixes the error from ticket #4791
**Fixes** # (issue)
If you are fixing a github Issue already existing, mention it here.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Using data sent by mail.

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.