### PR TITLE
fix(plugin) hardware::server::hp::ilo::restapi - Exclude enclosure

### DIFF
--- a/src/centreon/common/redfish/restapi/mode/components/chassis.pm
+++ b/src/centreon/common/redfish/restapi/mode/components/chassis.pm
@@ -36,6 +36,7 @@ sub check {
         my $instance = $chassis->{Id};
         
         next if ($self->check_filter(section => 'chassis', instance => $instance));
+        next if ($chassis->{ChassisType} eq 'Enclosure');
         $self->{components}->{chassis}->{total}++;
 
         $self->{output}->output_add(


### PR DESCRIPTION
## Description

With the type of chassis "Enclosure", we don't have the status/health values.
We should exclude this type of chassis.

**Fixes** # CTOR-1798

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
