### PR TITLE
AKCP hardware sensors - add new sensors for security port & buzzer for akcp sensorprobe2

### DIFF
--- a/src/hardware/sensors/akcp/snmp/mode/components/buzzer.pm
+++ b/src/hardware/sensors/akcp/snmp/mode/components/buzzer.pm
@@ -1,0 +1,66 @@
+#
+# Copyright 2025 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package hardware::sensors::akcp::snmp::mode::components::buzzer;
+
+use strict;
+use warnings;
+use hardware::sensors::akcp::snmp::mode::components::resources qw(%map_default1_status);
+
+my $mapping = {
+    buzzerDescription  => { oid => '.1.3.6.1.4.1.3854.3.5.11.1.2' },
+    buzzerStatus       => { oid => '.1.3.6.1.4.1.3854.3.5.11.1.6', map => \%map_default1_status },
+};
+my $oid_buzzerEntry = '.1.3.6.1.4.1.3854.3.5.11.1';
+
+sub load {
+    my ($self) = @_;
+    
+    push @{$self->{request}}, { oid => $oid_buzzerEntry };
+}
+
+sub check {
+    my ($self) = @_;
+
+    $self->{output}->output_add(long_msg => "Checking buzzers");
+    $self->{components}->{buzzer} = {name => 'buzzers', total => 0, skip => 0};
+    return if ($self->check_filter(section => 'buzzer'));
+
+    foreach my $oid ($self->{snmp}->oid_lex_sort(keys %{$self->{results}->{$oid_buzzerEntry}})) {
+        next if ($oid !~ /^$mapping->{buzzerStatus}->{oid}\.(.*)$/);
+        my $instance = $1;
+        my $result = $self->{snmp}->map_instance(mapping => $mapping, results => $self->{results}->{$oid_buzzerEntry}, instance => $instance);
+        
+        next if ($self->check_filter(section => 'buzzer', instance => $instance));
+        $self->{components}->{buzzer}->{total}++;
+        
+        $self->{output}->output_add(long_msg => sprintf("buzzer '%s' status is '%s' [instance = %s]",
+                                    $result->{buzzerDescription}, $result->{buzzerStatus}, $instance,
+                                    ));
+        
+        my $exit = $self->get_severity(label => 'default1', section => 'buzzer', value => $result->{buzzerStatus});
+        if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
+            $self->{output}->output_add(severity => $exit,
+                                        short_msg => sprintf("Buzzer '%s' status is '%s'", $result->{buzzerDescription}, $result->{buzzerStatus}));
+        }
+    }
+}
+
+1;

