### PR TITLE
enh(network::fortinet::fortigate::snmp): enhance plugin packaging to handle uptime CTOR-1662

### DIFF
--- a/packaging/centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp/pkg.json
+++ b/packaging/centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp/pkg.json
@@ -7,7 +7,8 @@
         "centreon/plugins/snmp.pm",
         "snmp_standard/mode/interfaces.pm",
         "snmp_standard/mode/listinterfaces.pm",
-	"snmp_standard/mode/resources/",
+        "snmp_standard/mode/uptime.pm",
+	    "snmp_standard/mode/resources/",
         "centreon/common/fortinet/fortigate/snmp/",
         "network/fortinet/fortigate/snmp/"
     ]

--- a/packaging/centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp/pkg.json
+++ b/packaging/centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp/pkg.json
@@ -8,7 +8,7 @@
         "snmp_standard/mode/interfaces.pm",
         "snmp_standard/mode/listinterfaces.pm",
         "snmp_standard/mode/uptime.pm",
-	    "snmp_standard/mode/resources/",
+        "snmp_standard/mode/resources/",
         "centreon/common/fortinet/fortigate/snmp/",
         "network/fortinet/fortigate/snmp/"
     ]


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

Enhance plugin packaging by adding uptime 
CTOR-1662

**Fixes** # (issue)
[Possible bug in centreon_fortinet_fortigate.pl for mode=uptime option?](https://thewatch.centreon.com/data-collection-6/possible-bug-in-centreon-fortinet-fortigate-pl-for-mode-uptime-option-4695)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

In a fresh env install the packaging: 
```
dnf install centreon-plugin-Network-Firewalls-Fortinet-Fortigate-Snmp
```
And try to run the `uptime` mode:
```
centreon_fortinet_fortigate.pl  --plugin=network::fortinet::fortigate::snmp::plugin --mode=uptime --hostname=localhost --snmp-version=2c --snmp-community='toto'
UNKNOWN: Cannot load module --mode.
Can't locate snmp_standard/mode/uptime.pm in @INC (you may need to install the snmp_standard::mode::uptime module) (@INC contains: /usr/lib/centreon/plugins FatPacked::94051310353376=HASH(0x558a06f1bbe0) /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at /usr/lib/centreon/plugins//centreon_fortinet_fortigate.pl line 6069.
```

## Checklist

- [x] I have **rebased** my development branch on the base branch (develop).
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
