### PR TITLE
New plugin Azure Vmware Solution

### DIFF
--- a/src/cloud/azure/compute/avs/mode/cpu.pm
+++ b/src/cloud/azure/compute/avs/mode/cpu.pm
@@ -1,0 +1,163 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::compute::avs::mode::cpu;
+
+use base qw(cloud::azure::custom::mode);
+
+use strict;
+use warnings;
+
+sub get_metrics_mapping {
+    my ($self, %options) = @_;
+
+    my $metrics_mapping = {
+        'CpuUsageAverage' => {
+            'output' => 'CPU usage',
+            'label'  => 'cpu-usage',
+            'nlabel' => 'avs.cluster.cpu.usage.percentage',
+            'unit'   => '%',
+            'min'    => '0',
+            'max'    => '100'
+        },
+        'EffectiveCpuAverage' => {
+            'output' => 'Effective CPU',
+            'label'  => 'cpu-effective',
+            'nlabel' => 'avs.cluster.cpu.effective.percentage',
+            'unit'   => '%',
+            'min'    => '0',
+            'max'    => '100'
+        }
+    };
+
+    return $metrics_mapping;
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'api-version:s'    => { name => 'api_version', default => '2018-01-01' },
+        'filter-metric:s'  => { name => 'filter_metric' },
+        'resource:s'       => { name => 'resource' },
+        'resource-group:s' => { name => 'resource_group' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{resource}) || $self->{option_results}->{resource} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify either --resource <name> with --resource-group option or --resource <id>.');
+        $self->{output}->option_exit();
+    }
+
+    $self->{api_version} = (defined($self->{option_results}->{api_version}) && $self->{option_results}->{api_version} ne '') ? $self->{option_results}->{api_version} : '2018-01-01';
+
+    my $resource       = $self->{option_results}->{resource};
+    my $resource_group = defined($self->{option_results}->{resource_group}) ? $self->{option_results}->{resource_group} : '';
+
+    if ($resource =~ /^\/subscriptions\/.*\/resourceGroups\/(.*)\/providers\/Microsoft\.AVS\/privateClouds\/(.*)$/) {
+        $resource_group = $1;
+        $resource       = $2;
+    }
+
+    $self->{az_resource}           = $resource;
+    $self->{az_resource_group}     = $resource_group;
+    $self->{az_resource_type}      = 'privateClouds';
+    $self->{az_resource_namespace} = 'Microsoft.AVS';
+    $self->{az_timeframe}          = defined($self->{option_results}->{timeframe})  ? $self->{option_results}->{timeframe}  : 900;
+    $self->{az_interval}           = defined($self->{option_results}->{interval})   ? $self->{option_results}->{interval}   : 'PT5M';
+    $self->{az_aggregations}       = ['Average'];
+
+    if (defined($self->{option_results}->{aggregation})) {
+        $self->{az_aggregations} = [];
+        foreach my $stat (@{$self->{option_results}->{aggregation}}) {
+            push @{$self->{az_aggregations}}, ucfirst(lc($stat)) if $stat ne '';
+        }
+    }
+
+    foreach my $metric (keys %{$self->{metrics_mapping}}) {
+        next if (defined($self->{option_results}->{filter_metric}) && $self->{option_results}->{filter_metric} ne ''
+            && $metric !~ /$self->{option_results}->{filter_metric}/);
+        push @{$self->{az_metrics}}, $metric;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Azure VMware Solution (AVS) private cloud cluster CPU metrics.
+
+Metric names in the Azure Monitor API:
+- C<CpuUsageAverage>: percentage of used CPU resources in the cluster (new)
+- C<EffectiveCpuAverage>: percentage of effective CPU resources in the cluster (legacy)
+
+Dimension: C<clustername>
+
+Example:
+
+perl centreon_plugins.pl --plugin=cloud::azure::compute::avs::plugin \
+  --custommode=api --mode=cpu \
+  --subscription=XXXX --tenant=XXXX --client-id=XXXX --client-secret=XXXX \
+  --resource=my-private-cloud --resource-group=my-rg \
+  --warning-cpu-usage=80 --critical-cpu-usage=90 --verbose
+
+=over 8
+
+=item B<--resource>
+
+Set resource name or ID (required).
+
+=item B<--resource-group>
+
+Set resource group (required if resource name is used).
+
+=item B<--filter-metric>
+
+Filter metrics (can be: C<CpuUsageAverage>, C<EffectiveCpuAverage>) (can be a regexp).
+
+=item B<--warning-cpu-usage>
+
+Warning threshold for cluster CPU usage percentage.
+
+=item B<--critical-cpu-usage>
+
+Critical threshold for cluster CPU usage percentage.
+
+=item B<--warning-cpu-effective>
+
+Warning threshold for effective CPU percentage.
+
+=item B<--critical-cpu-effective>
+
+Critical threshold for effective CPU percentage.
+
+=back
+
+=cut

--- a/src/cloud/azure/compute/avs/mode/cpu.pm
+++ b/src/cloud/azure/compute/avs/mode/cpu.pm
@@ -56,7 +56,7 @@ sub new {
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
-        'api-version:s'    => { name => 'api_version', default => '2018-01-01' },
+        'api-version:s'    => { name => 'api_version', default => '2024-02-01' },
         'filter-metric:s'  => { name => 'filter_metric' },
         'resource:s'       => { name => 'resource' },
         'resource-group:s' => { name => 'resource_group' }

--- a/src/cloud/azure/compute/avs/mode/datastore.pm
+++ b/src/cloud/azure/compute/avs/mode/datastore.pm
@@ -1,0 +1,185 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::compute::avs::mode::datastore;
+
+use base qw(cloud::azure::custom::mode);
+
+use strict;
+use warnings;
+
+sub get_metrics_mapping {
+    my ($self, %options) = @_;
+
+    my $metrics_mapping = {
+        'DiskUsedPercentage' => {
+            'output' => 'Disk used',
+            'label'  => 'datastore-disk-used-percentage',
+            'nlabel' => 'avs.datastore.disk.used.percentage',
+            'unit'   => '%',
+            'min'    => '0',
+            'max'    => '100'
+        },
+        'DiskUsedLatest' => {
+            'output' => 'Disk used',
+            'label'  => 'datastore-disk-used',
+            'nlabel' => 'avs.datastore.disk.used.bytes',
+            'unit'   => 'B',
+            'min'    => '0',
+            'max'    => ''
+        },
+        'DiskCapacityLatest' => {
+            'output' => 'Disk total capacity',
+            'label'  => 'datastore-disk-capacity',
+            'nlabel' => 'avs.datastore.disk.capacity.bytes',
+            'unit'   => 'B',
+            'min'    => '0',
+            'max'    => ''
+        }
+    };
+
+    return $metrics_mapping;
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'api-version:s'    => { name => 'api_version', default => '2018-01-01' },
+        'filter-metric:s'  => { name => 'filter_metric' },
+        'resource:s'       => { name => 'resource' },
+        'resource-group:s' => { name => 'resource_group' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{resource}) || $self->{option_results}->{resource} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify either --resource <name> with --resource-group option or --resource <id>.');
+        $self->{output}->option_exit();
+    }
+
+    $self->{api_version} = (defined($self->{option_results}->{api_version}) && $self->{option_results}->{api_version} ne '') ? $self->{option_results}->{api_version} : '2018-01-01';
+
+    my $resource       = $self->{option_results}->{resource};
+    my $resource_group = defined($self->{option_results}->{resource_group}) ? $self->{option_results}->{resource_group} : '';
+
+    if ($resource =~ /^\/subscriptions\/.*\/resourceGroups\/(.*)\/providers\/Microsoft\.AVS\/privateClouds\/(.*)$/) {
+        $resource_group = $1;
+        $resource       = $2;
+    }
+
+    $self->{az_resource}           = $resource;
+    $self->{az_resource_group}     = $resource_group;
+    $self->{az_resource_type}      = 'privateClouds';
+    $self->{az_resource_namespace} = 'Microsoft.AVS';
+    $self->{az_timeframe}          = defined($self->{option_results}->{timeframe})  ? $self->{option_results}->{timeframe}  : 1800;
+    $self->{az_interval}           = defined($self->{option_results}->{interval})   ? $self->{option_results}->{interval}   : 'PT30M';
+    $self->{az_aggregations}       = ['Average'];
+
+    if (defined($self->{option_results}->{aggregation})) {
+        $self->{az_aggregations} = [];
+        foreach my $stat (@{$self->{option_results}->{aggregation}}) {
+            push @{$self->{az_aggregations}}, ucfirst(lc($stat)) if $stat ne '';
+        }
+    }
+
+    foreach my $metric (keys %{$self->{metrics_mapping}}) {
+        next if (defined($self->{option_results}->{filter_metric}) && $self->{option_results}->{filter_metric} ne ''
+            && $metric !~ /$self->{option_results}->{filter_metric}/);
+        push @{$self->{az_metrics}}, $metric;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Azure VMware Solution (AVS) private cloud datastore disk metrics.
+
+Metric names in the Azure Monitor API:
+- C<DiskUsedPercentage>: percent of available disk used in the datastore (new)
+- C<DiskUsedLatest>: total disk used in the datastore (new)
+- C<DiskCapacityLatest>: total disk capacity in the datastore (new)
+
+Dimension: C<dsname>
+
+Note: datastore metrics have a minimum granularity of PT30M. Default timeframe
+is set to 1800 seconds (30 minutes) and interval to PT30M accordingly.
+
+Example:
+
+perl centreon_plugins.pl --plugin=cloud::azure::compute::avs::plugin \
+  --custommode=api --mode=datastore \
+  --subscription=XXXX --tenant=XXXX --client-id=XXXX --client-secret=XXXX \
+  --resource=my-private-cloud --resource-group=my-rg \
+  --warning-datastore-disk-used-percentage=70 \
+  --critical-datastore-disk-used-percentage=85 --verbose
+
+=over 8
+
+=item B<--resource>
+
+Set resource name or ID (required).
+
+=item B<--resource-group>
+
+Set resource group (required if resource name is used).
+
+=item B<--filter-metric>
+
+Filter metrics (can be: C<DiskUsedPercentage>, C<DiskUsedLatest>,
+C<DiskCapacityLatest>) (can be a regexp).
+
+=item B<--warning-datastore-disk-used-percentage>
+
+Warning threshold for datastore disk usage percentage.
+
+=item B<--critical-datastore-disk-used-percentage>
+
+Critical threshold for datastore disk usage percentage.
+
+=item B<--warning-datastore-disk-used>
+
+Warning threshold for disk used (bytes).
+
+=item B<--critical-datastore-disk-used>
+
+Critical threshold for disk used (bytes).
+
+=item B<--warning-datastore-disk-capacity>
+
+Warning threshold for total disk capacity (bytes).
+
+=item B<--critical-datastore-disk-capacity>
+
+Critical threshold for total disk capacity (bytes).
+
+=back
+
+=cut

--- a/src/cloud/azure/compute/avs/mode/datastore.pm
+++ b/src/cloud/azure/compute/avs/mode/datastore.pm
@@ -64,7 +64,7 @@ sub new {
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
-        'api-version:s'    => { name => 'api_version', default => '2018-01-01' },
+        'api-version:s'    => { name => 'api_version', default => '2024-02-01' },
         'filter-metric:s'  => { name => 'filter_metric' },
         'resource:s'       => { name => 'resource' },
         'resource-group:s' => { name => 'resource_group' }

--- a/src/cloud/azure/compute/avs/mode/memory.pm
+++ b/src/cloud/azure/compute/avs/mode/memory.pm
@@ -1,0 +1,198 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::compute::avs::mode::memory;
+
+use base qw(cloud::azure::custom::mode);
+
+use strict;
+use warnings;
+
+sub get_metrics_mapping {
+    my ($self, %options) = @_;
+
+    my $metrics_mapping = {
+        'MemUsageAverage' => {
+            'output' => 'Memory usage',
+            'label'  => 'memory-usage',
+            'nlabel' => 'avs.cluster.memory.usage.percentage',
+            'unit'   => '%',
+            'min'    => '0',
+            'max'    => '100'
+        },
+        'ClusterSummaryEffectiveMemory' => {
+            'output' => 'Effective memory',
+            'label'  => 'memory-effective',
+            'nlabel' => 'avs.cluster.memory.effective.bytes',
+            'unit'   => 'B',
+            'min'    => '0',
+            'max'    => ''
+        },
+        'ClusterSummaryTotalMemCapacityMB' => {
+            'output' => 'Total memory capacity',
+            'label'  => 'memory-total',
+            'nlabel' => 'avs.cluster.memory.total.bytes',
+            'unit'   => 'B',
+            'min'    => '0',
+            'max'    => ''
+        },
+        'MemOverheadAverage' => {
+            'output' => 'Memory overhead',
+            'label'  => 'memory-overhead',
+            'nlabel' => 'avs.cluster.memory.overhead.bytes',
+            'unit'   => 'B',
+            'min'    => '0',
+            'max'    => ''
+        }
+    };
+
+    return $metrics_mapping;
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'api-version:s'    => { name => 'api_version', default => '2018-01-01' },
+        'filter-metric:s'  => { name => 'filter_metric' },
+        'resource:s'       => { name => 'resource' },
+        'resource-group:s' => { name => 'resource_group' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if (!defined($self->{option_results}->{resource}) || $self->{option_results}->{resource} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify either --resource <name> with --resource-group option or --resource <id>.');
+        $self->{output}->option_exit();
+    }
+
+    $self->{api_version} = (defined($self->{option_results}->{api_version}) && $self->{option_results}->{api_version} ne '') ? $self->{option_results}->{api_version} : '2018-01-01';
+
+    my $resource       = $self->{option_results}->{resource};
+    my $resource_group = defined($self->{option_results}->{resource_group}) ? $self->{option_results}->{resource_group} : '';
+
+    if ($resource =~ /^\/subscriptions\/.*\/resourceGroups\/(.*)\/providers\/Microsoft\.AVS\/privateClouds\/(.*)$/) {
+        $resource_group = $1;
+        $resource       = $2;
+    }
+
+    $self->{az_resource}           = $resource;
+    $self->{az_resource_group}     = $resource_group;
+    $self->{az_resource_type}      = 'privateClouds';
+    $self->{az_resource_namespace} = 'Microsoft.AVS';
+    $self->{az_timeframe}          = defined($self->{option_results}->{timeframe})  ? $self->{option_results}->{timeframe}  : 900;
+    $self->{az_interval}           = defined($self->{option_results}->{interval})   ? $self->{option_results}->{interval}   : 'PT5M';
+    $self->{az_aggregations}       = ['Average'];
+
+    if (defined($self->{option_results}->{aggregation})) {
+        $self->{az_aggregations} = [];
+        foreach my $stat (@{$self->{option_results}->{aggregation}}) {
+            push @{$self->{az_aggregations}}, ucfirst(lc($stat)) if $stat ne '';
+        }
+    }
+
+    foreach my $metric (keys %{$self->{metrics_mapping}}) {
+        next if (defined($self->{option_results}->{filter_metric}) && $self->{option_results}->{filter_metric} ne ''
+            && $metric !~ /$self->{option_results}->{filter_metric}/);
+        push @{$self->{az_metrics}}, $metric;
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Azure VMware Solution (AVS) private cloud cluster memory metrics.
+
+Metric names in the Azure Monitor API:
+- C<MemUsageAverage>: memory usage as a percentage of total configured memory (new)
+- C<ClusterSummaryEffectiveMemory>: total available machine memory in cluster (new)
+- C<ClusterSummaryTotalMemCapacityMB>: total memory in cluster (new)
+- C<MemOverheadAverage>: host physical memory consumed by the virtualization infrastructure (new)
+
+Dimension: C<clustername>
+
+Example:
+
+perl centreon_plugins.pl --plugin=cloud::azure::compute::avs::plugin \
+  --custommode=api --mode=memory \
+  --subscription=XXXX --tenant=XXXX --client-id=XXXX --client-secret=XXXX \
+  --resource=my-private-cloud --resource-group=my-rg \
+  --warning-memory-usage=80 --critical-memory-usage=90 --verbose
+
+=over 8
+
+=item B<--resource>
+
+Set resource name or ID (required).
+
+=item B<--resource-group>
+
+Set resource group (required if resource name is used).
+
+=item B<--filter-metric>
+
+Filter metrics (can be: C<MemUsageAverage>, C<ClusterSummaryEffectiveMemory>,
+C<ClusterSummaryTotalMemCapacityMB>, C<MemOverheadAverage>) (can be a regexp).
+
+=item B<--warning-memory-usage>
+
+Warning threshold for memory usage percentage.
+
+=item B<--critical-memory-usage>
+
+Critical threshold for memory usage percentage.
+
+=item B<--warning-memory-effective>
+
+Warning threshold for effective memory (bytes). Use C<value:> syntax to alert when below a value.
+
+=item B<--critical-memory-effective>
+
+Critical threshold for effective memory (bytes).
+
+=item B<--warning-memory-total>
+
+Warning threshold for total memory capacity (bytes).
+
+=item B<--critical-memory-total>
+
+Critical threshold for total memory capacity (bytes).
+
+=item B<--warning-memory-overhead>
+
+Warning threshold for memory overhead (bytes).
+
+=item B<--critical-memory-overhead>
+
+Critical threshold for memory overhead (bytes).
+
+=back
+
+=cut

--- a/src/cloud/azure/compute/avs/mode/memory.pm
+++ b/src/cloud/azure/compute/avs/mode/memory.pm
@@ -72,7 +72,7 @@ sub new {
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
-        'api-version:s'    => { name => 'api_version', default => '2018-01-01' },
+        'api-version:s'    => { name => 'api_version', default => '2024-02-01' },
         'filter-metric:s'  => { name => 'filter_metric' },
         'resource:s'       => { name => 'resource' },
         'resource-group:s' => { name => 'resource_group' }

--- a/src/cloud/azure/compute/avs/plugin.pm
+++ b/src/cloud/azure/compute/avs/plugin.pm
@@ -1,0 +1,60 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package cloud::azure::compute::avs::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_custom);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{version} = '0.1';
+    %{$self->{modes}} = (
+        'cpu'           => 'cloud::azure::compute::avs::mode::cpu',
+        'datastore'     => 'cloud::azure::compute::avs::mode::datastore',
+        'memory'        => 'cloud::azure::compute::avs::mode::memory',
+    );
+
+    $self->{custom_modes}{azcli} = 'cloud::azure::custom::azcli';
+    $self->{custom_modes}{api}   = 'cloud::azure::custom::api';
+    return $self;
+}
+
+sub init {
+    my ($self, %options) = @_;
+
+    $self->{options}->add_options(arguments => {});
+
+    $self->SUPER::init(%options);
+}
+
+1;
+
+__END__
+
+=head1 PLUGIN DESCRIPTION
+
+Check Microsoft Azure VMware Solution (AVS) private cloud metrics.
+
+=cut


### PR DESCRIPTION
# Community contributors

## Description

Allow to monitor AVS (Azure Vmware Solution) resources

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

# CPU cluster
sudo -u centreon-engine perl centreon_plugins.pl --plugin=cloud::azure::compute::avs::plugin \
  --custommode=api --mode=cpu \
  --subscription='xxx' --tenant='xxx' --client-id='xxx' --client-secret='xxx' \
  --resource='xxx' --resource-group='xxx' \
  --warning-cpu-usage=80 --critical-cpu-usage=90

OK: Instance 'xxx' Statistic 'average' Metrics CPU usage: 32.00%, Effective CPU: 32.00% | 'xxx~average#avs.cluster.cpu.usage.percentage'=32.00%;0:80;0:90;0;100 'xxx~average#avs.cluster.cpu.effective.percentage'=32.00%;;;0;100

# Datastore (utilisation disque)
sudo -u centreon-engine perl centreon_plugins.pl --plugin=cloud::azure::compute::avs::plugin \
  --custommode=api --mode=datastore \
  --subscription='xxx' --tenant='xxx' --client-id='xxx' --client-secret='xxx' \
  --resource='xxx' --resource-group='xxx' \
  --warning-datastore-disk-used-percentage=70 --critical-datastore-disk-used-percentage=85

OK: Instance 'xxx' Statistic 'average' Metrics Disk total capacity: 52.40TB, Disk used: 23.86TB, Disk used: 45.00% | 'xxx~average#avs.datastore.disk.capacity.bytes'=57611315257344.00B;;;0; 'xxx~average#avs.datastore.disk.used.bytes'=26233016046628.50B;;;0; 'xxx~average#avs.datastore.disk.used.percentage'=45.00%;0:70;0:85;0;100

  
sudo -u centreon-engine perl centreon_plugins.pl --plugin=cloud::azure::compute::avs::plugin \
  --custommode=api --mode=memory \
  --subscription='xxx' --tenant='xxx' --client-id='xxx' --client-secret='xxx' \
  --resource='xxx' --resource-group='xxx' \
  --warning-memory-usage=80 --critical-memory-usage=90

OK: Instance 'xxx' Statistic 'average' Metrics Effective memory: 2.03TB, Total memory capacity: 2.03TB, Memory overhead: 7.07GB, Memory usage: 33.00% | 'xxx~average#avs.cluster.memory.effective.bytes'=2229359957333.33B;;;0; 'xxx~average#avs.cluster.memory.total.bytes'=2229359957333.33B;;;0; 'xxx~average#avs.cluster.memory.overhead.bytes'=7590789461.33B;;;0; 'xxx~average#avs.cluster.memory.usage.percentage'=33.00%;0:80;0:90;0;100

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (develop).
- [X] I have provide data or shown output displaying the result of this code in the plugin area concerned.

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 3 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added Azure VMware Solution plugin with CPU, memory, datastore modes


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101546178?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->