### PR TITLE
fix(ci): wait until snmpsim has fully started before running robot tests

### DIFF
--- a/.github/workflows/generic-plugins.yml
+++ b/.github/workflows/generic-plugins.yml
@@ -175,7 +175,12 @@ jobs:
           mkdir -p /var/lib/snmp/cert_indexes/
           useradd snmp || true
           snmpsim-command-responder --logging-method=null --agent-udpv4-endpoint=127.0.0.1:2024 --process-user=snmp --process-group=snmp --data-dir='./tests' &
-          sleep 2
+          # waiting till localhost is listening on UDP port 2024
+          timeout 60  bash -c 'while : ; do
+              # 0100007F:07E8 is 127.0.0.1:2024 in HEX
+              grep " 0100007F:07E8 " /proc/net/udp >/dev/null && break
+              sleep 0.5
+          done ; echo "snmpsim is listening"' || exit 1
           robot --include centreon-generic-snmp --exclude notauto --outputdir /tmp/robot-tests ./tests/os/linux/snmp/
         shell: bash
 


### PR DESCRIPTION
## Description

sometimes it's too slow, for sure...

Refs: CTOR-2270

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Waited until snmpsim UDP port was listening before running tests


<sup>[More info](https://app.aikido.dev/featurebranch/scan/103682098?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->