### PR TITLE
enh(ci): skip workflow on bump branches

### DIFF
--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -152,8 +152,15 @@ jobs:
       - name: Check if current workflow should be skipped
         id: skip_workflow
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
         with:
           script: |
+            if (/^bump-.+/.test(process.env.BRANCH_NAME)) {
+              core.notice('skipping workflow because it is a bump branch');
+              return true;
+            }
+
             if (${{ steps.has_skip_label.outputs.result }} === false) {
               return false;
             }


### PR DESCRIPTION
## Description

enh(ci): skip workflow on bump branches

**Fixes** CTOR-2130

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Skipped workflow execution for branches named with bump- prefix.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/94211308?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->