### PR TITLE
CTOR-2236 [PLUGIN] - same instruction in two sudoers files generate errors on gorgone

### DIFF
--- a/packaging/centreon-plugin-Operatingsystems-Linux-sudoers/pkg.json
+++ b/packaging/centreon-plugin-Operatingsystems-Linux-sudoers/pkg.json
@@ -13,7 +13,7 @@
         {
             "src": "../../src/os/linux/sudoers/sudoersCentreonLinuxPlugins",
             "dst": "/etc/sudoers.d/",
-            "file_mode": "0600"
+            "file_mode": "0440"
         }
     ],
     "skip_default_dependencies": true

--- a/src/os/linux/sudoers/sudoersCentreonLinuxPlugins
+++ b/src/os/linux/sudoers/sudoersCentreonLinuxPlugins
@@ -1,4 +1,4 @@
-User_Alias      CENTREON_COLLECT_USERS=centreon-engine,centreon-gorgone
-Defaults:CENTREON_COLLECT_USERS !requiretty
+User_Alias      CENTREON_COLLECT_LINUX_LOCAL_USERS=centreon-engine,centreon-gorgone
+Defaults:CENTREON_COLLECT_LINUX_LOCAL_USERS !requiretty
 
-CENTREON_COLLECT_USERS   ALL = NOPASSWD: /usr/lib/centreon/plugins/centreon_linux_local_process.pl *
+CENTREON_COLLECT_LINUX_LOCAL_USERS   ALL = NOPASSWD: /usr/lib/centreon/plugins/centreon_linux_local_process.pl *


### PR DESCRIPTION
## Description

[PLUGIN] - same instruction in two sudoers files generate errors on gorgone

**Fixes** # CTOR-2236

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Adjusted sudoers package file permissions to 0440 to prevent errors


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96277800?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->