### PR TITLE
enh(ci): replace GHA cache with ghcr.io for fat container images

### DIFF
--- a/.github/scripts/perl-cpan-libraries/cpan_matrix_lib.py
+++ b/.github/scripts/perl-cpan-libraries/cpan_matrix_lib.py
@@ -46,22 +46,22 @@ DEB_DEFAULTS = {
 # ── Fixed include entries ──────────────────────────────────────────────────────
 
 RPM_DISTRIB_INCLUDES = [
-    {"distrib": "el8",  "package_extension": "rpm", "image": "packaging-plugins-alma8"},
-    {"distrib": "el9",  "package_extension": "rpm", "image": "packaging-plugins-alma9"},
-    {"distrib": "el10", "package_extension": "rpm", "image": "packaging-plugins-alma10"},
+    {"distrib": "el8",  "package_extension": "rpm", "image": "packaging:alma8"},
+    {"distrib": "el9",  "package_extension": "rpm", "image": "packaging:alma9"},
+    {"distrib": "el10", "package_extension": "rpm", "image": "packaging:alma10"},
 ]
 
 DEB_BUILD_NAME_INCLUDES = [
-    {"build_name": "bullseye-amd64", "distrib": "bullseye", "package_extension": "deb", "image": "packaging-plugins-bullseye"},
-    {"build_name": "bookworm",       "distrib": "bookworm", "package_extension": "deb", "image": "packaging-plugins-bookworm"},
-    {"build_name": "trixie",         "distrib": "trixie",   "package_extension": "deb", "image": "packaging-plugins-trixie"},
-    {"build_name": "jammy",          "distrib": "jammy",    "package_extension": "deb", "image": "packaging-plugins-jammy"},
-    {"build_name": "noble",          "distrib": "noble",    "package_extension": "deb", "image": "packaging-plugins-noble"},
+    {"build_name": "bullseye-amd64", "distrib": "bullseye", "package_extension": "deb", "image": "packaging:bullseye"},
+    {"build_name": "bookworm",       "distrib": "bookworm", "package_extension": "deb", "image": "packaging:bookworm"},
+    {"build_name": "trixie",         "distrib": "trixie",   "package_extension": "deb", "image": "packaging:trixie"},
+    {"build_name": "jammy",          "distrib": "jammy",    "package_extension": "deb", "image": "packaging:jammy"},
+    {"build_name": "noble",          "distrib": "noble",    "package_extension": "deb", "image": "packaging:noble"},
     {
         "build_name": "bullseye-arm64",
         "distrib":    "bullseye",
         "package_extension": "deb",
-        "image": "packaging-plugins-bullseye-arm64",
+        "image": "packaging:bullseye",
         "arch": "arm64",
         "runner_name": "ubuntu-24.04-arm",
     },
@@ -69,7 +69,7 @@ DEB_BUILD_NAME_INCLUDES = [
         "build_name": "bookworm-arm64",
         "distrib":    "bookworm",
         "package_extension": "deb",
-        "image": "packaging-plugins-bookworm-arm64",
+        "image": "packaging:bookworm",
         "arch": "arm64",
         "runner_name": "ubuntu-24.04-arm",
     },
@@ -77,7 +77,7 @@ DEB_BUILD_NAME_INCLUDES = [
         "build_name": "trixie-arm64",
         "distrib":    "trixie",
         "package_extension": "deb",
-        "image": "packaging-plugins-trixie-arm64",
+        "image": "packaging:trixie",
         "arch": "arm64",
         "runner_name": "ubuntu-24.04-arm",
     },

--- a/.github/workflows/docker-builder-packaging-plugins.yml
+++ b/.github/workflows/docker-builder-packaging-plugins.yml
@@ -36,61 +36,99 @@ jobs:
         include:
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-alma8
-            image: packaging-plugins-alma8
+            image: packaging
+            distrib: alma8
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-alma9
-            image: packaging-plugins-alma9
+            image: packaging
+            distrib: alma9
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-alma10
-            image: packaging-plugins-alma10
+            image: packaging
+            distrib: alma10
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-java-alma8
-            image: packaging-plugins-java-alma8
+            image: packaging-java
+            distrib: alma8
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-java-alma9
-            image: packaging-plugins-java-alma9
+            image: packaging-java
+            distrib: alma9
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-java-alma10
-            image: packaging-plugins-java-alma10
+            image: packaging-java
+            distrib: alma10
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-bullseye
-            image: packaging-plugins-bullseye
+            image: packaging
+            distrib: bullseye
+            arch: amd64
           - runner: ubuntu-24.04-arm
             dockerfile: packaging-plugins-bullseye
-            image: packaging-plugins-bullseye-arm64
+            image: packaging
+            distrib: bullseye
+            arch: arm64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-bookworm
-            image: packaging-plugins-bookworm
+            image: packaging
+            distrib: bookworm
+            arch: amd64
           - runner: ubuntu-24.04-arm
             dockerfile: packaging-plugins-bookworm
-            image: packaging-plugins-bookworm-arm64
+            image: packaging
+            distrib: bookworm
+            arch: arm64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-trixie
-            image: packaging-plugins-trixie
+            image: packaging
+            distrib: trixie
+            arch: amd64
           - runner: ubuntu-24.04-arm
             dockerfile: packaging-plugins-trixie
-            image: packaging-plugins-trixie-arm64
+            image: packaging
+            distrib: trixie
+            arch: arm64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-java-bullseye
-            image: packaging-plugins-java-bullseye
+            image: packaging-java
+            distrib: bullseye
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-java-bookworm
-            image: packaging-plugins-java-bookworm
+            image: packaging-java
+            distrib: bookworm
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-java-trixie
-            image: packaging-plugins-java-trixie
+            image: packaging-java
+            distrib: trixie
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-jammy
-            image: packaging-plugins-jammy
+            image: packaging
+            distrib: jammy
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-java-jammy
-            image: packaging-plugins-java-jammy
+            image: packaging-java
+            distrib: jammy
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-noble
-            image: packaging-plugins-noble
+            image: packaging
+            distrib: noble
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-java-noble
-            image: packaging-plugins-java-noble
+            image: packaging-java
+            distrib: noble
+            arch: amd64
 
     runs-on: ${{ matrix.runner }}
 
@@ -117,6 +155,17 @@ jobs:
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ghcr.io/${{ github.repository }}/${{ matrix.image }}
+          labels: |
+            org.opencontainers.image.description=Packaging image for Centreon Plugins packaging
+            com.centreon.stability=${{ needs.get-environment.outputs.stability }}
+            com.centreon.version=${{ needs.get-environment.outputs.version }}
+
+
       - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           file: .github/docker/packaging/Dockerfile.${{ matrix.dockerfile }}
@@ -124,10 +173,72 @@ jobs:
           build-args: "REGISTRY_URL=${{ vars.DOCKER_PROXY_REGISTRY_URL }}"
           pull: true
           push: true
-          tags: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
+          tags: ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ matrix.distrib }}-${{ matrix.arch }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  compute-merge-matrix:
+    needs: [get-environment]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      needs.get-environment.outputs.stability != 'stable'
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Compute merge matrix
+        id: compute
+        shell: bash
+        run: |
+          matrix=$(yq -o=json '.jobs.dockerize.strategy.matrix.include' \
+            .github/workflows/docker-builder-packaging-plugins.yml | \
+            jq -c '
+              group_by([.image, .distrib]) |
+              map({
+                image: .[0].image,
+                distrib: .[0].distrib,
+                archs: (map(.arch) | join(" "))
+              }) |
+              {include: .}
+            ')
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+  merge:
+    needs: [get-environment, dockerize, compute-merge-matrix]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      needs.get-environment.outputs.stability != 'stable'
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.compute-merge-matrix.outputs.matrix) }}
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Create multi-platform manifest
+        shell: bash
+        run: |
+          SOURCE=""
+          for arch in ${{ matrix.archs }}; do
+            SOURCE="$SOURCE ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ matrix.distrib }}-$arch"
+          done
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ matrix.distrib }} \
+            $SOURCE
+
 
   set-skip-label:
