### PR TITLE
OCD(new mode): (network::paloalto::api::mode::edlcapacity) mode edl-capacity

### DIFF
--- a/src/network/paloalto/api/custom/api.pm
+++ b/src/network/paloalto/api/custom/api.pm
@@ -216,7 +216,7 @@ sub _parse_xml {
         if is_empty($content);
 
     $self->{output}->option_exit(short_msg => "Cannot find XML response in API reply.")
-        unless $content =~ /(<response cmd=["'].*?["'] status=["'](.*?)["']>.*<\/response>)/ms;
+        unless $content =~ /(<response\b[^>]*\bstatus=["'](.*?)["'][^>]*>.*<\/response>)/ms;
 
     my ($xml, $status) = ($1, $2);
     $self->{output}->option_exit(short_msg => "API response status: $status")

--- a/src/network/paloalto/api/custom/api.pm
+++ b/src/network/paloalto/api/custom/api.pm
@@ -216,7 +216,7 @@ sub _parse_xml {
         if is_empty($content);
 
     $self->{output}->option_exit(short_msg => "Cannot find XML response in API reply.")
-        unless $content =~ /(<response status=["'](.*?)["']>.*<\/response>)/ms;
+        unless $content =~ /(<response cmd=["'].*?["'] status=["'](.*?)["']>.*<\/response>)/ms;
 
     my ($xml, $status) = ($1, $2);
     $self->{output}->option_exit(short_msg => "API response status: $status")

--- a/src/network/paloalto/api/mode/edlcapacity.pm
+++ b/src/network/paloalto/api/mode/edlcapacity.pm
@@ -1,0 +1,193 @@
+#
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package network::paloalto::api::mode::edlcapacity;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+
+sub custom_usage_output {
+    my ($self, %options) = @_;
+    return sprintf(
+        'capacity usage: %d/%d entries (%.2f%%)',
+        $self->{result_values}->{used},
+        $self->{result_values}->{total},
+        $self->{result_values}->{prct_used}
+    );
+}
+
+sub custom_usage_perfdata {
+    my ($self, %options) = @_;
+
+    $self->{output}->perfdata_add(
+        nlabel    => 'edl.entries.usage.count',
+        instances => $self->{result_values}->{display},
+        value     => $self->{result_values}->{used},
+        min       => 0,
+        max       => $self->{result_values}->{total}
+    );
+    $self->{output}->perfdata_add(
+        nlabel    => 'edl.entries.usage.percentage',
+        unit      => '%',
+        instances => $self->{result_values}->{display},
+        value     => sprintf('%.2f', $self->{result_values}->{prct_used}),
+        warning   => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{thlabel}),
+        critical  => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{thlabel}),
+        min       => 0,
+        max       => 100
+    );
+}
+
+sub custom_usage_threshold {
+    my ($self, %options) = @_;
+    return $self->{perfdata}->threshold_check(
+        value     => $self->{result_values}->{prct_used},
+        threshold => [
+            { label => 'critical-' . $self->{thlabel}, exit_litteral => 'critical' },
+            { label => 'warning-'  . $self->{thlabel}, exit_litteral => 'warning'  }
+        ]
+    );
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        {
+            name             => 'edl',
+            type             => 1,
+            cb_prefix_output => 'prefix_edl_output',
+            message_multiple => 'All External Dynamic Lists are within capacity limits'
+        }
+    ];
+
+    $self->{maps_counters}->{edl} = [
+        {
+            label => 'usage',
+            set   => {
+                key_values => [
+                    { name => 'used' },
+                    { name => 'total' },
+                    { name => 'prct_used' },
+                    { name => 'display' }
+                ],
+                closure_custom_output    => $self->can('custom_usage_output'),
+                closure_custom_perfdata  => $self->can('custom_usage_perfdata'),
+                closure_custom_threshold => $self->can('custom_usage_threshold')
+            }
+        }
+    ];
+}
+
+sub prefix_edl_output {
+    my ($self, %options) = @_;
+    return "EDL '" . $options{instance_value}->{display} . "' ";
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-type:s'    => { name => 'filter_type' },
+        'warning-usage:s'  => { name => 'warning_usage',  default => '80:' },
+        'critical-usage:s' => { name => 'critical_usage', default => '90:' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    $self->{perfdata}->threshold_validate(label => 'warning-usage',  value => $self->{option_results}->{warning_usage});
+    $self->{perfdata}->threshold_validate(label => 'critical-usage', value => $self->{option_results}->{critical_usage});
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $result = $options{custom}->request_api(
+        type => 'op',
+        cmd  => '<request><system><external-list><list-capacities/></external-list></system></request>'
+    );
+
+    $self->{edl} = {};
+
+    foreach my $type (keys %$result) {
+
+        my $used  = $result->{$type}->{'running-cap'};
+        my $total = $result->{$type}->{'total-cap'};
+
+        next unless defined($used)  && $used  =~ /^\d+$/;
+        next unless defined($total) && $total =~ /^\d+$/ && $total > 0;
+
+        if (defined($self->{option_results}->{filter_type}) && $self->{option_results}->{filter_type} ne '') {
+            next if $type !~ /$self->{option_results}->{filter_type}/;
+        }
+
+        $self->{edl}->{$type} = {
+            display   => $type,
+            used      => int($used),
+            total     => int($total),
+            prct_used => ($used / $total) * 100
+        };
+    }
+
+    if (!%{$self->{edl}}) {
+        $self->{output}->add_option_msg(
+            short_msg => 'No External Dynamic List capacity found.'
+        );
+        $self->{output}->option_exit();
+    }
+
+    $self->{cache_name} = "paloalto_api_" . $self->{mode} . '_' . $options{custom}->get_hostname() . '_' .
+        ($self->{option_results}->{filter_type} // 'all');
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check Palo Alto External Dynamic Lists (EDL) capacity.
+
+=over 8
+
+=item B<--filter-type>
+
+Filter EDL entries by type (regexp). Only matching EDL types are checked.
+
+=item B<--warning-usage>
+
+Warning threshold as a percentage of total capacity (default: '80:').
+
+=item B<--critical-usage>
+
+Critical threshold as a percentage of total capacity (default: '90:').
+
+=back
+
+=cut

--- a/src/network/paloalto/api/mode/edlcapacity.pm
+++ b/src/network/paloalto/api/mode/edlcapacity.pm
@@ -19,54 +19,12 @@
 #
 
 package network::paloalto::api::mode::edlcapacity;
-
 use base qw(centreon::plugins::templates::counter);
-
 use strict;
 use warnings;
-
-sub custom_usage_output {
-    my ($self, %options) = @_;
-    return sprintf(
-        'capacity usage: %d/%d entries (%.2f%%)',
-        $self->{result_values}->{used},
-        $self->{result_values}->{total},
-        $self->{result_values}->{prct_used}
-    );
-}
-
-sub custom_usage_perfdata {
-    my ($self, %options) = @_;
-
-    $self->{output}->perfdata_add(
-        nlabel    => 'edl.entries.usage.count',
-        instances => $self->{result_values}->{display},
-        value     => $self->{result_values}->{used},
-        min       => 0,
-        max       => $self->{result_values}->{total}
-    );
-    $self->{output}->perfdata_add(
-        nlabel    => 'edl.entries.usage.percentage',
-        unit      => '%',
-        instances => $self->{result_values}->{display},
-        value     => sprintf('%.2f', $self->{result_values}->{prct_used}),
-        warning   => $self->{perfdata}->get_perfdata_for_output(label => 'warning-' . $self->{thlabel}),
-        critical  => $self->{perfdata}->get_perfdata_for_output(label => 'critical-' . $self->{thlabel}),
-        min       => 0,
-        max       => 100
-    );
-}
-
-sub custom_usage_threshold {
-    my ($self, %options) = @_;
-    return $self->{perfdata}->threshold_check(
-        value     => $self->{result_values}->{prct_used},
-        threshold => [
-            { label => 'critical-' . $self->{thlabel}, exit_litteral => 'critical' },
-            { label => 'warning-'  . $self->{thlabel}, exit_litteral => 'warning'  }
-        ]
-    );
-}
+use centreon::plugins::misc qw(is_excluded);
+use centreon::plugins::constants qw(:counters);
+use Digest::SHA qw(sha256_hex);
 
 sub set_counters {
     my ($self, %options) = @_;
@@ -74,25 +32,36 @@ sub set_counters {
     $self->{maps_counters_type} = [
         {
             name             => 'edl',
-            type             => 1,
+            type             => COUNTER_TYPE_INSTANCE,
             cb_prefix_output => 'prefix_edl_output',
-            message_multiple => 'All External Dynamic Lists are within capacity limits'
+            message_multiple => 'All External Dynamic Lists are ok'
         }
     ];
 
     $self->{maps_counters}->{edl} = [
         {
-            label => 'usage',
-            set   => {
+            label         => 'usage',
+            set           => {
                 key_values => [
-                    { name => 'used' },
-                    { name => 'total' },
-                    { name => 'prct_used' },
-                    { name => 'display' }
+                    { name => 'display' },
+                    { name => 'prct_used' }
                 ],
-                closure_custom_output    => $self->can('custom_usage_output'),
-                closure_custom_perfdata  => $self->can('custom_usage_perfdata'),
-                closure_custom_threshold => $self->can('custom_usage_threshold')
+                output_template => 'capacity usage: (%.2f%%)',
+                output_use      => 'prct_used',
+                threshold_use   => 'prct_used',
+                perfdatas       => [
+                    {
+                        nlabel              => 'edl.entries.usage.percentage',
+                        label               => 'usage-percentage',
+                        value               => 'prct_used',
+                        template            => '%.2f',
+                        unit                => '%',
+                        min                 => 0,
+                        max                 => 100,
+                        label_extra_instance => 1,
+                        instance_use        => 'display'
+                    }
+                ]
             }
         }
     ];
@@ -109,9 +78,10 @@ sub new {
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
-        'filter-type:s'    => { name => 'filter_type' },
-        'warning-usage:s'  => { name => 'warning_usage',  default => '80:' },
-        'critical-usage:s' => { name => 'critical_usage', default => '90:' }
+        'include-type:s'   => { name => 'include_type', default => '' },
+        'exclude-type:s'   => { name => 'exclude_type', default => '' },
+        'warning-usage:s'  => { name => 'warning_usage',  default => '~:80' },
+        'critical-usage:s' => { name => 'critical_usage', default => '~:90' }
     });
 
     return $self;
@@ -136,16 +106,13 @@ sub manage_selection {
     $self->{edl} = {};
 
     foreach my $type (keys %$result) {
+        next if is_excluded($type, $self->{option_results}->{include_type}, $self->{option_results}->{exclude_type});
 
         my $used  = $result->{$type}->{'running-cap'};
         my $total = $result->{$type}->{'total-cap'};
 
         next unless defined($used)  && $used  =~ /^\d+$/;
         next unless defined($total) && $total =~ /^\d+$/ && $total > 0;
-
-        if (defined($self->{option_results}->{filter_type}) && $self->{option_results}->{filter_type} ne '') {
-            next if $type !~ /$self->{option_results}->{filter_type}/;
-        }
 
         $self->{edl}->{$type} = {
             display   => $type,
@@ -156,14 +123,16 @@ sub manage_selection {
     }
 
     if (!%{$self->{edl}}) {
-        $self->{output}->add_option_msg(
-            short_msg => 'No External Dynamic List capacity found.'
-        );
+        $self->{output}->add_option_msg(short_msg => 'No External Dynamic List capacity found.');
         $self->{output}->option_exit();
     }
 
-    $self->{cache_name} = "paloalto_api_" . $self->{mode} . '_' . $options{custom}->get_hostname() . '_' .
-        ($self->{option_results}->{filter_type} // 'all');
+    $self->{cache_name} = 'paloalto_api_' . $self->{mode} . '_' . $options{custom}->get_hostname() . '_' .
+        sha256_hex(
+            (defined($self->{option_results}->{include_type}) ? $self->{option_results}->{include_type} : 'all') . '_' .
+            (defined($self->{option_results}->{exclude_type}) ? $self->{option_results}->{exclude_type} : 'none')
+        );
+
 }
 
 1;
@@ -176,17 +145,21 @@ Check Palo Alto External Dynamic Lists (EDL) capacity.
 
 =over 8
 
-=item B<--filter-type>
+=item B<--include-type>
 
-Filter EDL entries by type (regexp). Only matching EDL types are checked.
+Include EDL types matching this regexp.
+
+=item B<--exclude-type>
+
+Exclude EDL types matching this regexp.
 
 =item B<--warning-usage>
 
-Warning threshold as a percentage of total capacity (default: '80:').
+Warning threshold as a percentage of total capacity (default: '~:80').
 
 =item B<--critical-usage>
 
-Critical threshold as a percentage of total capacity (default: '90:').
+Critical threshold as a percentage of total capacity (default: '~:90').
 
 =back
 

--- a/src/network/paloalto/api/plugin.pm
+++ b/src/network/paloalto/api/plugin.pm
@@ -35,7 +35,8 @@ sub new {
         'ha'          => 'network::paloalto::api::mode::ha',
         'licenses'    => 'network::paloalto::api::mode::licenses',
         'system'      => 'network::paloalto::api::mode::system',
-        'ipsec'       => 'network::paloalto::api::mode::ipsec'
+        'ipsec'       => 'network::paloalto::api::mode::ipsec',
+        'edl-capacity' => 'network::paloalto::api::mode::edlcapacity'
     };
 
     $self->{custom_modes}->{api} = 'network::paloalto::api::custom::api';


### PR DESCRIPTION
# Community contributors

## Description

New PAN-OS XML API mode to monitor EDL Capacity usage percentage (used capacity/total capacity)
(PAN-OS Command: request system external-list list-capacities)


**Fixes** # (issue)
None

## Type of change

- [X] New functionality (non-breaking change)
- [X] Breaking change (patch or feature) that might cause side effects breaking part of the Software (src/network/paloalto/api/custom/api.pm)

## How this pull request can be tested ?


**Mode --help:**
```
Mode:
    Check Palo Alto External Dynamic Lists (EDL) capacity.

    --include-type
            Include EDL types matching this regexp.

    --exclude-type
            Exclude EDL types matching this regexp.

    --warning-usage
            Warning threshold as a percentage of total capacity (default:
            '~:80').

    --critical-usage
            Critical threshold as a percentage of total capacity (default:
            '~:90').
```

**Execution:**
```
./centreon_plugins.pl --plugin=network::paloalto::api::plugin --mode=edl-capacity --hostname='__HOSTNAME__' --insecure --api-key='__API_KEY_STRING__==' --verbose --debug --warning-usage='~:80'
```

**Execution STDOUT:**
```
WARNING: EDL 'IP' capacity usage: (68.18%) | 'Domain#usage-percentage'=5.27%;~:60;~:80;0;100 'IP#usage-percentage'=68.18%;~:60;~:80;0;100 'Predefined-IP#usage-percentage'=15.96%;~:60;~:80;0;100 'URL#usage-percentage'=0.47%;~:60;~:80;0;100

== Info:   Trying HOSTNAME...
== Info: TCP_NODELAY set
== Info: Connected to HOSTNAME (HOSTNAME) port 443 (#0)
== Info: ALPN, offering http/1.1
== Info: successfully set certificate verify locations:
== Info:   CAfile: /etc/pki/tls/certs/ca-bundle.crt
  CApath: none
== Info: TLSv1.3 (OUT), TLS handshake, Client hello (1):
== Info: TLSv1.3 (IN), TLS handshake, Server hello (2):
== Info: TLSv1.3 (IN), TLS handshake, [no content] (0):
== Info: TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
== Info: TLSv1.3 (IN), TLS handshake, [no content] (0):
== Info: TLSv1.3 (IN), TLS handshake, Certificate (11):
== Info: TLSv1.3 (IN), TLS handshake, [no content] (0):
== Info: TLSv1.3 (IN), TLS handshake, CERT verify (15):
== Info: TLSv1.3 (IN), TLS handshake, [no content] (0):
== Info: TLSv1.3 (IN), TLS handshake, Finished (20):
== Info: TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
== Info: TLSv1.3 (OUT), TLS handshake, [no content] (0):
== Info: TLSv1.3 (OUT), TLS handshake, Finished (20):
== Info: SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
== Info: ALPN, server accepted to use http/1.1
== Info: Server certificate:
== Info:  subject: 
== Info:  start date: 
== Info:  expire date: 
== Info:  issuer: 
== Info:  SSL certificate verify result: self signed certificate (18), continuing anyway.
== Info: TLSv1.3 (OUT), TLS app data, [no content] (0):
=> Send header: GET /api/?cmd=%3Crequest%3E%3Csystem%3E%3Cexternal-list%3E%3Clist-capacities%2F%3E%3C%2Fexternal-list%3E%3C%2Fsystem%3E%3C%2Frequest%3E&type=op HTTP/1.1
Host: HOSTNAME
X-PAN-KEY: API_KEY_STRING==
Accept: application/xml

== Info: TLSv1.3 (IN), TLS handshake, [no content] (0):
== Info: TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
== Info: TLSv1.3 (IN), TLS handshake, [no content] (0):
== Info: TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
== Info: TLSv1.3 (IN), TLS app data, [no content] (0):
=> Recv header: HTTP/1.1 200 OK
=> Recv header: Date: Mon, 20 Jul 2026 09:32:19 GMT
=> Recv header: Content-Type: application/xml; charset=UTF-8
=> Recv header: Content-Length: 564
=> Recv header: Connection: keep-alive
=> Recv header: Cache-Control: no-store, no-cache, must-revalidate
=> Recv header: Expires: Thu, 19 Nov 1981 08:52:00 GMT
=> Recv header: Pragma: no-cache
=> Recv header: Content-Security-Policy: frame-ancestors 'none'
=> Recv header: Strict-Transport-Security: max-age=86400
=> Recv header: X-Content-Type-Options: nosniff
=> Recv header: X-Frame-Options: DENY
=> Recv header:
=> Recv data: <response cmd="status" status="success"><result><IP>                 <running-cap>34092</running-cap>                 <total-cap>50000</total-cap>             </IP><Domain>                 <running-cap>52660</running-cap>                 <total-cap>1000000</total-cap>             </Domain><URL>                 <running-cap>472</running-cap>                 <total-cap>100000</total-cap>             </URL><Predefined-IP>                 <running-cap>7978</running-cap>                 <total-cap>50000</total-cap>             </Predefined-IP></result></response>
== Info: Connection #0 to host HOSTNAME left intact
API response: <response cmd="status" status="success"><result><IP>                 <running-cap>34092</running-cap>                 <total-cap>50000</total-cap>             </IP><Domain>                 <running-cap>52660</running-cap>                 <total-cap>1000000</total-cap>             </Domain><URL>                 <running-cap>472</running-cap>                 <total-cap>100000</total-cap>             </URL><Predefined-IP>                 <running-cap>7978</running-cap>                 <total-cap>50000</total-cap>             </Predefined-IP></result></response>
EDL 'Domain' capacity usage: (5.27%)
EDL 'IP' capacity usage: (68.18%)
EDL 'Predefined-IP' capacity usage: (15.96%)
EDL 'URL' capacity usage: (0.47%)
```

**API response example:**
```xml
<response cmd="status" status="success">
	<result>
		<IP>
			<running-cap>10735</running-cap>
			<total-cap>50000</total-cap>
		</IP>
		<Domain>
			<running-cap>44420</running-cap>
			<total-cap>1000000</total-cap>
		</Domain>
		<URL>
			<running-cap>455</running-cap>
			<total-cap>100000</total-cap>
		</URL>
		<Predefined-IP>
			<running-cap>7980</running-cap>
			<total-cap>50000</total-cap>
		</Predefined-IP>
	</result>
</response>
```
api response values:
running-cap = used capacity
total-cap = total capacity


## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (develop).
- [X] I have provide data or shown output displaying the result of this code in the plugin area concerned.


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added edl-capacity mode to monitor EDL capacity usage percentages

**⚡ Enhancements**
* Registered edl-capacity mode into plugin modes mapping for usage

**🔧 Refactors**
* Modified custom API module XML parsing and authentication header logic


<sup>[More info](https://app.aikido.dev/featurebranch/scan/104171903?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->