### PR TITLE
fix(ci): run plugins-suoders delivery only if packaging is triggered

### DIFF
--- a/.github/workflows/centreon-plugins-sudoers.yml
+++ b/.github/workflows/centreon-plugins-sudoers.yml
@@ -84,10 +84,7 @@ jobs:
   deliver-packages:
     needs: [get-environment, package]
     if: |
-      (contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) || ( needs.get-environment.outputs.stability == 'stable' && github.event_name != 'workflow_dispatch')) &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
+      (contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) || ( needs.get-environment.outputs.stability == 'stable' && github.event_name != 'workflow_dispatch'))
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false


### PR DESCRIPTION

# Centreon team (internal PR)

## Description

do not run delivery job for plugins-sudoers if packaging is not run
Fixes #MON-175664

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Please describe the **procedure** to verify that the goal of the PR is matched. 
Provide clear instructions so that it can be **correctly tested**.
Mention the automated tests included in this FOR (what they test like mode/option combinations).

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
