### PR TITLE
enh(vmware8::esx):  use statefiles to retain esx_id

### DIFF
--- a/src/apps/vmware/vsphere8/esx/mode.pm
+++ b/src/apps/vmware/vsphere8/esx/mode.pm
@@ -19,6 +19,8 @@
 #
 
 package apps::vmware::vsphere8::esx::mode;
+use centreon::plugins::statefile;
+use Digest::MD5 qw(md5_hex);
 use strict;
 use warnings;
 
@@ -30,33 +32,47 @@ sub new {
 
     $options{options}->add_options(
         arguments => {
-            'esx-id:s'          => { name => 'esx_id' },
-            'esx-name:s'        => { name => 'esx_name' }
+            'esx-id:s'   => { name => 'esx_id' },
+            'esx-name:s' => { name => 'esx_name' }
         }
     );
     $options{options}->add_help(package => __PACKAGE__, sections => 'VMWARE 8 HOST OPTIONS', once => 1);
+    $self->{cache} = centreon::plugins::statefile->new(%options);
 
     return $self;
 }
 
-sub get_esx_id_from_name {
+sub get_esx_id {
     my ($self, %options) = @_;
 
+    # return the id if we already have it in memory
+    return $self->{esx_id} if (!centreon::plugins::misc::is_empty($self->{esx_id}));
+
     if ( centreon::plugins::misc::is_empty($self->{esx_name}) ) {
-        $self->{output}->add_option_msg(short_msg => "get_esx_id_from_name method called without esx_name option. Please check configuration.");
-        $self->{output}->option_exit();
+        $self->{output}->option_exit(short_msg => "get_esx_id method called without esx_name option. Please check configuration.");
+    }
+
+    # return it from the cache if it is available
+    if ($self->{cache}->read(statefile => 'vsphere8_api_esx_info_' . md5_hex($self->{esx_name}))) {
+        my $esx_id = $self->{cache}->get(name => 'esx_id');
+        # store it to avoid re-reading the cache the next time it is asked
+        $self->{esx_id} = $esx_id;
+        return $self->{esx_id};
     }
 
     my $response = $options{custom}->request_api(
         'endpoint' => '/vcenter/host',
+        'get_param' => [ 'names='. $self->{esx_name} ],
         'method' => 'GET'
     );
 
     for my $rsrc (@$response) {
         next if ($rsrc->{name} ne $self->{esx_name});
         $self->{esx_id} = $rsrc->{host};
-        $self->{output}->add_option_msg(long_msg => "get_esx_id_from_name method called to get " . $self->{esx_name}
+        $self->{output}->add_option_msg(long_msg => "get_esx_id method called to get " . $self->{esx_name}
             . "'s id: " . $self->{esx_id} . ". Prefer using --esx-id to spare a query to the API.");
+        # store it in the cache for future runs
+        $self->{cache}->write(data => {updated => time(), esx_id => $self->{esx_id}});
         return $rsrc->{host};
     }
 
@@ -67,9 +83,8 @@ sub get_esx_id_from_name {
 sub get_esx_stats {
     my ($self, %options) = @_;
 
-    if ( centreon::plugins::misc::is_empty($options{esx_id}) && !$self->get_esx_id_from_name(%options) ) {
-        $self->{output}->add_option_msg(short_msg => "get_esx_stats method cannot get host ID from host name");
-        $self->{output}->option_exit();
+    if ( centreon::plugins::misc::is_empty($options{esx_id}) && !$self->get_esx_id(%options) ) {
+        $self->{output}->option_exit(short_msg => "get_esx_stats method cannot get host ID from host name");
     }
 
     return $options{custom}->get_stats(
@@ -88,6 +103,7 @@ sub check_options {
     my ($self, %options) = @_;
 
     $self->SUPER::check_options(%options);
+    $self->{cache}->check_options(option_results => $self->{option_results});
 
     if (centreon::plugins::misc::is_empty($self->{option_results}->{esx_id})
         && centreon::plugins::misc::is_empty($self->{option_results}->{esx_name})) {
@@ -132,7 +148,6 @@ apps::vmware::vsphere8::esx::mode - Template for modes monitoring VMware physica
     sub set_counters {...}
     sub manage_selection {
         my ($self, %options) = @_;
-
 
 
     $api->set_options(option_results => $option_results);


### PR DESCRIPTION
## Description

In complement to #5772, an optimization that regards only ESX monitoring.

Refs: CTOR-1513

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Please describe the **procedure** to verify that the goal of the PR is matched. 
Provide clear instructions so that it can be **correctly tested**.
Mention the automated tests included in this FOR (what they test like mode/option combinations).

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
