### PR TITLE
Allow downgrades in apt-get install command

### DIFF
--- a/.github/scripts/test-plugins.py
+++ b/.github/scripts/test-plugins.py
@@ -52,7 +52,7 @@ def install_plugin(plugin, archi, build):
                 install_name = f"./{plugin.lower()}*.deb"
             else:
                 install_name = plugin.lower()
-            command = f"apt-get install -o 'Binary::apt::APT::Keep-Downloaded-Packages=1;' -y {install_name}"
+            command = f"apt-get install -o 'Binary::apt::APT::Keep-Downloaded-Packages=1;' -y --allow-downgrades {install_name}"
             outfile.write(command + "\n")
             output_status = (subprocess.run(command, shell=True, check=False,
                              stderr=subprocess.STDOUT, stdout=outfile)).returncode


### PR DESCRIPTION
## Description

[Allow downgrades in apt-get install command](https://github.com/centreon/centreon-plugins/commit/f77d933a57c51d06d6079a5fce0999eea66284b6)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

