### PR TITLE
enh(connectors/vmware): add categories to tags

### DIFF
--- a/connectors/vmware/src/centreon/vmware/cisTags.pm
+++ b/connectors/vmware/src/centreon/vmware/cisTags.pm
@@ -204,6 +204,7 @@ sub tagsByResource {
     return $code if ($code);
 
     my $tags = {};
+    my $categories = {};
     my $result = { esx => {} , vm => {} };
     if (defined($tag_ids->{value})) {
         my $json_req = { tag_ids => [] };
@@ -214,8 +215,21 @@ sub tagsByResource {
             );
             return $code if ($code);
 
+            if (!defined($categories->{$tag_detail->{value}->{category_id}})) {
+                my ($code, $category_detail) = $self->request(
+                    method => 'GET',
+                    endpoint => '/rest/com/vmware/cis/tagging/category/id:' . $tag_detail->{value}->{category_id}
+                );
+                return $code if ($code);
+                $categories->{$tag_detail->{value}->{category_id}} = $category_detail->{value}->{name};
+            }
+
             push @{$json_req->{tag_ids}}, $tag_id; 
-            $tags->{ $tag_id } = { name => $tag_detail->{value}->{name}, description => $tag_detail->{value}->{description} };
+            $tags->{ $tag_id } = {
+                category => $categories->{$tag_detail->{value}->{category_id}},
+                description => $tag_detail->{value}->{description},
+                name => $tag_detail->{value}->{name}
+            };
         }
 
         my $data;


### PR DESCRIPTION
# Community contributors

## Description

Add a category attribute to tags as name and description are not enough to use in discovery mappers.

Of course discovery definition will have to be updated to declare the new category attribute.

Should look like:
![image](https://github.com/user-attachments/assets/4c06919e-b155-4a5d-a0a3-e4b1a7ade881)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

1. Execute the discovery mode of the VMware plugin with --tags option,

You should see 3 attributes for VMs.

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] I have provide data or shown output displaying the result of this code in the plugin area concerned.
