### PR TITLE
Aruba license: new status ES (enabled)

### DIFF
--- a/src/centreon/common/aruba/snmp/mode/license.pm
+++ b/src/centreon/common/aruba/snmp/mode/license.pm
@@ -111,7 +111,7 @@ sub new {
 }
 
 my %map_flags = (
-    'E' => 'enabled', 'A' => 'auto-generated', 'R' => 'reboot-required'
+    'E' => 'enabled', 'ES' => 'enabled', 'A' => 'auto-generated', 'R' => 'reboot-required'
 );
 
 my $oid_wlsxSysExtSwitchLicenseTable = '.1.3.6.1.4.1.14823.2.2.1.2.1.20.1';


### PR DESCRIPTION
Aruba has done some license change and on subscription licenses the status is ES and the license type will not recognized:

```
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.2.1 = hjOFGuTY-PuAcCU7A-
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.2.2 = eXCbr8rn-uhY3raug-
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.2.3 = D12ksZCk-G8GEY13P-
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.2.4 = A5Y1AH8F-KMMrbLyJ-
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.3.1 = 2025-05-19 09:44:04
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.3.2 = 2025-05-19 09:45:35
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.3.3 = 2025-06-12 15:40:36
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.3.4 = 2025-07-28 07:56:50[A5Y1AH8F-KM
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.4.1 = Never
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.4.2 = Never
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.4.3 = Never
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.4.4 = 2028-11-25 06:56:50
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.5.1 =  E
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.5.2 =  E
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.5.3 =  E
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.5.4 =  ES
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.6.1 = MC-VA-RW: 50
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.6.2 = Access Points: 25
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.6.3 = Next Generation Policy Enforcement Firewall Module: 25
.1.3.6.1.4.1.14823.2.2.1.2.1.20.1.6.4 = WebCC: 25
License 'Access Points: 25' status is 'enabled', never expires
License 'MC-VA-RW: 50' status is 'enabled', never expires
License 'Next Generation Policy Enforcement Firewall Module: 25' status is 'enabled', never expires
License 'WebCC: 25' status is 'unknown'expires in 2y 10M 2w 4d 51m 23s [2028-11-25 06:56:50]
```