### PR TITLE
fix(cloud::azure::storage::storagesync): fixed recalls mode by removing deprecated StorageSyncRecallIOTotalSizeBytes metric CTOR-1614

### DIFF
--- a/src/cloud/azure/storage/storagesync/mode/filessync.pm
+++ b/src/cloud/azure/storage/storagesync/mode/filessync.pm
@@ -144,6 +144,10 @@ Set resource name or ID (required).
 
 Set resource group (required if resource's name is used).
 
+=item B<--filter-metric>
+
+Filter on specific metrics. The Azure format must be used (can be a regexp).
+
 =item B<--warning-*>
 
 Warning threshold where '*' can be:

--- a/src/cloud/azure/storage/storagesync/mode/recalls.pm
+++ b/src/cloud/azure/storage/storagesync/mode/recalls.pm
@@ -53,14 +53,6 @@ sub get_metrics_mapping {
             'min'    => '0',
             'max'    => ''
 	    },
-        'storagesyncrecalliototalsizebytes' => {
-            'output' => 'Cloud tiering recall',
-            'label'  => 'total-recalls-size',
-            'nlabel' => 'storagesync.recalls.total.size.bytes',
-            'unit'   => 'B',
-            'min'    => '0',
-            'max'    => ''
-	    },
         'storagesyncrecallthroughputbytespersecond' => {
             'output' => 'Cloud tiering recall throughput',
             'label'  => 'throughput-recalls-size',

--- a/src/cloud/azure/storage/storagesync/mode/recalls.pm
+++ b/src/cloud/azure/storage/storagesync/mode/recalls.pm
@@ -152,6 +152,10 @@ Set resource name or ID (required).
 
 Set resource group (required if resource's name is used).
 
+=item B<--filter-metric>
+
+Filter on specific metrics. The Azure format must be used (can be a regexp).
+
 =item B<--warning-*>
 
 Warning threshold where '*' can be:

--- a/src/cloud/azure/storage/storagesync/mode/serverstatus.pm
+++ b/src/cloud/azure/storage/storagesync/mode/serverstatus.pm
@@ -128,6 +128,10 @@ Set resource name or ID (required).
 
 Set resource group (required if resource's name is used).
 
+=item B<--filter-metric>
+
+Filter on specific metrics. The Azure format must be used (can be a regexp).
+
 =item B<--warning-heartbeat>
 
 Warning threshold.


### PR DESCRIPTION
## Description

Remove the metric storagesyncrecalliototalsizebytes because it's not supported:
https://learn.microsoft.com/en-us/azure/azure-monitor/reference/supported-metrics/microsoft-storagesync-storagesyncservices-metrics

**Fixes** # CTOR-1614

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

