### PR TITLE
CTOR-2010 Plugin(apps::pvx::restapi): Bearer Authentication required for API calls

### DIFF
--- a/src/apps/pvx/restapi/custom/api.pm
+++ b/src/apps/pvx/restapi/custom/api.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -24,9 +24,10 @@ use strict;
 use warnings;
 use centreon::plugins::http;
 use DateTime;
-use JSON::XS;
 use URI::Encode;
-use centreon::plugins::misc;
+use centreon::plugins::misc qw/is_empty json_decode value_of/;
+use centreon::plugins::statefile;
+use Digest::SHA qw(sha256_hex);
 
 sub new {
     my ($class, %options) = @_;
@@ -44,25 +45,28 @@ sub new {
 
     if (!defined($options{noptions})) {
         $options{options}->add_options(arguments => {
-            'api-key:s'       => { name => 'api_key' },
-            'default-value:s' => { name => 'default_value' },
-            'hostname:s'      => { name => 'hostname' },
-            'url-path:s'      => { name => 'url_path' },
-            'port:s'          => { name => 'port' },
-            'proto:s'         => { name => 'proto' },
-            'credentials'     => { name => 'credentials' },
-            'basic'           => { name => 'basic' },
-            'username:s'      => { name => 'username' },
-            'password:s'      => { name => 'password' },
-            'timeout:s'       => { name => 'timeout', default => 10 },
-            'timeframe:s'     => { name => 'timeframe' },
-            'timezone:s'      => { name => 'timezone', default => 'UTC' }
+            'api-key:s'          => { name => 'api_key',          default => '' },
+            'default-value:s'    => { name => 'default_value' },
+            'hostname:s'         => { name => 'hostname',         default => '' },
+            'url-path:s'         => { name => 'url_path',         default => '/api' },
+            'auth-service-url:s' => { name => 'auth_service_url', default => '/api/v1/auth/login' },
+            'port:s'             => { name => 'port',             default => 443 },
+            'proto:s'            => { name => 'proto',            default => 'https' },
+            'credentials'        => { name => 'credentials' },
+            'basic'              => { name => 'basic' },
+            'username:s'         => { name => 'username',         default => '' },
+            'password:s'         => { name => 'password',         default => '' },
+            'use-auth-service'   => { name => 'use_auth_service' },
+            'timeout:s'          => { name => 'timeout',          default => 10 },
+            'timeframe:s'        => { name => 'timeframe',        default => 1 },
+            'timezone:s'         => { name => 'timezone',         default => 'UTC' }
         });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
 
     $self->{output} = $options{output};
     $self->{http} = centreon::plugins::http->new(%options);
+    $self->{cache} = centreon::plugins::statefile->new(%options);
 
     return $self;
 }
@@ -78,31 +82,23 @@ sub set_defaults {}
 sub check_options {
     my ($self, %options) = @_;
 
-    $self->{api_key} = (defined($self->{option_results}->{api_key})) ? $self->{option_results}->{api_key} : undef;
-    $self->{hostname} = (defined($self->{option_results}->{hostname})) ? $self->{option_results}->{hostname} : undef;
-    $self->{port} = (defined($self->{option_results}->{port})) ? $self->{option_results}->{port} : 443;
-    $self->{proto} = (defined($self->{option_results}->{proto})) ? $self->{option_results}->{proto} : 'https';
-    $self->{url_path} = (defined($self->{option_results}->{url_path})) ? $self->{option_results}->{url_path} : '/api';
-    $self->{timeout} = (defined($self->{option_results}->{timeout})) ? $self->{option_results}->{timeout} : 10;
-    $self->{username} = (defined($self->{option_results}->{username})) ? $self->{option_results}->{username} : undef;
-    $self->{password} = (defined($self->{option_results}->{password})) ? $self->{option_results}->{password} : undef;
+    $self->{$_} = $self->{option_results}->{$_}
+        foreach qw/api_key hostname port proto url_path timeout username password timeframe timezone auth_service_url/;
+
     $self->{credentials} = (defined($self->{option_results}->{credentials})) ? 1 : undef;
     $self->{basic} = (defined($self->{option_results}->{basic})) ? 1 : undef;
-    $self->{timeframe} = (defined($self->{option_results}->{timeframe})) ? $self->{option_results}->{timeframe} : undef;
 
-    if (!defined($self->{hostname}) || $self->{hostname} eq '') {
-        $self->{output}->add_option_msg(short_msg => "Need to specify hostname option.");
-        $self->{output}->option_exit();
-    }
-    if (!defined($self->{api_key}) || $self->{api_key} eq '') {
-        $self->{output}->add_option_msg(short_msg => "Need to specify api-key option.");
-        $self->{output}->option_exit();
-    }
+    $self->{output}->option_exit(short_msg => "Need to specify hostname option.")
+        if is_empty($self->{hostname});
 
-    $self->{timezone} = 'UTC';
-    if (defined($self->{option_results}->{timezone}) && $self->{option_results}->{timezone} ne '') {
-        $self->{timezone} = $self->{option_results}->{timezone};
-    }
+    $self->{cache}->check_options(option_results => $self->{option_results});
+
+    # Three authentication methods are supported: legacy username/password, API key, and username/password via
+    # the authentication server
+    $self->{use_auth_service} = $self->{option_results}->{use_auth_service} // 0;
+
+    $self->{output}->option_exit(short_msg => "You must provide either username/password or an API key.")
+        unless ($self->{username} && $self->{password}) || $self->{api_key};
 
     return 0;
 }
@@ -110,25 +106,48 @@ sub check_options {
 sub build_options_for_httplib {
     my ($self, %options) = @_;
 
-    $self->{option_results}->{hostname} = $self->{hostname};
-    $self->{option_results}->{timeout} = $self->{timeout};
-    $self->{option_results}->{port} = $self->{port};
-    $self->{option_results}->{proto} = $self->{proto};
-    $self->{option_results}->{credentials} = $self->{credentials};
-    $self->{option_results}->{basic} = $self->{basic};
-    $self->{option_results}->{username} = $self->{username};
-    $self->{option_results}->{password} = $self->{password};
+    $self->{option_results}->{$_} = $self->{$_}
+        foreach qw/hostname timeout port proto/;
+
+    unless ($self->{use_auth_service}) {
+        # Those options are no longer used by the plugin when we use auth service
+        $self->{option_results}->{$_} = $self->{$_}
+            foreach qw/credentials basic username password/;
+    }
+
     $self->{option_results}->{warning_status} = '';
     $self->{option_results}->{critical_status} = '';
+}
+
+sub auth_service_login {
+    my ($self, %options) = @_;
+    my $content = $self->{http}->request( url_path => $self->{auth_service_url},
+                                          method => 'POST',
+                                          post_params => { username => $self->{username},
+                                                           password => $self->{password}
+                                                         }
+                                        );
+
+    my $key = $self->{http}->get_header(name => 'authorization');
+
+    $self->{output}->option_exit(short_msg => "Authentication failed")
+        if $self->{http}->get_code() == 401;
+
+    $self->{output}->option_exit(short_msg => "Authentication error: ". ($self->{http}->get_message() || "Unknown error"))
+        if is_empty($key);
+
+    $self->{bearer_token} = $key // '';
+
+    $self->{cache}->write(data => { bearer_token => $self->{bearer_token} });
 }
 
 sub settings {
     my ($self, %options) = @_;
 
-    $self->build_options_for_httplib();
+    $self->build_options_for_httplib(%options);
     $self->{http}->add_header(key => 'Accept', value => 'application/json');
-    $self->{http}->add_header(key => 'Content-Type', value => 'application/x-www-form-urlencoded');
-    $self->{http}->add_header(key => 'PVX-Authorization', value => $self->{api_key});
+    $self->{http}->add_header(key => 'PVX-Authorization', value => $self->{api_key})
+        unless $self->{use_auth_service};
     $self->{http}->set_options(%{$self->{option_results}});
 }
 
@@ -182,21 +201,44 @@ sub get_endpoint {
     my ($self, %options) = @_;
 
     $self->settings;
-    my $response = $self->{http}->request(url_path => $self->{url_path} . $options{url_path});
-    
-    my $content;
-    eval {
-        $content = JSON::XS->new->utf8->decode($response);
-    };
-    if ($@) {
-        $self->{output}->add_option_msg(short_msg => "Cannot decode json response: $@");
-        $self->{output}->option_exit();
+
+    if ($self->{use_auth_service} && is_empty($self->{bearer_token})) {
+        $self->{cache}->read(statefile => 'pvx_restapi_' . sha256_hex($self->{hostname}.'_'.$self->{username}));
+        $self->{bearer_token} = $self->{cache}->get(name => 'bearer_token');
     }
 
-    if ($content->{type} eq 'error') {
-        $self->{output}->add_option_msg(short_msg => "Cannot get data: " . $content->{error});
-        $self->{output}->option_exit();
+    my $retry = ! is_empty($self->{bearer_token});
+    my $response;
+
+    while (1) {
+        if ($self->{use_auth_service} && is_empty($self->{bearer_token})) {
+            $self->auth_service_login(%options);
+
+            $self->{output}->option_exit(short_msg => "Authentication failed: No token received.")
+                if is_empty($self->{bearer_token});
+            $self->{http}->add_header(key => 'Authorization', value => $self->{bearer_token});
+        }
+
+        $response = $self->{http}->request(url_path => $self->{url_path} . $options{url_path},
+                                           header => [ 'content-type:application/x-www-form-urlencoded' ],
+                                           unknown_status => '');
+
+        if ($self->{use_auth_service} && $retry && $self->{http}->get_code() == 401) {
+            undef $self->{bearer_token};
+            undef $retry;
+            next
+        }
+
+        last
     }
+
+    $self->{output}->option_exit(short_msg => "Cannot get data: " . $self->{http}->get_message())
+        if $self->{http}->get_code() < 200 || $self->{http}->get_code() >= 300;
+
+    my $content = json_decode($response, output => $self->{output});
+
+    $self->{output}->option_exit(short_msg => "Cannot get data: " . value_of($content, "->{error}", "Unknown error"))
+        if ref $content ne 'HASH' || ($content->{type} && $content->{type} eq 'error');
 
     return $content->{result};
 }
@@ -207,11 +249,11 @@ __END__
 
 =head1 NAME
 
-PVX REST API
+Skylight Performance Analytics (previously PVX) REST API
 
 =head1 SYNOPSIS
 
-PVX Rest API custom mode
+Skylight Performance Analytics (previously PVX) Rest API custom mode
 
 =head1 REST API OPTIONS
 
@@ -229,6 +271,15 @@ Set timeframe in seconds (i.e. 3600 to check last hour).
 
 Set your timezone. 
 Can use format: 'Europe/London' or '+0100'.
+
+=item B<--use-auth-service>
+
+Three authentication methods are supported: legacy username/password, API key, and username/password via the authentication server.
+Starting with Accedian Skylight version 17 and later authentication must be performed via the authentication server using this --use-auth-service parameter.
+
+=item B<--auth-service-url>
+
+Authentication service URL (default: '/api/v1/auth/login')
 
 =item B<--api-key>
 

--- a/tests/apps/pvx/restapi/authent.robot
+++ b/tests/apps/pvx/restapi/authent.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Documentation       Check Accedian Skylight (previously PVX) authentication
+
+Resource            ${CURDIR}${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}pvx-mockoon.json
+${cmd}              ${CENTREON_PLUGINS}
+...                 --plugin=apps::pvx::restapi::plugin
+...                 --hostname=${HOSTNAME}
+...                 --proto='http'
+...                 --port=${APIPORT}
+...                 --mode=http-hits
+
+
+*** Test Cases ***
+authent ${tc}/1
+    [Tags]    apps    backup    rubrik    restapi    cache
+
+    ${command}    Catenate
+    ...    ${cmd}
+    ...    ${extra_options}
+
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:     tc    extra_options                                                         expected_result    --
+    ...           1     ${EMPTY}                                                              UNKNOWN: You must provide either username/password or an API key.
+    ...           2     --api-key=R@X@R                                                       OK: All metrics are ok | 'ratio_application'=0.96;;;0; 'hits_error_application'=5.000hits/s;;;0; 'hits_application'=120.000hits/s;;;0; 'ratio_network'=0.98;;;0; 'hits_error_network'=2.000hits/s;;;0; 'hits_network'=95.000hits/s;;;0;
+    ...           3     --username='username' --password='password' --use-auth-service=1      UNKNOWN: 401 Unauthorized
+    ...           4     --username='Us3rN@m3' --password='password' --use-auth-service=1      OK: All metrics are ok | 'ratio_application'=0.96;;;0; 'hits_error_application'=5.000hits/s;;;0; 'hits_application'=120.000hits/s;;;0; 'ratio_network'=0.98;;;0; 'hits_error_network'=2.000hits/s;;;0; 'hits_network'=95.000hits/s;;;0;
+

--- a/tests/apps/pvx/restapi/authent.robot
+++ b/tests/apps/pvx/restapi/authent.robot
@@ -20,7 +20,7 @@ ${cmd}              ${CENTREON_PLUGINS}
 
 *** Test Cases ***
 authent ${tc}/1
-    [Tags]    apps    backup    rubrik    restapi    cache
+    [Tags]    apps    pvx    restapi
 
     ${command}    Catenate
     ...    ${cmd}
@@ -31,6 +31,6 @@ authent ${tc}/1
     Examples:     tc    extra_options                                                         expected_result    --
     ...           1     ${EMPTY}                                                              UNKNOWN: You must provide either username/password or an API key.
     ...           2     --api-key=R@X@R                                                       OK: All metrics are ok | 'ratio_application'=0.96;;;0; 'hits_error_application'=5.000hits/s;;;0; 'hits_application'=120.000hits/s;;;0; 'ratio_network'=0.98;;;0; 'hits_error_network'=2.000hits/s;;;0; 'hits_network'=95.000hits/s;;;0;
-    ...           3     --username='username' --password='password' --use-auth-service=1      UNKNOWN: 401 Unauthorized
-    ...           4     --username='Us3rN@m3' --password='password' --use-auth-service=1      OK: All metrics are ok | 'ratio_application'=0.96;;;0; 'hits_error_application'=5.000hits/s;;;0; 'hits_application'=120.000hits/s;;;0; 'ratio_network'=0.98;;;0; 'hits_error_network'=2.000hits/s;;;0; 'hits_network'=95.000hits/s;;;0;
+    ...           3     --username='username' --password='password' --use-auth-service        UNKNOWN: 401 Unauthorized
+    ...           4     --username='Us3rN@m3' --password='password' --use-auth-service        OK: All metrics are ok | 'ratio_application'=0.96;;;0; 'hits_error_application'=5.000hits/s;;;0; 'hits_application'=120.000hits/s;;;0; 'ratio_network'=0.98;;;0; 'hits_error_network'=2.000hits/s;;;0; 'hits_network'=95.000hits/s;;;0;
 

--- a/tests/apps/pvx/restapi/pvx-mockoon.json
+++ b/tests/apps/pvx/restapi/pvx-mockoon.json
@@ -1,0 +1,247 @@
+{
+  "uuid": "220e7af0-dde9-4e3a-9513-70fa9d347640",
+  "lastMigration": 33,
+  "name": "Pvx mockoon",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3007,
+  "hostname": "",
+  "folders": [],
+  "routes": [
+    {
+      "uuid": "74fe65fb-f6df-48b5-a94f-61d98cbaf96a",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "api/v1/auth/login",
+      "responses": [
+        {
+          "uuid": "4ac4ad14-f2b0-4310-b44f-4f2f9ce632cb",
+          "body": "{\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "access-control-allow-headers",
+              "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+            },
+            {
+              "key": "access-control-allow-methods",
+              "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+            },
+            {
+              "key": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "key": "content-security-policy",
+              "value": "default-src 'none'"
+            },
+            {
+              "key": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "key": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "key": "Authorization",
+              "value": "Baerer D@aUtH3nT!fiC@ti@n"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "username",
+              "value": "Us3rN@m3",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
+          "uuid": "fc4f1c8f-1d95-4e8f-82ba-61fc1e17ab51",
+          "body": "UNAUTHORIZED",
+          "latency": 0,
+          "statusCode": 401,
+          "label": " (copy)",
+          "headers": [
+            {
+              "key": "access-control-allow-headers",
+              "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+            },
+            {
+              "key": "access-control-allow-methods",
+              "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+            },
+            {
+              "key": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "key": "content-security-policy",
+              "value": "default-src 'none'"
+            },
+            {
+              "key": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "key": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "key": "Authorization",
+              "value": "Baerer D@aUtH3nT!fiC@ti@n"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "body",
+              "modifier": "username",
+              "value": "Us3rN@m3",
+              "invert": true,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "8f89cf3c-fe0a-4479-95f8-be4972fbae1d",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "api/query",
+      "responses": [
+        {
+          "uuid": "bbf1df3c-8c06-4231-af5d-15fe824a5037",
+          "body": "{\n  \"result\": {\n    \"data\": [\n      {\n        \"key\": [\n          { \"value\": \"application\" }\n        ],\n        \"values\": [\n          { \"value\": 5 },\n          { \"value\": 120 }\n        ]\n      },\n      {\n        \"key\": [\n          { \"value\": \"network\" }\n        ],\n        \"values\": [\n          { \"value\": 2 },\n          { \"value\": 95 }\n        ]\n      }\n    ]\n  }\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "access-control-allow-headers",
+              "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+            },
+            {
+              "key": "access-control-allow-methods",
+              "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+            },
+            {
+              "key": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "key": "content-security-policy",
+              "value": "default-src 'none'"
+            },
+            {
+              "key": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "key": "x-content-type-options",
+              "value": "nosniff"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    }
+  ],
+  "rootChildren": [
+    {
+      "type": "route",
+      "uuid": "74fe65fb-f6df-48b5-a94f-61d98cbaf96a"
+    },
+    {
+      "type": "route",
+      "uuid": "8f89cf3c-fe0a-4479-95f8-be4972fbae1d"
+    }
+  ],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "application/json"
+    },
+    {
+      "key": "Access-Control-Allow-Origin",
+      "value": "*"
+    },
+    {
+      "key": "Access-Control-Allow-Methods",
+      "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+    },
+    {
+      "key": "Access-Control-Allow-Headers",
+      "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": [],
+  "callbacks": []
+}

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -4,6 +4,7 @@
 --3cx-version
 7210SAS
 7750SR
+Accedian
 ACS
 --add-cpu
 --add-disk-io
@@ -284,6 +285,7 @@ proto
 Proxmox
 --proxyurl
 psu
+PVX
 QoS
 Qtree
 queue-messages-inflighted


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

Plugin(apps::pvx::restapi): Bearer Authentication required for API calls

**Fixes** # CTOR-2010

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Implemented bearer authentication via auth service and token caching.
* Added new CLI options and sensible defaults for REST API.

**🔧 Refactors**
* Refactored option handling and consolidated option result assignments.
* Introduced statefile caching and improved HTTP header/token handling.

**📚 Documentation**
* Updated copyright year and maintained existing license header.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99001350?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->