### PR TITLE
fix(ci): clean up destination folder on unstable and testing delivery

### DIFF
--- a/.github/actions/package-delivery/action.yml
+++ b/.github/actions/package-delivery/action.yml
@@ -91,8 +91,8 @@ runs:
         JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
 
-    - if: ${{ inputs.stability == 'testing' }}
-      name: Clean existing testing packages
+    - if: ${{ contains(fromJson('["testing", "unstable"]'), inputs.stability) }}
+      name: Clean existing packages
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
@@ -101,8 +101,9 @@ runs:
               `jf rt del "${{ steps.get_repository_stability_path.outputs.repository_stability_path }}/*/${{ inputs.module_name }}/*.rpm" --exclusions "*/RPMS/*" --quiet`
             );
           } else if ('${{ steps.parse-distrib.outputs.package_extension }}' === 'deb') {
+            const releaseTypeProps = '${{ inputs.stability }}' === 'testing' ? '--props "release_type=${{ inputs.release_type }}"' : '';
             await exec.exec(
-              `jf rt del "${{ steps.get_repository_stability_path.outputs.repository_stability_path }}/pool/${{ inputs.module_name }}/*${{ steps.parse-distrib.outputs.package_distrib_name }}*.deb" --quiet --props "release_type=${{ inputs.release_type }}"`
+              `jf rt del "${{ steps.get_repository_stability_path.outputs.repository_stability_path }}/pool/${{ inputs.module_name }}/*${{ steps.parse-distrib.outputs.package_distrib_name }}*.deb" --quiet ${releaseTypeProps}`
             );
           }
 

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -613,4 +613,3 @@ jobs:
       ! contains(needs.*.result, 'failure') &&
       ! contains(needs.*.result, 'cancelled')
     uses: ./.github/workflows/set-pull-request-skip-label.yml
-


### PR DESCRIPTION
## Summary

- Extend the existing cleanup step to also run on **unstable** deliveries (previously only applied to testing)
- Rename the step from "Clean existing testing packages" to "Clean existing packages"
- For DEB packages, the `release_type` property filter is only applied when stability is `testing` (not applicable for unstable)

## Test plan

- [ ] Trigger an unstable delivery and verify old packages are removed from the destination folder before the new ones are uploaded
- [ ] Trigger a testing delivery and verify existing behaviour is preserved (cleanup still runs with `release_type` filter for DEB)
- [ ] Trigger a stable delivery and verify the cleanup step is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Extended cleanup step to run on unstable and testing deliveries
* Applied DEB release_type filter only when stability was testing

**🔧 Refactors**
* Renamed cleanup step and addressed actionlint formatting issues


<sup>[More info](https://app.aikido.dev/featurebranch/scan/94193935?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->