### PR TITLE
enh(snmp_standard::mode::processcount): handle unanticipated hrSWRunStatus values for processes

### DIFF
--- a/src/snmp_standard/mode/processcount.pm
+++ b/src/snmp_standard/mode/processcount.pm
@@ -336,9 +336,9 @@ sub run {
     
     $self->check_top() if (defined($self->{option_results}->{top}));
 
-    foreach my $pid (keys %{$self->{results}}) {
+    foreach my $pid (sort keys %{$self->{results}}) {
         my $long_msg = sprintf("Process '%s'", $pid);
-        foreach my $key (keys %{$self->{results}->{$pid}}) {
+        foreach my $key (sort keys %{$self->{results}->{$pid}}) {
             $long_msg .= sprintf(" [%s: %s]", $key, $self->{results}->{$pid}->{$key});
         }
         $self->{output}->output_add(long_msg => $long_msg);

--- a/tests/os/linux/snmp/processcount.robot
+++ b/tests/os/linux/snmp/processcount.robot
@@ -33,4 +33,4 @@ processcount ${tc}
             ...      3     --top-num                                           OK: Number of current processes running: 84 | 'nbproc'=84;;;0;
             ...      4     --top-size                                          OK: Number of current processes running: 84 | 'nbproc'=84;;;0;
             ...      5     --process-status='running|runnable|unHandle'                                     OK: Number of current processes running: 86 | 'nbproc'=86;;;0;
-            ...      6     --process-status='unHandled#-2' --process-name='Anonymized 228' --verbose        OK: Number of current processes running: 1 | 'nbproc'=1;;;0; Process '3534' [status: unHandled#-2] [name: Anonymized 228]
+            ...      6     --process-status='unHandled#-2' --process-name='Anonymized 228' --verbose        OK: Number of current processes running: 1 | 'nbproc'=1;;;0; Process '3534' [name: Anonymized 228] [status: unHandled#-2]


### PR DESCRIPTION
## Description

enh(snmp_standard::mode::processcount): handle unanticipated hrSWRunStatus values for processes

Fix tests

**Fixes** # CTOR-2037

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Handled unanticipated hrSWRunStatus values by adding 'invalid' mapping.

**🔧 Refactors**
* Imported sha256_hex from Digest::SHA to support state caching.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/98672788?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->