### PR TITLE
fix(apps::eclipse::mosquitto::mqtt): mode numeric-value

### DIFF
--- a/src/apps/eclipse/mosquitto/mqtt/mode/clients.pm
+++ b/src/apps/eclipse/mosquitto/mqtt/mode/clients.pm
@@ -38,7 +38,7 @@ sub set_counters {
              { label  => 'clients-' . $label,
                nlabel => 'clients.' . $label . '.count',
                set    => {
-                   key_values      => [{ name => $label }],
+                   key_values      => [ { name => $label } ],
                    output_template => ucfirst($label) . ' clients: %d',
                    perfdatas       => [
                        { label => $label . '_clients', template => '%d',
@@ -51,7 +51,7 @@ sub set_counters {
 
 sub new {
     my ($class, %options) = @_;
-    my $self              = $class->SUPER::new(package => __PACKAGE__, %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
     bless $self, $class;
 
     return $self;
@@ -62,7 +62,7 @@ sub manage_selection {
 
     my %results = $options{mqtt}->queries(
         base_topic => '$SYS/broker/clients/',
-        topics     => ['connected', 'maximum', 'active', 'inactive']
+        topics     => [ 'connected', 'maximum', 'active', 'inactive' ]
     );
 
     for my $topic (keys %results) {
@@ -80,10 +80,37 @@ Check clients statistics.
 
 =over 8
 
-=item B<--warning-*> B<--critical-*>
+=item B<--warning-clients-connected>
 
-Thresholds.
-Can be: 'clients-connected', 'clients-maximum', 'clients-active', 'clients-inactive'.
+Warning threshold for connected clients.
+
+=item B<--critical-clients-connected>
+
+Critical threshold for connected clients.
+
+=item B<--warning-clients-maximum>
+
+Warning threshold for maximum clients.
+
+=item B<--critical-clients-maximum>
+
+Critical threshold for maximum clients.
+
+=item B<--warning-clients-active>
+
+Warning threshold for active clients.
+
+=item B<--critical-clients-active>
+
+Critical threshold for active clients.
+
+=item B<--warning-clients-inactive>
+
+Warning threshold for inactive clients.
+
+=item B<--critical-clients-inactive>
+
+Critical threshold for inactive clients.
 
 =back
 

--- a/src/apps/eclipse/mosquitto/mqtt/mode/messages.pm
+++ b/src/apps/eclipse/mosquitto/mqtt/mode/messages.pm
@@ -38,7 +38,7 @@ sub set_counters {
              { label  => 'messages-' . $label,
                nlabel => 'messages.' . $label . '.count',
                set    => {
-                   key_values      => [{ name => $label }],
+                   key_values      => [ { name => $label } ],
                    output_template => ucfirst($label) . ' messages: %d',
                    perfdatas       => [
                        { label => $label . '_messages', template => '%d',
@@ -51,7 +51,7 @@ sub set_counters {
 
 sub new {
     my ($class, %options) = @_;
-    my $self              = $class->SUPER::new(package => __PACKAGE__, %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
     bless $self, $class;
 
     return $self;
@@ -62,7 +62,7 @@ sub manage_selection {
 
     my %results = $options{mqtt}->queries(
         base_topic => '$SYS/broker/messages/',
-        topics     => ['stored', 'received', 'sent']
+        topics     => [ 'stored', 'received', 'sent' ]
     );
     for my $topic (keys %results) {
         $self->{global}->{$topic} = $results{$topic};
@@ -79,10 +79,29 @@ Check messages statistics.
 
 =over 8
 
-=item B<--warning-*> B<--critical-*>
+=item B<--warning-messages-stored>
 
-Thresholds.
-Can be: 'messages-stored', 'messages-received', 'messages-sent'.
+Warning threshold for stored messages.
+
+=item B<--critical-messages-stored>
+
+Critical threshold for stored messages.
+
+=item B<--warning-messages-received>
+
+Warning threshold for received messages.
+
+=item B<--critical-messages-received>
+
+Critical threshold for received messages.
+
+=item B<--warning-messages-sent>
+
+Warning threshold for sent messages.
+
+=item B<--critical-messages-sent>
+
+Critical threshold for sent messages.
 
 =back
 

--- a/src/apps/eclipse/mosquitto/mqtt/mode/numericvalue.pm
+++ b/src/apps/eclipse/mosquitto/mqtt/mode/numericvalue.pm
@@ -176,7 +176,7 @@ Define a pattern to extract a number from the returned string.
 
 =item B<--format>
 
-Output format (default: 'current value is %s')
+Output format (default: 'current value is %s').
 
 =item B<--format-custom>
 
@@ -185,19 +185,19 @@ Apply a custom change on the value
 
 =item B<--perfdata-unit>
 
-Perfdata unit in perfdata output (default: '')
+Perfdata unit in perfdata output (default: '').
 
 =item B<--perfdata-name>
 
-Perfdata name in perfdata output (default: 'value')
+Perfdata name in perfdata output (default: 'value').
 
 =item B<--perfdata-min>
 
-Minimum value to add in perfdata output (default: '')
+Minimum value to add in perfdata output (default: '').
 
 =item B<--perfdata-max>
 
-Maximum value to add in perfdata output (default: '')
+Maximum value to add in perfdata output (default: '').
 
 =back
 

--- a/src/apps/eclipse/mosquitto/mqtt/mode/numericvalue.pm
+++ b/src/apps/eclipse/mosquitto/mqtt/mode/numericvalue.pm
@@ -30,7 +30,7 @@ use POSIX qw(floor);
 
 sub new {
     my ($class, %options) = @_;
-    my $self              = $class->SUPER::new(package => __PACKAGE__, %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
@@ -102,7 +102,7 @@ sub set_counters {
     $self->{maps_counters}->{global} = [
         { label => 'generic',
           set   => {
-              key_values                     => [{ name => 'numericvalue' }],
+              key_values                     => [ { name => 'numericvalue' } ],
               closure_custom_output          => $self->can('custom_generic_output'),
               closure_custom_perfdata        => $self->can('custom_generic_perfdata'),
               closure_custom_threshold_check => $self->can('custom_generic_threshold')

--- a/src/apps/eclipse/mosquitto/mqtt/mode/uptime.pm
+++ b/src/apps/eclipse/mosquitto/mqtt/mode/uptime.pm
@@ -28,7 +28,7 @@ use centreon::plugins::misc;
 use Time::HiRes qw(time);
 use POSIX qw(floor);
 
-my $unitdiv      = { s => 1, w => 604800, d => 86400, h => 3600, m => 60 };
+my $unitdiv = { s => 1, w => 604800, d => 86400, h => 3600, m => 60 };
 my $unitdiv_long = { s => 'seconds', w => 'weeks', d => 'days', h => 'hours', m => 'minutes' };
 
 sub custom_uptime_output {
@@ -76,7 +76,7 @@ sub set_counters {
     $self->{maps_counters}->{global} = [
         { label => 'uptime',
           set   => {
-              key_values                     => [{ name => 'uptime' }],
+              key_values                     => [ { name => 'uptime' } ],
               closure_custom_output          => $self->can('custom_uptime_output'),
               closure_custom_perfdata        => $self->can('custom_uptime_perfdata'),
               closure_custom_threshold_check => $self->can('custom_uptime_threshold')
@@ -87,7 +87,7 @@ sub set_counters {
 
 sub new {
     my ($class, %options) = @_;
-    my $self              = $class->SUPER::new(package => __PACKAGE__, %options);
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
@@ -109,7 +109,7 @@ sub check_options {
 sub manage_selection {
     my ($self, %options) = @_;
 
-    my $topic  = '$SYS/broker/uptime';
+    my $topic = '$SYS/broker/uptime';
     my $uptime = $options{mqtt}->query(
         topic => $topic
     );

--- a/tests/apps/eclipse/mosquitto/mqtt/clients.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/clients.robot
@@ -32,8 +32,7 @@ Mosquitto MQTT clients help
     ...    ${CMD}
     ...    --help
 
-    ${output}    Run    ${command}
-    ${output}    Strip String    ${output}
+    Ctn Run Command And Check Result As Regexp    ${command}    ^Plugin Description:
 
 Mosquitto MQTT clients ${tc}
     [Documentation]    Check Mosquitto MQTT clients

--- a/tests/apps/eclipse/mosquitto/mqtt/clients.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/clients.robot
@@ -1,11 +1,9 @@
 *** Settings ***
-Documentation       Eclipse Mosquitto MQTT plugin tests
+Documentation       Eclipse Mosquitto MQTT plugin clients mode
 
 Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
 
 Test Timeout        120s
-
-Keyword Tags        notauto
 
 
 *** Variables ***
@@ -14,17 +12,52 @@ ${MQTT_PORT}                8883
 ${MQTT_CA_CERTIFICATE}      /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/ca.crt
 ${MQTT_SSL_CERTIFICATE}     /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/client.crt
 ${MQTT_SSL_KEY}             /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/client.key
-${CMD}                      ${CENTREON_PLUGINS} --plugin=apps::eclipse::mosquitto::mqtt::plugin --hostname=${HOSTNAME} --mqtt-port=${MQTT_PORT} --mqtt-ca-certificate=${MQTT_CA_CERTIFICATE} --mqtt-ssl-certificate=${MQTT_SSL_CERTIFICATE} --mqtt-ssl-key=${MQTT_SSL_KEY}
+
+${CMD}                      ${CENTREON_PLUGINS}
+...                         --plugin=apps::eclipse::mosquitto::mqtt::plugin
+...                         --mode=clients
+...                         --hostname=${HOSTNAME}
+...                         --mqtt-port=${MQTT_PORT}
+...                         --mqtt-ca-certificate=${MQTT_CA_CERTIFICATE}
+...                         --mqtt-ssl-certificate=${MQTT_SSL_CERTIFICATE}
+...                         --mqtt-ssl-key=${MQTT_SSL_KEY}
+...                         --mqtt-timeout=10
 
 
 *** Test Cases ***
-Mosquitto MQTT clients
-    [Documentation]    Check Mosquitto MQTT uptime
+Mosquitto MQTT clients help
+    [Documentation]    Check Mosquitto MQTT clients help
     [Tags]    eclipse    mosquitto    mqtt
     ${command}    Catenate
     ...    ${CMD}
-    ...    --mode=clients
     ...    --help
 
     ${output}    Run    ${command}
     ${output}    Strip String    ${output}
+
+Mosquitto MQTT clients ${tc}
+    [Documentation]    Check Mosquitto MQTT clients
+    [Tags]    eclipse    mosquitto    mqtt    notauto
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    --warning-clients-connected=${warning-connected}
+    ...    --critical-clients-connected=${critical-connected}
+    ...    --warning-clients-maximum=${warning-maximum}
+    ...    --critical-clients-maximum=${critical-maximum}
+    ...    --warning-clients-active=${warning-active}
+    ...    --critical-clients-active=${critical-active}
+    ...    --warning-clients-inactive=${warning-inactive}
+    ...    --critical-clients-inactive=${critical-inactive}
+
+    Ctn Run Command And Check Result As Regexp    ${command}    ${expected_result}
+
+    Examples:    tc    warning-connected     critical-connected    warning-maximum    critical-maximum    warning-active    critical-active    warning-inactive    critical-inactive    expected_result    --
+        ...      1     ${EMPTY}              ${EMPTY}              ${EMPTY}           ${EMPTY}            ${EMPTY}          ${EMPTY}           ${EMPTY}            ${EMPTY}             ^OK: Connected clients: \\\\d+, Maximum clients: \\\\d+, Active clients: \\\\d+, Inactive clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      2     @0                    ${EMPTY}              ${EMPTY}           ${EMPTY}            ${EMPTY}          ${EMPTY}           ${EMPTY}            ${EMPTY}             ^WARNING: Connected clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;@0:0;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      3     ${EMPTY}              @0                    ${EMPTY}           ${EMPTY}            ${EMPTY}          ${EMPTY}           ${EMPTY}            ${EMPTY}             ^CRITICAL: Connected clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;@0:0;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      4     ${EMPTY}              ${EMPTY}              0                  ${EMPTY}            ${EMPTY}          ${EMPTY}           ${EMPTY}            ${EMPTY}             ^WARNING: Maximum clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;0:0;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      5     ${EMPTY}              ${EMPTY}              ${EMPTY}           0                   ${EMPTY}          ${EMPTY}           ${EMPTY}            ${EMPTY}             ^CRITICAL: Maximum clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;0:0;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      6     ${EMPTY}              ${EMPTY}              ${EMPTY}           ${EMPTY}            @0:1              ${EMPTY}           ${EMPTY}            ${EMPTY}             ^WARNING: Active clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;@0:1;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      7     ${EMPTY}              ${EMPTY}              ${EMPTY}           ${EMPTY}            ${EMPTY}          @0:1               ${EMPTY}            ${EMPTY}             ^CRITICAL: Active clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;@0:1;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      8     ${EMPTY}              ${EMPTY}              ${EMPTY}           ${EMPTY}            ${EMPTY}          ${EMPTY}           @0                  ${EMPTY}             ^WARNING: Inactive clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;@0:0;;\\\\d+;$
+        ...      9     ${EMPTY}              ${EMPTY}              ${EMPTY}           ${EMPTY}            ${EMPTY}          ${EMPTY}           ${EMPTY}            @0                   ^CRITICAL: Inactive clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;@0:0;\\\\d+;$

--- a/tests/apps/eclipse/mosquitto/mqtt/clients.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/clients.robot
@@ -40,24 +40,17 @@ Mosquitto MQTT clients ${tc}
     [Tags]    eclipse    mosquitto    mqtt    notauto
     ${command}    Catenate
     ...    ${CMD}
-    ...    --warning-clients-connected=${warning-connected}
-    ...    --critical-clients-connected=${critical-connected}
-    ...    --warning-clients-maximum=${warning-maximum}
-    ...    --critical-clients-maximum=${critical-maximum}
-    ...    --warning-clients-active=${warning-active}
-    ...    --critical-clients-active=${critical-active}
-    ...    --warning-clients-inactive=${warning-inactive}
-    ...    --critical-clients-inactive=${critical-inactive}
+    ...    ${extraoptions}
 
     Ctn Run Command And Check Result As Regexp    ${command}    ${expected_result}
 
-    Examples:    tc    warning-connected     critical-connected    warning-maximum    critical-maximum    warning-active    critical-active    warning-inactive    critical-inactive    expected_result    --
-        ...      1     ${EMPTY}              ${EMPTY}              ${EMPTY}           ${EMPTY}            ${EMPTY}          ${EMPTY}           ${EMPTY}            ${EMPTY}             ^OK: Connected clients: \\\\d+, Maximum clients: \\\\d+, Active clients: \\\\d+, Inactive clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
-        ...      2     @0                    ${EMPTY}              ${EMPTY}           ${EMPTY}            ${EMPTY}          ${EMPTY}           ${EMPTY}            ${EMPTY}             ^WARNING: Connected clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;@0:0;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
-        ...      3     ${EMPTY}              @0                    ${EMPTY}           ${EMPTY}            ${EMPTY}          ${EMPTY}           ${EMPTY}            ${EMPTY}             ^CRITICAL: Connected clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;@0:0;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
-        ...      4     ${EMPTY}              ${EMPTY}              0                  ${EMPTY}            ${EMPTY}          ${EMPTY}           ${EMPTY}            ${EMPTY}             ^WARNING: Maximum clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;0:0;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
-        ...      5     ${EMPTY}              ${EMPTY}              ${EMPTY}           0                   ${EMPTY}          ${EMPTY}           ${EMPTY}            ${EMPTY}             ^CRITICAL: Maximum clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;0:0;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
-        ...      6     ${EMPTY}              ${EMPTY}              ${EMPTY}           ${EMPTY}            @0:1              ${EMPTY}           ${EMPTY}            ${EMPTY}             ^WARNING: Active clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;@0:1;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
-        ...      7     ${EMPTY}              ${EMPTY}              ${EMPTY}           ${EMPTY}            ${EMPTY}          @0:1               ${EMPTY}            ${EMPTY}             ^CRITICAL: Active clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;@0:1;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
-        ...      8     ${EMPTY}              ${EMPTY}              ${EMPTY}           ${EMPTY}            ${EMPTY}          ${EMPTY}           @0                  ${EMPTY}             ^WARNING: Inactive clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;@0:0;;\\\\d+;$
-        ...      9     ${EMPTY}              ${EMPTY}              ${EMPTY}           ${EMPTY}            ${EMPTY}          ${EMPTY}           ${EMPTY}            @0                   ^CRITICAL: Inactive clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;@0:0;\\\\d+;$
+    Examples:    tc    extraoptions                       expected_result    --
+        ...      1     ${EMPTY}                           ^OK: Connected clients: \\\\d+, Maximum clients: \\\\d+, Active clients: \\\\d+, Inactive clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      2     --warning-clients-connected=@0     ^WARNING: Connected clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;@0:0;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      3     --critical-clients-connected=@0    ^CRITICAL: Connected clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;@0:0;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      4     --warning-clients-maximum=0        ^WARNING: Maximum clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;0:0;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      5     --critical-clients-maximum=0       ^CRITICAL: Maximum clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;0:0;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      6     --warning-clients-active=@0:1      ^WARNING: Active clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;@0:1;;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      7     --critical-clients-active=@0:1     ^CRITICAL: Active clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;@0:1;\\\\d+; 'inactive_clients'=\\\\d+;;;\\\\d+;$
+        ...      8     --warning-clients-inactive=@0      ^WARNING: Inactive clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;@0:0;;\\\\d+;$
+        ...      9     --critical-clients-inactive=@0      ^CRITICAL: Inactive clients: \\\\d+ \\\\| 'connected_clients'=\\\\d+;;;\\\\d+; 'maximum_clients'=\\\\d+;;;\\\\d+; 'active_clients'=\\\\d+;;;\\\\d+; 'inactive_clients'=\\\\d+;;@0:0;\\\\d+;$

--- a/tests/apps/eclipse/mosquitto/mqtt/messages.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/messages.robot
@@ -1,11 +1,9 @@
 *** Settings ***
-Documentation       Eclipse Mosquitto MQTT plugin tests
+Documentation       Checks Eclipse Mosquitto MQTT plugin messages mode
 
 Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
 
 Test Timeout        120s
-
-Keyword Tags        notauto
 
 
 *** Variables ***
@@ -14,17 +12,48 @@ ${MQTT_PORT}                8883
 ${MQTT_CA_CERTIFICATE}      /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/ca.crt
 ${MQTT_SSL_CERTIFICATE}     /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/client.crt
 ${MQTT_SSL_KEY}             /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/client.key
-${CMD}                      ${CENTREON_PLUGINS} --plugin=apps::eclipse::mosquitto::mqtt::plugin --hostname=${HOSTNAME} --mqtt-port=${MQTT_PORT} --mqtt-ca-certificate=${MQTT_CA_CERTIFICATE} --mqtt-ssl-certificate=${MQTT_SSL_CERTIFICATE} --mqtt-ssl-key=${MQTT_SSL_KEY}
+
+${CMD}                      ${CENTREON_PLUGINS}
+...                         --plugin=apps::eclipse::mosquitto::mqtt::plugin
+...                         --mode=messages
+...                         --hostname=${HOSTNAME}
+...                         --mqtt-port=${MQTT_PORT}
+...                         --mqtt-ca-certificate=${MQTT_CA_CERTIFICATE}
+...                         --mqtt-ssl-certificate=${MQTT_SSL_CERTIFICATE}
+...                         --mqtt-ssl-key=${MQTT_SSL_KEY}
+...                         --mqtt-timeout=10
 
 
-*** Test Cases ***  
-Mosquitto MQTT messages
-    [Documentation]    Check Mosquitto MQTT uptime
+*** Test Cases ***
+Mosquitto MQTT messages help
+    [Documentation]    Check Mosquitto MQTT messages help
     [Tags]    eclipse    mosquitto    mqtt
     ${command}    Catenate
     ...    ${CMD}
-    ...    --mode=messages
     ...    --help
 
     ${output}    Run    ${command}
     ${output}    Strip String    ${output}
+
+Mosquitto MQTT messages ${tc}
+    [Documentation]    Check Mosquitto MQTT messages
+    [Tags]    eclipse    mosquitto    mqtt   notauto
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    --warning-messages-stored=${warning-stored}
+    ...    --critical-messages-stored=${critical-stored}
+    ...    --warning-messages-received=${warning-received}
+    ...    --critical-messages-received=${critical-received}
+    ...    --warning-messages-sent=${warning-sent}
+    ...    --critical-messages-sent=${critical-sent}
+
+    Ctn Run Command And Check Result As Regexp    ${command}    ${expected_result}
+
+    Examples:    tc    warning-stored     critical-stored    warning-received    critical-received    warning-sent    critical-sent    expected_result    --
+        ...      1     ${EMPTY}           ${EMPTY}           ${EMPTY}            ${EMPTY}             ${EMPTY}        ${EMPTY}         ^OK: Stored messages: \\\\d+, Received messages: \\\\d+, Sent messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
+        ...      2     @0:                ${EMPTY}           ${EMPTY}            ${EMPTY}             ${EMPTY}        ${EMPTY}         ^WARNING: Stored messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;@0:;;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
+        ...      3     ${EMPTY}           @0:                ${EMPTY}            ${EMPTY}             ${EMPTY}        ${EMPTY}         ^CRITICAL: Stored messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;@0:;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
+        ...      4     ${EMPTY}           ${EMPTY}           @0:                 ${EMPTY}             ${EMPTY}        ${EMPTY}         ^WARNING: Received messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;@0:;;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
+        ...      5     ${EMPTY}           ${EMPTY}           ${EMPTY}            @0:                  ${EMPTY}        ${EMPTY}         ^CRITICAL: Received messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;;@0:;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
+        ...      6     ${EMPTY}           ${EMPTY}           ${EMPTY}            ${EMPTY}             @0:             ${EMPTY}         ^WARNING: Sent messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;@0:;;\\\\d+;$
+        ...      7     ${EMPTY}           ${EMPTY}           ${EMPTY}            ${EMPTY}             ${EMPTY}        @0:              ^CRITICAL: Sent messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;;@0:;\\\\d+;$

--- a/tests/apps/eclipse/mosquitto/mqtt/messages.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/messages.robot
@@ -37,7 +37,7 @@ Mosquitto MQTT messages help
 
 Mosquitto MQTT messages ${tc}
     [Documentation]    Check Mosquitto MQTT messages
-    [Tags]    eclipse    mosquitto    mqtt   notauto
+    [Tags]    eclipse    mosquitto    mqtt    notauto
     ${command}    Catenate
     ...    ${CMD}
     ...    --warning-messages-stored=${warning-stored}

--- a/tests/apps/eclipse/mosquitto/mqtt/messages.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/messages.robot
@@ -40,20 +40,15 @@ Mosquitto MQTT messages ${tc}
     [Tags]    eclipse    mosquitto    mqtt    notauto
     ${command}    Catenate
     ...    ${CMD}
-    ...    --warning-messages-stored=${warning-stored}
-    ...    --critical-messages-stored=${critical-stored}
-    ...    --warning-messages-received=${warning-received}
-    ...    --critical-messages-received=${critical-received}
-    ...    --warning-messages-sent=${warning-sent}
-    ...    --critical-messages-sent=${critical-sent}
+    ...    ${extraoptions}
 
     Ctn Run Command And Check Result As Regexp    ${command}    ${expected_result}
 
-    Examples:    tc    warning-stored     critical-stored    warning-received    critical-received    warning-sent    critical-sent    expected_result    --
-        ...      1     ${EMPTY}           ${EMPTY}           ${EMPTY}            ${EMPTY}             ${EMPTY}        ${EMPTY}         ^OK: Stored messages: \\\\d+, Received messages: \\\\d+, Sent messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
-        ...      2     @0:                ${EMPTY}           ${EMPTY}            ${EMPTY}             ${EMPTY}        ${EMPTY}         ^WARNING: Stored messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;@0:;;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
-        ...      3     ${EMPTY}           @0:                ${EMPTY}            ${EMPTY}             ${EMPTY}        ${EMPTY}         ^CRITICAL: Stored messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;@0:;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
-        ...      4     ${EMPTY}           ${EMPTY}           @0:                 ${EMPTY}             ${EMPTY}        ${EMPTY}         ^WARNING: Received messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;@0:;;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
-        ...      5     ${EMPTY}           ${EMPTY}           ${EMPTY}            @0:                  ${EMPTY}        ${EMPTY}         ^CRITICAL: Received messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;;@0:;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
-        ...      6     ${EMPTY}           ${EMPTY}           ${EMPTY}            ${EMPTY}             @0:             ${EMPTY}         ^WARNING: Sent messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;@0:;;\\\\d+;$
-        ...      7     ${EMPTY}           ${EMPTY}           ${EMPTY}            ${EMPTY}             ${EMPTY}        @0:              ^CRITICAL: Sent messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;;@0:;\\\\d+;$
+    Examples:    tc   extraoptions                         expected_result    --
+        ...      1     ${EMPTY}                            ^OK: Stored messages: \\\\d+, Received messages: \\\\d+, Sent messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
+        ...      2     --warning-messages-stored=@0:       ^WARNING: Stored messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;@0:;;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
+        ...      3     --critical-messages-stored=@0:      ^CRITICAL: Stored messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;@0:;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
+        ...      4     --warning-messages-received=@0:     ^WARNING: Received messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;@0:;;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
+        ...      5     --critical-messages-received=@0:    ^CRITICAL: Received messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;;@0:;\\\\d+; 'sent_messages'=\\\\d+;;;\\\\d+;$
+        ...      6     --warning-messages-sent=@0:         ^WARNING: Sent messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;@0:;;\\\\d+;$
+        ...      7     --critical-messages-sent=@0:        ^CRITICAL: Sent messages: \\\\d+ \\\\| 'stored_messages'=\\\\d+;;;\\\\d+; 'received_messages'=\\\\d+;;;\\\\d+; 'sent_messages'=\\\\d+;;@0:;\\\\d+;$

--- a/tests/apps/eclipse/mosquitto/mqtt/messages.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/messages.robot
@@ -32,8 +32,7 @@ Mosquitto MQTT messages help
     ...    ${CMD}
     ...    --help
 
-    ${output}    Run    ${command}
-    ${output}    Strip String    ${output}
+    Ctn Run Command And Check Result As Regexp    ${command}    ^Plugin Description:
 
 Mosquitto MQTT messages ${tc}
     [Documentation]    Check Mosquitto MQTT messages

--- a/tests/apps/eclipse/mosquitto/mqtt/numeric-value.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/numeric-value.robot
@@ -40,7 +40,23 @@ Mosquitto MQTT numeric-value ${tc}
     [Tags]    eclipse    mosquitto    mqtt    notauto
     ${command}    Catenate
     ...    ${CMD}
-    ...    --warning-uptime=${warning}
-    ...    --critical-uptime=${critical}
+    ...    --topic='${topic}'
+    ...    --warning=${warning}
+    ...    --critical=${critical}
+    ...    --extracted-pattern='${extracted_pattern}'
+    ...    --format='${format}'
+    ...    --format-custom='${format_custom}'
+    ...    --perfdata-unit=${perfdata_unit}
+    ...    --perfdata-name=${perfdata_name}
+    ...    --perfdata-min=${perfdata_min}
+    ...    --perfdata-max=${perfdata_max}
 
     Ctn Run Command And Check Result As Regexp    ${command}    ${expected_result}
+
+    Examples:    tc    topic                         warning     critical    extracted_pattern     format                         format_custom    perfdata_unit    perfdata_name     perfdata_min    perfdata_max    expected_result    --
+        ...      1     $SYS/broker/messages/sent     ${EMPTY}    ${EMPTY}    ${EMPTY}              current value is %s            ${EMPTY}         ${EMPTY}         value             ${EMPTY}        ${EMPTY}        ^OK: current value is \\\\d* \\\\| 'value'=\\\\d*;;;;$
+        ...      2     $SYS/broker/uptime            ${EMPTY}    ${EMPTY}    ^(\\\\d+) seconds$    current uptime is %ss          ${EMPTY}         s                uptime            ${EMPTY}        ${EMPTY}        ^OK: current uptime is \\\\d*s \\\\| 'uptime'=\\\\d*s;;;;$
+        ...      3     $SYS/broker/uptime            ${EMPTY}    ${EMPTY}    ^(\\\\d+) seconds$    current uptime is %sm          / 60             m                uptime            ${EMPTY}        ${EMPTY}        ^OK: current uptime is \\\\d*(\\\\.\\\\d*)?m \\\\| 'uptime'=\\\\d*(\\\\.\\\\d*)?m;;;;$
+        ...      4     $SYS/broker/clients/total     ${EMPTY}    ${EMPTY}    ${EMPTY}              there are %s total clients     + 2 / 2          ${EMPTY}         clients.total     0               2               ^OK: there are \\\\d* total clients \\\\| 'clients.total'=\\\\d*;;;0;2$
+        ...      5     $SYS/broker/clients/active    1           ${EMPTY}    ${EMPTY}              there are %s active clients    + 2              ${EMPTY}         clients.active    0               3               ^WARNING: there are \\\\d* active clients \\\\| 'clients.active'=\\\\d*;0:1;;0;3$
+        ...      6     $SYS/broker/clients/active    ${EMPTY}    1           ${EMPTY}              there are %s active clients    + 2              ${EMPTY}         clients.active    0               3               ^CRITICAL: there are \\\\d* active clients \\\\| 'clients.active'=\\\\d*;;0:1;0;3$

--- a/tests/apps/eclipse/mosquitto/mqtt/numeric-value.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/numeric-value.robot
@@ -1,11 +1,9 @@
 *** Settings ***
-Documentation       Eclipse Mosquitto MQTT plugin tests
+Documentation       Checks Eclipse Mosquitto MQTT plugin numeric-value mode
 
 Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
 
 Test Timeout        120s
-
-Keyword Tags        notauto
 
 
 *** Variables ***
@@ -14,17 +12,35 @@ ${MQTT_PORT}                8883
 ${MQTT_CA_CERTIFICATE}      /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/ca.crt
 ${MQTT_SSL_CERTIFICATE}     /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/client.crt
 ${MQTT_SSL_KEY}             /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/client.key
-${CMD}                      ${CENTREON_PLUGINS} --plugin=apps::eclipse::mosquitto::mqtt::plugin --hostname=${HOSTNAME} --mqtt-port=${MQTT_PORT} --mqtt-ca-certificate=${MQTT_CA_CERTIFICATE} --mqtt-ssl-certificate=${MQTT_SSL_CERTIFICATE} --mqtt-ssl-key=${MQTT_SSL_KEY}
+
+${CMD}                      ${CENTREON_PLUGINS}
+...                         --plugin=apps::eclipse::mosquitto::mqtt::plugin
+...                         --mode=numeric-value
+...                         --hostname=${HOSTNAME}
+...                         --mqtt-port=${MQTT_PORT}
+...                         --mqtt-ca-certificate=${MQTT_CA_CERTIFICATE}
+...                         --mqtt-ssl-certificate=${MQTT_SSL_CERTIFICATE}
+...                         --mqtt-ssl-key=${MQTT_SSL_KEY}
+...                         --mqtt-timeout=10
 
 
 *** Test Cases ***
-Mosquitto MQTT numeric-value
-    [Documentation]    Check Mosquitto MQTT uptime
+Mosquitto MQTT numeric-value help
+    [Documentation]    Check Mosquitto MQTT numeric-value help
     [Tags]    eclipse    mosquitto    mqtt
     ${command}    Catenate
     ...    ${CMD}
-    ...    --mode=numeric-value
     ...    --help
 
     ${output}    Run    ${command}
     ${output}    Strip String    ${output}
+
+Mosquitto MQTT numeric-value ${tc}
+    [Documentation]    Check Mosquitto MQTT numeric-value
+    [Tags]    eclipse    mosquitto    mqtt    notauto
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    --warning-uptime=${warning}
+    ...    --critical-uptime=${critical}
+
+    Ctn Run Command And Check Result As Regexp    ${command}    ${expected_result}

--- a/tests/apps/eclipse/mosquitto/mqtt/numeric-value.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/numeric-value.robot
@@ -32,8 +32,7 @@ Mosquitto MQTT numeric-value help
     ...    ${CMD}
     ...    --help
 
-    ${output}    Run    ${command}
-    ${output}    Strip String    ${output}
+    Ctn Run Command And Check Result As Regexp    ${command}    ^Plugin Description:
 
 Mosquitto MQTT numeric-value ${tc}
     [Documentation]    Check Mosquitto MQTT numeric-value

--- a/tests/apps/eclipse/mosquitto/mqtt/string-value.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/string-value.robot
@@ -1,11 +1,9 @@
 *** Settings ***
-Documentation       Eclipse Mosquitto MQTT plugin tests
+Documentation       Checks Eclipse Mosquitto MQTT plugin string-value mode
 
 Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
 
 Test Timeout        120s
-
-Keyword Tags        notauto
 
 
 *** Variables ***
@@ -14,17 +12,48 @@ ${MQTT_PORT}                8883
 ${MQTT_CA_CERTIFICATE}      /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/ca.crt
 ${MQTT_SSL_CERTIFICATE}     /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/client.crt
 ${MQTT_SSL_KEY}             /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/client.key
-${CMD}                      ${CENTREON_PLUGINS} --plugin=apps::eclipse::mosquitto::mqtt::plugin --hostname=${HOSTNAME} --mqtt-port=${MQTT_PORT} --mqtt-ca-certificate=${MQTT_CA_CERTIFICATE} --mqtt-ssl-certificate=${MQTT_SSL_CERTIFICATE} --mqtt-ssl-key=${MQTT_SSL_KEY}
+
+${CMD}                      ${CENTREON_PLUGINS}
+...                         --plugin=apps::eclipse::mosquitto::mqtt::plugin
+...                         --mode=string-value
+...                         --hostname=${HOSTNAME}
+...                         --mqtt-port=${MQTT_PORT}
+...                         --mqtt-ca-certificate=${MQTT_CA_CERTIFICATE}
+...                         --mqtt-ssl-certificate=${MQTT_SSL_CERTIFICATE}
+...                         --mqtt-ssl-key=${MQTT_SSL_KEY}
+...                         --mqtt-timeout=10
 
 
 *** Test Cases ***
-Mosquitto MQTT string-value
-    [Documentation]    Check Mosquitto MQTT uptime
+Mosquitto MQTT string-value help
+    [Documentation]    Check Mosquitto MQTT string-value help
     [Tags]    eclipse    mosquitto    mqtt
     ${command}    Catenate
     ...    ${CMD}
-    ...    --mode=string-value
     ...    --help
 
     ${output}    Run    ${command}
     ${output}    Strip String    ${output}
+
+Mosquitto MQTT string-value ${tc}
+    [Documentation]    Check Mosquitto MQTT string-value
+    [Tags]    eclipse    mosquitto    mqtt    notauto
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    --topic='${topic}'
+    ...    --warning-regexp='${warning}'
+    ...    --critical-regexp='${critical}'
+    ...    ${extraoptions}
+
+    Ctn Run Command And Check Result As Regexp    ${command}    ${expected_result}
+
+    Examples:   tc    topic                 warning        critical                          extraoptions                                         expected_result    --
+        ...     1    $SYS/broker/version    ${EMPTY}       ${EMPTY}                          ${EMPTY}                                             ^OK: value: mosquitto version \\\\d*\.\\\\d*\.\\\\d*$
+        ...     2    $SYS/broker/version    version 2.*    ${EMPTY}                          ${EMPTY}                                             ^WARNING: value: mosquitto version \\\\d*\.\\\\d*\.\\\\d*$
+        ...     3    $SYS/broker/version    ${EMPTY}       version 2.*                       ${EMPTY}                                             ^CRITICAL: value: mosquitto version \\\\d*\.\\\\d*\.\\\\d*$
+        ...     4    $SYS/broker/version    ${EMPTY}       MOSQUITTO.*2\.                    --regexp-insensitive                                 ^CRITICAL: value: mosquitto version \\\\d*\.\\\\d*\.\\\\d*$
+        ...     5    $SYS/broker/uptime     ${EMPTY}       ^\\\\d(\\\\d{1,}\\\\sSECOND)S$    ${EMPTY}                                             ^OK: value: \\\\d* seconds$
+        ...     6    $SYS/broker/uptime     ${EMPTY}       ^\\\\d(\\\\d{1,}\\\\sSECOND)S$    --regexp-insensitive                                 ^CRITICAL: value: \\\\d* seconds$
+        ...     7    $SYS/broker/version    ${EMPTY}       ${EMPTY}                          --format-ok='Value \\\%{value} is ok'                ^OK: Value mosquitto version \\\\d*\.\\\\d*\.\\\\d* is ok$
+        ...     8    $SYS/broker/version    version 2.*    ${EMPTY}                          --format-warning='Value \\\%{value} is a warning'    ^WARNING: Value mosquitto version \\\\d*\.\\\\d*\.\\\\d* is a warning$
+        ...     9    $SYS/broker/version    ${EMPTY}       version 2.*                       --format-critical='Value \\\%{value} is critical'    ^CRITICAL: Value mosquitto version \\\\d*\.\\\\d*\.\\\\d* is critical$

--- a/tests/apps/eclipse/mosquitto/mqtt/string-value.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/string-value.robot
@@ -32,8 +32,7 @@ Mosquitto MQTT string-value help
     ...    ${CMD}
     ...    --help
 
-    ${output}    Run    ${command}
-    ${output}    Strip String    ${output}
+    Ctn Run Command And Check Result As Regexp    ${command}    ^Plugin Description:
 
 Mosquitto MQTT string-value ${tc}
     [Documentation]    Check Mosquitto MQTT string-value

--- a/tests/apps/eclipse/mosquitto/mqtt/uptime.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/uptime.robot
@@ -40,12 +40,11 @@ Mosquitto MQTT uptime ${tc}
     [Tags]    eclipse    mosquitto    mqtt    notauto
     ${command}    Catenate
     ...    ${CMD}
-    ...    --warning-uptime=${warning}
-    ...    --critical-uptime=${critical}
+    ...    ${extraoptions}
 
     Ctn Run Command And Check Result As Regexp    ${command}    ${expected_result}
 
-    Examples:    tc    warning     critical    expected_result    --
-        ...      1     ${EMPTY}    ${EMPTY}    ^OK: uptime is:( \\\\d+d)?( \\\\d+h)?( \\\\d+m)?( \\\\d+s)? \\\\| 'uptime'=\\\\d+s;;;\\\\d+;$
-        ...      2     1           ${EMPTY}    ^WARNING: uptime is:( \\\\d+d)?( \\\\d+h)?( \\\\d+m)?( \\\\d+s)? \\\\| 'uptime'=\\\\d+s;0:1;;\\\\d+;$
-        ...      3     ${EMPTY}    1           ^CRITICAL: uptime is:( \\\\d+d)?( \\\\d+h)?( \\\\d+m)?( \\\\d+s)? \\\\| 'uptime'=\\\\d+s;;0:1;\\\\d+;$
+    Examples:    tc    extraoptions           expected_result    --
+        ...      1     ${EMPTY}               ^OK: uptime is:( \\\\d+d)?( \\\\d+h)?( \\\\d+m)?( \\\\d+s)? \\\\| 'uptime'=\\\\d+s;;;\\\\d+;$
+        ...      2     --warning-uptime=1     ^WARNING: uptime is:( \\\\d+d)?( \\\\d+h)?( \\\\d+m)?( \\\\d+s)? \\\\| 'uptime'=\\\\d+s;0:1;;\\\\d+;$
+        ...      3     --critical-uptime=1    ^CRITICAL: uptime is:( \\\\d+d)?( \\\\d+h)?( \\\\d+m)?( \\\\d+s)? \\\\| 'uptime'=\\\\d+s;;0:1;\\\\d+;$

--- a/tests/apps/eclipse/mosquitto/mqtt/uptime.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/uptime.robot
@@ -1,11 +1,9 @@
 *** Settings ***
-Documentation       Eclipse Mosquitto MQTT plugin tests
+Documentation       Checks Eclipse Mosquitto MQTT plugin uptime mode
 
 Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
 
 Test Timeout        120s
-
-Keyword Tags        notauto
 
 
 *** Variables ***
@@ -14,17 +12,40 @@ ${MQTT_PORT}                8883
 ${MQTT_CA_CERTIFICATE}      /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/ca.crt
 ${MQTT_SSL_CERTIFICATE}     /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/client.crt
 ${MQTT_SSL_KEY}             /home/code/tests/robot/apps/eclipse/mosquitto/mqtt/certs/client.key
-${CMD}                      ${CENTREON_PLUGINS} --plugin=apps::eclipse::mosquitto::mqtt::plugin --hostname=${HOSTNAME} --mqtt-port=${MQTT_PORT} --mqtt-ca-certificate=${MQTT_CA_CERTIFICATE} --mqtt-ssl-certificate=${MQTT_SSL_CERTIFICATE} --mqtt-ssl-key=${MQTT_SSL_KEY}
+
+${CMD}                      ${CENTREON_PLUGINS}
+...                         --plugin=apps::eclipse::mosquitto::mqtt::plugin
+...                         --mode=uptime
+...                         --hostname=${HOSTNAME}
+...                         --mqtt-port=${MQTT_PORT}
+...                         --mqtt-ca-certificate=${MQTT_CA_CERTIFICATE}
+...                         --mqtt-ssl-certificate=${MQTT_SSL_CERTIFICATE}
+...                         --mqtt-ssl-key=${MQTT_SSL_KEY}
+...                         --mqtt-timeout=10
 
 
 *** Test Cases ***
-Mosquitto MQTT uptime
-    [Documentation]    Check Mosquitto MQTT uptime
+Mosquitto MQTT uptime help
+    [Documentation]    Check Mosquitto MQTT uptime help
     [Tags]    eclipse    mosquitto    mqtt
     ${command}    Catenate
     ...    ${CMD}
-    ...    --mode=uptime
     ...    --help
 
     ${output}    Run    ${command}
     ${output}    Strip String    ${output}
+
+Mosquitto MQTT uptime ${tc}
+    [Documentation]    Check Mosquitto MQTT uptime
+    [Tags]    eclipse    mosquitto    mqtt    notauto
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    --warning-uptime=${warning}
+    ...    --critical-uptime=${critical}
+
+    Ctn Run Command And Check Result As Regexp    ${command}    ${expected_result}
+
+    Examples:    tc    warning     critical    expected_result    --
+        ...      1     ${EMPTY}    ${EMPTY}    ^OK: uptime is:( \\\\d+d)?( \\\\d+h)?( \\\\d+m)?( \\\\d+s)? \\\\| 'uptime'=\\\\d+s;;;\\\\d+;$
+        ...      2     1           ${EMPTY}    ^WARNING: uptime is:( \\\\d+d)?( \\\\d+h)?( \\\\d+m)?( \\\\d+s)? \\\\| 'uptime'=\\\\d+s;0:1;;\\\\d+;$
+        ...      3     ${EMPTY}    1           ^CRITICAL: uptime is:( \\\\d+d)?( \\\\d+h)?( \\\\d+m)?( \\\\d+s)? \\\\| 'uptime'=\\\\d+s;;0:1;\\\\d+;$

--- a/tests/apps/eclipse/mosquitto/mqtt/uptime.robot
+++ b/tests/apps/eclipse/mosquitto/mqtt/uptime.robot
@@ -32,8 +32,7 @@ Mosquitto MQTT uptime help
     ...    ${CMD}
     ...    --help
 
-    ${output}    Run    ${command}
-    ${output}    Strip String    ${output}
+    Ctn Run Command And Check Result As Regexp    ${command}    ^Plugin Description:
 
 Mosquitto MQTT uptime ${tc}
     [Documentation]    Check Mosquitto MQTT uptime


### PR DESCRIPTION
## Description

Fix Mosquitto MQTT numeric-value mode.

**Fixes** CTOR-1447

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [x] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [x] I have reviewed all the help messages in all the .pm files I have modified.
  - [x] All sentences begin with a capital letter.
  - [x] All sentences end with a period.
  - [x] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
