### PR TITLE
fix(hp-athonet-alertmanager): update pod and import

### DIFF
--- a/src/network/hp/athonet/alertmanager/api/custom/api.pm
+++ b/src/network/hp/athonet/alertmanager/api/custom/api.pm
@@ -27,6 +27,7 @@ use JSON::XS;
 use Digest::MD5 qw(md5_hex);
 use centreon::plugins::statefile;
 use centreon::plugins::misc qw/is_empty json_decode json_encode/;
+use centreon::plugins::constants qw(:messages);
 
 sub new {
     my ($class, %options) = @_;
@@ -132,8 +133,8 @@ sub get_access_token {
             refresh_token => $refresh_token
         };
         my $encoded = json_encode($json_request,
-                      errstr => 'cannot encode json request',
-                      output => $self->{output});
+                                  errstr => 'cannot encode json request',
+                                  output => $self->{output});
 
         my $content = $self->{http}->request(
             method          => 'POST',
@@ -268,25 +269,17 @@ __END__
 
 =head1 NAME
 
-Prometheus Rest API.
+HP Athonet Rest API.
 
 =head1 SYNOPSIS
 
-Prometheus Rest API custom mode.
+HP Athonet Rest API custom mode.
 
 =head1 REST API OPTIONS
 
-Prometheus Rest API.
+HP Athonet Rest API.
 
 =over 8
-
-=item B<--timeframe>
-
-Set timeframe in seconds (i.e. 3600 to check last hour).
-
-=item B<--step>
-
-Set the step of the metric query (examples: C<30s>, C<1m>, C<15m>, C<1h>).
 
 =item B<--hostname>
 


### PR DESCRIPTION
## Description

Removing non-existent options in pod and add import constants to fix json_decode error message.

Refs: CTOR-1613

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
