### PR TITLE
fix(storage::exagrid::snmp): fixed landing_used calculation to prevent negative values in server-usage mode

### DIFF
--- a/src/storage/exagrid/snmp/mode/serverusage.pm
+++ b/src/storage/exagrid/snmp/mode/serverusage.pm
@@ -168,7 +168,9 @@ sub manage_selection {
         retention_total => $result->{egRetentionSpaceConfiguredWholeGigabytes} * 1000 * 1000 * 1000,
         retention_used => $result->{egRetentionSpaceConfiguredWholeGigabytes} * 1000 * 1000 * 1000 - $result->{egRetentionSpaceAvailableWholeGigabytes} * 1000 * 1000 * 1000,
         landing_total => $result->{egLandingSpaceConfiguredWholeGigabytes} * 1000 * 1000 * 1000,
-        landing_used => $result->{egLandingSpaceConfiguredWholeGigabytes} * 1000 * 1000 * 1000 - $result->{egLandingSpaceAvailableWholeGigabytes} * 1000 * 1000 * 1000
+        landing_used => (($result->{egLandingSpaceConfiguredWholeGigabytes} * 1000 * 1000 * 1000 - $result->{egLandingSpaceAvailableWholeGigabytes} * 1000 * 1000 * 1000) < 0
+            ? 0
+            : ($result->{egLandingSpaceConfiguredWholeGigabytes} * 1000 * 1000 * 1000 - $result->{egLandingSpaceAvailableWholeGigabytes} * 1000 * 1000 * 1000))
     };
 }
 


### PR DESCRIPTION

# Community contributors

## Description

In some situations exagrid reports available landing space larger than configured space. In that case the plugin returns used landing space as negative.


## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

nagios@********:~$ '/usr/lib/nagios/plugins/centreon_plugins.pl' '--critical-landing-usage' '90' '--filter-counters' 'landing-usage' '--hostname' '*.*.*.*' '--mode' 'server-usage' '--plugin' 'storage::exagrid::snmp::plugin' '--snmp-community' '****' '--snmp-version' '2' '--warning-landing-usage' '80' --debug
CRITICAL: Landing Usage Total: 31.88 TB **Used: -3.58 TB (-11.24%)** Free: 35.47 TB (111.24%) | 'landing_used'=-3941000000000B;0:28043200000000;0:31548600000000;0;35054000000000
.1.3.6.1.4.1.14941.4.1.1.0 = 35054
.1.3.6.1.4.1.14941.4.1.2.0 = 833000000
.1.3.6.1.4.1.14941.4.1.3.0 = 38995
.1.3.6.1.4.1.14941.4.1.4.0 = 397762437

nagios@********:~$ '/usr/lib/nagios/plugins/centreon_plugins.pl' '--critical-landing-usage' '90' '--filter-counters' 'landing-usage' '--hostname' '*.*.*.*' '--mode' 'server-usage' '--plugin' 'storage::exagrid::snmp::plugin' '--snmp-community' '****' '--snmp-version' '2' '--warning-landing-usage' '80' --debug
OK: Landing Usage Total: 31.88 TB **Used: 0.00 B (0.00%)** Free: 31.88 TB (100.00%) | 'landing_used'=0B;0:28043200000000;0:31548600000000;0;35054000000000
.1.3.6.1.4.1.14941.4.1.1.0 = 35054
.1.3.6.1.4.1.14941.4.1.2.0 = 833000000
.1.3.6.1.4.1.14941.4.1.3.0 = 38995
