### PR TITLE
enh(mongodb): add counter for total queries output

### DIFF
--- a/src/database/mongodb/mode/queries.pm
+++ b/src/database/mongodb/mode/queries.pm
@@ -42,9 +42,17 @@ sub set_counters {
     $self->{maps_counters}->{global} = [
         { label => 'total', nlabel => 'queries.total.persecond', set => {
                 key_values => [ { name => 'total', per_second => 1 } ],
-                output_template => 'total: %d',
+                output_template => 'total: %.2f/s',
                 perfdatas => [
-                    { template => '%d', unit => '/s', min => 0 }
+                    { template => '%.2f', unit => '/s', min => 0 }
+                ]
+            }
+        },
+        { label => 'total-count', nlabel => 'queries.total.count', set => {
+                key_values => [ { name => 'total', diff => 1 } ],
+                output_template => 'total count: %d',
+                perfdatas => [
+                    { template => '%d', min => 0 }
                 ]
             }
         }


### PR DESCRIPTION
# Community contributors

## Description

This commit fixes the output of total queries so that the actual count is displayed as such, and adds a working per-second output.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Running the plugin in `queries` mode will add a `total count` output (and a corresponding `queries.total.count` metric) with the actual amount of requests, while the `queries.total.persecond` metric and `Requests total` output will contain the per-second values.

Before the fix:

```
# /usr/lib/centreon/plugins/centreon_mongodb.pl --plugin database::mongodb::plugin --hostname ... --username ... --password ... --mode=queries
OK: Requests total: 98 | 'queries.total.persecond'=98/s;;;0; 'queries.insert.persecond'=0.00/s;;;0; 'queries.insert.count'=0;;;0; 'queries.query.persecond'=96.35/s;;;0; 'queries.query.count'=1638;;;0; 'queries.update.persecond'=0.00/s;;;0; 'queries.update.count'=0;;;0; 'queries.delete.persecond'=0.00/s;;;0; 'queries.delete.count'=0;;;0; 'queries.getmore.persecond'=0.24/s;;;0; 'queries.getmore.count'=4;;;0; 'queries.command.persecond'=1.41/s;;;0; 'queries.command.count'=24;;;0;
```

After the fix:

```
# /usr/lib/centreon/plugins/centreon_mongodb.pl --plugin database::mongodb::plugin --hostname ... --username ... --password ... --mode=queries
OK: Requests total: 1.57/s, total count: 22 | 'queries.total.persecond'=1.57/s;;;0; 'queries.total.count'=22;;;0; 'queries.insert.persecond'=0.00/s;;;0; 'queries.insert.count'=0;;;0; 'queries.query.persecond'=0.00/s;;;0; 'queries.query.count'=0;;;0; 'queries.update.persecond'=0.00/s;;;0; 'queries.update.count'=0;;;0; 'queries.delete.persecond'=0.00/s;;;0; 'queries.delete.count'=0;;;0; 'queries.getmore.persecond'=0.14/s;;;0; 'queries.getmore.count'=2;;;0; 'queries.command.persecond'=1.43/s;;;0; 'queries.command.count'=20;;;0;
```

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
  - there isn't much to comment here
- [ ] I have **rebased** my development branch on the base branch (develop).
  - branched from fresh clone
- [x] I have provide data or shown output displaying the result of this code in the plugin area concerned.


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added separate total-count metric for absolute total query counts
* Updated per-second perfdata templates to use two-decimal formatting

**🐛 Bugfixes**
* Fixed total queries output to display correct per-second value


<sup>[More info](https://app.aikido.dev/featurebranch/scan/101807617?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->