### PR TITLE
Plugin(notification::microsoft::office365::teams) - Mode(alert) - Allow to wrap long text

### DIFF
--- a/src/notification/microsoft/office365/teams/mode/alert.pm
+++ b/src/notification/microsoft/office365/teams/mode/alert.pm
@@ -363,7 +363,8 @@ sub build_workflow_message {
         "size"   => "Large",
         "weight" => "Bolder",
         "style"  => "heading",
-        "color"  => $themecolor
+        "color"  => $themecolor,
+        "wrap"     => "true"
     };
     push @{$self->{body}}, {
         type     => "TextBlock",
@@ -371,7 +372,8 @@ sub build_workflow_message {
         "size"   => "Medium",
         "weight" => "Bolder",
         "style"  => "heading",
-        "color"  => $themecolor
+        "color"  => $themecolor,
+        "wrap"     => "true"
     };
 
     if (defined($self->{option_results}->{$resource_type . '_output'}) && $self->{option_results}->{$resource_type . '_output'} ne '') {
@@ -392,9 +394,9 @@ sub build_workflow_message {
     if (defined($self->{option_results}->{extra_info}) && $self->{option_results}->{extra_info} !~ m/^\/\/$/) {
         if ($self->{option_results}->{extra_info} =~ m/^(.*)\/\/(.*)$/) {
             push @{$self->{body}}, {
-                type   => "TextBlock",
-                text   => "Additional Information:  \n" . sprintf($self->{option_results}->{extra_info_format}, $1, $2),
-                wrap => "true"
+                type  => "TextBlock",
+                text  => "Additional Information:  \n" . sprintf($self->{option_results}->{extra_info_format}, $1, $2),
+                wrap  => "true"
             };
         }
     }


### PR DESCRIPTION
Refs:1905

# Centreon team (internal PR)

## Description

Allow to wrap long text to show the full notification message received in Teams.

**Fixes** # (issue)
Fix https://github.com/centreon/centreon-plugins/issues/5519

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software


## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
