### PR TITLE
enh(doc): improve NTP offset thresholds help

### DIFF
--- a/src/hardware/ats/apc/snmp/mode/ntp.pm
+++ b/src/hardware/ats/apc/snmp/mode/ntp.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -43,27 +43,26 @@ __END__
 
 =head1 MODE
 
-Check time offset of server with ntp server. Use local time if ntp-host option is not set. 
-SNMP gives a date with second precision (no milliseconds). Time precision is not very accurate.
-Use threshold with (+-) 2 seconds offset (minimum).
+Check time offset of server with NTP server. Use local time if C<--ntp-hostname> option is not set. 
+SNMP gives a date with second precision (no milliseconds).
 
 =over 8
 
 =item B<--warning-offset>
 
-Time offset warning threshold (in seconds).
+Time warning threshold range (in seconds), in the format -n:n (e.g., -5:5). Returns WARNING when the offset is less than -n seconds or greater than n seconds.
 
 =item B<--critical-offset>
 
-Time offset critical Threshold (in seconds).
+Time critical threshold range (in seconds), in the format -n:n (e.g., -5:5). Returns CRITICAL when the offset is less than -n seconds or greater than n seconds.
 
 =item B<--ntp-hostname>
 
-Set the ntp hostname (if not set, localtime is used).
+Set the NTP hostname (if not set, localtime is used).
 
 =item B<--ntp-port>
 
-Set the ntp port (default: 123).
+Set the NTP port (default: 123).
 
 =item B<--timezone>
 

--- a/src/hardware/pdu/apc/snmp/mode/ntp.pm
+++ b/src/hardware/pdu/apc/snmp/mode/ntp.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -43,7 +43,7 @@ __END__
 
 =head1 MODE
 
-Check time offset of server with ntp server. Use local time if ntp-host option is not set. 
+Check time offset of server with NTP server. Use local time if C<--ntp-hostname> option is not set. 
 SNMP gives a date with second precision (no milliseconds). Time precision is not very accurate.
 Use threshold with (+-) 2 seconds offset (minimum).
 
@@ -51,19 +51,19 @@ Use threshold with (+-) 2 seconds offset (minimum).
 
 =item B<--warning-offset>
 
-Time offset warning threshold (in seconds).
+Time warning threshold range (in seconds), in the format -n:n (e.g., -5:5). Returns WARNING when the offset is less than -n seconds or greater than n seconds.
 
 =item B<--critical-offset>
 
-Time offset critical Threshold (in seconds).
+Time critical threshold range (in seconds), in the format -n:n (e.g., -5:5). Returns CRITICAL when the offset is less than -n seconds or greater than n seconds.
 
 =item B<--ntp-hostname>
 
-Set the ntp hostname (if not set, localtime is used).
+Set the NTP hostname (if not set, localtime is used).
 
 =item B<--ntp-port>
 
-Set the ntp port (default: 123).
+Set the NTP port (default: 123).
 
 =item B<--timezone>
 

--- a/src/hardware/ups/apc/snmp/mode/ntp.pm
+++ b/src/hardware/ups/apc/snmp/mode/ntp.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2025 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -61,7 +61,7 @@ __END__
 
 =head1 MODE
 
-Check time offset of server with NTP server. Use local time if C<--ntp-host> option is not set. 
+Check time offset of server with NTP server. Use local time if C<--ntp-hostname> option is not set. 
 SNMP gives a date with second precision (no milliseconds). Time precision is not very accurate.
 Use threshold with (+-) 2 seconds offset (minimum).
 
@@ -69,11 +69,11 @@ Use threshold with (+-) 2 seconds offset (minimum).
 
 =item B<--warning-offset>
 
-Time offset warning threshold (in seconds).
+Time warning threshold range (in seconds), in the format -n:n (e.g., -5:5). Returns WARNING when the offset is less than -n seconds or greater than n seconds.
 
 =item B<--critical-offset>
 
-Time offset critical Threshold (in seconds).
+Time critical threshold range (in seconds), in the format -n:n (e.g., -5:5). Returns CRITICAL when the offset is less than -n seconds or greater than n seconds.
 
 =item B<--ntp-hostname>
 

--- a/src/os/linux/local/mode/ntp.pm
+++ b/src/os/linux/local/mode/ntp.pm
@@ -508,11 +508,11 @@ Critical threshold minimum amount of NTP-Server
 
 =item B<--warning-offset>
 
