### PR TITLE
ci(secu): replace gitleaks secret and remove PRT

### DIFF
--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -104,7 +104,7 @@ jobs:
 
   get-environment:
     if: |
-      contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) &&
+      contains(fromJSON('["pull_request"]') , github.event_name) &&
       (startsWith(github.base_ref, 'release-') || startsWith(github.base_ref, 'hotfix-'))
     uses: ./.github/workflows/get-environment.yml
 
@@ -112,7 +112,7 @@ jobs:
     needs: [get-environment, check-status]
     runs-on: ubuntu-24.04
     if: |
-      contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) &&
+      contains(fromJSON('["pull_request"]') , github.event_name) &&
       needs.get-environment.outputs.target_stability == 'testing' &&
       ! contains(needs.get-environment.outputs.labels, 'skip-cherry-pick')
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -52,7 +52,7 @@ jobs:
             let hasSkipLabel = false;
             let labels = [];
 
-            if (${{ contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) }} === true) {
+            if (${{ contains(fromJSON('["pull_request"]') , github.event_name) }} === true) {
               try {
                 const fetchedLabels = await github.rest.issues.listLabelsOnIssue({
                   owner: context.repo.owner,

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: gitleaks/gitleaks-action@83373cf2f8c4db6e24b41c1a9b086bb9619e9cd3 # v2.3.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}}
+          GITLEAKS_LICENSE: "Centreon"
           GITLEAKS_ENABLE_COMMENTS: false
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
           GITLEAKS_ENABLE_SUMMARY: false

--- a/.github/workflows/set-pull-request-external-label.yml
+++ b/.github/workflows/set-pull-request-external-label.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_target:
+  pull_request:
 
 jobs:
   set-pull-request-external-label:

--- a/.github/workflows/set-pull-request-skip-label.yml
+++ b/.github/workflows/set-pull-request-skip-label.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   set-pull-request-skip-label:
-    if: ${{ success() && contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) }}
+    if: ${{ success() && contains(fromJSON('["pull_request"]') , github.event_name) }}
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
## Description

Remove secret in order to allow dependabot and external PR to be able to run the gitleaks mandatory workflow