### PR TITLE
fix(storage::ibm::fs900::snmp): remove wrong default value all CTOR-544

### DIFF
--- a/src/storage/ibm/fs900/snmp/mode/hardware.pm
+++ b/src/storage/ibm/fs900/snmp/mode/hardware.pm
@@ -80,7 +80,7 @@ Check hardware (batteries, fan modules, fibre channels, flashcards, power suppli
 =item B<--component>
 
 Which component to check (default: '.*').
-Can be: 'battery', 'fan', C<'fibrechannel'>, 'flashcard', 'psu'.
+Can be: C<battery>, C<fan>, C<fibrechannel>, C<flashcard>, C<psu>.
 
 =item B<--filter>
 
@@ -89,7 +89,7 @@ You can also exclude items from specific instances: --filter=fan,1
 
 =item B<--absent-problem>
 
-Return an error if an entity is not C<'notAvailable'> (default is skipping) (comma separated list)
+Return an error if an entity is not C<notAvailable> (default is skipping) (comma separated list).
 Can be specific or global: --absent-problem=fan,2
 
 =item B<--no-component>

--- a/src/storage/ibm/fs900/snmp/mode/hardware.pm
+++ b/src/storage/ibm/fs900/snmp/mode/hardware.pm
@@ -79,7 +79,7 @@ Check hardware (batteries, fan modules, fibre channels, flashcards, power suppli
 
 =item B<--component>
 
-Which component to check (default: 'all').
+Which component to check (default: '.*').
 Can be: 'battery', 'fan', 'fibrechannel', 'flashcard', 'psu'.
 
 =item B<--filter>

--- a/src/storage/ibm/fs900/snmp/mode/hardware.pm
+++ b/src/storage/ibm/fs900/snmp/mode/hardware.pm
@@ -80,7 +80,7 @@ Check hardware (batteries, fan modules, fibre channels, flashcards, power suppli
 =item B<--component>
 
 Which component to check (default: '.*').
-Can be: 'battery', 'fan', 'fibrechannel', 'flashcard', 'psu'.
+Can be: 'battery', 'fan', C<'fibrechannel'>, 'flashcard', 'psu'.
 
 =item B<--filter>
 
@@ -89,7 +89,7 @@ You can also exclude items from specific instances: --filter=fan,1
 
 =item B<--absent-problem>
 
-Return an error if an entity is not 'notAvailable' (default is skipping) (comma separated list)
+Return an error if an entity is not C<'notAvailable'> (default is skipping) (comma separated list)
 Can be specific or global: --absent-problem=fan,2
 
 =item B<--no-component>

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -75,6 +75,7 @@ eth
 ext4
 fanspeed
 FCCapacity
+fibre
 --filter-fs
 --filter-imei
 --filter-ppid


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

Remove wrong default value
CTOR-544

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

```
perl centreon_plugins.pl --plugin=storage::ibm::fs900::snmp::plugin --hostname=localhost --snmp-version=2c --snmp-community=local/fs900-test --snmp-port=2024 --mode=hardware --debug --component=all
UNKNOWN: Wrong option. Cannot find component 'all'. 
```

and

```
perl centreon_plugins.pl --plugin=storage::ibm::fs900::snmp::plugin --hostname=localhost --snmp-version=2c --snmp-community=local/fs900-test --snmp-port=2024 --mode=hardware --debug --component=.*
OK: All 0 components are ok []. 
Checking batteries
Checking fan modules
Checking fibre channels
Checking flashcards
Checking psu
```

## Checklist

- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
