### PR TITLE
Ci build cpan libs by stability

### DIFF
--- a/.github/actions/test-cpan-libs/action.yml
+++ b/.github/actions/test-cpan-libs/action.yml
@@ -10,6 +10,9 @@ inputs:
   arch:
     description: "The architecture (amd64 or arm64)"
     required: true
+  stability:
+    description: "The repository stability (stable, testing, unstable)"
+    required: true
 
 runs:
   using: "composite"
@@ -19,46 +22,58 @@ runs:
       name: Install zstd, perl and Centreon repositories
       env:
         DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
       run: |
         dnf install -y zstd perl epel-release 'dnf-command(config-manager)' perl-App-cpanminus
         dnf config-manager --set-enabled powertools || true # alma 8
         dnf config-manager --set-enabled crb || true # alma 9
+        # Map stability to repo channel: stable → stable, testing → testing, anything else → unstable
+        case "$STABILITY" in
+          stable|testing) REPO_STABILITY="$STABILITY" ;;
+          *) REPO_STABILITY="unstable" ;;
+        esac
         # Import Centreon GPG key
         GPG_KEY_URL="https://yum-gpg.centreon.com/RPM-GPG-KEY-CES"
         curl -sSL $GPG_KEY_URL -o RPM-GPG-KEY-CES
         rpm --import RPM-GPG-KEY-CES
-        # Add Centreon stable repository so that pre-existing packaged dependencies are available
+        # Add Centreon repository matching the current stability so that pre-existing packaged dependencies are available
         {
-          echo '[centreon-plugins-stable]'
-          echo 'name=centreon plugins stable x86_64'
-          echo "baseurl=https://packages.centreon.com/rpm-plugins/${DISTRIB}/stable/x86_64"
+          echo "[centreon-plugins-${REPO_STABILITY}]"
+          echo "name=centreon plugins ${REPO_STABILITY} x86_64"
+          echo "baseurl=https://packages.centreon.com/rpm-plugins/${DISTRIB}/${REPO_STABILITY}/x86_64"
           echo 'enabled=1'
           echo 'gpgcheck=1'
           echo 'gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES'
           echo ''
-          echo '[centreon-plugins-stable-noarch]'
-          echo 'name=centreon plugins stable noarch'
-          echo "baseurl=https://packages.centreon.com/rpm-plugins/${DISTRIB}/stable/noarch"
+          echo "[centreon-plugins-${REPO_STABILITY}-noarch]"
+          echo "name=centreon plugins ${REPO_STABILITY} noarch"
+          echo "baseurl=https://packages.centreon.com/rpm-plugins/${DISTRIB}/${REPO_STABILITY}/noarch"
           echo 'enabled=1'
           echo 'gpgcheck=1'
           echo 'gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES'
-        } > /etc/yum.repos.d/centreon-plugins-stable.repo
+        } > /etc/yum.repos.d/centreon-plugins-${REPO_STABILITY}.repo
       shell: bash
 
     - if: ${{ inputs.package_extension == 'deb' }}
       name: Install zstd, perl and Centreon repositories
       env:
         DISTRIB: ${{ inputs.distrib }}
+        STABILITY: ${{ inputs.stability }}
       run: |
         export DEBIAN_FRONTEND=noninteractive
         apt-get update
         apt-get install -y zstd perl wget gpg apt-utils procps build-essential cpanminus
         wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
-        # Add Centreon stable repository so that pre-existing packaged dependencies are available
+        # Map stability to repo channel: stable → stable, testing → testing, anything else → unstable
+        case "$STABILITY" in
+          stable|testing) REPO_STABILITY="$STABILITY" ;;
+          *) REPO_STABILITY="unstable" ;;
+        esac
+        # Add Centreon repository matching the current stability so that pre-existing packaged dependencies are available
         if [[ "$DISTRIB" == "jammy" || "$DISTRIB" == "noble" ]]; then
-          repo="ubuntu-plugins-stable"
+          repo="ubuntu-plugins-${REPO_STABILITY}"
         else
-          repo="apt-plugins-stable"
+          repo="apt-plugins-${REPO_STABILITY}"
         fi
         echo "deb https://packages.centreon.com/$repo/ $DISTRIB main" | tee /etc/apt/sources.list.d/centreon-plugins.list
         # Avoid apt to clean packages cache directory