-    needs: [get-environment, dockerize]
+    needs: [get-environment, merge]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&

--- a/.github/workflows/docker-builder-packaging-plugins.yml
+++ b/.github/workflows/docker-builder-packaging-plugins.yml
@@ -94,16 +94,12 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    permissions:
+      packages: write
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Login to Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
 
       - name: Login to proxy registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
@@ -111,6 +107,13 @@ jobs:
           registry: ${{ vars.DOCKER_PROXY_REGISTRY_URL }}
           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -121,7 +124,7 @@ jobs:
           build-args: "REGISTRY_URL=${{ vars.DOCKER_PROXY_REGISTRY_URL }}"
           pull: true
           push: true
-          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:latest
+          tags: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
 
   set-skip-label:
     needs: [get-environment, dockerize]

--- a/.github/workflows/docker-builder-testing-plugins.yml
+++ b/.github/workflows/docker-builder-testing-plugins.yml
@@ -65,16 +65,12 @@ jobs:
 
     runs-on: ${{ matrix.runner }}
 
+    permissions:
+      packages: write
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Login to Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
 
       - name: Login to proxy registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
@@ -82,6 +78,13 @@ jobs:
           registry: ${{ vars.DOCKER_PROXY_REGISTRY_URL }}
           username: ${{ secrets.HARBOR_CENTREON_PUSH_USERNAME }}
           password: ${{ secrets.HARBOR_CENTREON_PUSH_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -95,7 +98,7 @@ jobs:
             "PNPM_VERSION=10.24.0"
           pull: true
           push: true
-          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/testing-plugins-${{ matrix.image }}:latest
+          tags: ghcr.io/${{ github.repository }}/testing-plugins-${{ matrix.image }}:latest
 
   set-skip-label:
     needs: [get-environment, dockerize]

--- a/.github/workflows/docker-builder-testing-plugins.yml
+++ b/.github/workflows/docker-builder-testing-plugins.yml
@@ -36,31 +36,49 @@ jobs:
         include:
           - runner: ubuntu-24.04
             dockerfile: alma8
-            image: alma8
+            image: testing
+            distrib: alma8
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: alma9
-            image: alma9
+            image: testing
+            distrib: alma9
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: alma10
-            image: alma10
+            image: testing
+            distrib: alma10
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: bullseye
-            image: bullseye
+            image: testing
+            distrib: bullseye
+            arch: amd64
           - runner: ubuntu-24.04-arm
             dockerfile: bullseye
-            image: bullseye-arm64
+            image: testing
+            distrib: bullseye
+            arch: arm64
           - runner: ubuntu-24.04
             dockerfile: bookworm
-            image: bookworm
+            image: testing
+            distrib: bookworm
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: trixie
-            image: trixie
+            image: testing
+            distrib: trixie
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: jammy
-            image: jammy
+            image: testing
+            distrib: jammy
+            arch: amd64
           - runner: ubuntu-24.04
             dockerfile: noble
-            image: noble
+            image: testing
+            distrib: noble
+            arch: amd64
 
 
     runs-on: ${{ matrix.runner }}
@@ -88,6 +106,16 @@ jobs:
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ghcr.io/${{ github.repository }}/${{ matrix.image }}
+          labels: |
+            org.opencontainers.image.description=Testing image for Centreon Plugins
+            com.centreon.stability=${{ needs.get-environment.outputs.stability }}
+            com.centreon.version=${{ needs.get-environment.outputs.version }}
+
       - uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           file: .github/docker/testing/Dockerfile.testing-plugins-${{ matrix.dockerfile }}
@@ -98,10 +126,71 @@ jobs:
             "PNPM_VERSION=10.24.0"
           pull: true
           push: true
-          tags: ghcr.io/${{ github.repository }}/testing-plugins-${{ matrix.image }}:latest
+          tags: ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ matrix.distrib }}-${{ matrix.arch }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  compute-merge-matrix:
+    needs: [get-environment]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      needs.get-environment.outputs.stability != 'stable'
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Compute merge matrix
+        id: compute
+        shell: bash
+        run: |
+          matrix=$(yq -o=json '.jobs.dockerize.strategy.matrix.include' \
+            .github/workflows/docker-builder-testing-plugins.yml | \
+            jq -c '
+              group_by([.image, .distrib]) |
+              map({
+                image: .[0].image,
+                distrib: .[0].distrib,
+                archs: (map(.arch) | join(" "))
+              }) |
+              {include: .}
+            ')
+          echo "matrix=$matrix" >> $GITHUB_OUTPUT
+
+  merge:
+    needs: [get-environment, dockerize, compute-merge-matrix]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      needs.get-environment.outputs.stability != 'stable'
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.compute-merge-matrix.outputs.matrix) }}
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Create multi-platform manifest
+        shell: bash
+        run: |
+          SOURCE=""
+          for arch in ${{ matrix.archs }}; do
+            SOURCE="$SOURCE ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ matrix.distrib }}-$arch"
+          done
+          docker buildx imagetools create \
+            --tag ghcr.io/${{ github.repository }}/${{ matrix.image }}:${{ matrix.distrib }} \
+            $SOURCE
 
   set-skip-label:
