### PR TITLE
chore: enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
+* text=auto eol=lf
+
 tests/resources/spellcheck/*.txt diff


### PR DESCRIPTION
Add `* text=auto eol=lf` to prevent CRLF from being committed, which can break Perl shebang lines and script execution on Linux.

Refs: MON-32897


