### PR TITLE
fix(apps::protocols::http): handle nested JSON path in collection mode

### DIFF
--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -473,19 +473,30 @@ sub parse_structure {
             if ($ref eq 'HASH') {
 
                 if (!defined($value->{ $_->{id} })) {
-                    # Check and assume in case of hash reference first part is the hash ref and second the hash key
-                    if($_->{id} =~ /^(.+?)\.(.*)$/){
-                        if (!defined($value->{$1}->{$2})) {
+                    # Traverse dotted path to reach nested hash values
+                    my @keys = split(/\./, $_->{id});
+                    if (scalar(@keys) > 1) {
+                        my $current = $value;
+                        my $found = 1;
+                        foreach my $key (@keys) {
+                            if (ref($current) eq 'HASH' && defined($current->{$key})) {
+                                $current = $current->{$key};
+                            } else {
+                                $found = 0;
+                                last;
+                            }
+                        }
+                        if ($found) {
+                            $entry->{ $_->{id} } = $current;
+                        } else {
                             $entry->{ $_->{id} } = '';
                             next;
-                        }else{
-                            $entry->{ $_->{id} } = $value->{$1}->{$2};
                         }
-                    }else {
+                    } else {
                         $entry->{ $_->{id} } = '';
                         next;
                     }
-                }else {
+                } else {
                     $entry->{ $_->{id} } = $value->{ $_->{id} };
                 }
             } elsif (ref($value) eq 'ARRAY') {

--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -2025,19 +2025,18 @@ sub manage_selection {
 
 sub traverse_hash {
     my ($self, $search, $data) = @_;
-    if ($search !~ /\./) {
-        # last run or found nothing
-        return $data->{$search} // "";
-    }
 
+    # if $search is not nested, return the found value or ""
+    return $data->{$search} // "" unless $search =~ /\./;
+
+    # if $search is still nested dive one level deeper
     my @parts = split(/\./, $search);
-    my $key   = shift(@parts);
+    my $key = shift(@parts);
+    my $remaining = join(".", @parts);
 
-    # need to go deeper
-    return $self->traverse_hash(join(".", @parts), $data->{$key})
-        if (ref($data->{$key}) eq "HASH");
+    return $self->traverse_hash($remaining, $data->{$key})
+        if ref($data->{$key}) eq "HASH";
 
-    # array case not handled (yet)
     return "";
 }
 
@@ -2067,5 +2066,21 @@ Add a constant.
 Example: --constant='warning=30' --constant='critical=45'
 
 =back
+
+=cut
+
+=head1 traverse_hash
+
+Recursively traverse a nested hash structure using dot-notation paths.
+
+Parameters:
+  - C<$search>: dot-separated path to traverse (e.g., 'response.data.status')
+  - C<$data>: hash reference to traverse
+
+Returns the value at the specified path, or an empty string if the path
+does not exist or is not a hash reference.
+
+Example:
+  my $status = $self->traverse_hash('api.response.status', $hash_ref);
 
 =cut

--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -471,27 +471,9 @@ sub parse_structure {
 
             my $ref = ref($value);
             if ($ref eq 'HASH') {
-
                 if (!defined($value->{ $_->{id} })) {
-                    # Traverse dotted path to reach nested hash values
-                    my @keys = split(/\./, $_->{id});
-                    if (scalar(@keys) > 1) {
-                        my $current = $value;
-                        my $found = 1;
-                        foreach my $key (@keys) {
-                            if (ref($current) eq 'HASH' && defined($current->{$key})) {
-                                $current = $current->{$key};
-                            } else {
-                                $found = 0;
-                                last;
-                            }
-                        }
-                        if ($found) {
-                            $entry->{ $_->{id} } = $current;
-                        } else {
-                            $entry->{ $_->{id} } = '';
-                            next;
-                        }
+                    if ($_->{id} =~ /\./) {
+                        $entry->{ $_->{id} } = $self->traverse_hash($_->{id}, $value);
                     } else {
                         $entry->{ $_->{id} } = '';
                         next;
@@ -866,7 +848,7 @@ sub get_local_variable {
     if (defined( $self->{expand}->{ $options{name} })) {
         return $self->{expand}->{ $options{name} };
     } else {
-        $self->{output}->add_option_msg(short_msg => "Key '" . $options{name} . "' not found in ('" . join("', '", keys(%{$self->{expand}})) . "')", debug => 1);
+        $self->{output}->add_option_msg(short_msg => "Key '" . $options{name} . "' not found in ('" . join("', '", sort keys(%{$self->{expand}})) . "')", debug => 1);
         return undef;
     }
 
@@ -891,7 +873,7 @@ sub get_table {
     my ($self, %options) = @_;
 
     if (!defined($self->{http_collected}->{tables}->{ $options{table} })) {
-        $self->{output}->add_option_msg(short_msg => "Table '" . $options{table} . "' not found in ('" . join("', '", keys(%{$self->{http_collected}->{tables}})) . "')", debug => 1);
+        $self->{output}->add_option_msg(short_msg => "Table '" . $options{table} . "' not found in ('" . join("', '", sort keys(%{$self->{http_collected}->{tables}})) . "')", debug => 1);
         return undef;
     }
     return $self->{http_collected}->{tables}->{ $options{table} };
@@ -901,11 +883,11 @@ sub get_table_instance {
     my ($self, %options) = @_;
 
     if (!defined($self->{http_collected}->{tables}->{ $options{table} })) {
-        $self->{output}->add_option_msg(short_msg => "Table '" . $options{table} . "' not found in ('" . join("', '", keys(%{$self->{http_collected}->{tables}})) . "')", debug => 1);
+        $self->{output}->add_option_msg(short_msg => "Table '" . $options{table} . "' not found in ('" . join("', '", sort keys(%{$self->{http_collected}->{tables}})) . "')", debug => 1);
         return undef;
     }
     if (!defined($self->{http_collected}->{tables}->{ $options{table} }->{ $options{instance} })) {
-        $self->{output}->add_option_msg(short_msg => "Table '" . $options{instance} . "' not found in ('" . join("', '", keys(%{$self->{http_collected}->{tables}->{ $options{table} }})) . "')", debug => 1);
+        $self->{output}->add_option_msg(short_msg => "Table '" . $options{instance} . "' not found in ('" . join("', '", sort keys(%{$self->{http_collected}->{tables}->{ $options{table} }})) . "')", debug => 1);
         return undef;
     }
     return $self->{http_collected}->{tables}->{ $options{table} }->{ $options{instance} };
@@ -2048,6 +2030,30 @@ sub manage_selection {
     $self->add_selection();
     $self->add_selection_loop();
     $self->set_formatting();
+}
+
+sub traverse_hash {
+    my ($self, $search, $data) = @_;
+    if ($search !~ /\./) {
+        # last run or found nothing
+        if (defined($data->{$search})) {
+            return $data->{$search};
+        }
+        else {
+            return "";
+        }
+    }
+
+    my @parts = split(/\./, $search);
+    my $key   = shift(@parts);
+    if (ref($data->{$key}) eq "HASH") {
+        # need to go deeper
+        return $self->traverse_hash(join(".", @parts), $data->{$key});
+    }
+    else {
+        # array case not handled (yet)
+        return "";
+    }
 }
 
 1;

--- a/src/apps/protocols/http/mode/collection.pm
+++ b/src/apps/protocols/http/mode/collection.pm
@@ -471,16 +471,7 @@ sub parse_structure {
 
             my $ref = ref($value);
             if ($ref eq 'HASH') {
-                if (!defined($value->{ $_->{id} })) {
-                    if ($_->{id} =~ /\./) {
-                        $entry->{ $_->{id} } = $self->traverse_hash($_->{id}, $value);
-                    } else {
-                        $entry->{ $_->{id} } = '';
-                        next;
-                    }
-                } else {
-                    $entry->{ $_->{id} } = $value->{ $_->{id} };
-                }
+                $entry->{ $_->{id} } = $self->traverse_hash($_->{id}, $value);
             } elsif (ref($value) eq 'ARRAY') {
                 next;
             } elsif ($ref eq '' || $ref eq 'JSON::PP::Boolean') {
@@ -2036,24 +2027,18 @@ sub traverse_hash {
     my ($self, $search, $data) = @_;
     if ($search !~ /\./) {
         # last run or found nothing
-        if (defined($data->{$search})) {
-            return $data->{$search};
-        }
-        else {
-            return "";
-        }
+        return $data->{$search} // "";
     }
 
     my @parts = split(/\./, $search);
     my $key   = shift(@parts);
-    if (ref($data->{$key}) eq "HASH") {
-        # need to go deeper
-        return $self->traverse_hash(join(".", @parts), $data->{$key});
-    }
-    else {
-        # array case not handled (yet)
-        return "";
-    }
+
+    # need to go deeper
+    return $self->traverse_hash(join(".", @parts), $data->{$key})
+        if (ref($data->{$key}) eq "HASH");
+
+    # array case not handled (yet)
+    return "";
 }
 
 1;

--- a/tests/apps/protocols/http/collection-deep-path-check-nested.collection.json
+++ b/tests/apps/protocols/http/collection-deep-path-check-nested.collection.json
@@ -1,0 +1,89 @@
+{
+  "constants": {
+    "protocol": "http",
+    "port": "3000",
+    "hostname": "127.0.0.1"
+  },
+  "http": {
+    "requests": [
+      {
+        "name": "itemsRequest",
+        "hostname": "%(constants.hostname)",
+        "proto": "%(constants.protocol)",
+        "port": "%(constants.port)",
+        "endpoint": "/api/items",
+        "method": "GET",
+        "headers": [
+          "Accept:application/json"
+        ],
+        "timeout": 30,
+        "backend": "curl",
+        "rtype": "json",
+        "parse": [
+          {
+            "name": "entries",
+            "type": "body",
+            "path": "$.items[*]",
+            "entries": [
+              {
+                "id": "name"
+              },
+              {
+                "id": "location.datacenter"
+              },
+              {
+                "id": "location.rack.row"
+              },
+              {
+                "id": "location.rack.position.slot"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "selection_loop": [
+    {
+      "name": "ItemsLoop",
+      "source": "%(http.tables.itemsRequestEntries)",
+      "warning": "1",
+      "formatting": {
+        "display_ok": true,
+        "printf_msg": "%s: dc=%s, row=%s, slot=%s",
+        "printf_var": [
+          "%(itemsRequestEntries.name)",
+          "%(itemsRequestEntries.location.datacenter)",
+          "%(itemsRequestEntries.location.rack.row)",
+          "%(itemsRequestEntries.location.rack.position.slot)"
+        ]
+      }
+    }
+  ],
+  "selection": [
+    {
+      "name": "totalSelection",
+      "functions": [
+        {
+          "type": "count",
+          "src": "%(http.tables.itemsRequestEntries)",
+          "save": "%(itemsCount)"
+        }
+      ],
+      "perfdatas": [
+        {
+          "nlabel": "items.count",
+          "value": "%(itemsCount)",
+          "min": 0
+        }
+      ],
+      "formatting": {
+        "printf_msg": "Items: %s",
+        "printf_var": [
+          "%(itemsCount)"
+        ],
+        "display_ok": false
+      }
+    }
+  ]
+}

--- a/tests/apps/protocols/http/collection-deep-path.mockoon.json
+++ b/tests/apps/protocols/http/collection-deep-path.mockoon.json
@@ -1,0 +1,93 @@
+{
+  "uuid": "a7b3c4d5-e6f7-8901-abcd-ef0123456789",
+  "lastMigration": 32,
+  "name": "Mock for deep JSON path testing in HTTP Collections",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3001,
+  "hostname": "",
+  "folders": [],
+  "routes": [
+    {
+      "uuid": "b1c2d3e4-f5a6-7890-bcde-f01234567890",
+      "type": "http",
+      "documentation": "API items with deeply nested fields",
+      "method": "get",
+      "endpoint": "api/items",
+      "responses": [
+        {
+          "uuid": "c2d3e4f5-a6b7-8901-cdef-012345678901",
+          "body": "",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "content-type",
+              "value": "application/json; charset=utf-8"
+            }
+          ],
+          "bodyType": "DATABUCKET",
+          "filePath": "",
+          "databucketID": "dpth",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null
+    }
+  ],
+  "rootChildren": [
+    {
+      "type": "route",
+      "uuid": "b1c2d3e4-f5a6-7890-bcde-f01234567890"
+    }
+  ],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "application/json"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": [
+    {
+      "uuid": "d4e5f6a7-b8c9-0123-defa-bcdef0123456",
+      "id": "dpth",
+      "name": "Deeply nested items response",
+      "documentation": "Response with items containing deeply nested fields for testing path traversal",
+      "value": "{\n  \"items\": [\n    {\n      \"id\": 1,\n      \"name\": \"server1\",\n      \"location\": {\n        \"datacenter\": \"dc1\",\n        \"rack\": {\n          \"row\": \"A\",\n          \"position\": {\n            \"slot\": 42\n          }\n        }\n      }\n    },\n    {\n      \"id\": 2,\n      \"name\": \"server2\",\n      \"location\": {\n        \"datacenter\": \"dc2\",\n        \"rack\": {\n          \"row\": \"B\",\n          \"position\": {\n            \"slot\": 7\n          }\n        }\n      }\n    }\n  ]\n}"
+    }
+  ],
+  "callbacks": []
+}

--- a/tests/apps/protocols/http/collection-deep-path.robot
+++ b/tests/apps/protocols/http/collection-deep-path.robot
@@ -1,0 +1,29 @@
+*** Settings ***
+Documentation       Tests for deep JSON path traversal in HTTP Collection mode
+
+Resource            ${CURDIR}${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}collection-deep-path.mockoon.json
+
+${CMD}              ${CENTREON_PLUGINS} --plugin=apps::protocols::http::plugin
+...                 --mode collection
+...                 --constant='hostname=${HOSTNAME}'
+...                 --constant='protocol=http'
+...                 --constant='port=${APIPORT}'
+
+
+*** Test Cases ***
+Check if ${test_desc}
+    [Tags]    collections    http
+    ${command}    Catenate
+    ...    ${CMD}    --config=${CURDIR}/${collection}
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:    test_desc                          collection                                               expected_result   --
+        ...      nested JSON paths are traversed    collection-deep-path-check-nested.collection.json        WARNING: server1: dc=dc1, row=A, slot=42 - server2: dc=dc2, row=B, slot=7 | 'items.count'=2;;;0;


### PR DESCRIPTION
## Description

Fixes: [CTOR-865](https://centreon.atlassian.net/browse/CTOR-865)

Add Robot Framework tests demonstrating that `parse_structure` in HTTP collection mode fails to traverse JSON paths deeper than 2 levels. The regex `^(.+?)\.(.*)$` at line 477 of `collection.pm` only splits on the first dot, treating the remainder as a literal key instead of recursively traversing the hash.

The test uses:
- A Mockoon mock returning nested JSON (up to 4 levels deep)
- A collection config parsing paths at 1, 2, 3, and 4 levels of nesting
- A Robot Framework test verifying the deep path values are correctly extracted

These tests will **fail** until the fix for deep path traversal is applied, then **pass** after.

## Type of change

- [x] Test (addition of tests for existing functionality)

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.04.x
- [ ] 25.10.x
- [x] master

[CTOR-865]: https://centreon.atlassian.net/browse/CTOR-865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added Robot Framework tests for deep JSON path extraction.

**🐛 Bugfixes**
* Fixed deep JSON path traversal in HTTP collection mode.

**📚 Documentation**
* Updated copyright year and header comments in collection.pm.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/97001432?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->