--- a/.github/docker/testing/Dockerfile.testing-plugins-alma10
+++ b/.github/docker/testing/Dockerfile.testing-plugins-alma10
@@ -43,8 +43,10 @@ name=centreon plugins stable noarch\n\
 baseurl=https://packages.centreon.com/rpm-plugins/el10/stable/noarch\n\
 enabled=1\n\
 gpgcheck=1\n\
-gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n\
-[centreon-plugins-testing]\n\
+gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n'\
+>> /etc/yum.repos.d/centreon-plugins-stable.repo
+
+echo -e '[centreon-plugins-testing]\n\
 name=centreon plugins testing x86_64\n\
 baseurl=https://packages.centreon.com/rpm-plugins/el10/testing/x86_64\n\
 enabled=1\n\
@@ -55,8 +57,10 @@ name=centreon plugins testing noarch\n\
 baseurl=https://packages.centreon.com/rpm-plugins/el10/testing/noarch\n\
 enabled=1\n\
 gpgcheck=1\n\
-gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n\
-[centreon-plugins-unstable]\n\
+gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n'\
+>> /etc/yum.repos.d/centreon-plugins-testing.repo
+
+echo -e '[centreon-plugins-unstable]\n\
 name=centreon plugins unstable x86_64\n\
 baseurl=https://packages.centreon.com/rpm-plugins/el10/unstable/x86_64\n\
 enabled=1\n\
@@ -68,7 +72,7 @@ baseurl=https://packages.centreon.com/rpm-plugins/el10/unstable/noarch\n\
 enabled=1\n\
 gpgcheck=1\n\
 gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n'\
->> /etc/yum.repos.d/centreon-plugins.repo
+>> /etc/yum.repos.d/centreon-plugins-unstable.repo
 
 # Add Centreon plugins repositories
 #dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/25.10/el10/centreon-25.10.repo

--- a/.github/docker/testing/Dockerfile.testing-plugins-alma8
+++ b/.github/docker/testing/Dockerfile.testing-plugins-alma8
@@ -39,8 +39,10 @@ name=centreon plugins stable noarch\n\
 baseurl=https://packages.centreon.com/rpm-plugins/el8/stable/noarch\n\
 enabled=1\n\
 gpgcheck=1\n\
-gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n\
-[centreon-plugins-testing]\n\
+gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n'\
+>> /etc/yum.repos.d/centreon-plugins-stable.repo
+
+echo -e '[centreon-plugins-testing]\n\
 name=centreon plugins testing x86_64\n\
 baseurl=https://packages.centreon.com/rpm-plugins/el8/testing/x86_64\n\
 enabled=1\n\
@@ -51,8 +53,10 @@ name=centreon plugins testing noarch\n\
 baseurl=https://packages.centreon.com/rpm-plugins/el8/testing/noarch\n\
 enabled=1\n\
 gpgcheck=1\n\
-gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n\
-[centreon-plugins-unstable]\n\
+gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n'\
+>> /etc/yum.repos.d/centreon-plugins-testing.repo
+
+echo -e '[centreon-plugins-unstable]\n\
 name=centreon plugins unstable x86_64\n\
 baseurl=https://packages.centreon.com/rpm-plugins/el8/unstable/x86_64\n\
 enabled=1\n\
@@ -64,7 +68,7 @@ baseurl=https://packages.centreon.com/rpm-plugins/el8/unstable/noarch\n\
 enabled=1\n\
 gpgcheck=1\n\
 gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n'\
->> /etc/yum.repos.d/centreon-plugins.repo
+>> /etc/yum.repos.d/centreon-plugins-unstable.repo
 
 dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/24.10/el8/centreon-24.10.repo
 dnf install -y centreon-connector-perl centreon-clib

--- a/.github/docker/testing/Dockerfile.testing-plugins-alma9
+++ b/.github/docker/testing/Dockerfile.testing-plugins-alma9
@@ -44,8 +44,10 @@ name=centreon plugins stable noarch\n\
 baseurl=https://packages.centreon.com/rpm-plugins/el9/stable/noarch\n\
 enabled=1\n\
 gpgcheck=1\n\
-gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n\
-[centreon-plugins-testing]\n\
+gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n'\
+>> /etc/yum.repos.d/centreon-plugins-stable.repo
+
+echo -e '[centreon-plugins-testing]\n\
 name=centreon plugins testing x86_64\n\
 baseurl=https://packages.centreon.com/rpm-plugins/el9/testing/x86_64\n\
 enabled=1\n\
@@ -56,8 +58,10 @@ name=centreon plugins testing noarch\n\
 baseurl=https://packages.centreon.com/rpm-plugins/el9/testing/noarch\n\
 enabled=1\n\
 gpgcheck=1\n\
-gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n\
-[centreon-plugins-unstable]\n\
+gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n'\
+>> /etc/yum.repos.d/centreon-plugins-testing.repo
+
+echo -e '[centreon-plugins-unstable]\n\
 name=centreon plugins unstable x86_64\n\
 baseurl=https://packages.centreon.com/rpm-plugins/el9/unstable/x86_64\n\
 enabled=1\n\
@@ -69,7 +73,7 @@ baseurl=https://packages.centreon.com/rpm-plugins/el9/unstable/noarch\n\
 enabled=1\n\
 gpgcheck=1\n\
 gpgkey=https://yum-gpg.centreon.com/RPM-GPG-KEY-CES\n'\
->> /etc/yum.repos.d/centreon-plugins.repo
+>> /etc/yum.repos.d/centreon-plugins-unstable.repo
 
 # Add Centreon plugins repositories
 dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/24.10/el9/centreon-24.10.repo

--- a/.github/docker/testing/Dockerfile.testing-plugins-bookworm
+++ b/.github/docker/testing/Dockerfile.testing-plugins-bookworm
@@ -50,9 +50,9 @@ echo 'export PATH="~/node_modules/.bin/:$PATH"' >> ~/.bashrc
 
 # Add Centreon plugins repositories
 echo "deb https://packages.centreon.com/apt-standard-24.10-stable bookworm main" | tee /etc/apt/sources.list.d/centreon.list
-echo "deb https://packages.centreon.com/apt-plugins-stable/ bookworm main" | tee /etc/apt/sources.list.d/centreon-plugins.list
-echo "deb https://packages.centreon.com/apt-plugins-testing/ bookworm main" | tee -a /etc/apt/sources.list.d/centreon-plugins.list
-echo "deb https://packages.centreon.com/apt-plugins-unstable/ bookworm main" | tee -a /etc/apt/sources.list.d/centreon-plugins.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ bookworm main" | tee /etc/apt/sources.list.d/centreon-plugins-stable.list
+echo "deb https://packages.centreon.com/apt-plugins-testing/ bookworm main" | tee /etc/apt/sources.list.d/centreon-plugins-testing.list
+echo "deb https://packages.centreon.com/apt-plugins-unstable/ bookworm main" | tee /etc/apt/sources.list.d/centreon-plugins-unstable.list
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 
 # Update

--- a/.github/docker/testing/Dockerfile.testing-plugins-bullseye
+++ b/.github/docker/testing/Dockerfile.testing-plugins-bullseye
@@ -50,9 +50,9 @@ echo 'export PATH="~/node_modules/.bin/:$PATH"' >> ~/.bashrc
 
 # Add Centreon plugins repositories
 echo "deb https://packages.centreon.com/apt-standard-24.04-stable bullseye main" | tee /etc/apt/sources.list.d/centreon.list
-echo "deb https://packages.centreon.com/apt-plugins-stable/ bullseye main" | tee /etc/apt/sources.list.d/centreon-plugins.list
-echo "deb https://packages.centreon.com/apt-plugins-testing/ bullseye main" | tee -a /etc/apt/sources.list.d/centreon-plugins.list
-echo "deb https://packages.centreon.com/apt-plugins-unstable/ bullseye main" | tee -a /etc/apt/sources.list.d/centreon-plugins.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ bullseye main" | tee /etc/apt/sources.list.d/centreon-plugins-stable.list
+echo "deb https://packages.centreon.com/apt-plugins-testing/ bullseye main" | tee /etc/apt/sources.list.d/centreon-plugins-testing.list
+echo "deb https://packages.centreon.com/apt-plugins-unstable/ bullseye main" | tee /etc/apt/sources.list.d/centreon-plugins-unstable.list
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 apt-get update
 