--- a/src/hardware/sensors/akcp/snmp/mode/components/securityport.pm
+++ b/src/hardware/sensors/akcp/snmp/mode/components/securityport.pm
@@ -40,22 +40,22 @@ sub check {
     my ($self) = @_;
 
     $self->{output}->output_add(long_msg => "Checking security ports");
-    $self->{components}->{security_port} = {name => 'security ports', total => 0, skip => 0};
-    return if ($self->check_filter(section => 'security'));
+    $self->{components}->{securityport} = {name => 'security ports', total => 0, skip => 0};
+    return if ($self->check_filter(section => 'securityport'));
 
     foreach my $oid ($self->{snmp}->oid_lex_sort(keys %{$self->{results}->{$oid_securityPortEntry}})) {
         next if ($oid !~ /^$mapping->{securityPortStatus}->{oid}\.(.*)$/);
         my $instance = $1;
         my $result = $self->{snmp}->map_instance(mapping => $mapping, results => $self->{results}->{$oid_securityPortEntry}, instance => $instance);
         
-        next if ($self->check_filter(section => 'security_port', instance => $instance));
-        $self->{components}->{security_port}->{total}++;
+        next if ($self->check_filter(section => 'securityport', instance => $instance));
+        $self->{components}->{securityport}->{total}++;
         
         $self->{output}->output_add(long_msg => sprintf("security port '%s' status is '%s' [instance = %s]",
                                     $result->{securityPortDescription}, $result->{securityPortStatus}, $instance,
                                     ));
         
-        my $exit = $self->get_severity(label => 'default2', section => 'security_port', value => $result->{securityPortStatus});
+        my $exit = $self->get_severity(label => 'default2', section => 'securityport', value => $result->{securityPortStatus});
         if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
             $self->{output}->output_add(severity => $exit,
                                         short_msg => sprintf("Security port '%s' status is '%s'", $result->{securityPortDescription}, $result->{securityPortStatus}));

--- a/src/hardware/sensors/akcp/snmp/mode/components/securityport.pm
+++ b/src/hardware/sensors/akcp/snmp/mode/components/securityport.pm
@@ -1,0 +1,66 @@
+#
+# Copyright 2025 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package hardware::sensors::akcp::snmp::mode::components::securityport;
+
+use strict;
+use warnings;
+use hardware::sensors::akcp::snmp::mode::components::resources qw(%map_default2_status);
+
+my $mapping = {
+    securityPortDescription  => { oid => '.1.3.6.1.4.1.3854.3.5.10.1.2' },
+    securityPortStatus       => { oid => '.1.3.6.1.4.1.3854.3.5.10.1.6', map => \%map_default2_status },
+};
+my $oid_securityPortEntry = '.1.3.6.1.4.1.3854.3.5.10.1';
+
+sub load {
+    my ($self) = @_;
+    
+    push @{$self->{request}}, { oid => $oid_securityPortEntry };
+}
+
+sub check {
+    my ($self) = @_;
+
+    $self->{output}->output_add(long_msg => "Checking security ports");
+    $self->{components}->{security_port} = {name => 'security ports', total => 0, skip => 0};
+    return if ($self->check_filter(section => 'security'));
+
+    foreach my $oid ($self->{snmp}->oid_lex_sort(keys %{$self->{results}->{$oid_securityPortEntry}})) {
+        next if ($oid !~ /^$mapping->{securityPortStatus}->{oid}\.(.*)$/);
+        my $instance = $1;
+        my $result = $self->{snmp}->map_instance(mapping => $mapping, results => $self->{results}->{$oid_securityPortEntry}, instance => $instance);
+        
+        next if ($self->check_filter(section => 'security_port', instance => $instance));
+        $self->{components}->{security_port}->{total}++;
+        
+        $self->{output}->output_add(long_msg => sprintf("security port '%s' status is '%s' [instance = %s]",
+                                    $result->{securityPortDescription}, $result->{securityPortStatus}, $instance,
+                                    ));
+        
+        my $exit = $self->get_severity(label => 'default2', section => 'security_port', value => $result->{securityPortStatus});
+        if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
+            $self->{output}->output_add(severity => $exit,
+                                        short_msg => sprintf("Security port '%s' status is '%s'", $result->{securityPortDescription}, $result->{securityPortStatus}));
+        }
+    }
+}
+
+1;

--- a/src/hardware/sensors/akcp/snmp/mode/sensors.pm
+++ b/src/hardware/sensors/akcp/snmp/mode/sensors.pm
@@ -53,7 +53,7 @@ sub set_system {
     };
 
     $self->{components_path} = 'hardware::sensors::akcp::snmp::mode::components';
-    $self->{components_module} = ['temperature', 'humidity', 'switch', 'serial', 'water'];
+    $self->{components_module} = ['temperature', 'humidity', 'switch', 'serial', 'water', 'securityport', 'buzzer'];
 }
 
 sub snmp_execute {
@@ -86,7 +86,7 @@ Check sensors.
 =item B<--component>
 
 Which component to check (default: '.*').
-Can be: 'temperature', 'humidity', 'switch', 'serial', 'water'.
+Can be: 'temperature', 'humidity', 'switch', 'serial', 'water', 'securityport', 'buzzer'.
 
 =item B<--filter>
 

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -271,6 +271,7 @@ Sansymphony
 SAS
 scenarii
 --scope-datacenter
+securityport
 SFOS
 sfp.temperature
 SignalR


### PR DESCRIPTION
# Community contributors

## Description

New sensor components check for security port & buzzers. The snmpwalk is tested and plugin simulated on a "**akcp sensorprobe2**"

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Here is the snmpwalk

[akcp-PR.snmpwalk.txt](https://github.com/user-attachments/files/22564406/akcp-PR.snmpwalk.txt)

The new sensors status are always in the .6 OID. The status works with the existing status mappings of the plugin (no new changes needed)

**For security port**

In case of door open the status = 4 

<img width="285" height="150" alt="image" src="https://github.com/user-attachments/assets/8f4ac65f-33dc-406f-896c-f12612dd695c" />

<img width="884" height="196" alt="image" src="https://github.com/user-attachments/assets/8ec0a77c-74ec-4638-a502-62cf6fa34768" />

In case of door closed the status = 2

<img width="641" height="195" alt="image" src="https://github.com/user-attachments/assets/c5c73b84-32e0-4eed-ae3f-1966a07275bd" />

**For buzzer**

the status is always in OID .6

<img width="578" height="242" alt="image" src="https://github.com/user-attachments/assets/0a3e93a7-a29e-49f5-b547-c9d70d4643ae" />

<img width="260" height="270" alt="image" src="https://github.com/user-attachments/assets/58addb30-f1b3-41cb-9f3c-907dd57affc0" />



## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.
