### PR TITLE
fix(dependencies): switch from dh_make_perl to nfpm to handle dependencies

### DIFF
--- a/.github/packaging/cpan-libraries.json
+++ b/.github/packaging/cpan-libraries.json
@@ -185,7 +185,9 @@
     {
       "name": "JMX::Jmx4Perl",
       "rpm": {},
-      "deb": {}
+      "deb": {
+        "use_dh_make_perl": "false"
+      }
     },
     {
       "name": "JSON::Path",

--- a/.github/packaging/cpan-libraries.json
+++ b/.github/packaging/cpan-libraries.json
@@ -186,7 +186,9 @@
       "name": "JMX::Jmx4Perl",
       "rpm": {},
       "deb": {
-        "use_dh_make_perl": "false"
+        "use_dh_make_perl": "false",
+        "no-auto-depends": "true",
+        "deb_dependencies": "libmodule-find-perl"
       }
     },
     {

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -590,3 +590,4 @@ jobs:
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
     uses: ./.github/workflows/set-pull-request-skip-label.yml
+


### PR DESCRIPTION
## Description

CPAN dependencies are ignored by dh_make_perl, I switchted the build ox jmx4perl to nfpm.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software



<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Switched JMX::Jmx4Perl Debian packaging to nfpm and dependencies


<sup>[More info](https://app.aikido.dev/featurebranch/scan/92616789?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->