--- a/.github/docker/testing/Dockerfile.testing-plugins-jammy
+++ b/.github/docker/testing/Dockerfile.testing-plugins-jammy
@@ -51,11 +51,10 @@ cd /usr/local/src
 pnpm install --frozen-lockfile
 
 # Add Centreon plugins repositories
-echo "deb https://packages.centreon.com/ubuntu-standard-24.04-stable/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
-echo "deb https://packages.centreon.com/ubuntu-plugins-stable/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-plugins.list
-echo "deb https://packages.centreon.com/ubuntu-plugins-testing/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-plugins.list
-echo "deb https://packages.centreon.com/ubuntu-plugins-unstable/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-plugins.list
-echo "deb https://packages.centreon.com/ubuntu-connectors-stable/ jammy main" | tee /etc/apt/sources.list.d/centreon-connectors.list
+echo "deb https://packages.centreon.com/ubuntu-standard-24.04-stable/ jammy main" | tee -a /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/ubuntu-plugins-stable/ jammy main" | tee /etc/apt/sources.list.d/centreon-plugins-stable.list
+echo "deb https://packages.centreon.com/ubuntu-plugins-testing/ jammy main" | tee /etc/apt/sources.list.d/centreon-plugins-testing.list
+echo "deb https://packages.centreon.com/ubuntu-plugins-unstable/ jammy main" | tee /etc/apt/sources.list.d/centreon-plugins-unstable.list
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 apt-get update
 

--- a/.github/docker/testing/Dockerfile.testing-plugins-noble
+++ b/.github/docker/testing/Dockerfile.testing-plugins-noble
@@ -51,10 +51,10 @@ cd /usr/local/src
 pnpm install --frozen-lockfile
 
 # Add Centreon plugins repositories
-echo "deb https://packages.centreon.com/ubuntu-standard-24.10-stable/ noble main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
-echo "deb https://packages.centreon.com/ubuntu-plugins-stable/ noble main" | tee -a /etc/apt/sources.list.d/centreon-plugins.list
-echo "deb https://packages.centreon.com/ubuntu-plugins-testing/ noble main" | tee -a /etc/apt/sources.list.d/centreon-plugins.list
-echo "deb https://packages.centreon.com/ubuntu-plugins-unstable/ noble main" | tee -a /etc/apt/sources.list.d/centreon-plugins.list
+echo "deb https://packages.centreon.com/ubuntu-standard-24.10-stable/ noble main" | tee /etc/apt/sources.list.d/centreon.list
+echo "deb https://packages.centreon.com/ubuntu-plugins-stable/ noble main" | tee /etc/apt/sources.list.d/centreon-plugins-stable.list
+echo "deb https://packages.centreon.com/ubuntu-plugins-testing/ noble main" | tee /etc/apt/sources.list.d/centreon-plugins-testing.list
+echo "deb https://packages.centreon.com/ubuntu-plugins-unstable/ noble main" | tee /etc/apt/sources.list.d/centreon-plugins-unstable.list
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 apt-get update
 

--- a/.github/docker/testing/Dockerfile.testing-plugins-trixie
+++ b/.github/docker/testing/Dockerfile.testing-plugins-trixie
@@ -53,9 +53,9 @@ echo 'export PATH="~/node_modules/.bin/:$PATH"' >> ~/.bashrc
 
 # Add Centreon plugins repositories
 #echo "deb https://packages.centreon.com/apt-standard trixie-25.10-stable main" | tee /etc/apt/sources.list.d/centreon.list
-echo "deb https://packages.centreon.com/apt-plugins-stable/ trixie main" | tee /etc/apt/sources.list.d/centreon-plugins.list
-echo "deb https://packages.centreon.com/apt-plugins-testing/ trixie main" | tee -a /etc/apt/sources.list.d/centreon-plugins.list
-echo "deb https://packages.centreon.com/apt-plugins-unstable/ trixie main" | tee -a /etc/apt/sources.list.d/centreon-plugins.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ trixie main" | tee /etc/apt/sources.list.d/centreon-plugins-stable.list
+echo "deb https://packages.centreon.com/apt-plugins-testing/ trixie main" | tee /etc/apt/sources.list.d/centreon-plugins-testing.list
+echo "deb https://packages.centreon.com/apt-plugins-unstable/ trixie main" | tee /etc/apt/sources.list.d/centreon-plugins-unstable.list
 wget -O- https://apt-key.centreon.com | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 
 # Update

