### PR TITLE
AlmaLinux 8 partially implements CURLOPT_AWS_SIGV4

### DIFF
--- a/.github/docker/unit-tests/Dockerfile.unit-tests-alma8
+++ b/.github/docker/unit-tests/Dockerfile.unit-tests-alma8
@@ -56,4 +56,6 @@ mkdir -p /var/lib/centreon/centplugins/
 chmod 777 /var/lib/centreon/centplugins/
 NONINTERACTIVE_TESTING=1 PERL_MM_USE_DEFAULT=1 cpan Test2::Harness UUID
 rm -fr /root/.cpan*
+
+sed -i 's/grep { \/\^CURL\/x } keys %{Net::Curl::Easy::};/grep { \/^CURL\/x \&\& !\/_AWS_\/ } keys %{Net::Curl::Easy::};/' /usr/local/lib64/perl5/Net/Curl/Easy.pm
 EOF

--- a/.github/docker/unit-tests/Dockerfile.unit-tests-alma8
+++ b/.github/docker/unit-tests/Dockerfile.unit-tests-alma8
@@ -56,6 +56,4 @@ mkdir -p /var/lib/centreon/centplugins/
 chmod 777 /var/lib/centreon/centplugins/
 NONINTERACTIVE_TESTING=1 PERL_MM_USE_DEFAULT=1 cpan Test2::Harness UUID
 rm -fr /root/.cpan*
-
-sed -i 's/grep { \/\^CURL\/x } keys %{Net::Curl::Easy::};/grep { \/^CURL\/x \&\& !\/_AWS_\/ } keys %{Net::Curl::Easy::};/' /usr/local/lib64/perl5/Net/Curl/Easy.pm
 EOF

--- a/tests/centreon/plugins/curllogger.t
+++ b/tests/centreon/plugins/curllogger.t
@@ -256,7 +256,8 @@ SKIP: {
                          password => 'Pa$$w@rd' , curl_opt => [ "CURLOPT_AWS_SIGV4 => osc" ] } };
 
     eval "CURLOPT_AWS_SIGV4";
-    if ($@) {
+    my $curl = `curl --aws-sigv4 2>&1` // '';
+    if ($@ || $curl =~ /is unknown/) {
         print "test ".$test->{title}."\n";
         skip "CURLOPT_AWS_SIGV4 is unsupported on this platform", 5;
     }


### PR DESCRIPTION

## Description

AlmaLinux 8 partially implements CURLOPT_AWS_SIGV4

**Fixes** # CTOR-2261

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Patched Net::Curl::Easy to exclude AWS entries via sed


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101103071?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->