### PR TITLE
fix(mongodb): ignore hashes or lists returned in `opcounters`

### DIFF
--- a/src/database/mongodb/mode/queries.pm
+++ b/src/database/mongodb/mode/queries.pm
@@ -93,6 +93,7 @@ sub manage_selection {
 
     $self->{global} = {};
     foreach my $query (keys %{$server_stats->{opcounters}}) {
+        next if ref $server_stats->{opcounters}->{$query};
         $self->{global}->{$query} = $server_stats->{opcounters}->{$query};
         $self->{global}->{total} += $server_stats->{opcounters}->{$query};
     }


### PR DESCRIPTION
# Community contributors

## Description

This PR fixes a bug in the MongoDB plugin's `queries` mode, triggered when the MongoDB server returns non-scalar entries in its `opcounters` table (such as, in our case, the `deprecated` table). The address of the reference to the table would be added to the total, resulting in random, usually quite high, total queries / total queries per second output.

The fix simply causes the plugin to ignore `ref` entries.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Before this PR, running the plugin with `--mode=queries` would result in random values appearing in the total requests output (and per-second perf data). After applying it, the behavior should be unchanged on systems that don't have a hash in the MongoDB output, and should no longer output random values on affected systems.

For example, here's the output before the change on a mostly inactive system:

```
# /usr/lib/centreon/plugins/centreon_mongodb.pl --plugin database::mongodb::plugin --hostname ... --username ... --password ... --mode=queries                                                                                                                                                                                                                  
OK: Requests total: 24274782078 | 'queries.total.persecond'=24274782078/s;;;0; 'queries.insert.persecond'=0.00/s;;;0; 'queries.insert.count'=0;;;0; 'queries.query.persecond'=0.00/s;;;0; 'queries.query.count'=0;;;0; 'queries.update.persecond'=0.00/s;;;0; 'queries.update.count'=0;;;0; 'queries.delete.persecond'=0.00/s;;;0; 'queries.delete.count'=0;;;0; 'queries.getmore.persecond'=0.15/s;;;0; 'queries.getmore.count'=5;;;0; 'queries.command.persecond'=1.30/s;;;0; 'queries.command.count'=43;;;0;                                                                                                                                                                                    
```

and after the update: 

```
# /usr/lib/centreon/plugins/centreon_mongodb.pl --plugin database::mongodb::plugin --hostname ... --username ... --password ... --mode=queries                                                                                                                                                                                                                  
OK: Requests total: 1 | 'queries.total.persecond'=1/s;;;0; 'queries.insert.persecond'=0.00/s;;;0; 'queries.insert.count'=0;;;0; 'queries.query.persecond'=0.00/s;;;0; 'queries.query.count'=0;;;0; 'queries.update.persecond'=0.00/s;;;0; 'queries.update.count'=0;;;0; 'queries.delete.persecond'=0.00/s;;;0; 'queries.delete.count'=0;;;0; 'queries.getmore.persecond'=0.17/s;;;0; 'queries.getmore.count'=6;;;0; 'queries.command.persecond'=1.31/s;;;0; 'queries.command.count'=46;;;0
```

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
  - there's only one line...
- [ ] I have **rebased** my development branch on the base branch (develop).
  - fresh clone
- [x] I have provide data or shown output displaying the result of this code in the plugin area concerned.


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Ignored non-scalar entries in opcounters to prevent incorrect totals


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101557014?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->