--- a/.github/scripts/perl-cpan-libraries/cpan_matrix_lib.py
+++ b/.github/scripts/perl-cpan-libraries/cpan_matrix_lib.py
@@ -79,7 +79,7 @@ DEB_CHECK_DISTRIB_TO_BUILD_NAMES: dict = {}
 for _e in DEB_BUILD_NAME_INCLUDES:
     DEB_CHECK_DISTRIB_TO_BUILD_NAMES.setdefault(_e["distrib"], []).append(_e["build_name"])
 
-# ── Centreon stable repository ─────────────────────────────────────────────────
+# ── Centreon repository ────────────────────────────────────────────────────────
 
 CPAN_MODULE_NAME = "perl-cpan-libraries"
 
@@ -265,13 +265,13 @@ def filter_to_includes(libs, pkg_key, cpanm_infos, available):
 
 
 # ══════════════════════════════════════════════════════════════════════════════
-# CENTREON STABLE REPOSITORY HELPERS
+# CENTREON REPOSITORY HELPERS
 # ══════════════════════════════════════════════════════════════════════════════
 
 _RPM_PKG_RE = re.compile(r"^perl-(.+?)-([0-9v][0-9.]*)-\d+\.\w+\.(noarch|x86_64)\.rpm$")
-_DEB_PKG_RE = re.compile(r"^(.+?)_([0-9v][0-9.]*)[+\-].+_[^_]+\.deb$")
+_DEB_VERSION_RE = re.compile(r"^([0-9v][0-9.]*)(?:[+\-]|$)")
 
-_deb_pool_cache: dict = {}
+_deb_packages_cache: dict = {}  # (repo, distrib, arch) → {pkg_name: version}
 
 
 _ALLOWED_ARTIFACTORY_HOSTS = {"packages.centreon.com"}
@@ -305,14 +305,14 @@ def _artifactory_list_folder(base_url, repo_path):
         return []
 
 
-def get_stable_rpm_packages(base_url, distrib):
-    """Return {cpan_dist_name: version} for packages already in the Centreon stable RPM repo.
+def get_centreon_rpm_packages(base_url, distrib, stability):
+    """Return {cpan_dist_name: version} for packages already in the Centreon RPM repo.
 
     Example filename: perl-JSON-Path-1.0.6-2.el9.noarch.rpm
       → cpan_dist_name = "JSON-Path", version = "1.0.6"
     """
     files = _artifactory_list_folder(
-        base_url, f"rpm-plugins/{distrib}/stable/noarch/RPMS/{CPAN_MODULE_NAME}"
+        base_url, f"rpm-plugins/{distrib}/{stability}/noarch/RPMS/{CPAN_MODULE_NAME}"
     )
     result = {}
     for fname in files:
@@ -322,31 +322,60 @@ def get_stable_rpm_packages(base_url, distrib):
     return result
 
 
-def get_stable_deb_packages(base_url, distrib, arch="amd64", family="debian", suffix=""):
-    """Return {pkg_name: version} for packages already in the Centreon stable DEB repo.
+def _fetch_packages_index(base_url, repo, distrib, arch):
+    """Fetch and parse the Packages index for a specific DEB distrib/arch.
 
-    All distribs of the same family (debian / ubuntu) share the same pool folder;
-    files are distinguished by the distrib suffix in their version string and the
-    arch in their filename.
-
-    Example filename: libjson-path-perl_1.0.6+deb12u1_amd64.deb
-      → pkg_name = "libjson-path-perl", version = "1.0.6"
-
-    family and suffix come from the parse-distrib action outputs, passed through
-    the partial-matrix JSON produced by check-official-repos.py.
+    Uses the direct download URL:
+      GET {base_url}/artifactory/{repo}/dists/{distrib}/main/binary-{arch}/Packages
+    Returns an empty dict on any error.
     """
