### PR TITLE
add certs and key parameters to redis plugin

### DIFF
--- a/src/apps/redis/sentinel/custom/cli.pm
+++ b/src/apps/redis/sentinel/custom/cli.pm
@@ -49,6 +49,8 @@ sub new {
             'password:s'      => { name => 'password' },
             'tls'             => { name => 'tls' },
             'cacert:s'        => { name => 'cacert' },
+            'cert:s'          => { name => 'cert' },
+            'key:s'           => { name => 'key' },
             'insecure'        => { name => 'insecure' },
             'timeout:s'       => { name => 'timeout' }
         });
@@ -82,6 +84,8 @@ sub check_options {
     $self->{tls} = defined($self->{option_results}->{tls}) ? 1 : 0;
     $self->{insecure} = defined($self->{option_results}->{insecure}) ? 1 : 0;
     $self->{cacert} = defined($self->{option_results}->{cacert}) && $self->{option_results}->{cacert} ne '' ? $self->{option_results}->{cacert} : '';
+    $self->{cert} = defined($self->{option_results}->{cert}) && $self->{option_results}->{cert} ne '' ? $self->{option_results}->{cert} : '';
+    $self->{key} = defined($self->{option_results}->{key}) && $self->{option_results}->{key} ne '' ? $self->{option_results}->{key} : '';
 
     if ($self->{server} eq '') {
         $self->{output}->add_option_msg(short_msg => 'Need to specify --server option.');
@@ -159,6 +163,8 @@ sub get_extra_options {
     my $options = '';
     $options .= ' --tls' if ($self->{tls} == 1);
     $options .= " --cacert '" . $self->{cacert} . "'" if ($self->{cacert} ne '');
+    $options .= " --cert '" . $self->{cert} . "'" if ($self->{cert} ne '');
+    $options .= " --key '" . $self->{key} . "'" if ($self->{key} ne '');
     $options .= ' --insecure' if ($self->{insecure} == 1);
     $options .= " --user '" . $self->{username} . "'" if ($self->{username} ne '');
     $options .= " -a '" . $self->{password} . "'" if ($self->{password} ne '');
@@ -225,6 +231,14 @@ Establish a secure TLS connection (redis-cli >= 6.x mandatory).
 =item B<--cacert>
 
 CA Certificate file to verify with (redis-cli >= 6.x mandatory).
+
+=item B<--cert>
+
+Client certificate to authenticate with.
+
+=item B<--key>
+
+Private key file to authenticate with.
 
 =item B<--insecure>
 

--- a/src/database/redis/custom/cli.pm
+++ b/src/database/redis/custom/cli.pm
@@ -52,6 +52,8 @@ sub new {
             'service:s'       => { name => 'service' },
             'tls'             => { name => 'tls' },
             'cacert:s'        => { name => 'cacert' },
+            'cert:s'          => { name => 'cert' },
+            'key:s'           => { name => 'key' },
             'insecure'        => { name => 'insecure' },
             'timeout:s'       => { name => 'timeout' }
         });
@@ -86,6 +88,8 @@ sub check_options {
     $self->{tls} = defined($self->{option_results}->{tls}) ? 1 : 0;
     $self->{insecure} = defined($self->{option_results}->{insecure}) ? 1 : 0;
     $self->{cacert} = defined($self->{option_results}->{cacert}) && $self->{option_results}->{cacert} ne '' ? $self->{option_results}->{cacert} : '';
+    $self->{cert} = defined($self->{option_results}->{cert}) && $self->{option_results}->{cert} ne '' ? $self->{option_results}->{cert} : '';
+    $self->{key} = defined($self->{option_results}->{key}) && $self->{option_results}->{key} ne '' ? $self->{option_results}->{key} : '';
     $self->{sentinel} = [];
     if (defined($self->{option_results}->{sentinel})) {
         foreach my $addr (@{$self->{option_results}->{sentinel}}) {
@@ -172,6 +176,8 @@ sub get_extra_options {
     my $options = '';
     $options .= ' --tls' if ($self->{tls} == 1);
     $options .= " --cacert '" . $self->{cacert} . "'" if ($self->{cacert} ne '');
+    $options .= " --cert '" . $self->{cert} . "'" if ($self->{cert} ne '');
+    $options .= " --key '" . $self->{key} . "'" if ($self->{key} ne '');
     $options .= ' --insecure' if ($self->{insecure} == 1);
     $options .= " --user '" . $self->{username} . "'" if ($self->{username} ne '');
     $options .= " -a '" . $self->{password} . "'" if ($self->{password} ne '');
@@ -268,6 +274,14 @@ Establish a secure TLS connection (redis-cli >= 6.x mandatory).
 =item B<--cacert>
 
 CA Certificate file to verify with (redis-cli >= 6.x mandatory).
+
+=item B<--cert>
+
+Client certificate to authenticate with.
+
+=item B<--key>
+
+Private key file to authenticate with.
 
 =item B<--insecure>
 


### PR DESCRIPTION
# Community contributors

## Description

Add new parameters to database::redis::plugin in order to allow passing cert and key parameters to redis-cli. This is usefullwhen we're using self-signed certificate with redis.
This change is compatible with all redis mode and redis sentinel

**Fixes** # (issue)
If you are fixing a github Issue already existing, mention it here.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Setup a redis database with TLS configured with self-signed certificate.

```bash
# check redis with self signed certificate and without new params
./centreon_plugins.pl --plugin='database::redis::plugin' --server='127.0.0.1' --port='6379' --username='user' --password='password' --tls --cacert='ca.crt' --mode='memory' --custommode='cli' --verbose
# output
UNKNOWN: Command error: Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe. -  - I/O error -  - I/O error - Error: Server closed the connection 

# check redis with self signed certificate with new params
./centreon_plugins.pl --plugin='database::redis::plugin' --server='127.0.0.1' --port='6379' --username='user' --password='password' --tls --cacert='ca.crt' --cert='cert.crt' --key='cert.key' --mode='memory' --custommode='cli'  --verbose
# output
OK: used: 2.47 MB (0.13%) - rss: 17.05 MB (0.87%) - peak: 2.51 MB (0.13%) - overhead: 2.19 MB (0.11%) - startup: 1.04 MB (0.05%) - dataset: 285.95 KB (0.01%) - lua: 31.00 KB (0.00%) - fragmentation ratio: 6.97, defragmentation running: 0, lazyfree pending objects: 0 | 'memory.usage.bytes'=2586416B;;;0;2059177984 'memory.rss.usage.bytes'=17879040B;;;0;2059177984 'memory.peak.usage.bytes'=2630216B;;;0;2059177984 'memory.overhead.usage.bytes'=2293608B;;;0;2059177984 'memory.startup.usage.bytes'=1092624B;;;0;2059177984 'memory.dataset.usage.bytes'=292808B;;;0;2059177984 'memory.lua.usage.bytes'=31744B;;;0;2059177984 'memory.fragmentation.ratio.count'=6.97;;;0; 'memory.defragmentation.running.count'=0;;;0; 'memory.lazy_pending_objects.count'=0;;;0;
```
and for redis sentinel
```bash
# check redis sentinel with self signed certificate and without new params
./centreon_plugins.pl --plugin='apps::redis::sentinel::plugin' --server='127.0.0.1' --port='26379' --username='user' --password='password' --tls --cacert='ca.crt' --mode='redis-clusters' --custommode='cli' --filter-cluster-name='cluster' --unknown-status='' --warning-status='' --critical-status=''  --verbose
# output
UNKNOWN: Command error: Warning: Using a password with '-a' or '-u' option on the command line interface may not be safe. -  - I/O error -  - I/O error - Error: Server closed the connection 

# check redis with self signed certificate with new params
./centreon_plugins.pl --plugin='apps::redis::sentinel::plugin' --server='127.0.0.1' --port='26379' --username='user' --password='password' --tls --cacert='ca.crt' --cert='cert.crt' --key='cert.key' --mode='redis-clusters' --custommode='cli' --filter-cluster-name='cluster' --unknown-status='' --warning-status='' --critical-status=''  --verbose
# output
OK: cluster 'cluster' number of detected slaves: 2, subjectively down instances: 0, objectively down instances: 0 - slave replication offset standard deviation: 0.00 - All redis instances are ok | 'cluster#cluster.redis.slaves.detected.count'=2;;;0; 'cluster#cluster.redis.subjectively_down.count'=0;;;0; 'cluster#cluster.redis.objectively_down.count'=0;;;0; 'cluster.redis.slave_replication_offset.stddev.count'=0.00;;;; 'cluster~127.0.0.1:6379#cluster.redis.ping_ok.latency.milliseconds'=585s;;;0; 'cluster~127.0.0.1:6380#cluster.redis.ping_ok.latency.milliseconds'=618s;;;0; 'cluster~127.0.0.1:6381#cluster.redis.ping_ok.latency.milliseconds'=618s;;;0;
checking cluster 'cluster'
    number of detected slaves: 2, subjectively down instances: 0, objectively down instances: 0
    slave replication offset standard deviation: 0.00
    instance '127.0.0.1:6379' status: master [role: master], last ok ping: 585 ms
    instance '127.0.0.1:6380' status: slave [role: slave], last ok ping: 618 ms
    instance '127.0.0.1:6381' status: slave [role: slave], last ok ping: 618 ms

```

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] I have provide data or shown output displaying the result of this code in the plugin area concerned.
