### PR TITLE
fix(ci): add missing entry for distrib noble in test-packages perl cp…

### DIFF
--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -692,6 +692,7 @@ jobs:
             runner_name: ubuntu-24.04
           - package_extension: deb
             image: ubuntu:noble
+            distrib: noble
             arch: amd64
             runner_name: ubuntu-24.04
           - package_extension: deb


### PR DESCRIPTION
…an libraries

# Centreon team (internal PR)

## Description

* add missing entry in perl cpan libraries workflow for noble, causing test environment to be set up with jammy cache instead of noble cache

**Fixes** #MON-172435

If you are fixing a github Issue already existing, mention it here.
If you are fixing a github Issue already existing, mention it here.
If you are fixing one or more JIRA ticket, mention it here too.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Please describe the **procedure** to verify that the goal of the PR is matched. 
Provide clear instructions so that it can be **correctly tested**.
Mention the automated tests included in this FOR (what they test like mode/option combinations).

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
