### PR TITLE
Fix status for pdisk.state : ready

### DIFF
--- a/src/hardware/server/dell/idrac/snmp/mode/hardware.pm
+++ b/src/hardware/server/dell/idrac/snmp/mode/hardware.pm
@@ -63,7 +63,7 @@ sub set_system {
             ['unknown', 'UNKNOWN'],
             ['readySpareDedicated', 'OK'],
             ['readySpareGlobal', 'OK'],
-            ['ready', 'WARNING'],
+            ['ready', 'OK'],
             ['online', 'OK'],
             ['foreign', 'OK'],
             ['offline', 'WARNING'],


### PR DESCRIPTION
## Description

There was a wrong state for the pdisk status "ready".

**Fixes** # CTOR-1949

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
