### PR TITLE
Change rights after install

### DIFF
--- a/connectors/vmware/packaging/scripts/postinstall.sh
+++ b/connectors/vmware/packaging/scripts/postinstall.sh
@@ -9,8 +9,8 @@ function migrateConfigFromPmToJson() {
         /usr/bin/centreon_vmware_convert_config_file "$perl_config_file_path" > "$json_config_file_path"
         mv "$perl_config_file_path" "${perl_config_file_path}.deprecated"
     fi
-    chown centreon: "$json_config_file_path"
-    chmod 640 "$json_config_file_path"
+    chown centreon-gorgone:centreon "$json_config_file_path"
+    chmod 660 "$json_config_file_path"
 }
 
 function applyToSystemD() {


### PR DESCRIPTION
## Description

After an install of VMWare daemon, the rights are:
`-rw-r----- 1 centreon centreon 221 Apr 29 11:48 /etc/centreon/centreon_vmware.json`

It should be these ones:
`-rw-rw---- 1 centreon-gorgone centreon 221 Apr 29 11:48 /etc/centreon/centreon_vmware.json`

It allows apache (central) and centreon-gorgone (poller) to update the file after a config export.

**Fixes** # CTOR-1636

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software


