### PR TITLE
Added option to filter by service path

### DIFF
--- a/src/snmp_standard/mode/listprocesses.pm
+++ b/src/snmp_standard/mode/listprocesses.pm
@@ -32,6 +32,7 @@ sub new {
     
     $options{options}->add_options(arguments => {
         'filter-name:s' => { name => 'filter_name' },
+        'filter-path:s' => { name => 'filter_path' },
         'add-stats'     => { name => 'add_stats' },
     });
 
@@ -105,6 +106,12 @@ sub manage_selection {
             next;
         }
 
+        if (defined($self->{option_results}->{filter_path}) && $self->{option_results}->{filter_path} ne '' &&
+            $result->{path} !~ /$self->{option_results}->{filter_path}/) {
+            $self->{output}->output_add(long_msg => "skipping '" . $result->{path} . "': no matching filter.", debug => 1);
+            next;
+        }
+
         $results->{$instance} = { %$result, pid => $instance };
     }
 
@@ -160,6 +167,10 @@ List processes.
 =item B<--filter-name>
 
 Filter by service name (can be a regexp).
+
+=item B<--filter-path>
+
+Filter by service path (can be a regexp).
 
 =item B<--add-stats>
 


### PR DESCRIPTION
# Community contributors

## Description

Added an option that allows filtering by service path.
This is an alternative to the current `--filter-name` option, that allows to filter content of **hrSWRunPath** 

## Type of change

- [X] New functionality (non-breaking change)

## How this pull request can be tested ?

* **SNMP**: MIB files and full snmpwalk of enterprise branch (`snmpwalk -ObentU -v 2c -c public address .1.3.6.1.4.1 > equipment.snmpwalk`) or [SNMP collections](https://thewatch.centreon.com/product-how-to-21/snmp-collection-tutorial-132).

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (develop).
- [X] I have provide data or shown output displaying the result of this code in the plugin area concerned.