### PR TITLE
enh(cloud::kubernetes): Kubernetes Deployment status : permit to filter on label

### DIFF
--- a/src/cloud/kubernetes/mode/deploymentstatus.pm
+++ b/src/cloud/kubernetes/mode/deploymentstatus.pm
@@ -32,27 +32,27 @@ sub custom_status_perfdata {
     $self->{output}->perfdata_add(
         nlabel => 'deployment.replicas.desired.count',
         value => $self->{result_values}->{desired},
-        instances => $self->{result_values}->{name}
+        instances => $self->{result_values}->{namespace} . '/' . $self->{result_values}->{name}
     );
     $self->{output}->perfdata_add(
         nlabel => 'deployment.replicas.current.count',
         value => $self->{result_values}->{current},
-        instances => $self->{result_values}->{name}
+        instances => $self->{result_values}->{namespace} . '/' . $self->{result_values}->{name}
     );
     $self->{output}->perfdata_add(
         nlabel => 'deployment.replicas.available.count',
         value => $self->{result_values}->{available},
-        instances => $self->{result_values}->{name}
+        instances => $self->{result_values}->{namespace} . '/' . $self->{result_values}->{name}
     );
     $self->{output}->perfdata_add(
         nlabel => 'deployment.replicas.ready.count',
         value => $self->{result_values}->{ready},
-        instances => $self->{result_values}->{name}
+        instances => $self->{result_values}->{namespace} . '/' . $self->{result_values}->{name}
     );
     $self->{output}->perfdata_add(
         nlabel => 'deployment.replicas.uptodate.count',
         value => $self->{result_values}->{up_to_date},
-        instances => $self->{result_values}->{name}
+        instances => $self->{result_values}->{namespace} . '/' . $self->{result_values}->{name}
     );
 }
 
@@ -72,7 +72,7 @@ sub custom_status_output {
 sub prefix_deployment_output {
     my ($self, %options) = @_;
 
-    return "Deployment '" . $options{instance_value}->{name} . "' ";
+    return "Deployment '" . $options{instance_value}->{namespace} . "/" . $options{instance_value}->{name} . "' ";
 }
 
 sub set_counters {

--- a/src/cloud/kubernetes/mode/deploymentstatus.pm
+++ b/src/cloud/kubernetes/mode/deploymentstatus.pm
@@ -149,9 +149,10 @@ sub manage_selection {
                 foreach my $key (keys %{$set}) {
                     my $val = defined($set->{$key}) ? $set->{$key} : '';
                     if (defined($filter_key)) {
-                        if ($key =~ /$filter_key/ && $val =~ /$filter_value/) { $found = 1; last; }
+                        # Use m{} to avoid issues with '/' in label keys (e.g. 'app.kubernetes.io/name')
+                        if ($key =~ m{$filter_key} && $val =~ m{$filter_value}) { $found = 1; last; }
                     } else {
-                        if ($key =~ /$filter/ || $val =~ /$filter/) { $found = 1; last; }
+                        if ($key =~ m{$filter} || $val =~ m{$filter}) { $found = 1; last; }
                     }
                 }
                 last if ($found);
@@ -161,7 +162,6 @@ sub manage_selection {
                 next;
             }
         }
-
         $self->{deployments}->{ $deployment->{metadata}->{uid} } = {
             name => $deployment->{metadata}->{name},
             namespace => $deployment->{metadata}->{namespace},


### PR DESCRIPTION
# Community contributors

## Description

Kubernetes Deployment status : permit to filter on label

**Fixes** # (issue)
If you are fixing a github Issue already existing, mention it here.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

./centreon_kubernetes_api.pl --plugin=cloud::kubernetes::plugin --mode=deployment-status --custommode='api' --hostname='<IP-or-hostname>' --port'<port>' --proto='https' --token='<token>' --filter-label '<label>'
OK: All deployments status are ok

This command should return only deployments matching the label filter.

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (develop).
- [X] I have provide data or shown output displaying the result of this code in the plugin area concerned.


