### PR TITLE
fix(plugin) cloud::prometheus::direct::kubernetes - mode daemonset-status - key up_to_date

### DIFF
--- a/src/cloud/prometheus/direct/kubernetes/mode/daemonsetstatus.pm
+++ b/src/cloud/prometheus/direct/kubernetes/mode/daemonsetstatus.pm
@@ -229,13 +229,13 @@ __END__
 
 =head1 MODE
 
-Check daemonset status.
+Check DaemonSet status.
 
 =over 8
 
 =item B<--daemonset>
 
-Filter on a specific daemonset (must be a PromQL filter, Default: 'daemonset=~".*"')
+Filter on a specific DaemonSet (must be a PromQL filter, Default: 'daemonset=~".*"')
 
 =item B<--warning-status>
 

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -58,6 +58,7 @@ cpu-utilization-5m
 cpu-utilization-5s
 CX
 Cyberoam
+DaemonSet
 Datacore
 Datastore
 datasource
@@ -244,6 +245,7 @@ prct
 Primera
 Procurve
 Proxmox
+PromQL
 proto
 --proxyurl
 psu


### PR DESCRIPTION
## Description

With the old key, it didn't returned any status for up_to_date

**Fixes** # CTOR-1864

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

