### PR TITLE
hardware-ups-apc-snmp wrong offset when --timezone not the same as the poller OS TZ

### DIFF
--- a/src/hardware/ups/apc/snmp/mode/ntp.pm
+++ b/src/hardware/ups/apc/snmp/mode/ntp.pm
@@ -46,9 +46,6 @@ sub get_target_time {
         $timezone = $self->{option_results}->{timezone};
     }
 
-    # change temp the timezone
-    local $ENV{TZ} = $timezone;
-
     my $epoch = Date::Parse::str2time($snmp_result->{$oid_mconfigClockDate} . ' ' . $snmp_result->{$oid_mconfigClockTime}, $timezone);
     return $self->get_from_epoch(date => $epoch);
 }


### PR DESCRIPTION
# Community contributors

## Description

In the case that host (--timezone parameter of the plugin) in a different timezone that the poller the epoch is not converted correctly and the plugin shows a false positive of a false Offset. In my case the poller is New-York and the host Mexico. In this case is showing a 2 hour offset what's wrong.

**Fixes** # (issue)
The difference to snmp_standard::mode::ntp is that APC does not return an epoch from snmp, but rather a string that is then converted into an epoch. However, with Date::Parse::str2time, --timezone must also be specified, otherwise it will no longer match when calling $self->get_from_epoch(date => $epoch).

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.