### PR TITLE
enh(apps::mq::ibmmq::mqi): remove perl lib msqseries dependency

### DIFF
--- a/packaging/centreon-plugin-Applications-Ibmmq-Mqi/deb.json
+++ b/packaging/centreon-plugin-Applications-Ibmmq-Mqi/deb.json
@@ -1,5 +1,3 @@
 {
-    "dependencies": [
-        "perl-mqseries"
-    ]
+    "dependencies": []
 }

--- a/packaging/centreon-plugin-Applications-Ibmmq-Mqi/rpm.json
+++ b/packaging/centreon-plugin-Applications-Ibmmq-Mqi/rpm.json
@@ -1,5 +1,3 @@
 {
-    "dependencies": [
-        "perl(MQSeries)"
-    ]
+    "dependencies": []
 }


### PR DESCRIPTION
## Description

The perl mqseries library is going to be removed from centreon repository, so we need to remove the dependency.

**Fixes** CTOR-1639

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
