### PR TITLE
Update ntp.pm

### DIFF
--- a/src/snmp_standard/mode/ntp.pm
+++ b/src/snmp_standard/mode/ntp.pm
@@ -173,7 +173,7 @@ sub manage_selection {
         $ref_time = time();
     }
 
-    my $offset = $distant_time - $ref_time;
+    my $offset = abs( $distant_time - $ref_time);
     my $remote_date_formated = sprintf(
         'Local Time : %02d-%02d-%02dT%02d:%02d:%02d (%s)',
         $remote_date->[0], $remote_date->[1], $remote_date->[2],


### PR DESCRIPTION
offset with a negative "-1 second" output cause a critical status of the plugin.  Offsets should be positive integers

# Community contributors

## Description

Sometimes, centreon_linux_snmp.pl --plugin=os::linux::snmp::plugin --mode=time trigger critical status when the checked host is just a second behind the ref_time
```
sudo -u centreon-engine /usr/lib/centreon/plugins//centreon_linux_snmp.pl --plugin=os::linux::snmp::plugin --mode=time --hostname=192.168.1.118 --snmp-version=2c --snmp-community=****** --warning-offset=120 --critical-offset=300 
CRITICAL: Time offset -1 second(s): Local Time : 2025-12-01T09:42:30 (Europe/Paris) | 'offset'=-1s;0:120;0:300;;
```

## Type of change

- Patch fixing an issue (non-breaking change)

## How this pull request can be tested ?

Check against an host which have it clock set near 1s behing ntp ref time
The unpatched check is tossed be criticals when it retrives exactly "-1" (second) as offset
This patched check, returning in that case "1" stay with status OK

tested with:

```
sudo -u centreon-engine /usr/lib/centreon/plugins//centreon_linux_snmp.pl --plugin=os::linux::snmp::plugin --mode=time --hostname=192.168.1.118 --snmp-version=2c --snmp-community=****** --warning-offset=120 --critical-offset=300 
OK: Time offset 1 second(s): Local Time : 2025-12-01T09:51:12 (+0100) | 'offset'=1s;0:120;0:300;;
```

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] I have provide data or shown output displaying the result of this code in the plugin area concerned.
