### PR TITLE
fix(hardware::server::huawei::hmm::snmp): removed experimental keys on scalar for components CTOR-1776

### DIFF
--- a/src/hardware/server/huawei/hmm/snmp/mode/components/cpu.pm
+++ b/src/hardware/server/huawei/hmm/snmp/mode/components/cpu.pm
@@ -54,7 +54,7 @@ sub load {
 sub check {
     my ($self) = @_;
 
-    foreach my $entry (keys $mapping) {
+    foreach my $entry (keys %{$mapping}) {
         $mapping->{$entry}->{oid} =~ s/#/$self->{blade_id}/;
     }
 

--- a/src/hardware/server/huawei/hmm/snmp/mode/components/disk.pm
+++ b/src/hardware/server/huawei/hmm/snmp/mode/components/disk.pm
@@ -53,7 +53,7 @@ sub load {
 sub check {
     my ($self) = @_;
 
-    foreach my $entry (keys $mapping) {
+    foreach my $entry (keys %{$mapping}) {
         $mapping->{$entry}->{oid} =~ s/#/$self->{blade_id}/;
     }
 

--- a/src/hardware/server/huawei/hmm/snmp/mode/components/memory.pm
+++ b/src/hardware/server/huawei/hmm/snmp/mode/components/memory.pm
@@ -53,7 +53,7 @@ sub load {
 sub check {
     my ($self) = @_;
 
-    foreach my $entry (keys $mapping) {
+    foreach my $entry (keys %{$mapping}) {
         $mapping->{$entry}->{oid} =~ s/#/$self->{blade_id}/;
     }
 

--- a/src/hardware/server/huawei/hmm/snmp/mode/components/mezz.pm
+++ b/src/hardware/server/huawei/hmm/snmp/mode/components/mezz.pm
@@ -53,7 +53,7 @@ sub load {
 sub check {
     my ($self) = @_;
 
-    foreach my $entry (keys $mapping) {
+    foreach my $entry (keys %{$mapping}) {
         $mapping->{$entry}->{oid} =~ s/#/$self->{blade_id}/;
     }
 

--- a/src/hardware/server/huawei/hmm/snmp/mode/components/raidcontroller.pm
+++ b/src/hardware/server/huawei/hmm/snmp/mode/components/raidcontroller.pm
@@ -52,7 +52,7 @@ sub load {
 sub check {
     my ($self) = @_;
 
-    foreach my $entry (keys $mapping) {
+    foreach my $entry (keys %{$mapping}) {
         $mapping->{$entry}->{oid} =~ s/#/$self->{blade_id}/;
     }
 

--- a/src/hardware/server/huawei/hmm/snmp/mode/components/temperature.pm
+++ b/src/hardware/server/huawei/hmm/snmp/mode/components/temperature.pm
@@ -39,7 +39,7 @@ sub load {
 sub check {
     my ($self) = @_;
 
-    foreach my $entry (keys $mapping) {
+    foreach my $entry (keys %{$mapping}) {
         $mapping->{$entry}->{oid} =~ s/#/$self->{blade_id}/;
     }
 


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

Removed experimental keys on scalar for components

**Fixes** # (issue)
CTOR-1776
https://github.com/centreon/centreon-plugins/issues/5615

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

-

## Checklist

- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
