### PR TITLE
Plugin(cloud::aws::cloudwatch) - Mode(getmetrics): fix zeroed option

### DIFF
--- a/src/cloud/aws/cloudwatch/mode/getmetrics.pm
+++ b/src/cloud/aws/cloudwatch/mode/getmetrics.pm
@@ -172,17 +172,23 @@ sub manage_selection {
 
     $self->{metrics} = {};
     foreach my $label (keys %{$metric_results}) {
-        foreach my $stat (('minimum', 'maximum', 'average', 'sum')) {
-            next if (!defined($metric_results->{$label}->{$stat}));
+        foreach my $statistic (@{$self->{aws_statistics}}) {
+            next if (!defined($metric_results->{$label}->{lc($statistic)}) && 
+                !defined($self->{option_results}->{zeroed}));
 
-            my $name = $label . '_' . $stat;
+            my $name = $label . '_' . $statistic;
             $name = $self->{dimension_name} . '_' . $name if ($self->{dimension_name} ne '');
             $self->{metrics}->{$name} = {
                 display => $name,
-                value => $metric_results->{$label}->{$stat},
-                perf_label => $label . '_' . $stat,
+                value => defined($metric_results->{$label}->{lc($statistic)}) ? $metric_results->{$label}->{lc($statistic)} : 0,
+                perf_label => $label . '_' . $statistic,
             };
         }
+    }
+
+    if (scalar(keys %{$self->{metrics}}) <= 0) {
+        $self->{output}->add_option_msg(short_msg => 'No metrics. Check your options or use --zeroed option to set 0 on undefined values');
+        $self->{output}->option_exit();
     }
 }
 


### PR DESCRIPTION
Refs:CTOR-1706

# Centreon team (internal PR)

## Description

Fix the `--zeroed` option for the Cloudwatch getmetrics mode.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
