### PR TITLE
Plugin(database::mysql::plugin) - Mode(dbi,mysqlcmd): Error when retrieving the server version

### DIFF
--- a/src/database/mysql/dbi.pm
+++ b/src/database/mysql/dbi.pm
@@ -36,9 +36,8 @@ sub set_version {
 
     $self->{is_mariadb} = 0;
     $self->{version} = $self->{instance}->get_info(18); # SQL_DBMS_VER
-    # MariaDB: 5.5.5-10.1.36-MariaDB or 10.1.36-MariaDB
-    if ($self->{version} =~ /([0-9\.]*?)-MariaDB/i) {
-        $self->{version} = $1;
+    # MariaDB: 5.5.5-10.1.36-MariaDB, 10.1.36-MariaDB or 11.4.4-2-MariaDB-enterprise-log
+    if ($self->{version} =~ /(?:\d\.\d\.\d-)?(\d+\.\d+\.\d+).*MariaDB/i) {
         $self->{is_mariadb} = 1;
     }
 }

--- a/src/database/mysql/mysqlcmd.pm
+++ b/src/database/mysql/mysqlcmd.pm
@@ -209,8 +209,8 @@ sub set_version {
 
     $self->{is_mariadb} = 0;
     $self->{version} = $options{version};
-    # MariaDB: 5.5.5-10.1.36-MariaDB or 10.1.36-MariaDB
-    if ($self->{version} =~ /([0-9\.]*?)-MariaDB/i) {
+    # MariaDB: 5.5.5-10.1.36-MariaDB, 10.1.36-MariaDB or 11.4.4-2-MariaDB-enterprise-log
+    if ($self->{version} =~ /(?:\d\.\d\.\d-)?(\d+\.\d+\.\d+).*MariaDB/i) {
         $self->{version} = $1;
         $self->{is_mariadb} = 1;
     }

--- a/src/database/mysql/mysqlcmd.pm
+++ b/src/database/mysql/mysqlcmd.pm
@@ -53,7 +53,7 @@ sub new {
             'sql-errors-exit:s' => { name => 'sql_errors_exit', default => 'unknown' }
         });
     }
-    $options{options}->add_help(package => __PACKAGE__, sections => 'MYSQLCMD OPTIONS', once => 1);
+    $options{options}->add_help(package => __PACKAGE__, sections => 'MYSQL COMMAND OPTIONS', once => 1);
 
     $self->{output} = $options{output};
     $self->{sqlmode_name} = $options{sqlmode_name};

--- a/src/database/mysql/mysqlcmd.pm
+++ b/src/database/mysql/mysqlcmd.pm
@@ -307,13 +307,13 @@ __END__
 
 =head1 NAME
 
-mysqlcmd global
+MySQL command global
 
 =head1 SYNOPSIS
 
-mysqlcmd class
+MySQL command class
 
-=head1 MYSQLCMD OPTIONS
+=head1 MYSQL COMMAND OPTIONS
 
 =over 8
 


### PR DESCRIPTION
Refs:CTOR-1562

# Centreon team (internal PR)

## Description

The regex doesn't work for strings like '11.4.4-2-MariaDB-enterprise-log'. This PR adapts the regex to handle this case. 
The regex seems more complicated, `([0-9\.\-]*?)-MariaDB` would be sufficient but it doesn't return the same result as before. For example for `5.5.5-10.1.36-MariaDB`, the group 1 would be `5.5.5-10.1.36` instead of `10.1.36`. It's working fine so you tell me which one you prefer.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
