### PR TITLE
fix(cpan-libraries): Crypt::OpenSSL::AES not available on centos7

### DIFF
--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distrib: [el8, el9]
+        distrib: [el7, el8, el9]
         name:
           [
             "ARGV::Struct",
@@ -93,13 +93,16 @@ jobs:
             "ZMQ::LibZMQ4"
           ]
         include:
-          - build_distribs: "el8,el9"
+          - build_distribs: "el7, el8,el9"
           - rpm_dependencies: ""
           - rpm_provides: ""
           - version: ""
           - spec_file: ""
           - no-auto-depends: "false"
           - preinstall_cpanlibs: ""
+          - distrib: el7
+            package_extension: rpm
+            image: packaging-plugins-alma8
           - distrib: el8
             package_extension: rpm
             image: packaging-plugins-alma8
@@ -277,7 +280,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [el8, el9]
+        distrib: [el7, el8, el9]
 
     steps:
       - name: Merge Artifacts
@@ -303,7 +306,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        distrib: [el8, el9]
+        distrib: [el7, el8, el9]
     name: sign rpm ${{ matrix.distrib }}
     container:
       image: docker.centreon.com/centreon-private/rpm-signing:latest
@@ -690,6 +693,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - distrib: el7
+            package_extension: rpm
           - distrib: el8
             package_extension: rpm
           - distrib: el9


### PR DESCRIPTION
## Description

The plugins are still updated/delivered for centos7, but not the cpan libraries, needed by some of them.

**Fixes** CTOR-1309

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
