### PR TITLE
MON-182595 Fix centreon-plugins nightly ticket creation

### DIFF
--- a/.github/actions/create-jira-ticket/action.yml
+++ b/.github/actions/create-jira-ticket/action.yml
@@ -133,6 +133,11 @@ runs:
                 }
               }
 
+            if (project_name === "CTOR") {
+              ticket_data.fields["customfield_10016"] = 1;
+              ticket_data.fields["customfield_11022"] = [{"id": "10557"}]; // TargetBranches: "develop"
+            }
+
             if (current_sprint !== null) {
               ticket_data.fields.customfield_10007 = parseInt(current_sprint, 10);
             }
@@ -171,7 +176,10 @@ runs:
             console.log(`Response on priority change: ${response}`);
 
             // Update ticket status to NEED REFINEMENT and then SPRINT READY so that squad members can see it in their respective sprints
-            for (const transition_id of [11, 21]) {
+            // MON: 11 = "Select for refinement" (NEED REFINEMENT), 21 = "Ready to develop" (SPRINT READY)
+            // CTOR: 61 = "Select for refinement" (NEED REFINEMENT), 81 = "Ready to develop" (SPRINT READY)
+            const transition_ids = project_name === "CTOR" ? [61, 81] : [11, 21];
+            for (const transition_id of transition_ids) {
               response = execSync(
                 `curl --request POST \
                   --url "${{ inputs.jira_base_url }}/rest/api/latest/issue/${ticket_key}/transitions" \


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                                                                                                                                                              
  The nightly build failure action (`.github/actions/create-jira-ticket/action.yml`) was hardcoding Jira transition IDs `[11, 21]` which only work for MON project tickets. For CTOR   project tickets (CONNECTORS squad), this caused:                                                                                                                                   
  - Transition `11` → HTTP error (does not exist in CTOR)                                                                                                                            
  - Transition `21` → mapped to "In progress" instead of "NEED REFINEMENT"                                                                                                           

  Additionally, CTOR tickets require two extra fields that were not being set.

  ## Changes

  **Fix transition IDs per project:**
  - MON: `[11, 21]` (unchanged) → NEED REFINEMENT → SPRINT READY
  - CTOR: `[61, 81]` → NEED REFINEMENT → SPRINT READY

  **Add CTOR-specific fields on ticket creation:**
  - `customfield_10016 = 1` — story points (default: 1)
  - `customfield_11022 = [{"id": "10557"}]` — TargetBranches set to "develop" (confirmed from existing CTOR ticket CTOR-2127)

  ## Scope

  Only `create-jira-ticket/action.yml` is modified. No logic changes for MON tickets.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Corrected Jira transition IDs per project to prevent invalid transitions
* Added CTOR-specific Jira fields for story points and target branches


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101544219?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->