### PR TITLE
fix(storage::hp::msa2000::snmp): fixed packaging after hardwarefibrealliance rework in previous release CTOR-1985

### DIFF
--- a/packaging/centreon-plugin-Hardware-Storage-Hp-Msa2000-Snmp/pkg.json
+++ b/packaging/centreon-plugin-Hardware-Storage-Hp-Msa2000-Snmp/pkg.json
@@ -6,9 +6,10 @@
         "centreon/plugins/script_snmp.pm",
         "centreon/plugins/snmp.pm",
         "snmp_standard/mode/hardwarefibrealliance.pm",
+        "snmp_standard/mode/components/",
         "snmp_standard/mode/interfaces.pm",
         "snmp_standard/mode/listinterfaces.pm",
-	"snmp_standard/mode/resources/",
+	    "snmp_standard/mode/resources/",
         "storage/hp/msa2000/snmp/"
     ]
 }

--- a/packaging/centreon-plugin-Hardware-Storage-Lenovo-Sseries-Snmp/pkg.json
+++ b/packaging/centreon-plugin-Hardware-Storage-Lenovo-Sseries-Snmp/pkg.json
@@ -6,9 +6,10 @@
         "centreon/plugins/script_snmp.pm",
         "centreon/plugins/snmp.pm",
         "snmp_standard/mode/hardwarefibrealliance.pm",
+        "snmp_standard/mode/components/",
         "snmp_standard/mode/interfaces.pm",
         "snmp_standard/mode/listinterfaces.pm",
-	"snmp_standard/mode/resources/",
+	    "snmp_standard/mode/resources/",
         "storage/lenovo/sseries/snmp/"
     ]
 }


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

fixed packaging after hardwarefibrealliance rework in previous release (CTPR-1623 : https://github.com/centreon/centreon-plugins/pull/5677/files#diff-ff64d2d08c434cb951d06e4c11a214e5d041a41772eedf301cd028733435afed )

**Fixes** # (issue)
CTOR-1985

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

- Install HP MSA2000 connector
- Create host and Hardware service
- Result is:
```
/usr/lib/centreon/plugins//centreon_hp_msa2000.pl --plugin=storage::hp::msa2000::snmp::plugin --mode=hardware --hostname=localhost
UNKNOWN: Can't use an undefined value as a subroutine reference at /usr/lib/centreon/plugins//centreon_hp_msa2000.pl line 11169.
```

## Checklist

- [x] I have **rebased** my development branch on the base branch (develop).
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
