### PR TITLE
Extend QNAP plugin for type QuTS hero

### DIFF
--- a/src/storage/qnap/snmp/mode/components/temperature.pm
+++ b/src/storage/qnap/snmp/mode/components/temperature.pm
@@ -32,6 +32,10 @@ my $mapping = {
         cpu_temp    => { oid => '.1.3.6.1.4.1.55062.1.12.10' }, # cpuTemperature
         system_temp => { oid => '.1.3.6.1.4.1.55062.1.12.11' }  # systemTemperature
     },
+    quts => {
+        cpu_temp    => { oid => '.1.3.6.1.4.1.55062.2.12.10' }, # cpuTemperature
+        system_temp => { oid => '.1.3.6.1.4.1.55062.2.12.11' }  # systemTemperature
+    },
     ex => {
         cpu_temp    => { oid => '.1.3.6.1.4.1.24681.1.3.5' }, # cpu-TemperatureEX
         system_temp => { oid => '.1.3.6.1.4.1.24681.1.3.6' }  # systemTemperatureEX
@@ -112,6 +116,16 @@ sub check_temp_qts {
     check_temp_result($self, result => $result);
 }
 
+sub check_temp_quts {
+    my ($self, %options) = @_;
+
+    my $snmp_result = $self->{snmp}->get_leef(
+        oids => [ map($_->{oid} . '.0', values(%{$mapping->{quts}})) ]
+    );
+    my $result = $self->{snmp}->map_instance(mapping => $mapping->{quts}, results => $snmp_result, instance => 0);
+    check_temp_result($self, result => $result);
+}
+
 sub check_temp_es {
     my ($self, %options) = @_;
 
@@ -146,6 +160,8 @@ sub check {
 
     if ($self->{is_qts} == 1) {
         check_temp_qts($self);
+    } elsif ($self->{is_quts} == 1) {
+        check_temp_quts($self);
     } elsif ($self->{is_es} == 1) {
         check_temp_es($self);
     } else {

--- a/src/storage/qnap/snmp/mode/hardware.pm
+++ b/src/storage/qnap/snmp/mode/hardware.pm
@@ -86,16 +86,21 @@ sub snmp_execute {
 
     $self->{is_es} = 0;
     $self->{is_qts} = 0;
+    $self->{is_quts} = 0;
     my $oid_es_uptime = '.1.3.6.1.4.1.24681.2.2.4.0'; # es-SystemUptime
     my $oid_qts_model = '.1.3.6.1.4.1.55062.1.12.3.0'; # systemModel
+    my $oid_quts_disk_table = '.1.3.6.1.4.1.55062.2.10.7.1.1.1'; # quts-poolTable
     my $snmp_result = $self->{snmp}->get_leef(
-        oids => [$oid_es_uptime, $oid_qts_model]
+        oids => [$oid_es_uptime, $oid_qts_model, $oid_quts_disk_table]
     ); 
     if (defined($snmp_result->{$oid_es_uptime})) {
         $self->{is_es} = 1;
     }
     if (defined($snmp_result->{$oid_qts_model})) {
         $self->{is_qts} = 1;
+    }
+    if (defined($snmp_result->{$oid_quts_disk_table})) {
+        $self->{is_quts} = 1;
     }
 }
 

--- a/src/storage/qnap/snmp/mode/pools.pm
+++ b/src/storage/qnap/snmp/mode/pools.pm
@@ -178,6 +178,12 @@ my $mapping = {
         total  => { oid => '.1.3.6.1.4.1.24681.2.2.23.1.3' }, # es-SysPoolCapacity
         free   => { oid => '.1.3.6.1.4.1.24681.2.2.23.1.4' }, # es-SysPoolFreeSize
         status => { oid => '.1.3.6.1.4.1.24681.2.2.23.1.5' }  # es-SysPoolStatus
+    },
+    quts => {
+        name   => { oid => '.1.3.6.1.4.1.55062.2.10.7.1.2' }, # es-SysPoolID
+        total  => { oid => '.1.3.6.1.4.1.55062.2.10.7.1.3' }, # es-SysPoolCapacity
+        free   => { oid => '.1.3.6.1.4.1.55062.2.10.7.1.4' }, # es-SysPoolFreeSize
+        status => { oid => '.1.3.6.1.4.1.55062.2.10.7.1.5', , map => $map_status }  # es-SysPoolStatus
     }
 };
 
@@ -197,7 +203,7 @@ sub check_pools {
             next;
         }
 
-        if (defined($options{convert})) {
+        if ($options{type} ne "quts" && defined($options{convert})) {
             $result->{total} = $self->convert_bytes(value => $result->{total});
             $result->{free} = $self->convert_bytes(value => $result->{free});
         }
@@ -233,6 +239,12 @@ sub manage_selection {
         oid => '.1.3.6.1.4.1.24681.1.4.1.1.1.2.2.2' # poolTable
     );
     return if ($self->check_pools(snmp => $options{snmp}, type => 'ex', snmp_result => $snmp_result));
+
+    $snmp_result = $options{snmp}->get_table(
+        oid => '.1.3.6.1.4.1.55062.2.10.7', # QuTS hero storagePoolTable
+        nothing_quit => 1
+    );
+    return if $self->check_pools(snmp => $options{snmp}, type => 'quts', snmp_result => $snmp_result, convert => 1);
 
     $snmp_result = $options{snmp}->get_table(
         oid => '.1.3.6.1.4.1.24681.2.2.23', # es-SystemPoolTable

--- a/src/storage/qnap/snmp/mode/volumes.pm
+++ b/src/storage/qnap/snmp/mode/volumes.pm
@@ -178,6 +178,12 @@ my $mapping = {
         free   => { oid => '.1.3.6.1.4.1.55062.1.10.9.1.4' }, # volumeFreeSize
         status => { oid => '.1.3.6.1.4.1.55062.1.10.9.1.5' }, # volumeStatus
         name   => { oid => '.1.3.6.1.4.1.55062.1.10.9.1.8' }  # volumeName
+    },
+    quts => {
+        total  => { oid => '.1.3.6.1.4.1.55062.2.10.9.1.3' }, # volumeCapacity
+        free   => { oid => '.1.3.6.1.4.1.55062.2.10.9.1.4' }, # volumeFreeSize
+        status => { oid => '.1.3.6.1.4.1.55062.2.10.9.1.5' }, # volumeStatus
+        name   => { oid => '.1.3.6.1.4.1.55062.2.10.9.1.2' }  # volumeName
     }
 };
 
@@ -231,6 +237,11 @@ sub manage_selection {
 
     my $snmp_result;
     if (!defined($self->{option_results}->{force_counters_legacy})) {
+        $snmp_result = $options{snmp}->get_table(
+            oid => '.1.3.6.1.4.1.55062.2.10.9' # sharedFolderTable
+        );
+        return if ($self->check_volumes(snmp => $options{snmp}, type => 'quts', snmp_result => $snmp_result));
+
         $snmp_result = $options{snmp}->get_table(
             oid => '.1.3.6.1.4.1.55062.1.10.9' # volumeTable
         );

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -222,6 +222,7 @@ psu
 QoS
 Qtree
 queue-messages-inflighted
+quts
 raidvolume
 ReplicaJobSession
 RestAPI


### PR DESCRIPTION
# Community contributors

## Description

QNAP also has a QuTS Operating System which is used for certain components as well as for the pools and volumes on other OIDs.

Attached the MIB file

[QNAP_NAS.mib.txt](https://github.com/user-attachments/files/19939717/QNAP_NAS.mib.txt)

The snmpwalk i will deliver via email.

In the MIB file there should be also the OIDs for the msatadisk infos but in my case my devices doesn't respond on this OID's so i don't extend the mdisk check yet.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software