### PR TITLE
fix(hardware-pdu-apc-snmp): added missing time and uptime in packaging CTOR-2002

### DIFF
--- a/packaging/centreon-plugin-Hardware-Pdu-Apc-Snmp/pkg.json
+++ b/packaging/centreon-plugin-Hardware-Pdu-Apc-Snmp/pkg.json
@@ -5,6 +5,8 @@
     "files": [
         "centreon/plugins/script_snmp.pm",
         "centreon/plugins/snmp.pm",
-        "hardware/pdu/apc/snmp/"
+        "hardware/pdu/apc/snmp/",
+        "snmp_standard/mode/ntp.pm",
+        "snmp_standard/mode/uptime.pm"
     ]
 }


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

added missing time and uptime in packaging 
CTOR-2002

**Fixes** # (issue)
https://github.com/centreon/centreon-plugins/issues/5828
https://github.com/centreon/centreon-plugins/issues/5829
https://github.com/centreon/centreon-plugins/issues/4814

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

As explained in the Github issues.

## Checklist

- [x] I have **rebased** my development branch on the base branch (develop).
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
