### PR TITLE
fix(apps-controlm-restapi): fixed typo in jobs mode CTOR-1998

### DIFF
--- a/src/apps/controlm/restapi/mode/jobs.pm
+++ b/src/apps/controlm/restapi/mode/jobs.pm
@@ -321,11 +321,45 @@ You can use the following variables: %{name}, %{status}, %{elapsed}, %{applicati
 Set critical threshold for long jobs.
 You can use the following variables: %{name}, %{status}, %{elapsed}, %{application}, %{folder}, %{type}
 
-=item B<--warning-*> B<--critical-*>
+=item B<--warning-jobs-succeeded>
 
-Thresholds.
-Can be: 'jobs-succeeded', 'jobs-failed', 'jobs-executing', 'jobs-waiting',
-'job-failed'.
+Threshold.
+
+=item B<--critical-jobs-succeeded>
+
+Threshold.
+
+=item B<--warning-jobs-failed>
+
+Threshold.
+
+=item B<--critical-jobs-failed>
+
+Threshold.
+
+=item B<--warning-jobs-executing>
+
+Threshold.
+
+=item B<--critical-jobs-executing>
+
+Threshold.
+
+=item B<--warning-jobs-waiting>
+
+Threshold.
+
+=item B<--critical-jobs-waiting>
+
+Threshold.
+
+=item B<--warning-job-failed>
+
+Threshold.
+
+=item B<--critical-job-failedg>
+
+Threshold.
 
 =back
 


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

fixed typo in jobs mode 

**Fixes** # (issue)
REFs: CTOR-1998

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [x] I have **rebased** my development branch on the base branch (develop).
- [x] I have reviewed all the help messages in all the .pm files I have modified.
  - [x] All sentences begin with a capital letter.
  - [x] All sentences end with a period.
  - [x] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
