### PR TITLE
CTOR-1656-plugin-apps-nmap-cli-add-test-and-move-centreon-plugins-sudoers-to-centreon-plugin-repository

### DIFF
--- a/tests/apps/nmap/cli/discovery.robot
+++ b/tests/apps/nmap/cli/discovery.robot
@@ -1,0 +1,33 @@
+*** Settings ***
+Documentation       Test the Podman container-usage mode
+Library             Collections
+
+Resource            ${CURDIR}${/}..${/}..${/}..${/}resources/import.resource
+
+Test Timeout        120s
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}podman.json
+
+${cmd}              ${CENTREON_PLUGINS}
+...                 --plugin=apps::nmap::cli::plugin
+...                 --mode=discovery
+
+*** Test Cases ***
+Container usage ${tc}
+    [Documentation]    Check nmap discovery
+    [Tags]    apps    nmap
+    Log To Console    \n
+    ${command}    Catenate
+    ...    ${cmd}
+    ...    --subnet='127.0.0.1/32'
+    ...    ${extraoptions}
+
+    Ctn Run Command And Check Result As Json    ${command}    ${expected_result}
+
+    Examples:         tc    extraoptions          expected_result    --
+    ...       1     ${EMPTY}                       {"end_time":1747232859,"discovered_items":1,"results":[{"hostname":"localhost","ip":"127.0.0.1","hostnames":[{"type":"PTR","name":"localhost"}],"vendor":null,"status":"up","addresses":[{"address":"127.0.0.1","type":"ipv4"}],"os_accuracy":null,"os":null,"services":null,"type":"unknown"}],"duration":0,"start_time":1747232859}
+    ...       2     --nmap-options='-sS -sU -R -O --osscan-limit --osscan-guess -p U:161,162,T:21-25,80,139,443,3306,5985,5986,8080,8443 -oX - '                   {"end_time":1747232859,"discovered_items":1,"results":[{"hostname":"localhost","ip":"127.0.0.1","hostnames":[{"type":"PTR","name":"localhost"}],"vendor":null,"status":"up","addresses":[{"address":"127.0.0.1","type":"ipv4"}],"os_accuracy":null,"os":null,"services":null,"type":"unknown"}],"duration":1,"start_time":1747232859}
+    ...       3     --nmap-options='-sS -oX - '    {"results":[{"ip":"127.0.0.1","type":"unknown","os_accuracy":null,"status":"up","services":null,"hostnames":[{"type":"PTR","name":"localhost"}],"os":null,"hostname":"localhost","vendor":null,"addresses":[{"address":"127.0.0.1","type":"ipv4"}]}],"duration":0,"discovered_items":1,"start_time":1747234100,"end_time":1747234100}
+
+*** Keywords ***

--- a/tests/centreon/plugins/misc.t
+++ b/tests/centreon/plugins/misc.t
@@ -1,0 +1,96 @@
+use strict;
+use warnings;
+use Test2::V0;
+use Test2::Tools::Compare qw{is like match};
+use FindBin;
+use lib "$FindBin::RealBin/../../../src";
+use centreon::plugins::misc;
+use centreon::plugins::output;
+use centreon::plugins::options;
+# in real world one should use execute(), but as many options are not supported by windows_execute,
+# the signature is not coherent, and we want to test everything on this unix_execute()
+sub test_unix_execute {
+    my $mock_output = mock 'centreon::plugins::output'; # this is from Test2::Tools::Mock, included by Test2::V0
+
+    my $option = centreon::plugins::options->new();
+    my $output = centreon::plugins::output->new(options => $option);
+
+    my @tests = (
+        {
+            expect => '"string to" output "$( echo noworking)"',
+            msg    => 'double quote stay when no interpretation',
+            args   => {
+                command_path            => "/bin",
+                command                 => 'echo',
+                command_options         => '"string to" output "$( echo noworking)"',
+                no_shell_interpretation => 1,
+            }
+        },
+        {
+            expect => 'string to output noworking',
+            msg    => 'double quote diseapear when interpretation is enabled',
+            args   => {
+                command_path    => "/bin",
+                command         => 'echo',
+                command_options => '"string to" output "$( echo noworking)"',
+            }
+        },
+        {
+            expect => 'stringToOutput adding',
+            msg    => 'interpretation by default active',
+            args   => {
+                command => 'echo stringToOutput $(echo adding)',
+            }
+        },
+        {
+            expect => 'stringToOutput $(echo adding)',
+            msg    => 'interpretation by default active',
+            args   => {
+                command                 => 'echo stringToOutput $(echo adding)',
+                no_shell_interpretation => 1,
+            }
+        },
+        {
+            expect => '',
+            msg    => "no error when no argument given to command without interpolation",
+            args   => {
+                command                 => 'echo',
+                no_shell_interpretation => 1,
+            }
+        }
+
+    );
+    for my $test (@tests) {
+        my ($stdout, $exit_code) = centreon::plugins::misc::unix_execute(
+            output  => $output,
+            options => { timeout => 10 },
+                    no_quit                 => 1,
+            %{$test->{args}},
+        );
+        is($stdout, $test->{expect}, $test->{msg});
+    }
+
+    my ($stdout, $exit_code) = centreon::plugins::misc::unix_execute(
+        output                  => $output,
+        options                 => { timeout => 10 },
+        command                 => 'NoBinary',
+        command_output          => '"string to" output "$( echo noworking)"',
+        no_shell_interpretation => 1,
+        no_quit                 => 1
+    );
+    like($stdout, qr/Can't exec "NoBinary": No such file or directory at.*/, 'no_quit option always return');
+    ($stdout, $exit_code) = centreon::plugins::misc::unix_execute(
+        output                  => $output,
+        options                 => { timeout => 10 },
+        sudo                    => 1,
+        command                 => 'NoBinary',
+        command_output          => '"string to" output "$( echo noworking)"',
+        no_shell_interpretation => 1,
+        no_quit                 => 1
+    );
+    like($stdout, qr/Can't exec "sudo": No such file or directory at.*/, 'sudo option add sudo binary before command');
+
+}
+
+test_unix_execute();
+done_testing();

--- a/tests/resources/resources.resource
+++ b/tests/resources/resources.resource
@@ -85,3 +85,13 @@ Ctn Verify Command Output
     ...    Wrong output result for command:\n${command}\n\nObtained:\n${output}\n\nExpected:\n${expected_result}\n
     ...    values=False
     ...    collapse_spaces=True
+
+Ctn Run Command And Check Result As Json
+    [Arguments]    ${command}    ${expected}
+    Log To Console    ${command}
+    ${output}    Run    ${command}
+    ${output}    Strip String    ${output}
+    ${json_output}=    evaluate    json.loads('''${output}''')    json
+    ${json_expected}=    evaluate    json.loads('''${expected}''')    json
+    Dictionaries Should Be Equal    ${json_output}    ${json_expected}    ignore_keys=['end_time', 'start_time', 'duration']
+    Log Dictionary    ${json_output}


### PR DESCRIPTION
## Description

Add automated test on the nmap plugin
Add the centroen-plugins-sudoers package to avoid cyclic deps.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

See automated tests, all plugin requiring this lib should be installable without the central package repository

plugin to tests: 
  centreon-plugin-applications-nmap-cli
  centreon-plugin-applications-protocol-dhcp
  centreon-plugin-applications-protocol-udp

Automated tests should also pass.

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [X] I have implemented automated tests related to my commits.
  - [X] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
