### PR TITLE
enh(pfsense-snmp): add generic snmp mode to pfsense plugin

### DIFF
--- a/packaging/centreon-plugin-Network-Firewalls-Pfsense-Snmp/pkg.json
+++ b/packaging/centreon-plugin-Network-Firewalls-Pfsense-Snmp/pkg.json
@@ -5,6 +5,12 @@
     "files": [
         "centreon/plugins/script_snmp.pm",
         "centreon/plugins/snmp.pm",
-        "apps/pfsense/snmp"
+        "apps/pfsense/snmp",
+        "snmp_standard/mode/loadaverage.pm",
+        "snmp_standard/mode/swap.pm",
+        "snmp_standard/mode/memory.pm",
+        "snmp_standard/mode/cpudetailed.pm",
+        "snmp_standard/mode/uptime.pm",
+        "snmp_standard/mode/cpu.pm"
     ]
 }

--- a/src/apps/pfsense/snmp/plugin.pm
+++ b/src/apps/pfsense/snmp/plugin.pm
@@ -34,7 +34,15 @@ sub new {
         'packet-stats'      => 'apps::pfsense::snmp::mode::packetstats',
         'pfinterfaces'      => 'apps::pfsense::snmp::mode::pfinterfaces',
         'runtime'           => 'apps::pfsense::snmp::mode::runtime',
-        'state-table'       => 'apps::pfsense::snmp::mode::statetable'
+        'state-table'       => 'apps::pfsense::snmp::mode::statetable',
+        'load'              => 'snmp_standard::mode::loadaverage',
+        'cpu'               => 'snmp_standard::mode::cpu',
+        'cpu-detailed'      => 'snmp_standard::mode::cpudetailed',
+        'uptime'            => 'snmp_standard::mode::uptime',
+        'swap'              => 'snmp_standard::mode::swap',
+        'memory'            => 'os::freebsd::snmp::mode::memory',
+
+
     };
 
     return $self;


### PR DESCRIPTION
## Description

pfsense is a tool built atop freebsd, so some generic plugin which work for linux or bsd work for pfsense too.
This PR add them in the packaging so they are easy to acces


**Fixes** # CTOR-1788


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

New plugin mode should run without problem
You can install a pfsense server to test it correctly respond as I did with virtualbox


## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
