### PR TITLE
Plugin(storage::ibm::storwize::ssh): fixed when the ssh commands response has a banner message the checks has no output

### DIFF
--- a/src/storage/ibm/storwize/ssh/custom/api.pm
+++ b/src/storage/ibm/storwize/ssh/custom/api.pm
@@ -88,6 +88,8 @@ sub get_hasharray {
     my $result = [];
     return $result if ($options{content} eq '');
 
+    $self->{output}->add_option_msg(long_msg => "Response: $options{content}", debug => 1);
+
     my @lines = split /\n/, $options{content};
     my $header;
     my @clean_lines;


### PR DESCRIPTION
# Community contributors

## Description

I have a Storwize that always returns the following message as a banner/welcome when queried via SSH: 

Access permitted only to authorized persons

This shifts the splitting in the parsing of the “get_hasharray” function in api.pm, rendering the hasharray invalid because a header with field1:field2:field3 is expected.

Deshalb ist der Output aller checks leer

<img width="1072" height="260" alt="image" src="https://github.com/user-attachments/assets/fc095f01-f810-4315-867f-66aa1933e978" />



**Fixes** # (issue)
I did some research and testing and saw that every mode of “get_hasharray” expects multiple fields.

That's why I extended the function so that it always loops through the content using the delimiter until it finds a line in the header format with at least two fields after splitting with the delimiter. The former lines are cut away, so to speak.

After my fix:
<img width="1665" height="206" alt="image" src="https://github.com/user-attachments/assets/f0a1716c-00bb-4954-b24f-6b960706e5c2" />

I added a debug output for the response content that was very helpful for me to understand the problem

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

To test simple add some text line to the top of the content. For example here in the host.pm
<img width="849" height="356" alt="image" src="https://github.com/user-attachments/assets/c2da1873-6ab1-4a33-be87-23da943e1da4" />


## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.