### PR TITLE
fix(plugin) apps::backup::veeam::local::plugin - jobstatus: initialize undefined values

### DIFF
--- a/src/apps/backup/veeam/local/mode/jobstatus.pm
+++ b/src/apps/backup/veeam/local/mode/jobstatus.pm
@@ -217,6 +217,9 @@ sub manage_selection {
             $session = $sessions->[1];
         }
 
+        $session->{creationTimeUTC} = '' if (!defined($session->{creationTimeUTC}));
+        $session->{endTimeUTC} = '' if (!defined($session->{endTimeUTC}));
+
         $session->{creationTimeUTC} =~ s/,/\./;
         $session->{endTimeUTC} =~ s/,/\./;
 
@@ -253,8 +256,8 @@ sub manage_selection {
             is_continuous => $job->{isContinuous},
             is_running => $job->{isRunning} =~ /True|1/ ? 1 : ($session->{creationTimeUTC} !~ /[0-9]/ ? 2 : 0),
             scheduled => $job->{scheduled} =~ /True|1/i ? 1 : 0, 
-            status => defined($job_result->{ $session->{result} }) && $job_result->{ $session->{result} } ne '' ?
-                $job_result->{ $session->{result} } : '-'
+            status => defined($session->{result}) && $session->{result} ne '' ?
+                $session->{result} : '-'
         };
         $self->{global}->{total}++;
     }


### PR DESCRIPTION
## Description

Fir the undefined values we can met on jobs that never run.

**Fixes** # CTOR-2269

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Initialized undefined job fields to avoid errors for never-run jobs


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103650042?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->