### PR TITLE
fix(cloud::microsoft::office365::onedrive): change hash key in listsites mode

### DIFF
--- a/src/cloud/microsoft/office365/onedrive/mode/listsites.pm
+++ b/src/cloud/microsoft/office365/onedrive/mode/listsites.pm
@@ -61,7 +61,7 @@ sub manage_selection {
             next;
         }
 
-        $self->{sites}->{$site->{'Site URL'}} = {
+        $self->{sites}->{$site->{'Site Id'}} = {
             owner => $site->{'Owner Display Name'},
             url => $site->{'Site URL'},
         }


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

fix(cloud::microsoft::office365::onedrive): change hash key in listsites mode
REF: CTOR-1597

**Fixes** # (issue)
https://github.com/centreon/centreon-plugins/issues/5238

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Using datas provided in the Issue debug

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