-    repo = "ubuntu-plugins-stable" if family == "ubuntu" else "apt-plugins-stable"
-    if repo not in _deb_pool_cache:
-        _deb_pool_cache[repo] = _artifactory_list_folder(
-            base_url, f"{repo}/pool/{CPAN_MODULE_NAME}"
-        )
+    parsed_base = urllib.parse.urlparse(base_url)
+    if parsed_base.scheme != "https" or parsed_base.hostname not in _ALLOWED_ARTIFACTORY_HOSTS:
+        print(f"  WARNING: {base_url} is not an allowed Artifactory base URL, skipping.", file=sys.stderr)
+        return {}
+    url = f"{base_url}/artifactory/{repo}/dists/{distrib}/main/binary-{arch}/Packages"
+    parsed_url = urllib.parse.urlparse(url)
+    if parsed_url.scheme != "https" or parsed_url.hostname not in _ALLOWED_ARTIFACTORY_HOSTS:
+        print(f"  WARNING: {url} is not an allowed Artifactory URL, skipping.", file=sys.stderr)
+        return {}
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "generate-cpan-matrix/1.0"})
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            content = resp.read().decode("utf-8")
+    except Exception as exc:
+        print(f"  WARNING: could not fetch {url}: {exc}", file=sys.stderr)
+        return {}
     result = {}
-    for fname in _deb_pool_cache[repo]:
-        if not fname.endswith(f"_{arch}.deb"):
-            continue
-        if suffix and suffix not in fname:
-            continue
-        m = _DEB_PKG_RE.match(fname)
-        if m:
-            result[m.group(1)] = m.group(2)
+    for stanza in content.split("\n\n"):
+        pkg_name = None
+        version = None
+        for line in stanza.splitlines():
+            if line.startswith("Package: "):
+                pkg_name = line[9:].strip()
+            elif line.startswith("Version: "):
+                m = _DEB_VERSION_RE.match(line[9:].strip())
+                if m:
+                    version = m.group(1)
+        if pkg_name and version:
+            result[pkg_name] = version
     return result
+
+
+def get_centreon_deb_packages(base_url, distrib, stability, arch="amd64", family="debian"):
+    """Return {pkg_name: version} for packages already in the Centreon DEB repo.
+
+    Queries and merges the Packages indexes for the given arch and for 'all':
+      dists/{distrib}/main/binary-{arch}/Packages
+      dists/{distrib}/main/binary-all/Packages
+
+    Example entry: Package: libjson-path-perl, Version: 1.0.6+deb12u1-1
+      → pkg_name = "libjson-path-perl", version = "1.0.6"
+    """
+    repo = f"ubuntu-plugins-{stability}" if family == "ubuntu" else f"apt-plugins-{stability}"
+    cache_key = (repo, distrib, arch)
+    if cache_key not in _deb_packages_cache:
+        packages = _fetch_packages_index(base_url, repo, distrib, arch)
+        if arch != "all":
+            packages.update(_fetch_packages_index(base_url, repo, distrib, "all"))
+        _deb_packages_cache[cache_key] = packages
+    return _deb_packages_cache[cache_key]

--- a/.github/scripts/perl-cpan-libraries/generate-matrices.py
+++ b/.github/scripts/perl-cpan-libraries/generate-matrices.py
@@ -41,17 +41,20 @@ from cpan_matrix_lib import (
     extras_from_partials,
     get_cpanm_infos,
     dist_to_deb_package,
-    get_stable_rpm_packages,
-    get_stable_deb_packages,
+    get_centreon_rpm_packages,
+    get_centreon_deb_packages,
 )
 
 
-def merge_matrices(partial_matrices_dir, libraries, artifactory_url=None):
+def merge_matrices(partial_matrices_dir, libraries, artifactory_url=None, stability="unstable"):
     """Return (rpm_matrix, deb_matrix) as dicts with an 'include' list each.
 
     Generates flat include-only matrices: one entry per (lib, distrib/build_name)
     combination that actually needs to be built. No 2D cross-product, no excludes.
     """
+    # Map stability to the actual repo channel: stable → stable, testing → testing, anything else → unstable
+    repo_stability = stability if stability in ("stable", "testing") else "unstable"
+
     rpm_partials = {}  # distrib      → partial matrix data
     deb_partials = {}  # check_distrib → partial matrix data
 
