### PR TITLE
enh(as400): mode message-queue add filters for text and reply status

### DIFF
--- a/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/msgqueue/MessageQueueHandler.java
+++ b/as400/connector.as400/src/main/java/com/centreon/connector/as400/check/handler/msgqueue/MessageQueueHandler.java
@@ -94,10 +94,10 @@ public class MessageQueueHandler extends AbstractHandler implements IMessageQueu
                         .debug("Message found : " + message.getID() + " - " + message.getText().replace('|', ' '));
 
                 if ((message.getSeverity() >= minSeverityLevel) && (message.getSeverity() < maxSeverityLevel)) {
-                    if ("A".equals(message.getReplyStatus())) {
-                        // The message has been acknowledge already and we don't take it into account
-                        continue;
-                    }
+                    //if ("A".equals(message.getReplyStatus())) {
+                    // The message has been acknowledge already and we don't take it into account
+                    //    continue;
+                    //}
 
                     final String messageId = message.getID();
                     if (messageIdfilterPattern != null && !messageId.matches(messageIdfilterPattern)) {
@@ -112,6 +112,7 @@ public class MessageQueueHandler extends AbstractHandler implements IMessageQueu
                     attrs.put("jobName", message.getFromJobName());
                     attrs.put("jobNumber", message.getFromJobNumber());
                     attrs.put("user", message.getUser());
+                    attrs.put("replyStatus", message.getReplyStatus());
                     data.getResult().add(attrs);
                 }
             }

--- a/src/os/as400/connector/mode/messagequeue.pm
+++ b/src/os/as400/connector/mode/messagequeue.pm
@@ -112,6 +112,7 @@ sub manage_selection {
     }
 
     foreach my $entry (@{$messages->{result}}) {
+        # compatibility with old as400 daemon version
         $entry->{replyStatus} = '-' if (exists($entry->{replyStatus}) && (!defined($entry->{replyStatus}) || $entry->{replyStatus} eq ''));
         next if (defined($entry->{replyStatus}) && defined($self->{option_results}->{filter_reply_status}) && $self->{option_results}->{filter_reply_status} ne '' &&
             $entry->{replyStatus} !~ /$self->{option_results}->{filter_reply_status}/);


### PR DESCRIPTION
# Community contributors

## Description

Fix the following issue: https://github.com/centreon/centreon-plugins/issues/5104

CTOR-792

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

With the following commands:
```
$ perl centreon_plugins.pl --plugin=os::as400::connector::plugin --mode=message-queue --as400-hostname=127.0.0.1 --as400-username=xxxx --as400-password=yyy --message-queue-path=zzzz --display-messages --verbose --exclude-reply-status='A' --exclude-text=''
OK: number of messages: 1 | 'zzzz#mq.messages.count'=1;;;0;
message [id: 1000] [severity: 99] [date: Wed Mar  5 03:49:33 2025] [user: PMSOFTICF] [replyStatus: B]: D
```

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.
