### PR TITLE
fix(database::mssql): wrong output unit in locks-wait mode CTOR-2026

### DIFF
--- a/src/database/mssql/mode/lockswaits.pm
+++ b/src/database/mssql/mode/lockswaits.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2025 Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -34,7 +34,7 @@ sub set_counters {
     $self->{maps_counters}->{lockswaits} = [
         { label => 'lockswaits', nlabel => 'mssql.lockswaits.count', set => {
                 key_values => [ { name => 'value' } ],
-                output_template => '%.2f dead locks/s',
+                output_template => '%.2f locks waits/s',
                 perfdatas => [
                     { template => '%.2f', min => 0 }
                 ]


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

wrong output unit in locks-wait mode 
REFs: CTOR-2026

**Fixes** # (issue)
CTOR-2026
https://github.com/centreon/centreon-plugins/issues/5855

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [x] I have **rebased** my development branch on the base branch (develop).
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