-    needs: [get-environment, dockerize]
+    needs: [get-environment, merge]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
       ! cancelled() &&

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -161,13 +161,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
       - name: Pull packaging image from ghcr.io
         env:
           GHCR_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -144,60 +144,8 @@ jobs:
           name: partial-matrix-*
           failOnError: false
 
-  get-packaging-images:
-    needs: [get-environment]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable'
-    strategy:
-      fail-fast: false
-      max-parallel: 3
-      matrix:
-        include:
-          - image: packaging-plugins-alma8
-          - image: packaging-plugins-alma9
-          - image: packaging-plugins-alma10
-          - image: packaging-plugins-bullseye
-          - image: packaging-plugins-bookworm
-          - image: packaging-plugins-trixie
-          - image: packaging-plugins-jammy
-          - image: packaging-plugins-noble
-          - image: packaging-plugins-bullseye-arm64
-          - image: packaging-plugins-bookworm-arm64
-          - image: packaging-plugins-trixie-arm64
-    runs-on: ${{ contains(matrix.image, 'arm') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
-    steps:
-      - name: Login to Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-
-      - name: Login to Proxy Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_PROXY_REGISTRY_URL }}
-          username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-          password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
-
-      - name: Pull and save image
-        env:
-          DOCKER_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}
-          IMAGE_NAME: ${{ matrix.image }}
-        run: |
-          docker image prune -af
-          docker pull "${DOCKER_IMAGE}:latest"
-          docker save -o "./${IMAGE_NAME}" "${DOCKER_IMAGE}:latest"
-        shell: bash
-
-      - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ./${{ matrix.image }}
-          key: ${{ matrix.image }}-${{ github.sha }}-${{ github.run_id }}
-
   package-rpm:
