### PR TITLE
fix(centreon::plugins::mqtt): fixed syntax error

### DIFF
--- a/src/centreon/plugins/mqtt.pm
+++ b/src/centreon/plugins/mqtt.pm
@@ -122,7 +122,7 @@ sub query {
         $self->{mqtt}->unsubscribe($options{topic});
     };
     if (%mqtt_received) {
-        return %mqtt_received{$options{topic}};
+        return $mqtt_received{$options{topic}};
     } else {
         $self->{output}->add_option_msg(short_msg => 'No message in topic: ' . $options{topic});
         $self->{output}->option_exit();


### PR DESCRIPTION
The script will fail with this error:

```
UNKNOWN: Cannot load module --plugin.
syntax error at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/mqtt.pm line 125, near "%mqtt_received{"
syntax error at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/mqtt.pm line 126, near "}"
Global symbol "$self" requires explicit package name at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/mqtt.pm line 127.
Global symbol "%options" requires explicit package name at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/mqtt.pm line 127.
Global symbol "$self" requires explicit package name at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/mqtt.pm line 128.
syntax error at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/mqtt.pm line 129, near "}"
Can't use global @_ in "my" at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/mqtt.pm line 135, near "= @_"
Global symbol "$self" requires explicit package name at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/mqtt.pm line 137.
Global symbol "%options" requires explicit package name at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/mqtt.pm line 137.
syntax error at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/mqtt.pm line 146, near "}"
/opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/mqtt.pm has too many errors.
Compilation failed in require at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/script_mqtt.pm line 25.
BEGIN failed--compilation aborted at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/script_mqtt.pm line 25.
Compilation failed in require at (eval 5) line 2.
        ...propagated at /usr/share/perl5/base.pm line 84.
BEGIN failed--compilation aborted at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/apps/eclipse/mosquitto/mqtt/plugin.pm line 25.
Compilation failed in require at /opt/pgum/software/monitoring/plugins/centreon/20250400/src/centreon/plugins/misc.pm line 223.

```