### PR TITLE
CTOR-1836 Plugin(apps::vtom::restapi) - Mode(jobs): Unknown option --token in the legacy custom mode

### DIFF
--- a/src/apps/vtom/restapi/custom/legacy.pm
+++ b/src/apps/vtom/restapi/custom/legacy.pm
@@ -272,27 +272,27 @@ VTOM Rest API
 
 =item B<--hostname>
 
-Set hostname.
+Set the hostname.
 
 =item B<--port>
 
-Port used (default: 30002)
+Set the port used (default: 30002).
 
 =item B<--proto>
 
-Specify https if needed (default: 'http')
+Specify the protocol (default: 'http').
 
 =item B<--api-username>
 
-API username.
+Set the API username.
 
 =item B<--api-password>
 
-API password.
+Set the API password.
 
 =item B<--timeout>
 
-Set timeout in seconds (default: 30).
+Set the timeout in seconds (default: 30).
 
 =back
 

--- a/src/apps/vtom/restapi/custom/legacy.pm
+++ b/src/apps/vtom/restapi/custom/legacy.pm
@@ -52,6 +52,7 @@ sub new {
             'unknown-http-status:s'  => { name => 'unknown_http_status' },
             'warning-http-status:s'  => { name => 'warning_http_status' },
             'critical-http-status:s' => { name => 'critical_http_status' },
+            'token:s'                => { name => 'token' },
             'cache-use'              => { name => 'cache_use' }
         });
     }


### PR DESCRIPTION
Refs:CTOR-1836

# Centreon team (internal PR)

## Description

The ` --token` option is forced on the commands pack but it does not exit when using the legacy custom mode. The quick fix is to simply add the ` --token` option to that custom mode but that option does not do anything and is not documented.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