-    needs: [get-environment, generate-matrices, get-packaging-images]
+    needs: [get-environment, generate-matrices]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -213,22 +161,22 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Restore packaging image from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
-          path: ./${{ matrix.image }}
-          key: ${{ matrix.image }}-${{ github.sha }}-${{ github.run_id }}
-          fail-on-cache-miss: true
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
-      - name: Load packaging image
+      - name: Pull packaging image from ghcr.io
         env:
-          IMAGE_NAME: ${{ matrix.image }}
-        run: docker load --input "./${IMAGE_NAME}"
+          GHCR_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
+        run: docker pull "${GHCR_IMAGE}"
         shell: bash
 
       - if: ${{ matrix.spec_file == '' }}
         env:
-          DOCKER_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}
+          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
           VERSION: ${{ matrix.version || matrix.cpan_version }}
           RPM_DEPENDENCIES: ${{ matrix.rpm_dependencies }}
           RPM_PROVIDES: ${{ matrix.rpm_provides }}
@@ -246,20 +194,20 @@ jobs:
             -e VERSION -e RPM_DEPENDENCIES -e RPM_PROVIDES \
             -e NO_AUTO_DEPENDS -e PREINSTALL_CPANLIBS -e PREINSTALL_PACKAGES \
             -e PKG_NAME -e PKG_EXT -e DISTRIB -e REVISION \