-Warning threshold offset deviation value in milliseconds
+Time warning threshold range (in milliseconds), in the format -n:n (e.g., -5:5). Returns WARNING when the offset is less than -n seconds or greater than n seconds.
 
 =item B<--critical-offset>
 
-Critical threshold offset deviation value in milliseconds
+Time critical threshold range (in milliseconds), in the format -n:n (e.g., -5:5). Returns CRITICAL when the offset is less than -n seconds or greater than n seconds.
 
 =item B<--warning-stratum>
 

--- a/src/os/windows/local/mode/ntp.pm
+++ b/src/os/windows/local/mode/ntp.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -166,29 +166,29 @@ __END__
 
 =head1 MODE
 
-Check time offset of server with ntp server.
+Check time offset of server with NTP server.
 
 =over 8
 
 =item B<--warning>
 
-Warning threshold.
+Time warning threshold range (in seconds), in the format -n:n (e.g., -5:5). Returns WARNING when the offset is less than -n seconds or greater than n seconds.
 
 =item B<--critical>
 
-Critical threshold.
+Time critical threshold range (in seconds), in the format -n:n (e.g., -5:5). Returns CRITICAL when the offset is less than -n seconds or greater than n seconds.
 
 =item B<--ntp-hostname>
 
-Set the ntp hostname (if not set, we try to find it with w32tm command).
+Set the NTP hostname (if not set, we try to find it with C<w32tm> command).
 
 =item B<--ntp-port>
 
-Set the ntp port (default: 123).
+Set the NTP port (default: 123).
 
 =item B<--timeout>
 
-Set timeout time for 'w32tm' command execution (default: 30 sec)
+Set timeout time for C<w32tm> command execution (default: 30 sec)
 
 =back
 

--- a/src/snmp_standard/mode/ntp.pm
+++ b/src/snmp_standard/mode/ntp.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -192,7 +192,7 @@ __END__
 
 =head1 MODE
 
-Check time offset of server with ntp server. Use local time if ntp-host option is not set. 
+Check time offset of server with NTP server. Use local time if C<--ntp-hostname> option is not set. 
 SNMP gives a date with second precision (no milliseconds). Time precision is not very accurate.
 Use threshold with (+-) 2 seconds offset (minimum).
 
@@ -204,19 +204,19 @@ Override default OID.
 
 =item B<--warning-offset>
 
-Time offset warning threshold (in seconds).
+Time warning threshold range (in seconds), in the format -n:n (e.g., -5:5). Returns WARNING when the offset is less than -n seconds or greater than n seconds.
 
 =item B<--critical-offset>
 
-Time offset critical Threshold (in seconds).
+Time critical threshold range (in seconds), in the format -n:n (e.g., -5:5). Returns CRITICAL when the offset is less than -n seconds or greater than n seconds.
 
 =item B<--ntp-hostname>
 
-Set the ntp hostname (if not set, localtime is used).
+Set the NTP hostname (if not set, localtime is used).
 
 =item B<--ntp-port>
 
-Set the ntp port (default: 123).
+Set the NTP port (default: 123).
 
 =item B<--timezone>
 

--- a/src/storage/hp/p2000/xmlapi/mode/ntp.pm
+++ b/src/storage/hp/p2000/xmlapi/mode/ntp.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -178,7 +178,7 @@ __END__
 
 =head1 MODE
 
-Check ntp status.
+Check NTP status.
 
 =over 8
 
@@ -199,16 +199,19 @@ Can use special variables like: %{status}
 
 =item B<--timezone>
 
-Set timezone for ntp contact time (default is 'UTC').
+Set timezone for NTP contact time (default is 'UTC').
 
 =item B<--unit>
 
 Select the time unit for the performance data and thresholds. May be 's' for seconds, 'm' for minutes, 'h' for hours, 'd' for days, 'w' for weeks. Default is seconds.
 
-=item B<--warning-*> B<--critical-*>
+=item B<--warning-contact-last-time>
 
 Thresholds.
-Can be: 'contact-last-time'.
+
+=item B<--critical-contact-last-time>
+
+Thresholds.
 
 =back
 


### PR DESCRIPTION
Refs: CTOR-2067

Improve the help for offset thresholds in NTP modes 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Doc




<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added timezone validation and local TZ setting for UPS APC NTP.

**📚 Documentation**
* Updated NTP help texts to clarify threshold range format.
* Replaced '--ntp-host' mentions with '--ntp-hostname' and examples.
* Normalized NTP capitalization and clarified timezone option wording.
* Bumped copyright headers to '2026-Present' across files.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/97016821?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->