### PR TITLE
CTOR-2144 Plugin(storage::dell::me4::restapi::plugin) - mode(interfaces): Cannot decode response with host-phy-statistics requests 

### DIFF
--- a/src/storage/dell/me4/restapi/mode/interfaces.pm
+++ b/src/storage/dell/me4/restapi/mode/interfaces.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -24,8 +24,10 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
-use Digest::MD5 qw(md5_hex);
+use Digest::SHA qw(sha256_hex);
+use centreon::plugins::constants qw/:counters :values/;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+use centreon::plugins::misc qw/is_excluded/;
 
 sub custom_status_output {
     my ($self, %options) = @_;
@@ -59,10 +61,10 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'ports', type => 3, cb_prefix_output => 'prefix_port_output', cb_long_output => 'port_long_output', indent_long_output => '    ', message_multiple => 'All interfaces are ok',
+        { name => 'ports', type => COUNTER_TYPE_MULTIPLE, cb_prefix_output => 'prefix_port_output', cb_long_output => 'port_long_output', indent_long_output => '    ', message_multiple => 'All interfaces are ok',
             group => [
-                { name => 'port_global', type => 0, skipped_code => { -10 => 1 } },
-                { name => 'interfaces', display_long => 1, cb_prefix_output => 'prefix_interface_output',  message_multiple => 'All interfaces are ok', type => 1, skipped_code => { -10 => 1 } }
+                { name => 'port_global', type => COUNTER_MULTIPLE_INSTANCE, skipped_code => { NO_VALUE() => 1 } },
+                { name => 'interfaces', display_long => 1, cb_prefix_output => 'prefix_interface_output',  message_multiple => 'All interfaces are ok', type => COUNTER_MULTIPLE_SUBINSTANCE, skipped_code => { NO_VALUE() => 1 } }
             ]
         }
     ];