-            "${DOCKER_IMAGE}:latest" \
+            "${DOCKER_IMAGE}" \
             bash .github/scripts/perl-cpan-libraries/package-cpan-rpm.sh
         shell: bash
 
       - if: ${{ matrix.spec_file != '' }}
         env:
-          DOCKER_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}
+          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
           SPEC_FILE: ${{ matrix.spec_file }}
         run: |
           docker run --rm \
             -v "$(pwd):/work" \
             --workdir /work \
             -e SPEC_FILE \
-            "${DOCKER_IMAGE}:latest" \
+            "${DOCKER_IMAGE}" \
             bash -c '
               mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
               rpmbuild --undefine=_disable_source_fetch -ba "$SPEC_FILE"
@@ -349,7 +297,7 @@ jobs:
           key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
 
   package-deb:
-    needs: [get-environment, generate-matrices, get-packaging-images]
+    needs: [get-environment, generate-matrices]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable'
@@ -364,17 +312,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Restore packaging image from cache
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
-          path: ./${{ matrix.image }}
-          key: ${{ matrix.image }}-${{ github.sha }}-${{ github.run_id }}
-          fail-on-cache-miss: true
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
-      - name: Load packaging image
+      - name: Pull packaging image from ghcr.io
         env:
-          IMAGE_NAME: ${{ matrix.image }}
-        run: docker load --input "./${IMAGE_NAME}"
+          GHCR_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
+        run: docker pull "${GHCR_IMAGE}"
         shell: bash
 
       - name: Parse distrib name
@@ -385,7 +333,7 @@ jobs:
 
       - if: ${{ matrix.use_dh_make_perl == 'false' }}
         env:
-          DOCKER_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}
+          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
           VERSION: ${{ matrix.version || matrix.cpan_version }}
           DEB_DEPENDENCIES: ${{ matrix.deb_dependencies }}
           DEB_PROVIDES: ${{ matrix.deb_provides }}
@@ -406,13 +354,13 @@ jobs:
             -e NO_AUTO_DEPENDS -e PREINSTALL_CPANLIBS -e PREINSTALL_PACKAGES \
             -e PKG_NAME -e PKG_EXT -e DISTRIB -e REVISION \
             -e DISTRIB_SEPARATOR -e DISTRIB_SUFFIX \
-            "${DOCKER_IMAGE}:latest" \
+            "${DOCKER_IMAGE}" \
             bash .github/scripts/perl-cpan-libraries/package-cpan-deb-fpm.sh
         shell: bash
 
       - if: ${{ matrix.use_dh_make_perl == 'true' }}
         env:
-          DOCKER_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}
+          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
           VERSION: ${{ matrix.version || matrix.cpan_version }}
           PREINSTALL_CPANLIBS: ${{ matrix.preinstall_cpanlibs }}
           PREINSTALL_PACKAGES: ${{ matrix.preinstall_packages }}
@@ -428,7 +376,7 @@ jobs:
             -e VERSION -e PREINSTALL_CPANLIBS -e PREINSTALL_PACKAGES \
             -e PKG_NAME -e DISTRIB -e REVISION \
             -e DISTRIB_SEPARATOR -e DISTRIB_SUFFIX \
-            "${DOCKER_IMAGE}:latest" \
+            "${DOCKER_IMAGE}" \
             bash .github/scripts/perl-cpan-libraries/package-cpan-deb-dhmaker.sh
         shell: bash
 

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -170,13 +170,13 @@ jobs:
 
       - name: Pull packaging image from ghcr.io
         env:
-          GHCR_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
+          GHCR_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}
         run: docker pull "${GHCR_IMAGE}"
         shell: bash
 
       - if: ${{ matrix.spec_file == '' }}
         env:
-          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
+          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}
           VERSION: ${{ matrix.version || matrix.cpan_version }}
           RPM_DEPENDENCIES: ${{ matrix.rpm_dependencies }}
           RPM_PROVIDES: ${{ matrix.rpm_provides }}
@@ -200,7 +200,7 @@ jobs:
 
       - if: ${{ matrix.spec_file != '' }}
         env:
-          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
+          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}
           SPEC_FILE: ${{ matrix.spec_file }}
         run: |
           docker run --rm \
@@ -268,7 +268,7 @@ jobs:
         distrib: [el8, el9, el10]
     name: sign rpm ${{ matrix.distrib }}
     container:
-      image: docker.centreon.com/centreon-private/rpm-signing:latest
+      image: docker.centreon.com/centreon-private/rpm-signing
       options: -t
       credentials:
         username: ${{ secrets.HARBOR_CENTREON_PRIVATE_USERNAME }}
@@ -321,7 +321,7 @@ jobs:
 
       - name: Pull packaging image from ghcr.io
         env:
-          GHCR_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
+          GHCR_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}
         run: docker pull "${GHCR_IMAGE}"
         shell: bash
 
@@ -333,7 +333,7 @@ jobs:
 
       - if: ${{ matrix.use_dh_make_perl == 'false' }}
         env:
-          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
+          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}
           VERSION: ${{ matrix.version || matrix.cpan_version }}
           DEB_DEPENDENCIES: ${{ matrix.deb_dependencies }}
           DEB_PROVIDES: ${{ matrix.deb_provides }}
@@ -360,7 +360,7 @@ jobs:
 
       - if: ${{ matrix.use_dh_make_perl == 'true' }}
         env:
-          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}:latest
+          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.image }}
           VERSION: ${{ matrix.version || matrix.cpan_version }}
           PREINSTALL_CPANLIBS: ${{ matrix.preinstall_cpanlibs }}
           PREINSTALL_PACKAGES: ${{ matrix.preinstall_packages }}

--- a/.github/workflows/plugins-robot-tests.yml
+++ b/.github/workflows/plugins-robot-tests.yml
@@ -47,7 +47,7 @@ on:
         default: ""
 jobs:
   robot-test:
-    runs-on: ${{ contains(inputs.image, 'arm') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
 
     strategy:
       fail-fast: false
@@ -70,7 +70,7 @@ jobs:
 
       - name: Pull test image from ghcr.io
         env:
-          GHCR_IMAGE: ghcr.io/${{ github.repository }}/${{ inputs.image }}:latest
+          GHCR_IMAGE: ghcr.io/${{ github.repository }}/${{ inputs.image }}
         run: docker pull "${GHCR_IMAGE}"
         shell: bash
 
@@ -92,7 +92,7 @@ jobs:
       - name: Install, test and remove plugin
         shell: bash
         env:
-          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ inputs.image }}:latest
+          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ inputs.image }}
           PACKAGE_EXTENSION: ${{ inputs.package-extension }}
           RUNNER_ID: ${{ matrix.index }}
           SKIP_ROBOT_TESTS: ${{ inputs.skip-robot-tests }}

--- a/.github/workflows/plugins-robot-tests.yml
+++ b/.github/workflows/plugins-robot-tests.yml
@@ -45,57 +45,8 @@ on:
         description: "Robot tags to include in tests"
         type: string
         default: ""
-    secrets:
-      registry_username:
-        required: true
-      registry_password:
-        required: true
-
 jobs:
-  test-image-to-cache:
-    runs-on: ${{ contains(inputs.image, 'arm') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Login to Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}
-          username: ${{ secrets.registry_username }}
-          password: ${{ secrets.registry_password }}
-
-      - name: Login to Proxy Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ${{ vars.DOCKER_PROXY_REGISTRY_URL }}
-          username: ${{ secrets.registry_username }}
-          password: ${{ secrets.registry_password }}
-
-      - name: Load image
-        env:
-          DOCKER_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ inputs.image }}
-        run: |
-          docker image prune -af
-          docker pull $DOCKER_IMAGE
-        shell: bash
-
-      - name: Save image on disk
-        env:
-          IMAGE_NAME: ${{ inputs.image }}
-          DOCKER_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ inputs.image }}
-        run: |
-          docker save -o ./$IMAGE_NAME $DOCKER_IMAGE
-        shell: bash
-
-      - name: Save image into cache
-        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        with:
-          path: ./${{ inputs.image }}
-          key: ${{ inputs.image }}-${{ github.sha }}-${{ github.run_id }}
-
   robot-test:
-    needs: [test-image-to-cache]
     runs-on: ${{ contains(inputs.image, 'arm') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
 
     strategy:
@@ -110,12 +61,18 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Get the cached docker image for tests
-        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
-          path: ./${{ inputs.image }}
-          key: ${{ inputs.image }}-${{ github.sha }}-${{ github.run_id }}
-          fail-on-cache-miss: true
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Pull test image from ghcr.io
+        env:
+          GHCR_IMAGE: ghcr.io/${{ github.repository }}/${{ inputs.image }}:latest
+        run: docker pull "${GHCR_IMAGE}"
+        shell: bash
 
       - name: Get the cached plugins
         if: ${{ inputs.get-packages == 'True' }}
@@ -132,15 +89,10 @@ jobs:
           key: ${{ inputs.plugins-json-cache-key }}
           fail-on-cache-miss: true
 
-      - name: Load image
-        env:
-          IMAGE_NAME: ${{ inputs.image }}
-        run: docker load --input ./$IMAGE_NAME
-
       - name: Install, test and remove plugin
         shell: bash
         env:
-          DOCKER_IMAGE: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ inputs.image }}
+          DOCKER_IMAGE: ghcr.io/${{ github.repository }}/${{ inputs.image }}:latest
           PACKAGE_EXTENSION: ${{ inputs.package-extension }}
           RUNNER_ID: ${{ matrix.index }}
           SKIP_ROBOT_TESTS: ${{ inputs.skip-robot-tests }}

--- a/.github/workflows/plugins-robot-tests.yml
+++ b/.github/workflows/plugins-robot-tests.yml
@@ -61,13 +61,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
       - name: Pull test image from ghcr.io
         env:
           GHCR_IMAGE: ghcr.io/${{ github.repository }}/${{ inputs.image }}

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -432,9 +432,6 @@ jobs:
       plugins-json-cache-key: plugins-${{ github.sha }}-${{ github.run_id }}
       skip-robot-tests: ${{ matrix.skip_robot_tests }}
       exclude-robot-tags: centreon-generic-snmp
-    secrets:
-      registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-      registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
 
   deliver-packages:
     needs: [get-environment, get-plugins, test-plugins]

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -319,9 +319,6 @@ jobs:
 
     container:
       image: ghcr.io/${{ github.repository }}/${{ matrix.image }}
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
 
     name: "Package ${{ matrix.distrib }}"
 

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -293,35 +293,35 @@ jobs:
       matrix:
         include:
           - package_extension: rpm
-            image: packaging-plugins-alma8
+            image: packaging:alma8
             distrib: el8
           - package_extension: rpm
-            image: packaging-plugins-alma9
+            image: packaging:alma9
             distrib: el9
           - package_extension: rpm
-            image: packaging-plugins-alma10
+            image: packaging:alma10
             distrib: el10
           - package_extension: deb
-            image: packaging-plugins-bullseye
+            image: packaging:bullseye
             distrib: bullseye
           - package_extension: deb
-            image: packaging-plugins-bookworm
+            image: packaging:bookworm
             distrib: bookworm
           - package_extension: deb
-            image: packaging-plugins-trixie
+            image: packaging:trixie
             distrib: trixie
           - package_extension: deb
-            image: packaging-plugins-jammy
+            image: packaging:jammy
             distrib: jammy
           - package_extension: deb
-            image: packaging-plugins-noble
+            image: packaging:noble
             distrib: noble
 
     container:
-      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}
+      image: ghcr.io/${{ github.repository }}/${{ matrix.image }}
       credentials:
-        username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
-        password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     name: "Package ${{ matrix.distrib }}"
 
@@ -376,45 +376,45 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [testing-plugins-alma8, testing-plugins-alma9, testing-plugins-alma10, testing-plugins-jammy, testing-plugins-bullseye, testing-plugins-bookworm, testing-plugins-trixie, testing-plugins-noble, testing-plugins-bullseye-arm64]
+        image: [testing:alma8, testing:alma9, testing:alma10, testing:jammy, testing:bullseye, testing:bookworm, testing:trixie, testing:noble]
         include:
           - skip_robot_tests: false
           - package_extension: rpm
-            image: testing-plugins-alma8
+            image: testing:alma8
             distrib: el8
             arch: amd64
           - package_extension: rpm
-            image: testing-plugins-alma9
+            image: testing:alma9
             distrib: el9
             arch: amd64
           - package_extension: rpm
-            image: testing-plugins-alma10
+            image: testing:alma10
             distrib: el10
             arch: amd64
             skip_robot_tests: true
           - package_extension: deb
-            image: testing-plugins-bullseye
+            image: testing:bullseye
             distrib: bullseye
             arch: amd64
           - package_extension: deb
-            image: testing-plugins-bookworm
+            image: testing:bookworm
             distrib: bookworm
             arch: amd64
           - package_extension: deb
-            image: testing-plugins-trixie
+            image: testing:trixie
             distrib: trixie
             arch: amd64
             skip_robot_tests: true
           - package_extension: deb
-            image: testing-plugins-jammy
+            image: testing:jammy
             distrib: jammy
             arch: amd64
           - package_extension: deb
-            image: testing-plugins-noble
+            image: testing:noble
             distrib: noble
             arch: amd64
           - package_extension: deb
-            image: testing-plugins-bullseye-arm64
+            image: testing:bullseye
             distrib: bullseye
             arch: arm64
 


### PR DESCRIPTION
## Context

  GitHub Actions cache limits are hit fast due to very large Docker images being saved as cache artifacts, leading to broken runs and frustration for anyone using the pipelines.    

  ## Changes

  Replaced the `docker save → cache/save` / `cache/restore → docker load` pattern with a direct push/pull to `ghcr.io` for the following workflows:

  **`perl-cpan-libraries.yml`**
  - `get-packaging-images` job: pull from Harbor → tag → push to `ghcr.io`
  - `package-rpm` / `package-deb` jobs: pull directly from `ghcr.io` (no cache restore, no docker load)

  **`plugins-robot-tests.yml`**
  - Renamed `test-image-to-cache` → `push-test-image-to-ghcr`
  - Same pattern: pull from Harbor → tag → push to `ghcr.io`
  - `robot-test` job: pull directly from `ghcr.io`

  ## Image naming

  `ghcr.io/${{ github.repository }}/<image>:<sha>-<run_id>` — same uniqueness as the previous cache key, maintaining run isolation.

  ## Auth

  Uses `GITHUB_TOKEN` with `packages: write` — no extra secret or PAT needed, consistent with MON-196690.

  ## Follow-up

  Ephemeral images tagged with `sha-run_id` will accumulate in ghcr.io. A cleanup mechanism (similar to `cleanup-ghcr-registry.yml` in delivery-tooling) should be added as a        
  follow-up.

  ## Related

  - MON-196408
  - MON-196690 (phase 1 — same approach validated for centreon/centreon-collect, centreon/centreon, centreon/centreon-modules)

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Replaced GHA cache flow with ghcr.io push/pull for images
* Standardized image naming to ghcr.io/${{ github.repository }}/image:sha-run_id
* Granted packages: write permission and logged into ghcr.io using GITHUB_TOKEN
* Added multi-platform manifest creation and merged build matrix logic

**🔧 Refactors**
* Renamed and removed intermediary cache jobs and Harbor credentials


<sup>[More info](https://app.aikido.dev/featurebranch/scan/112351593?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->