### PR TITLE
CTOR-2232 [hardware::server::hp::ilo::xmlapi::plugin] - mode(hardware): ILO3 incorrect thresholds temperature

### DIFF
--- a/src/hardware/server/hp/ilo/xmlapi/mode/components/temperature.pm
+++ b/src/hardware/server/hp/ilo/xmlapi/mode/components/temperature.pm
@@ -72,19 +72,18 @@ sub check {
         # When no thresholds are defined by the user we add thresholds based on the CAUTION and CRITICAL fields returned by ILO
         unless ($checked) {
             my $add_one = 0;
-
             foreach ( { ilo_code =>'CAUTION', centreon_code => 'warning' }, { ilo_code => 'CRITICAL', centreon_code => 'critical' } ) {
                 next if !$result->{ $_->{ilo_code} }->{VALUE} || $result->{ $_->{ilo_code} }->{VALUE} eq 'N/A';
-
                 $self->{numeric_threshold}->{temperature} = []
                     unless $self->{numeric_threshold}->{temperature};
 
                 my $label = $_->{centreon_code}.'-temperature-'.@{$self->{numeric_threshold}->{temperature}};
                 $self->{perfdata}->threshold_validate(  label => $label,
                                                         value => '@'.$result->{ $_->{ilo_code} }->{VALUE}.':');
+                # We escape the instance name to prevent these thresholds from applying to other instances
                 push @{$self->{numeric_threshold}->{temperature}},
                                     {  label => $label,
-                                       threshold => $_->{centreon_code}, instance => $instance
+                                       threshold => $_->{centreon_code}, instance => '^'.quotemeta($instance).'$'
                                     };
                 $add_one = 1;
             }


### PR DESCRIPTION
## Description

[hardware::server::hp::ilo::xmlapi::plugin] - mode(hardware): ILO3 incorrect thresholds temperature

**Fixes** # CTOR-2232

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Escaped instance names for numeric thresholds to prevent cross-instance application


<sup>[More info](https://app.aikido.dev/featurebranch/scan/92512466?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->