### PR TITLE
fix(network::stonesoft::snmp): fixed typo in memory mode pod

### DIFF
--- a/src/network/stonesoft/snmp/mode/memory.pm
+++ b/src/network/stonesoft/snmp/mode/memory.pm
@@ -167,7 +167,7 @@ __END__
 
 =head1 MODE
 
-Check <CStonesoft> Firewall memory usage <C(STONESOFT-FIREWALL-MIB)>.
+Check C<Stonesoft> Firewall memory usage (C<STONESOFT-FIREWALL-MIB>).
 
 =over 8
 


### PR DESCRIPTION
fixed typo in memory mode pod