### PR TITLE
Ctor-1217-mysql-contribution-add-uptime-in-output

### DIFF
--- a/src/database/mysql/mode/uptime.pm
+++ b/src/database/mysql/mode/uptime.pm
@@ -31,8 +31,8 @@ sub new {
     my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
 
-    # Ajout des options spécifiques à ce mode
-    $options{options}->add_options(arguments => { 
+    # Adding options specific to this mode
+    $options{options}->add_options(arguments => {
         "warning:s"  => { name => 'warning' },
         "critical:s" => { name => 'critical' },
         "seconds"    => { name => 'seconds' }
@@ -45,10 +45,13 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::init(%options);
 
+    # Validating warning threshold
     if (($self->{perfdata}->threshold_validate(label => 'warning', value => $self->{option_results}->{warning})) == 0) {
         $self->{output}->add_option_msg(short_msg => "Wrong warning threshold '" . $self->{option_results}->{warning} . "'.");
         $self->{output}->option_exit();
     }
+
+    # Validating critical threshold
     if (($self->{perfdata}->threshold_validate(label => 'critical', value => $self->{option_results}->{critical})) == 0) {
         $self->{output}->add_option_msg(short_msg => "Wrong critical threshold '" . $self->{option_results}->{critical} . "'.");
         $self->{output}->option_exit();
@@ -58,38 +61,45 @@ sub check_options {
 sub run {
     my ($self, %options) = @_;
 
-    $options{sql}->connect();    
+    $options{sql}->connect();
 
+    # Checking if MySQL version is supported
     if (!($options{sql}->is_version_minimum(version => '5'))) {
         $self->{output}->add_option_msg(short_msg => "MySQL version '" . $self->{sql}->{version} . "' is not supported (need version >= '5.x').");
         $self->{output}->option_exit();
     }
 
+    # Querying MySQL for Uptime status
     $options{sql}->query(query => q{SHOW /*!50000 global */ STATUS LIKE 'Uptime'});
     my ($name, $value) = $options{sql}->fetchrow_array();
-    
+
+    # Handling case where uptime value is not available
     if (!defined($value)) {
         $self->{output}->add_option_msg(short_msg => "Cannot get uptime.");
         $self->{output}->option_exit();
     }
 
+    # Checking the threshold and determining exit code
     my $exit_code = $self->{perfdata}->threshold_check(value => $value, threshold => [ { label => 'critical', exit_litteral => 'critical' }, { label => 'warning', exit_litteral => 'warning' } ]);
 
+    # Calculating uptime in days or seconds based on user preference
     my $uptime_days = floor($value / 86400);
     my $msg = sprintf("database is up since %d days", $uptime_days);
     if (defined($self->{option_results}->{seconds})) {
         $msg = sprintf("database is up since %d seconds", $value);
     }
 
+    # Adding start time information to the message
     $msg .= sprintf(" (Start time = %s)", strftime("%Y/%m/%d %H:%M:%S", localtime(time - $value)));
 
+    # Adding output message and performance data
     $self->{output}->output_add(
         severity => $exit_code,
         short_msg => $msg
     );
 
     $self->{output}->perfdata_add(
-        label => 'uptime', 
+        label => 'uptime',
         nlabel => 'database.uptime.seconds',
         unit => 's',
         value => $value,
@@ -98,6 +108,7 @@ sub run {
         min => 0
     );
 
+    # Displaying the output and exiting
     $self->{output}->display();
 
     $self->{output}->exit();
@@ -106,7 +117,6 @@ sub run {
 1;
 
 __END__
-
 
 =head1 MODE
 


### PR DESCRIPTION
## Description
external contribution from #4853, thanks @SavCent 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

manual test for now as it is on a database

checkout the branch and run : 
``` 
sudo perl src/centreon_plugins.pl --plugin='database::mysql::plugin' --mode='uptime' --datasource='mysql:mysql' --critical='9' --warning='5' ```

It will test the local database without any authentication : 

CRITICAL: database is up since 0 days (Start time = 2025/04/02 09:51:29) | 'database.uptime.seconds'=8348s;0:5;0:9;0;

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
