### PR TITLE
QNAP better support for QuTS hero

### DIFF
--- a/src/storage/qnap/snmp/mode/components/fan.pm
+++ b/src/storage/qnap/snmp/mode/components/fan.pm
@@ -36,6 +36,10 @@ my $mapping = {
         description => { oid => '.1.3.6.1.4.1.55062.1.12.9.1.2' }, # sysFanDescr
         speed       => { oid => '.1.3.6.1.4.1.55062.1.12.9.1.3' }  # sysFanSpeed
     },
+    quts => {
+        description => { oid => '.1.3.6.1.4.1.55062.2.12.9.1.2' }, # sysFanDescr
+        speed       => { oid => '.1.3.6.1.4.1.55062.2.12.9.1.3' }  # sysFanSpeed
+    },
     ex => {
         description => { oid => '.1.3.6.1.4.1.24681.1.4.1.1.1.1.2.2.1.2' }, # systemFanID
         status      => { oid => '.1.3.6.1.4.1.24681.1.4.1.1.1.1.2.2.1.4', map => $map_status }, # systemFanStatus
@@ -116,6 +120,18 @@ sub check_fan_qts {
     check_fan_result($self, type => 'qts', snmp_result => $snmp_result);
 }
 
+sub check_fan_quts {
+    my ($self, %options) = @_;
+
+    return if (defined($self->{fan_checked}));
+
+    my $snmp_result = $self->{snmp}->get_table(
+        oid => '.1.3.6.1.4.1.55062.2.12.9', # systemFanTable
+        start => $mapping->{quts}->{description}->{oid}
+    );
+    check_fan_result($self, type => 'quts', snmp_result => $snmp_result);
+}
+
 sub check_fan_legacy {
     my ($self, %options) = @_;
 
@@ -147,6 +163,8 @@ sub check {
 
     if ($self->{is_qts} == 1) {
         check_fan_qts($self);
+    } elsif ($self->{is_quts} == 1) {
+        check_fan_quts($self);
     } elsif ($self->{is_es} == 1) {
         check_fan_es($self);
     } else {

--- a/src/storage/qnap/snmp/mode/memory.pm
+++ b/src/storage/qnap/snmp/mode/memory.pm
@@ -128,6 +128,10 @@ my $mapping = {
     qts => {
         ram_total => { oid => '.1.3.6.1.4.1.55062.1.12.13' }, # systemTotalMem
         ram_free  => { oid => '.1.3.6.1.4.1.55062.1.12.15' }  # systemAvailableMem
+    },
+    quts => {
+        ram_total => { oid => '.1.3.6.1.4.1.55062.2.12.13' }, # systemTotalMem
+        ram_free  => { oid => '.1.3.6.1.4.1.55062.2.12.15' }  # systemAvailableMem
     }
 };
 
@@ -165,13 +169,15 @@ sub manage_selection {
                 values(%{$mapping->{legacy}}),
                 values(%{$mapping->{ex}}),
                 values(%{$mapping->{es}}),
-                values(%{$mapping->{qts}})
+                values(%{$mapping->{qts}}),
+                values(%{$mapping->{quts}})
             )
         ],
         nothing_quit => 1
     );
 
     if (!defined($self->{option_results}->{force_counters_legacy})) {
+        $self->check_memory(snmp => $options{snmp}, type => 'quts', snmp_result => $snmp_result);
         $self->check_memory(snmp => $options{snmp}, type => 'qts', snmp_result => $snmp_result);
         $self->check_memory(snmp => $options{snmp}, type => 'ex', snmp_result => $snmp_result);
         $self->check_memory(snmp => $options{snmp}, type => 'es', snmp_result => $snmp_result, convert => 1);


### PR DESCRIPTION
## Description

Support of QuTS hero (OID .1.3.6.1.4.1.55062.2, very similar to QTS .1.3.6.1.4.1.55062.1). Amendment to #5580.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

snmpwalk from our testing box:
[qnap.snmpwalk.txt](https://github.com/user-attachments/files/25665905/qnap.snmpwalk.txt)

```
$ centreon_plugins.pl --plugin storage::qnap::snmp::plugin [host_and_snmp_options] --mode hardware --component psu --verbose
OK: All 1 components are ok [1/1 psu]. | 'hardware.psu.count'=1;;;;
Checking power supplies
system power supply status is 'ok' [instance: 1]

$ centreon_plugins.pl --plugin storage::qnap::snmp::plugin [host_and_snmp_options] --mode hardware --component fan --verbose
OK: All 3 components are ok [3/3 fans]. | '1#hardware.fan.speed.rpm'=1762rpm;;;0; '2#hardware.fan.speed.rpm'=1961rpm;;;0; '3#hardware.fan.speed.rpm'=1882rpm;;;0; 'hardware.fan.count'=3;;;;
Checking fans
fan 'System FAN 1' speed is 1762 [instance: 1, status: n/a]
fan 'System FAN 2' speed is 1961 [instance: 2, status: n/a]
fan 'System FAN 3' speed is 1882 [instance: 3, status: n/a]

$ centreon_plugins.pl --plugin storage::qnap::snmp::plugin [host_and_snmp_options] --mode memory
OK: Memory total: 7.55 GB used: 2.24 GB (29.66%) free: 5.31 GB (70.34%) | 'memory.usage.bytes'=2405962752B;;;0;8111026176 'memory.free.bytes'=5705063424B;;;0;8111026176 'memory.usage.percentage'=29.66%;;;0;100

$ centreon_plugins.pl --plugin storage::qnap::snmp::plugin [host_and_snmp_options] --mode upgrade
OK: upgrade is unavailable [model: TS-464eU] [version: h5.2.8.3359] 
```

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.
