### PR TITLE
add hashicorp nomad plugin

### DIFF
--- a/src/apps/hashicorp/nomad/restapi/custom/api.pm
+++ b/src/apps/hashicorp/nomad/restapi/custom/api.pm
@@ -1,0 +1,258 @@
+package apps::hashicorp::nomad::restapi::custom::api;
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use centreon::plugins::statefile;
+use JSON::XS;
+use Digest::MD5 qw(md5_hex);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self  = {};
+    bless $self, $class;
+
+    if (!defined($options{output})) {
+        print "Class Custom: Need to specify 'output' argument.\n";
+        exit 3;
+    };
+    if (!defined($options{options})) {
+        $options{output}->add_option_msg(short_msg => "Class Custom: Need to specify 'options' argument.");
+        $options{output}->option_exit();
+    };
+
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            'api-version:s'          => { name => 'api_version' },
+            'critical-http-status:s' => { name => 'critical_http_status' },
+            'hostname:s'             => { name => 'hostname' },
+            'port:s'                 => { name => 'port' },
+            'proto:s'                => { name => 'proto' },
+            'warning-http-status:s'  => { name => 'warning_http_status' },
+            'unknown-http-status:s'  => { name => 'unknown_http_status' },
+            'nomad-token:s'         => { name => 'nomad_token'}
+        });
+    };
+    $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
+
+    $self->{output} = $options{output};
+    $self->{http} = centreon::plugins::http->new(%options);
+    $self->{cache} = centreon::plugins::statefile->new(%options);
+
+    return $self;
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+
+    $self->{option_results} = $options{option_results};
+}
+
+sub set_defaults {}
+
+sub check_options {
+    my ($self, %options) = @_;
+
+    if (defined($options{option_results}->{auth_path})) {		
+        $self->{auth_path} = lc($options{option_results}->{auth_path});
+    };
+
+    $self->{hostname} = (defined($self->{option_results}->{hostname})) ? $self->{option_results}->{hostname} : '';
+    $self->{port} = (defined($self->{option_results}->{port})) ? $self->{option_results}->{port} : 4646;
+    $self->{proto} = (defined($self->{option_results}->{proto})) ? $self->{option_results}->{proto} : 'http';
+    $self->{timeout} = (defined($self->{option_results}->{timeout})) ? $self->{option_results}->{timeout} : 10;
+    $self->{nomad_token} = $self->{option_results}->{nomad_token};
+    $self->{api_version} = (defined($self->{option_results}->{api_version})) ? $self->{option_results}->{api_version} : 'v1';
+    $self->{unknown_http_status} = (defined($self->{option_results}->{unknown_http_status})) ? $self->{option_results}->{unknown_http_status} : '%{http_code} < 200 or %{http_code} >= 300';
+    $self->{warning_http_status} = (defined($self->{option_results}->{warning_http_status})) ? $self->{option_results}->{warning_http_status} : '';
+    $self->{critical_http_status} = (defined($self->{option_results}->{critical_http_status})) ? $self->{option_results}->{critical_http_status} : '';
+    $self->{reload_cache_time} = (defined($self->{option_results}->{reload_cache_time})) ? $self->{option_results}->{reload_cache_time} : 180;
+    $self->{cache}->check_options(option_results => $self->{option_results});
+
+    return 0;
+}
+
+sub build_options_for_httplib {
+    my ($self, %options) = @_;
+
+    $self->{option_results}->{hostname} = $self->{hostname};
+    $self->{option_results}->{timeout} = $self->{timeout};
+    $self->{option_results}->{port} = $self->{port};
+    $self->{option_results}->{proto} = $self->{proto};
+    $self->{option_results}->{timeout} = $self->{timeout};
+    $self->{option_results}->{basic} = 1;
+}
+
+sub settings {
+    my ($self, %options) = @_;
+
+    return if (defined($self->{settings_done}));
+    $self->build_options_for_httplib();
+    $self->{http}->add_header(key => 'Accept', value => 'application/json');
+
+    if (defined($self->{option_results}->{auth_method}) && $self->{option_results}->{auth_method} ne 'token') {
+        $self->{nomad_token} = $self->get_access_token(statefile => $self->{cache});
+    };
+
+    if (defined($self->{nomad_token})) {
+        $self->{http}->add_header(key => 'X-Nomad-Token', value => $self->{nomad_token});
+    };
+
+    $self->{http}->set_options(%{$self->{option_results}});
+
+
+    $self->{settings_done} = 1;
+}
+
+sub get_hostname {
+    my ($self, %options) = @_;
+
+    return $self->{hostname};
+}
+
+sub get_access_token {
+    my ($self, %options) = @_;
+
+
+    my $has_cache_file = $options{statefile}->read(statefile => 'nomad_restapi_' . md5_hex($self->{hostname}) . '_' . md5_hex($self->{auth_method}));
+    my $expires_on = $options{statefile}->get(name => 'expires_on');
+    my $access_token = $options{statefile}->get(name => 'access_token');
+    if ( $has_cache_file == 0 || !defined($access_token) || (($expires_on - time()) < 10) ) {
+        my $decoded;
+        my $login = $self->parse_auth_method(method => $self->{auth_method}, settings => $self->{auth_settings});
+        my $post_json = JSON::XS->new->utf8->encode($login);
+        if (!defined($self->{auth_path}) || $self->{auth_path} eq '') {
+            $self->{auth_path} = $self->{auth_method};
+        }
+        my $url_path = '/' . $self->{api_version} . '/auth/'. $self->{auth_path} . '/login/';
+        $url_path .= $self->{auth_settings}->{username} if (defined($self->{auth_settings}->{username}) && $self->{auth_method} =~ 'userpass|login') ;
+
+        my $content = $self->{http}->request(
+            hostname => $self->{hostname},
+            port => $self->{port},
+            proto => $self->{proto},
+            method => 'POST',
+            header => ['Content-type: application/json'],
+            query_form_post => $post_json,
+            url_path => $url_path
+        );
+
+        if (!defined($content) || $content eq '') {
+            $self->{output}->add_option_msg(short_msg => "Authentication endpoint returns empty content [code: '" . $self->{http}->get_code() . "'] [message: '" . $self->{http}->get_message() . "']");
+            $self->{output}->option_exit();
+        };
+
+        eval {
+            $decoded = JSON::XS->new->utf8->decode($content);
+        };
+        if ($@) {
+            $self->{output}->output_add(long_msg => $content, debug => 1);
+            $self->{output}->add_option_msg(short_msg => "Cannot decode response (add --debug option to display returned content)");
+            $self->{output}->option_exit();
+        };
+        if (defined($decoded->{errors}[0])) {
+            $self->{output}->output_add(long_msg => "Error message : " . $decoded->{errors}[0], debug => 1);
+            $self->{output}->add_option_msg(short_msg => "Authentication endpoint returns error code '" . $decoded->{errors}[0] . "' (add --debug option for detailed message)");
+            $self->{output}->option_exit();
+        };
+        $access_token = $decoded->{auth}->{client_token};
+        my $datas = { last_timestamp => time(), access_token => $decoded->{access_token}, expires_on => time() + 3600 };
+        $options{statefile}->write(data => $datas);
+    };
+
+    return $access_token;
+}
+
+sub parse_auth_method {
+    my ($self, %options) = @_;
+
+    my $login_settings;
+    my $settings_mapping = {
+        azure    => [ 'role', 'jwt' ],
+        cert     => [ 'name' ],
+        github   => [ 'token' ],
+        ldap     => [ 'username', 'password' ],
+        okta     => [ 'username', 'password', 'totp' ],
+        radius   => [ 'username', 'password' ],
+        userpass => [ 'username', 'password' ]
+    };
+
+    foreach (@{$settings_mapping->{$options{method}}}) {
+        if (!defined($options{settings}->{$_})) {
+            $self->{output}->add_option_msg(short_msg => 'Missing authentication setting: ' . $_);
+            $self->{output}->option_exit();
+        }
+        $login_settings->{$_} = $options{settings}->{$_};
+    };
+
+    return $login_settings;
+}
+
+sub request_api {
+    my ($self, %options) = @_;
+
+    $self->settings(%options);
+    my ($json, $response);
+
+    $response = $self->{http}->request(
+        method => 'GET',
+        url_path => '/' . $self->{api_version} . '/' . $options{url_path}
+    );
+    $self->{output}->output_add(long_msg => $response, debug => 1);
+
+    eval {
+        $json = JSON::XS->new->utf8->decode($response);
+    };
+    if ($@) {
+        $self->{output}->add_option_msg(short_msg => "Cannot decode Nomad JSON response: $@");
+        $self->{output}->option_exit();
+    };
+
+    return $json;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+HashiCorp Nomad Rest API
+
+=head1 REST API OPTIONS
+
+HashiCorp Nomad Rest API
+
+=over 8
+
+=item B<--hostname>
+
+HashiCorp Nomad hostname.
+
+=item B<--port>
+
+Port used (default: 4646)
+
+=item B<--proto>
+
+Specify https if needed (default: 'http')
+
+=item B<--api-version>
+
+Specify the Nomad API version (default: 'v1')
+
+=item B<--nomad-token>
+
+Specify the Nomad access token (only for the 'token' authentication method)
+
+=item B<--timeout>
+
+Set timeout in seconds (default: 10).
+
+=back
+
+=head1 DESCRIPTION
+
+B<custom>.
+
+=cut

--- a/src/apps/hashicorp/nomad/restapi/mode/health.pm
+++ b/src/apps/hashicorp/nomad/restapi/mode/health.pm
@@ -1,0 +1,100 @@
+package apps::hashicorp::nomad::restapi::mode::health;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'nomad_cluster', type => 1, cb_prefix_output => 'custom_prefix_output'},
+    ];
+
+    $self->{maps_counters}->{nomad_cluster} = [
+        { label => 'client-status', type => 2, critical_default => '%{client} ne "ok"', set => {
+                key_values => [ { name => 'client' } ],
+                output_template => "client status : %s",
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        },
+        { label => 'server-status', type => 2, critical_default => '%{server} ne "ok"', set => {
+                key_values => [ { name => 'server' } ],
+                output_template => "server status : %s",
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub custom_prefix_output {
+    my ($self, %options) = @_;
+
+    return 'Nomad ';
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+    });
+
+    return $self;
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(url_path => 'agent/health');
+
+    $self->{nomad_cluster}->{$self->{option_results}->{hostname}} = {
+        client => $result->{client}->{ok} ? 'ok' : 'not ok',
+        server => $result->{server}->{ok} ? 'ok' : 'not ok',
+    };
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Hashicorp Nomad Health status.
+
+Example:
+perl centreon_plugins.pl --plugin=apps::hashicorp::nomad::restapi::plugin --mode=health
+--hostname=10.0.0.1 --nomad-token='s.aBCD123DEF456GHI789JKL012' --verbose
+
+More information on'https://developer.hashicorp.com/nomad/api-docs/agent#health'.
+
+=over 8
+
+=item B<--warning-client-status>
+
+Set warning threshold for status (default: none).
+
+=item B<--critical-client-status>
+
+Set critical threshold for seal status (default: '%{client} ne "ok"').
+
+=item B<--warning-server-status>
+
+Set warning threshold for status (default: none).
+
+=item B<--critical-server-status>
+
+Set critical threshold for seal status (default: '%{server} ne "ok"').
+
+=back
+
+=cut

--- a/src/apps/hashicorp/nomad/restapi/plugin.pm
+++ b/src/apps/hashicorp/nomad/restapi/plugin.pm
@@ -1,0 +1,28 @@
+package apps::hashicorp::nomad::restapi::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_custom);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{version} = '1.0';
+    $self->{modes} = {
+        'health'       => 'apps::hashicorp::nomad::restapi::mode::health',
+    };
+
+    $self->{custom_modes}->{api} = 'apps::hashicorp::nomad::restapi::custom::api';
+    return $self;
+}
+
+1;
+
+__END__
+=head1 PLUGIN DESCRIPTION
+
+Check HashiCorp Nomad using RestAPI.
+
+=cut


### PR DESCRIPTION
# Community contributors

## Description

Adding Hashicorp nomad plugin. This plugin is based from Hashicorp Vault plugin

**Fixes** # (issue)
If you are fixing a github Issue already existing, mention it here.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Create a nomad cluster, and check via the following command line:

```bash
# curl chech
curl https://<IP-or-hostname>:4646/v1/agent/health
```
output
```json
{"server":{"message":"ok","ok":true}, "client":{"message":"ok","ok":true}}
```
Depending on the configuration of your nomad cluster, you can either have only the `server` part, the `client` part, or both, whether or not your nomad agent are the same as your nomad server.
```bash
# centreon check
./centreon_plugins.pl --plugin='apps::hashicorp::nomad::restapi::plugin' --hostname='<IP-or-hostname>' --port='4646' --proto='https' --mode='health' --custommode='api' --api-version='v1' --ssl-opt='SSL_verify_mode => SSL_VERIFY_NONE' --nomad-token='<centreon-token>' --verbose
```
output
```
OK: Nomad client status : ok, server status : ok 
Nomad client status : ok, server status : ok
```
As saif before, depending on your nomad cluster config, you can have nomad client and server on different host. You can play with the centreon parameters `--critical-server-status` and `--critical-client-status` to correspond with your configuration

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] I have provide data or shown output displaying the result of this code in the plugin area concerned.