@@ -104,14 +107,14 @@ def merge_matrices(partial_matrices_dir, libraries, artifactory_url=None):
         for check_distrib in DEB_CHECK_DISTRIB_TO_BUILD_NAMES:
             deb_lib_extras.setdefault(check_distrib, {}).update(cpanm_extras)
 
-    # Optionally query Centreon stable repository
+    # Optionally query Centreon repository for the target stability
     rpm_stable: dict = {}  # distrib → {cpan_dist_name: version}
     deb_stable: dict = {}  # (check_distrib, arch) → {pkg_name: version}
     if artifactory_url:
-        print("Checking Centreon stable repository…", file=sys.stderr)
+        print(f"Checking Centreon {repo_stability} repository…", file=sys.stderr)
         for distrib in RPM_DISTRIBS:
-            rpm_stable[distrib] = get_stable_rpm_packages(artifactory_url, distrib)
-            print(f"  RPM {distrib}: {len(rpm_stable[distrib])} packages in stable", file=sys.stderr)
+            rpm_stable[distrib] = get_centreon_rpm_packages(artifactory_url, distrib, repo_stability)
+            print(f"  RPM {distrib}: {len(rpm_stable[distrib])} packages in {repo_stability}", file=sys.stderr)
         seen: set = set()
         for bn_entry in DEB_BUILD_NAME_INCLUDES:
             check_distrib = DEB_IMAGE_TO_CHECK_DISTRIB[bn_entry["image"]]
@@ -120,12 +123,11 @@ def merge_matrices(partial_matrices_dir, libraries, artifactory_url=None):
             if key not in seen:
                 seen.add(key)
                 meta = deb_distrib_meta.get(check_distrib, {})
