### PR TITLE
fix(test): fix apache serverstatus requests robot test after errors during nightly check

### DIFF
--- a/tests/apps/apache/serverstatus/requests.robot
+++ b/tests/apps/apache/serverstatus/requests.robot
@@ -13,8 +13,7 @@ Test Timeout        120s
 
 *** Variables ***
 ${MOCKOON_JSON}     ${CURDIR}${/}serverstatus.mockoon.json
-${HOSTNAME}         127.0.0.1
-${APIPORT}          3000
+
 ${CMD}              ${CENTREON_PLUGINS}
 ...                 --plugin=apps::apache::serverstatus::plugin
 ...                 --mode=requests
@@ -28,17 +27,18 @@ Requests ${tc}
     ${command}    Catenate
     ...    ${CMD}
     ...    ${extra_options}
-
-    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+    # Check regexp instead of exact value because there can be variations with data calculation that uses the cache depending on the execution time.
+    Ctn Run Command And Check Result As Regexp    ${command}    ${expected_result}
 
     Examples:    tc    extra_options                                       expected_result    --
-        ...      1     ${EMPTY}                                            OK: bytesPerSec : Buffer creation, accessPerSec : Buffer creation, RequestPerSec: 300.00, BytesPerRequest: 2.11 MB | 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=2211284.85B;;;0; 'apache.bytes.average.persecond'=10B;;;0;
-        ...      2     --urlpath=/server-status-2                          OK: BytesPerSec: 607.00 KB, AccessPerSec: 484.00, RequestPerSec: 300.00, BytesPerRequest: 1.25 KB | 'apache.bytes.persecond'=621568.00B;;;0; 'apache.access.persecond'=484.00;;;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=1284.23B;;;0; 'apache.bytes.average.persecond'=100B;;;0;
-        ...      3     --warning-apache.bytes.persecond=:400               WARNING: BytesPerSec: 57.61 MB | 'apache.bytes.persecond'=60408832.00B;0:400;;0; 'apache.access.persecond'=474516.00;;;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=2211284.85B;;;0; 'apache.bytes.average.persecond'=10B;;;0;
-        ...      4     --critical-apache-access-persecond=:10 --urlpath=/server-status-2    CRITICAL: AccessPerSec: 484.00 | 'apache.bytes.persecond'=621568.00B;;;0; 'apache.access.persecond'=484.00;;0:10;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=1284.23B;;;0; 'apache.bytes.average.persecond'=100B;;;0;
-        ...      5     --critical-apache-request-average-persecond=400:    CRITICAL: RequestPerSec: 300.00 | 'apache.bytes.persecond'=60408832.00B;;;0; 'apache.access.persecond'=474516.00;;;0; 'apache.request.average.persecond'=300.00;;400:;0; 'apache.bytes.average.perrequest'=2211284.85B;;;0; 'apache.bytes.average.persecond'=10B;;;0;
-        ...      6     --warning-apache-bytes-average-perrequest=:10 --urlpath=/server-status-2      WARNING: BytesPerRequest: 1.25 KB | 'apache.bytes.persecond'=621568.00B;;;0; 'apache.access.persecond'=484.00;;;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=1284.23B;0:10;;0; 'apache.bytes.average.persecond'=100B;;;0;
-        ...      7     --warning-apache-bytes-average-persecond=400:       WARNING: avg_bytesPerSec : 10 | 'apache.bytes.persecond'=60408832.00B;;;0; 'apache.access.persecond'=474516.00;;;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=2211284.85B;;;0; 'apache.bytes.average.persecond'=10B;400:;;0;
-        ...      8     --warning=400: --urlpath=/server-status-2           WARNING: RequestPerSec: 300.00 | 'apache.bytes.persecond'=621568.00B;;;0; 'apache.access.persecond'=484.00;;;0; 'apache.request.average.persecond'=300.00;400:;;0; 'apache.bytes.average.perrequest'=1284.23B;;;0; 'apache.bytes.average.persecond'=100B;;;0;
-        ...      9     --critical-access=:10                               CRITICAL: AccessPerSec: 474516.00 | 'apache.bytes.persecond'=60408832.00B;;;0; 'apache.access.persecond'=474516.00;;0:10;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=2211284.85B;;;0; 'apache.bytes.average.persecond'=10B;;;0;
-        ...      10    --warning-bytes=:10 --urlpath=/server-status-2      WARNING: BytesPerSec: 607.00 KB | 'apache.bytes.persecond'=621568.00B;0:10;;0; 'apache.access.persecond'=484.00;;;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=1284.23B;;;0; 'apache.bytes.average.persecond'=100B;;;0;
+        ...      1     ${EMPTY}                                            OK: bytesPerSec : Buffer creation, accessPerSec : Buffer creation, RequestPerSec: 300.00, BytesPerRequest: 2.11 MB \\\\| 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=2211284.85B;;;0; 'apache.bytes.average.persecond'=10B;;;0;
+        ...      2     --urlpath=/server-status-2                          OK: BytesPerSec: 607.00 KB, AccessPerSec: 484.00, RequestPerSec: 300.00, BytesPerRequest: 1.25 KB \\\\| 'apache.bytes.persecond'=\\\\d+.00B;;;0; 'apache.access.persecond'=\\\\d+.00;;;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=1284.23B;;;0; 'apache.bytes.average.persecond'=100B;;;0;
+        ...      3     --urlpath=/server-status-2                          OK: BytesPerSec: 0.00 B, AccessPerSec: 0.00, RequestPerSec: 300.00, BytesPerRequest: 1.25 KB \\\\| 'apache.bytes.persecond'=0.00B;;;0; 'apache.access.persecond'=0.00;;;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=1284.23B;;;0; 'apache.bytes.average.persecond'=100B;;;0;
+        ...      4     --warning-apache.bytes.persecond=:400               WARNING: BytesPerSec: 57.61 MB \\\\| 'apache.bytes.persecond'=\\\\d+.00B;0:400;;0; 'apache.access.persecond'=\\\\d+.00;;;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=2211284.85B;;;0; 'apache.bytes.average.persecond'=10B;;;0;
+        ...      5     --critical-apache-access-persecond=:10 --urlpath=/server-status-2    CRITICAL: AccessPerSec: 484.00 \\\\| 'apache.bytes.persecond'=\\\\d+.00B;;;0; 'apache.access.persecond'=\\\\d+.00;;0:10;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=1284.23B;;;0; 'apache.bytes.average.persecond'=100B;;;0;
+        ...      6     --critical-apache-request-average-persecond=400:    CRITICAL: RequestPerSec: 300.00 \\\\| 'apache.bytes.persecond'=\\\\d+.00B;;;0; 'apache.access.persecond'=\\\\d+.00;;;0; 'apache.request.average.persecond'=300.00;;400:;0; 'apache.bytes.average.perrequest'=2211284.85B;;;0; 'apache.bytes.average.persecond'=10B;;;0;
+        ...      7     --warning-apache-bytes-average-perrequest=:10 --urlpath=/server-status-2      WARNING: BytesPerRequest: 1.25 KB \\\\| 'apache.bytes.persecond'=\\\\d+.00B;;;0; 'apache.access.persecond'=\\\\d+.00;;;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=1284.23B;0:10;;0; 'apache.bytes.average.persecond'=100B;;;0;
+        ...      8     --warning-apache-bytes-average-persecond=400:       WARNING: avg_bytesPerSec : 10 \\\\| 'apache.bytes.persecond'=\\\\d+.00B;;;0; 'apache.access.persecond'=\\\\d+.00;;;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=2211284.85B;;;0; 'apache.bytes.average.persecond'=10B;400:;;0;
+        ...      9     --warning=400: --urlpath=/server-status-2           WARNING: RequestPerSec: 300.00 \\\\| 'apache.bytes.persecond'=\\\\d+.00B;;;0; 'apache.access.persecond'=\\\\d+.00;;;0; 'apache.request.average.persecond'=300.00;400:;;0; 'apache.bytes.average.perrequest'=1284.23B;;;0; 'apache.bytes.average.persecond'=100B;;;0;
+        ...      10     --critical-access=:10                               CRITICAL: AccessPerSec: 474516.00 \\\\| 'apache.bytes.persecond'=\\\\d+.00B;;;0; 'apache.access.persecond'=\\\\d+.00;;0:10;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=2211284.85B;;;0; 'apache.bytes.average.persecond'=10B;;;0;
+        ...      11    --warning-bytes=:10 --urlpath=/server-status-2      WARNING: BytesPerSec: 607.00 KB \\\\| 'apache.bytes.persecond'=\\\\d+.00B;0:10;;0; 'apache.access.persecond'=\\\\d+.00;;;0; 'apache.request.average.persecond'=300.00;;;0; 'apache.bytes.average.perrequest'=1284.23B;;;0; 'apache.bytes.average.persecond'=100B;;;0;

--- a/tests/apps/apache/serverstatus/serverstatus.mockoon.json
+++ b/tests/apps/apache/serverstatus/serverstatus.mockoon.json
@@ -4,7 +4,7 @@
   "name": "Apache",
   "endpointPrefix": "",
   "latency": 0,
-  "port": 3006,
+  "port": 3000,
   "hostname": "",
   "folders": [],
   "routes": [


### PR DESCRIPTION
## Description

Random errors during tests of apache serverstatus requests due to cache read issues depending on execution speed. 

**Fixes** CTOR-1898

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