@@ -70,7 +72,7 @@ sub set_counters {
     $self->{maps_counters}->{port_global} = [
          {
              label => 'port-status',
-             type => 2,
+             type => COUNTER_KIND_TEXT,
              unknown_default => '%{health} =~ /unknown/i',
              warning_default => '%{health} =~ /degraded/i',
              critical_default => '%{health} =~ /fault/i',
@@ -151,7 +153,7 @@ sub new {
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
-        'filter-port-name:s' => { name => 'filter_port_name' },
+        'filter-port-name:s' => { name => 'filter_port_name', default => '' },
         'omit-phy-statistics' => { name => 'omit_phy_statistics' }
     });
 
@@ -183,8 +185,7 @@ sub manage_selection {
     foreach my $port (@{$result_ports->{port}}) {
         my $port_name = $port->{port};
 
-        next if (defined($self->{option_results}->{filter_port_name}) && $self->{option_results}->{filter_port_name} ne ''
-            && $port_name !~ /$self->{option_results}->{filter_port_name}/);
+        next if is_excluded($port_name, $self->{option_results}->{filter_port_name});
 
         $mapping_ports->{ $port->{'durable-id'} } = $port_name;
 
@@ -223,8 +224,7 @@ sub manage_selection {
     }
 
     $self->{cache_name} = 'dell_me4_' . $self->{mode} . '_' . $options{custom}->get_hostname() . '_' .
-        (defined($self->{option_results}->{filter_counters}) ? md5_hex($self->{option_results}->{filter_counters}) : md5_hex('all')) . '_' .
-        (defined($self->{option_results}->{filter_port_name}) ? md5_hex($self->{option_results}->{filter_port_name}) : md5_hex('all'));
+        sha256_hex(($self->{option_results}->{filter_counters} // '').'_'.$self->{option_results}->{filter_port_name});
 }
 
 1;
@@ -260,11 +260,61 @@ You can use the following variables: %{status}, %{health}, %{display}
 Define the conditions to match for the status to be CRITICAL (default: '%{status} =~ /fault/i').
 You can use the following variables: %{status}, %{health}, %{display}
 
-=item B<--warning-*> B<--critical-*>
+=item B<--warning-interface-disparity-errors>
 
-Thresholds.
-Can be: 'read-iops', 'write-iops', 'read-traffic', 'write-traffic',
-'interface-disparity-errors', 'interface-lost-dwords', 'interface-invalid-dwords'.
+Threshold.
+
+=item B<--critical-interface-disparity-errors>
+
+Threshold.
+
+=item B<--warning-interface-invalid-dwords>
+
+Threshold.
+
+=item B<--critical-interface-invalid-dwords>
+
+Threshold.
+
+=item B<--warning-interface-lost-dwords>
+
+Threshold.
+
+=item B<--critical-interface-lost-dwords>
+
+Threshold.
+
+=item B<--warning-read-iops>
+
+Threshold in iops.
+
+=item B<--critical-read-iops>
+
+Threshold in iops.
+
+=item B<--warning-read-traffic>
+
+Threshold in b/s.
+
+=item B<--critical-read-traffic>
+
+Threshold in b/s.
+
+=item B<--warning-write-iops>
+
+Threshold in iops.
+
+=item B<--critical-write-iops>
+
+Threshold in iops.
+
+=item B<--warning-write-traffic>
+
+Threshold in b/s.
+
+=item B<--critical-write-traffic>
+
+Threshold in b/s.
 
 =back
 

--- a/tests/storage/dell/me4/restapi/interfaces.robot
+++ b/tests/storage/dell/me4/restapi/interfaces.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Documentation       Check Dell Me4 interfaces
+
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}me4.mockoon.json
+${HOSTNAME}         127.0.0.1
+${APIPORT}          3000
+${CMD}              ${CENTREON_PLUGINS}
+...                 --plugin=storage::dell::me4::restapi::plugin
+...                 --hostname=${HOSTNAME}
+...                 --proto=http
+...                 --port=${APIPORT}
+...                 --mode=interfaces
+
+
+*** Test Cases ***
+Interfaces ${tc}
+    [Tags]    storage    dell    me4    restapi
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:    tc    extra_options                                                                  expected_result    --
+         ...     1     --api-username=test --api-password=test                                        OK: All interfaces are ok | 'A0~phy-0#port.interface.disparity.errors.count'=3;;;0; 'A0~phy-0#port.interface.lost.dwords.count'=1;;;0; 'A0~phy-0#port.interface.invalid.dwords.count'=12;;;0; 'A0~phy-1#port.interface.disparity.errors.count'=0;;;0; 'A0~phy-1#port.interface.lost.dwords.count'=0;;;0; 'A0~phy-1#port.interface.invalid.dwords.count'=0;;;0; 'B0~phy-0#port.interface.disparity.errors.count'=1;;;0; 'B0~phy-0#port.interface.lost.dwords.count'=0;;;0; 'B0~phy-0#port.interface.invalid.dwords.count'=5;;;0;
+         ...     2     --api-username=test --api-password=test --omit-phy-statistics                  OK: All interfaces are ok | 'A0#port.io.read.usage.iops'=0.00iops;;;0; 'A0#port.io.write.usage.iops'=0.00iops;;;0; 'A0#port.traffic.read.usage.bitspersecond'=0b/s;;;0; 'A0#port.traffic.write.usage.bitspersecond'=0b/s;;;0; 'B0#port.io.read.usage.iops'=0.00iops;;;0; 'B0#port.io.write.usage.iops'=0.00iops;;;0; 'B0#port.traffic.read.usage.bitspersecond'=0b/s;;;0; 'B0#port.traffic.write.usage.bitspersecond'=0b/s;;;0;
+         ...     3     --api-username=testdellsan --api-password=testdellsan                          UNKNOWN: Cannot decode response (add --debug option to display returned content)
+         ...     4     --api-username=testdellsan --api-password=testdellsan --omit-phy-statistics    OK: All interfaces are ok | 'A0#port.io.read.usage.iops'=0.00iops;;;0; 'A0#port.io.write.usage.iops'=0.00iops;;;0; 'A0#port.traffic.read.usage.bitspersecond'=0b/s;;;0; 'A0#port.traffic.write.usage.bitspersecond'=0b/s;;;0; 'B0#port.io.read.usage.iops'=0.00iops;;;0; 'B0#port.io.write.usage.iops'=0.00iops;;;0; 'B0#port.traffic.read.usage.bitspersecond'=0b/s;;;0; 'B0#port.traffic.write.usage.bitspersecond'=0b/s;;;0;

--- a/tests/storage/dell/me4/restapi/me4.mockoon.json
+++ b/tests/storage/dell/me4/restapi/me4.mockoon.json
@@ -1,0 +1,494 @@
+{
+  "uuid": "a4e5b157-3237-487a-93f2-6a70dc23c14d",
+  "lastMigration": 33,
+  "name": "Me4.mockoon",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3001,
+  "hostname": "",
+  "folders": [],
+  "routes": [
+    {
+      "uuid": "f9caa42b-404d-45fe-a805-fdd51ee436db",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "",
+      "responses": [
+        {
+          "uuid": "0fae16b6-43c7-4b0e-b483-6c3df23b08a2",
+          "body": "{}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "547602fb-ff65-4054-8872-ea142942e900",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "api/login/f032f27ee18f9de67a3bb9c16eae57b3",
+      "responses": [
+        {
+          "uuid": "3ca0e58d-650d-4160-92eb-a266ca74f5c9",
+          "body": "{\n  \"status\": [\n    {\n      \"response-type\": \"Success\",\n      \"response-type-numeric\": 0,\n      \"response\": \"f032f27ee18f9de67a3bb9c16eae57b3\"\n    }\n  ]\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "access-control-allow-headers",
+              "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+            },
+            {
+              "key": "access-control-allow-methods",
+              "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+            },
+            {
+              "key": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "key": "content-security-policy",
+              "value": "default-src 'none'"
+            },
+            {
+              "key": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "key": "x-content-type-options",
+              "value": "nosniff"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "cc5bbbf0-12ab-4cde-b1e2-f9f8d2c3e4f5",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "api/login/308203f4315f24ad5fe7aae1ebd1c198",
+      "responses": [
+        {
+          "uuid": "5b9c0a1d-3e2f-4a5b-8c7d-6f9e8a1b2c3d",
+          "body": "{\n  \"status\": [\n    {\n      \"response-type\": \"Success\",\n      \"response-type-numeric\": 0,\n      \"response\": \"308203f4315f24ad5fe7aae1ebd1c198\"\n    }\n  ]\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "content-type",
+              "value": "text/html; charset=utf-8"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "dd4ccae3-54c6-4466-a2be-a9aa5c6e1a7e",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "api/set/cli-parameters/locale/English",
+      "responses": [
+        {
+          "uuid": "5a8c2e3e-880d-4061-b242-34e32861394e",
+          "body": "{\n  \"status\": [\n    {\n      \"response-type\": \"Success\",\n      \"response-type-numeric\": 0\n    }\n  ]\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "access-control-allow-headers",
+              "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+            },
+            {
+              "key": "access-control-allow-methods",
+              "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+            },
+            {
+              "key": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "key": "content-security-policy",
+              "value": "default-src 'none'"
+            },
+            {
+              "key": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "key": "x-content-type-options",
+              "value": "nosniff"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "7b89647b-d83b-4f9a-a599-5c5989ecb552",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "api/show/ports",
+      "responses": [
+        {
+          "uuid": "036550d5-32cb-4cd5-91aa-270262e88c78",
+          "body": "{\n  \"status\": [\n    {\n      \"response-type\": \"Success\",\n      \"response-type-numeric\": 0,\n      \"response\": \"Command completed successfully.\"\n    }\n  ],\n  \"port\": [\n    {\n      \"port\": \"A0\",\n      \"durable-id\": \"port-A0-123\",\n      \"health-numeric\": 0,\n      \"status-numeric\": 0\n    },\n    {\n      \"port\": \"B0\",\n      \"durable-id\": \"port-B0-456\",\n      \"health-numeric\": 0,\n      \"status-numeric\": 0\n    }\n  ]\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "access-control-allow-headers",
+              "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+            },
+            {
+              "key": "access-control-allow-methods",
+              "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+            },
+            {
+              "key": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "key": "content-security-policy",
+              "value": "default-src 'none'"
+            },
+            {
+              "key": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "key": "x-content-type-options",
+              "value": "nosniff"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "e5968d1b-cf71-4448-a3c3-e013bf50b51e",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "api/show/host-port-statistics",
+      "responses": [
+        {
+          "uuid": "131b0fd3-db1e-404c-8695-8d66f9b44b44",
+          "body": "{\n  \"status\": [\n    {\n      \"response-type\": \"Success\",\n      \"response-type-numeric\": 0,\n      \"response\": \"Command completed successfully.\"\n    }\n  ],\n  \"host-port-statistics\": [\n    {\n      \"durable-id\": \"port-A0-123\",\n      \"number-of-reads\": 15000,\n      \"number-of-writes\": 8500,\n      \"data-read-numeric\": 536870912000,\n      \"data-write-numeric\": 268435456000\n    },\n    {\n      \"durable-id\": \"port-B0-456\",\n      \"number-of-reads\": 12000,\n      \"number-of-writes\": 6500,\n      \"data-read-numeric\": 429496729600,\n      \"data-write-numeric\": 214748364800\n    }\n  ]\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "access-control-allow-headers",
+              "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+            },
+            {
+              "key": "access-control-allow-methods",
+              "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+            },
+            {
+              "key": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "key": "content-security-policy",
+              "value": "default-src 'none'"
+            },
+            {
+              "key": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "key": "x-content-type-options",
+              "value": "nosniff"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "a3d1abd4-a82b-41e0-9b16-5234975b9d07",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "api/show/host-phy-statistics",
+      "responses": [
+        {
+          "uuid": "7d147ef1-8a32-4ccd-a745-5e15f6e56883",
+          "body": "{\n  \"status\": [\n    {\n      \"response-type\": \"Success\",\n      \"response-type-numeric\": 0,\n      \"response\": \"Command completed successfully.\"\n    }\n  ],\n  \"sas-host-phy-statistics\": [\n    {\n      \"port\": \"A0\",\n      \"phy\": \"phy-0\",\n      \"disparity-errors\": 3,\n      \"invalid-dwords\": 12,\n      \"lost-dwords\": 1\n    },\n    {\n      \"port\": \"A0\",\n      \"phy\": \"phy-1\",\n      \"disparity-errors\": 0,\n      \"invalid-dwords\": 0,\n      \"lost-dwords\": 0\n    },\n    {\n      \"port\": \"B0\",\n      \"phy\": \"phy-0\",\n      \"disparity-errors\": 1,\n      \"invalid-dwords\": 5,\n      \"lost-dwords\": 0\n    }\n  ]\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "access-control-allow-headers",
+              "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+            },
+            {
+              "key": "access-control-allow-methods",
+              "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+            },
+            {
+              "key": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "key": "content-security-policy",
+              "value": "default-src 'none'"
+            },
+            {
+              "key": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "key": "x-content-type-options",
+              "value": "nosniff"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "header",
+              "modifier": "Sessionkey",
+              "value": "308203f4315f24ad5fe7aae1ebd1c198",
+              "invert": true,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        },
+        {
+          "uuid": "01911015-c937-44c6-a4ad-0f899827cb2d",
+          "body": "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\n<HTML><HEAD>\n<TITLE>400 Bad Request</TITLE>\n</HEAD><BODY>\n<H1>Bad Request</H1>\n</BODY></HTML>",
+          "latency": 0,
+          "statusCode": 400,
+          "label": "dell san",
+          "headers": [
+            {
+              "key": "access-control-allow-headers",
+              "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+            },
+            {
+              "key": "access-control-allow-methods",
+              "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+            },
+            {
+              "key": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "key": "content-security-policy",
+              "value": "default-src 'none'"
+            },
+            {
+              "key": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "key": "x-content-type-options",
+              "value": "nosniff"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [
+            {
+              "target": "header",
+              "modifier": "Sessionkey",
+              "value": "308203f4315f24ad5fe7aae1ebd1c198",
+              "invert": false,
+              "operator": "equals"
+            }
+          ],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    }
+  ],
+  "rootChildren": [
+    {
+      "type": "route",
+      "uuid": "f9caa42b-404d-45fe-a805-fdd51ee436db"
+    },
+    {
+      "type": "route",
+      "uuid": "547602fb-ff65-4054-8872-ea142942e900"
+    },
+    {
+      "type": "route",
+      "uuid": "cc5bbbf0-12ab-4cde-b1e2-f9f8d2c3e4f5"
+    },
+    {
+      "type": "route",
+      "uuid": "dd4ccae3-54c6-4466-a2be-a9aa5c6e1a7e"
+    },
+    {
+      "type": "route",
+      "uuid": "7b89647b-d83b-4f9a-a599-5c5989ecb552"
+    },
+    {
+      "type": "route",
+      "uuid": "e5968d1b-cf71-4448-a3c3-e013bf50b51e"
+    },
+    {
+      "type": "route",
+      "uuid": "a3d1abd4-a82b-41e0-9b16-5234975b9d07"
+    }
+  ],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "application/json"
+    },
+    {
+      "key": "Access-Control-Allow-Origin",
+      "value": "*"
+    },
+    {
+      "key": "Access-Control-Allow-Methods",
+      "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+    },
+    {
+      "key": "Access-Control-Allow-Headers",
+      "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": [],
+  "callbacks": []
+}


### PR DESCRIPTION
# Community contributors

## Description

Plugin(storage::dell::me4::restapi::plugin) - mode(interfaces): Cannot decode response with host-phy-statistics requests 

**Fixes** # CTOR-2144

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated copyright year and added tests for new behavior.

**🐛 Bugfixes**
* Added option to omit host-phy-statistics request to prevent decoding.

**🔧 Refactors**
* Changed filter handling to use exclusion helper for port names.
* Replaced Digest::MD5 usage across module with Digest::SHA sha256 implementation.
* Converted counter and type literals to centreon constants and kinds.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/96584578?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->