### PR TITLE
fix(network::huawei::standard::snmp): fixed uninitialized value in fan status for short output CTOR-1986

### DIFF
--- a/src/centreon/common/huawei/standard/snmp/mode/components/fan.pm
+++ b/src/centreon/common/huawei/standard/snmp/mode/components/fan.pm
@@ -65,7 +65,7 @@ sub check {
         my $exit = $self->get_severity(section => 'fan', value => $result->{hwEntityFanState});
         if (!$self->{output}->is_status(value => $exit, compare => 'ok', litteral => 1)) {
             $self->{output}->output_add(severity => $exit,
-                                        short_msg => sprintf("fan '%s' state is '%s'", $instance, $result->{infoFanState}));
+                                        short_msg => sprintf("fan '%s' state is '%s'", $instance, $result->{hwEntityFanState}));
         }        
         
         next if (!defined($result->{hwEntityFanSpeed}) || $result->{hwEntityFanSpeed} !~ /[0-9]/);


### PR DESCRIPTION
# Centreon team (internal PR)

Fixed uninitialized value in fan status for short output
CTOR-1986

**Fixes** # (issue)
https://github.com/centreon/centreon-plugins/issues/5810

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Using data provided in https://github.com/centreon/centreon-plugins/issues/5810

## Checklist

- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
