### PR TITLE
add code parameters to hashicorp vault plugin

### DIFF
--- a/src/apps/hashicorp/vault/restapi/mode/health.pm
+++ b/src/apps/hashicorp/vault/restapi/mode/health.pm
@@ -62,7 +62,9 @@ sub new {
     my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
 
-    $options{options}->add_options(arguments => {});
+    $options{options}->add_options(arguments => {
+        'code-parameters:s' => { name => 'code_parameters' }
+    });
 
     return $self;
 }
@@ -74,7 +76,8 @@ sub set_options {
 sub manage_selection {
     my ($self, %options) = @_;
 
-    my $code_param = '?sealedcode=200&uninitcode=200'; # By default API will return error codes if sealed or uninit
+
+    my $code_param = (defined($self->{option_results}->{code_parameters})) ? $self->{option_results}->{code_parameters} : '?sealedcode=200&uninitcode=200'; # By default API will return error codes if sealed or uninit
     my $result = $options{custom}->request_api(url_path => 'health' . $code_param);
     my $cluster_name = defined($result->{cluster_name}) ? $result->{cluster_name} : $self->{option_results}->{hostname};
 
@@ -100,6 +103,12 @@ perl centreon_plugins.pl --plugin=apps::hashicorp::vault::restapi::plugin --mode
 More information on'https://www.vaultproject.io/api-docs/system/health'.
 
 =over 8
+
+=item B<--code-parameters>
+
+Specify the code parameters when calling health api (default: ?sealedcode=200&uninitcode=200).
+
+More information here: https://developer.hashicorp.com/vault/api-docs/system/health#parameters
 
 =item B<--warning-seal-status>
 


### PR DESCRIPTION
# Community contributors

## Description

Add new parameter to apps::hashicorp::vault::restapi::plugin for health mode in order to add more parameters in the API call sys/health, following this resource: https://developer.hashicorp.com/vault/api-docs/system/health#parameters.

This will allow the addition of more parameters to those who were already present, 

Please include a short resume of the changes and what is the purpose of this pull request. 
Any relevant information should be added to help **reviewers** to understand what are the stakes 
of the pull request.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Setup a Vault cluster of 2 node, initialize and unseal all of them. One the the node will be the "master" node, and the other will be "standby" node.

```bash
# check on master node, without new parameter
perl centreon_plugins.pl --plugin='apps::hashicorp::vault::restapi::plugin' --hostname='127.0.0.1' --port='8200' --proto='https' --mode='health' --custommode='api' --api-version='v1' --ssl-opt='SSL_verify_mode => SSL_VERIFY_NONE' --vault-token='none' --verbose
# output
OK: Server vault-cluster-816c61e4 seal status : unsealed, init status : initialized 
Server vault-cluster-816c61e4 seal status : unsealed, init status : initialized
...
# check on master node, with new parameter
perl centreon_plugins.pl --plugin='apps::hashicorp::vault::restapi::plugin' --hostname='127.0.0.1' --port='8200' --proto='https' --mode='health' --custommode='api' --api-version='v1' --ssl-opt='SSL_verify_mode => SSL_VERIFY_NONE' --vault-token='none' --code-parameters='?standbyok=true&sealedcode=200&uninitcode=200' --verbose
# output
OK: Server vault-cluster-816c61e4 seal status : unsealed, init status : initialized 
Server vault-cluster-816c61e4 seal status : unsealed, init status : initialized
```
Standby node respond with a 429 http status, even if they are well initialized and unsealed (see https://developer.hashicorp.com/vault/api-docs/system/health#429). The new code-parameter of the centreon plugin allow the addiction of other parameters to bypass this issue, and allow the correct display of the plugin.
```bash
# check on standby node, without new parameter
perl centreon_plugins.pl --plugin='apps::hashicorp::vault::restapi::plugin' --hostname='127.0.0.1' --port='8200' --proto='https' --mode='health' --custommode='api' --api-version='v1' --ssl-opt='SSL_verify_mode => SSL_VERIFY_NONE' --vault-token='none' --verbose
# output
UNKNOWN: 429 Too Many Requests 
...
# check on master node, with new parameter
perl centreon_plugins.pl --plugin='apps::hashicorp::vault::restapi::plugin' --hostname='127.0.0.1' --port='8201' --proto='https' --mode='health' --custommode='api' --api-version='v1' --ssl-opt='SSL_verify_mode => SSL_VERIFY_NONE' --vault-token='none' --code-parameters='?standbyok=true&sealedcode=200&uninitcode=200' --verbose
# output
OK: Server vault-cluster-816c61e4 seal status : unsealed, init status : initialized 
Server vault-cluster-816c61e4 seal status : unsealed, init status : initialized
```

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] I have provide data or shown output displaying the result of this code in the plugin area concerned.

