### PR TITLE
Fix - storage::netapp::ontap::restapi::mode::volumes: missing "state" in volume fields

### DIFF
--- a/src/storage/netapp/ontap/restapi/mode/volumes.pm
+++ b/src/storage/netapp/ontap/restapi/mode/volumes.pm
@@ -382,7 +382,7 @@ sub check_options {
 sub manage_selection {
     my ($self, %options) = @_;
 
-    my $endpoint = '/api/storage/volumes?fields=svm,name,space,metric';
+    my $endpoint = '/api/storage/volumes?fields=svm,name,state,space,metric';
     
     if (defined($self->{option_results}->{filter_volume_name}) && $self->{option_results}->{filter_volume_name} ne '' ) {
         $endpoint .= '&name=' . $self->{option_results}->{filter_volume_name};


### PR DESCRIPTION
# Community contributors

## Description

The state is skipped ..

<img width="1555" height="36" alt="image" src="https://github.com/user-attachments/assets/409da7a9-c982-4c3f-8fea-bff99bf12eb1" />

after commit

<img width="1397" height="145" alt="image" src="https://github.com/user-attachments/assets/9abc2358-33c9-4229-b72a-f94943490b86" />

https://github.com/centreon/centreon-plugins/commit/942c0b7940ce2667f1513716e77fbc058434e98c

Before this fix it was "*"

<img width="862" height="141" alt="image" src="https://github.com/user-attachments/assets/52eb8c71-ac53-495c-8102-b89f23e7f320" />

Now there is a fix list of fields:

<img width="1048" height="123" alt="image" src="https://github.com/user-attachments/assets/caa845fa-23bd-4703-a54b-b1212902e3d1" />

but no "state". So i added it

<img width="672" height="62" alt="image" src="https://github.com/user-attachments/assets/13253e72-a0c0-442e-adbd-52e3900a992b" />

works again:

<img width="1558" height="40" alt="image" src="https://github.com/user-attachments/assets/12c0106f-e85d-476b-93b4-360e98e6083d" />

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Here the output before my fix:

[debug-output-before-fix.json](https://github.com/user-attachments/files/23455007/debug-output-before-fix.json)

Here the output after my fix:

[new-debug-output.json](https://github.com/user-attachments/files/23455009/new-debug-output.json)