-                deb_stable[key] = get_stable_deb_packages(
-                    artifactory_url, check_distrib, arch,
+                deb_stable[key] = get_centreon_deb_packages(
+                    artifactory_url, check_distrib, repo_stability, arch,
                     family=meta.get("family", "debian"),
-                    suffix=meta.get("suffix", ""),
                 )
-                print(f"  DEB {check_distrib} {arch}: {len(deb_stable[key])} packages in stable",
+                print(f"  DEB {check_distrib} {arch}: {len(deb_stable[key])} packages in {repo_stability}",
                       file=sys.stderr)
 
     # ── RPM matrix ────────────────────────────────────────────────────────────
@@ -155,7 +157,7 @@ def merge_matrices(partial_matrices_dir, libraries, artifactory_url=None):
                 if stable_version is not None:
                     required = rpm.get("version", "") or cpan_version
                     if versions_match(stable_version, required):
-                        print(f"  Skip RPM {name}/{distrib}: Centreon stable has v{stable_version}",
+                        print(f"  Skip RPM {name}/{distrib}: Centreon {repo_stability} has v{stable_version}",
                               file=sys.stderr)
                         continue
             rpm_includes.append({**RPM_DEFAULTS, **distrib_entry, "name": name,
@@ -193,7 +195,7 @@ def merge_matrices(partial_matrices_dir, libraries, artifactory_url=None):
                 if stable_version is not None:
                     required = deb.get("version", "") or cpan_version
                     if versions_match(stable_version, required):
-                        print(f"  Skip DEB {name}/{build_name}: Centreon stable has v{stable_version}",
+                        print(f"  Skip DEB {name}/{build_name}: Centreon {repo_stability} has v{stable_version}",
                               file=sys.stderr)
                         continue
             deb_includes.append({**DEB_DEFAULTS, **bn_entry, "name": name,
@@ -217,8 +219,14 @@ def main():
         "--artifactory-url", metavar="URL",
         help="Base URL of the public Artifactory instance "
              "(e.g. https://packages.centreon.com). When provided, packages already "
-             "present in the Centreon stable repository at the expected version are "
+             "present in the Centreon repository at the expected version are "
              "skipped (not rebuilt).",
+    )
+    parser.add_argument(
+        "--stability", metavar="STABILITY", default="unstable",
+        help="Stability from the CI environment (stable, testing, unstable, canary, …). "
+             "Mapped to the repo channel: stable → stable, testing → testing, "
+             "anything else → unstable.",
     )
     args = parser.parse_args()
 
@@ -228,6 +236,7 @@ def main():
     rpm_matrix, deb_matrix = merge_matrices(
         args.partial_matrices_dir, libraries,
         artifactory_url=args.artifactory_url,
+        stability=args.stability,
     )
 
     github_output = os.environ.get("GITHUB_OUTPUT", "")

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -189,10 +189,17 @@ jobs:
           docker save -o "./${IMAGE_NAME}" "${DOCKER_IMAGE}:latest"
         shell: bash
 
-      - uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ./${{ matrix.image }}
           key: ${{ matrix.image }}-${{ github.sha }}-${{ github.run_id }}
+
+      - name: Restore packaging image from cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        with:
+          path: ./${{ matrix.image }}
+          key: ${{ matrix.image }}-${{ github.sha }}-${{ github.run_id }}
+          fail-on-cache-miss: true
 
   package-rpm:
     needs: [get-environment, generate-matrices, get-packaging-images]
@@ -212,7 +219,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Restore packaging image from cache
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ./${{ matrix.image }}
           key: ${{ matrix.image }}-${{ github.sha }}-${{ github.run_id }}
@@ -341,7 +348,7 @@ jobs:
       - run: rpmsign --addsign ./*.rpm
         shell: bash
 
-      - uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ./*.rpm
           key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
@@ -363,7 +370,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Restore packaging image from cache
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ./${{ matrix.image }}
           key: ${{ matrix.image }}-${{ github.sha }}-${{ github.run_id }}
@@ -485,7 +492,7 @@ jobs:
           name: packages-deb-${{ matrix.distrib }}
           path: ./
 
-      - uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ./*.deb
           key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -189,7 +189,7 @@ jobs:
           docker save -o "./${IMAGE_NAME}" "${DOCKER_IMAGE}:latest"
         shell: bash
 
-      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ./${{ matrix.image }}
           key: ${{ matrix.image }}-${{ github.sha }}-${{ github.run_id }}
@@ -212,7 +212,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Restore packaging image from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ./${{ matrix.image }}
           key: ${{ matrix.image }}-${{ github.sha }}-${{ github.run_id }}
@@ -341,7 +341,7 @@ jobs:
       - run: rpmsign --addsign ./*.rpm
         shell: bash
 
-      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ./*.rpm
           key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
@@ -363,7 +363,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Restore packaging image from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ./${{ matrix.image }}
           key: ${{ matrix.image }}-${{ github.sha }}-${{ github.run_id }}
@@ -485,7 +485,7 @@ jobs:
           name: packages-deb-${{ matrix.distrib }}
           path: ./
 
-      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ./*.deb
           key: ${{ github.sha }}-${{ github.run_id }}-deb-${{ matrix.distrib }}

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -194,13 +194,6 @@ jobs:
           path: ./${{ matrix.image }}
           key: ${{ matrix.image }}-${{ github.sha }}-${{ github.run_id }}
 
-      - name: Restore packaging image from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ./${{ matrix.image }}
-          key: ${{ matrix.image }}-${{ github.sha }}-${{ github.run_id }}
-          fail-on-cache-miss: true
-
   package-rpm:
     needs: [get-environment, generate-matrices, get-packaging-images]
     if: |

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -128,10 +128,13 @@ jobs:
 
       - name: Merge partial matrices into RPM and DEB matrices
         id: generate
+        env:
+          STABILITY: ${{ needs.get-environment.outputs.stability }}
         run: |
           python3 .github/scripts/perl-cpan-libraries/generate-matrices.py \
             --partial-matrices-dir official-repos \
             --artifactory-url https://packages.centreon.com \
+            --stability "$STABILITY" \
             .github/packaging/cpan-libraries.json
         shell: bash
 
@@ -554,6 +557,7 @@ jobs:
           package_extension: ${{ matrix.package_extension }}
           distrib: ${{ matrix.distrib }}
           arch: ${{ matrix.arch }}
+          stability: ${{ needs.get-environment.outputs.stability }}
 
       - name: Upload error log
         if: failure()


### PR DESCRIPTION
## Description

The cpan libs existence check was always using the centreon plugins stable repo instead of the one on which the packages are delivered.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 2 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Used specified stability repository when checking CPAN packages.
* Accepted stability parameter in generate-matrices and passed to checks.
* Added stability input to test-cpan-libs action and mapped repos.
* Split Dockerfiles to create separate repo files per stability.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99011399?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->