### PR TITLE
chore(ci): harden pnpm install with supply chain security flags

### DIFF
--- a/.github/docker/testing/Dockerfile.testing-plugins-alma10
+++ b/.github/docker/testing/Dockerfile.testing-plugins-alma10
@@ -28,7 +28,11 @@ dnf install -y nodejs24
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} bash -
 source ~/.bashrc
 cd /usr/local/src
-pnpm install --frozen-lockfile
+pnpm install \
+  --frozen-lockfile \
+  --config.trustPolicy=no-downgrade \
+  --config.minimumReleaseAge=2880 \
+  --config.blockExoticSubdeps=true
 echo 'export PATH="~/node_modules/.bin/:$PATH"' >> ~/.bashrc
 
 # Add Centreon plugins repositories

--- a/.github/docker/testing/Dockerfile.testing-plugins-alma8
+++ b/.github/docker/testing/Dockerfile.testing-plugins-alma8
@@ -24,7 +24,11 @@ dnf install -y nodejs
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} sh -
 source ~/.bashrc
 cd /usr/local/src
-pnpm install --frozen-lockfile
+pnpm install \
+  --frozen-lockfile \
+  --config.trustPolicy=no-downgrade \
+  --config.minimumReleaseAge=2880 \
+  --config.blockExoticSubdeps=true
 echo 'export PATH="~/node_modules/.bin/:$PATH"' >> ~/.bashrc
 
 # Add Centreon plugins repositories

--- a/.github/docker/testing/Dockerfile.testing-plugins-alma9
+++ b/.github/docker/testing/Dockerfile.testing-plugins-alma9
@@ -29,7 +29,11 @@ dnf install -y nodejs
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} bash -
 source ~/.bashrc
 cd /usr/local/src
-pnpm install --frozen-lockfile
+pnpm install \
+  --frozen-lockfile \
+  --config.trustPolicy=no-downgrade \
+  --config.minimumReleaseAge=2880 \
+  --config.blockExoticSubdeps=true
 echo 'export PATH="~/node_modules/.bin/:$PATH"' >> ~/.bashrc
 
 # Add Centreon plugins repositories

--- a/.github/docker/testing/Dockerfile.testing-plugins-bookworm
+++ b/.github/docker/testing/Dockerfile.testing-plugins-bookworm
@@ -45,7 +45,11 @@ apt-get install -y nodejs
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} bash -
 source ~/.bashrc
 cd /usr/local/src
-pnpm install --frozen-lockfile
+pnpm install \
+  --frozen-lockfile \
+  --config.trustPolicy=no-downgrade \
+  --config.minimumReleaseAge=2880 \
+  --config.blockExoticSubdeps=true
 echo 'export PATH="~/node_modules/.bin/:$PATH"' >> ~/.bashrc
 
 # Add Centreon plugins repositories

--- a/.github/docker/testing/Dockerfile.testing-plugins-bullseye
+++ b/.github/docker/testing/Dockerfile.testing-plugins-bullseye
@@ -45,7 +45,11 @@ apt-get install -y nodejs
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} bash -
 source ~/.bashrc
 cd /usr/local/src
-pnpm install --frozen-lockfile
+pnpm install \
+  --frozen-lockfile \
+  --config.trustPolicy=no-downgrade \
+  --config.minimumReleaseAge=2880 \
+  --config.blockExoticSubdeps=true
 echo 'export PATH="~/node_modules/.bin/:$PATH"' >> ~/.bashrc
 
 # Add Centreon plugins repositories

--- a/.github/docker/testing/Dockerfile.testing-plugins-jammy
+++ b/.github/docker/testing/Dockerfile.testing-plugins-jammy
@@ -48,7 +48,11 @@ curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} bas
 sed -e '/[ -z "\$PS1" ] && return/ s/^#*/#/' -i \$HOME/.bashrc
 source ~/.bashrc
 cd /usr/local/src
-pnpm install --frozen-lockfile
+pnpm install \
+  --frozen-lockfile \
+  --config.trustPolicy=no-downgrade \
+  --config.minimumReleaseAge=2880 \
+  --config.blockExoticSubdeps=true
 
 # Add Centreon plugins repositories
 echo "deb https://packages.centreon.com/ubuntu-standard-24.04-stable/ jammy main" | tee -a /etc/apt/sources.list.d/centreon-stable.list

--- a/.github/docker/testing/Dockerfile.testing-plugins-noble
+++ b/.github/docker/testing/Dockerfile.testing-plugins-noble
@@ -48,7 +48,11 @@ apt-get install -y nodejs
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} bash -
 source ~/.bashrc
 cd /usr/local/src
-pnpm install --frozen-lockfile
+pnpm install \
+  --frozen-lockfile \
+  --config.trustPolicy=no-downgrade \
+  --config.minimumReleaseAge=2880 \
+  --config.blockExoticSubdeps=true
 
 # Add Centreon plugins repositories
 echo "deb https://packages.centreon.com/ubuntu-standard-24.10-stable/ noble main" | tee -a /etc/apt/sources.list.d/centreon-stable.list

--- a/.github/docker/testing/Dockerfile.testing-plugins-trixie
+++ b/.github/docker/testing/Dockerfile.testing-plugins-trixie
@@ -48,7 +48,11 @@ apt-get install -y nodejs
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} bash -
 source ~/.bashrc
 cd /usr/local/src
-pnpm install --frozen-lockfile
+pnpm install \
+  --frozen-lockfile \
+  --config.trustPolicy=no-downgrade \
+  --config.minimumReleaseAge=2880 \
+  --config.blockExoticSubdeps=true
 echo 'export PATH="~/node_modules/.bin/:$PATH"' >> ~/.bashrc
 
 # Add Centreon plugins repositories


### PR DESCRIPTION
## Description

Add supply chain security flags to all `pnpm install` commands in testing Dockerfiles:
- `--config.trustPolicy=no-downgrade`
- `--config.minimumReleaseAge=2880`
- `--config.blockExoticSubdeps=true`

**Fixes** MON-197308

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added supply chain security flags to pnpm install commands across testing Dockerfiles


<sup>[More info](https://app.aikido.dev/featurebranch/scan/99834023?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->