### PR TITLE
enh(vmware-daemon): add missing logrotate file

### DIFF
--- a/connectors/vmware/packaging/centreon-plugin-virtualization-vmware-daemon.yaml
+++ b/connectors/vmware/packaging/centreon-plugin-virtualization-vmware-daemon.yaml
@@ -76,6 +76,10 @@ contents:
     type: config|noreplace
     packager: deb
 
+  - src: "config/logrotate/centreon_vmware"
+    dst: "/etc/logrotate.d/centreon_vmware"
+    type: config|noreplace
+
   - src: "config/centreon_vmware-conf.json"
     dst: "/etc/centreon/centreon_vmware.json"
     type: config|noreplace

--- a/connectors/vmware/packaging/config/logrotate/centreon_vmware
+++ b/connectors/vmware/packaging/config/logrotate/centreon_vmware
@@ -1,0 +1,12 @@
+/var/log/centreon/centreon_vmware.log {
+    copytruncate
+    weekly
+    maxsize 50M
+    rotate 12
+    compress
+    delaycompress
+    notifempty
+    missingok
+    su root root
+}
+


### PR DESCRIPTION
## Description

Add a logrotate file with:
- force rotate if size > 50M
- rotate weekly
- max 3 months

Refs: CTOR-1532

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

- Install the package
- run `logrotate /etc/logrotate.d/centreon_vmware`

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
