### PR TITLE
fix(cloud::docker::restapi::plugin) : Mode(Container-Usage) : Handle cgroup v1 and v2 hosts

### DIFF
--- a/src/cloud/docker/restapi/mode/containerusage.pm
+++ b/src/cloud/docker/restapi/mode/containerusage.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -24,7 +24,8 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
-use Digest::MD5 qw(md5_hex);
+use Digest::SHA qw(sha256_hex);
+use centreon::plugins::constants qw/:values :counters/;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
 sub custom_status_output {
@@ -129,12 +130,12 @@ sub set_counters {
     my ($self, %options) = @_;
     
     $self->{maps_counters_type} = [
-        { name => 'containers', type => 1, cb_prefix_output => 'prefix_containers_output', message_multiple => 'All containers are ok', skipped_code => { -10 => 1, -11 => 1 } },
-        { name => 'containers_traffic', type => 1, cb_prefix_output => 'prefix_containers_traffic_output', message_multiple => 'All container traffics are ok', skipped_code => { -11 => 1 } }
+        { name => 'containers', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_containers_output', message_multiple => 'All containers are ok', skipped_code => { NO_VALUE() => 1 } },
+        { name => 'containers_traffic', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_containers_traffic_output', message_multiple => 'All container traffics are ok' }
     ];
 
     $self->{maps_counters}->{containers} = [
-         { label => 'container-status', type => 2, set => {
+         { label => 'container-status', type => COUNTER_KIND_TEXT, set => {
                 key_values => [ { name => 'state' }, { name => 'health' }, { name => 'name' } ],
                 closure_custom_output => $self->can('custom_status_output'),
                 closure_custom_perfdata => sub { return 0; },
@@ -275,7 +276,10 @@ sub manage_selection {
             $self->{containers}->{$container_id}->{cpu_number} = scalar(@{$result->{$container_id}->{Stats}->{cpu_stats}->{cpu_usage}->{percpu_usage}});
         }
 
-        $self->{containers}->{$container_id}->{memory_usage} = $result->{$container_id}->{Stats}->{memory_stats}->{usage} - $result->{$container_id}->{Stats}->{memory_stats}->{stats}->{inactive_file} // 0;
+        # https://docs.docker.com/reference/cli/docker/container/stats/
+        # On cgroup v1 hosts the cache usage to subtract is defined as total_inactive_file, on cgroup v2 hosts it is defined as inactive_file
+        my $inactive = $result->{$container_id}->{Stats}->{memory_stats}->{stats}->{total_inactive_file} // $result->{$container_id}->{Stats}->{memory_stats}->{stats}->{inactive_file} // 0;
+        $self->{containers}->{$container_id}->{memory_usage} = $result->{$container_id}->{Stats}->{memory_stats}->{usage} - $inactive;
         $self->{containers}->{$container_id}->{memory_total} = $result->{$container_id}->{Stats}->{memory_stats}->{limit};
 
         foreach my $interface (keys %{$result->{$container_id}->{Stats}->{networks}}) {
@@ -296,7 +300,7 @@ sub manage_selection {
 
     my $hostnames = $options{custom}->get_hostnames();
     $self->{cache_name} = 'docker_' . $self->{mode} . '_' . join('_', @$hostnames) . '_' . $options{custom}->get_port() . '_' .
-        md5_hex(
+        sha256_hex(
             (defined($self->{option_results}->{filter_counters}) ? $self->{option_results}->{filter_counters} : '') . '_' .
             (defined($self->{option_results}->{filter_name}) ? $self->{option_results}->{filter_name} : '') . '_' .
             (defined($self->{option_results}->{container_id}) ? $self->{option_results}->{container_id} : '') . '_' .
@@ -354,11 +358,53 @@ You can use the following variables: C<%{name}>, C<%{state}>, C<%{health}>.
 Define the conditions to match for the status to be CRITICAL.
 You can use the following variables: C<%{name}>, C<%{state}>, C<%{health}>.
 
-=item B<--warning-*> B<--critical-*>
+=item B<--warning-cpu>
 
-Thresholds.
-Can be: 'read-iops', 'write-iops', 'traffic-in', 'traffic-out', 
-'cpu' (%), 'memory' (%).
+Threshold in percentage.
+
+=item B<--critical-cpu>
+
+Threshold in percentage.
+
+=item B<--warning-memory>
+
+Threshold.
+
+=item B<--critical-memory>
+
+Threshold.
+
+=item B<--warning-read-iops>
+
+Threshold in iops.
+
+=item B<--critical-read-iops>
+
+Threshold in iops.
+
+=item B<--warning-traffic-in>
+
+Threshold in b/s.
+
+=item B<--critical-traffic-in>
+
+Threshold in b/s.
+
+=item B<--warning-traffic-out>
+
+Threshold in b/s.
+
+=item B<--critical-traffic-out>
+
+Threshold in b/s.
+
+=item B<--warning-write-iops>
+
+Threshold in iops.
+
+=item B<--critical-write-iops>
+
+Threshold in iops.
 
 =back
 

--- a/tests/cloud/docker/restapi/container-cgroupv1.robot
+++ b/tests/cloud/docker/restapi/container-cgroupv1.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation       Cloud Docker REST API Container
+Documentation       Cloud Docker REST API Container cgroup V1
 
 Resource            ${CURDIR}${/}..${/}..${/}..${/}resources/import.resource
 
@@ -9,7 +9,7 @@ Test Timeout        120s
 
 
 *** Variables ***
-${MOCKOON_JSON}     ${CURDIR}${/}docker.json
+${MOCKOON_JSON}     ${CURDIR}${/}docker-cgroupv1.json
 ${HOSTNAME}         127.0.0.1
 ${APIPORT}          3000
 ${CMD}              ${CENTREON_PLUGINS}
@@ -20,7 +20,7 @@ ${CMD}              ${CENTREON_PLUGINS}
 
 
 *** Test Cases ***
-Container usage ${tc}
+Container cgroupv1 usage ${tc}
     [Tags]    cloud    kubernetes
 
     ${command}    Catenate
@@ -36,10 +36,10 @@ Container usage ${tc}
     ...    --
     ...    1
     ...    ${EMPTY}
-    ...    OK: Container 'containerId' state: running, cpu : Buffer creation, memory total: 7.65 GB used: 75.97 MB (0.97%) free: 7.58 GB (99.03%), read-iops : Buffer creation, write-iops : Buffer creation - All container traffics are ok | 'memory_used'=79664947B;;;0;8217579520
+    ...    OK: Container 'containerId' state: running, cpu : Buffer creation, memory total: 7.47 GB used: 358.07 MB (4.68%) free: 7.12 GB (95.32%), read-iops : Buffer creation, write-iops : Buffer creation - Container 'containerId.eth0' traffic-in : Buffer creation, traffic-out : Buffer creation | 'memory_used'=375459840B;;;0;8025042944
     ...    2
     ...    ${EMPTY}
-    ...    OK: Container 'containerId' state: running, cpu usage: 0.00 %, memory total: 7.65 GB used: 75.97 MB (0.97%) free: 7.58 GB (99.03%), read IOPs: 0.00, write IOPs: 0.00 - All container traffics are ok | 'cpu'=0.00%;;;0;100 'memory_used'=79664947B;;;0;8217579520 'read_iops'=0.00iops;;;0; 'write_iops'=0.00iops;;;0; 'traffic_in_containerId.eth0'=0.00b/s;;;0; 'traffic_out_containerId.eth0'=0.00b/s;;;0; 'traffic_in_containerId.eth5'=0.00b/s;;;0; 'traffic_out_containerId.eth5'=0.00b/s;;;0;
+    ...    OK: Container 'containerId' state: running, cpu usage: 0.00 %, memory total: 7.47 GB used: 358.07 MB (4.68%) free: 7.12 GB (95.32%), read IOPs: 0.00, write IOPs: 0.00 - Container 'containerId.eth0' traffic in: 0.00 b/s, traffic out: 0.00 b/s | 'cpu'=0.00%;;;0;100 'memory_used'=375459840B;;;0;8025042944 'read_iops'=0.00iops;;;0; 'write_iops'=0.00iops;;;0; 'traffic_in'=0.00b/s;;;0; 'traffic_out'=0.00b/s;;;0;
     ...    3
     ...    --use-name --no-stats
     ...    OK: Container '/containerName' state: running

--- a/tests/cloud/docker/restapi/docker-cgroupv1.json
+++ b/tests/cloud/docker/restapi/docker-cgroupv1.json
@@ -1,0 +1,154 @@
+{
+  "uuid": "09a83e8d-9112-477a-b6e0-6e97198d7a82",
+  "lastMigration": 33,
+  "name": "Docker cgroupv1",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3010,
+  "hostname": "",
+  "folders": [],
+  "routes": [
+    {
+      "uuid": "4f1c750c-6f0d-4add-b1ed-405c6d1293df",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "containers/json",
+      "responses": [
+        {
+          "uuid": "dfbfffb4-80e0-4f46-a563-d19a09486ed4",
+          "body": "[\r\n  {\r\n    \"Id\": \"containerId\",\r\n    \"Names\": [\r\n      \"/containerName\"\r\n    ],\r\n    \"State\": \"running\"\r\n      }\r\n]",
+          "latency": 0,
+          "statusCode": 404,
+          "label": "",
+          "headers": [
+            {
+              "key": "access-control-allow-headers",
+              "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+            },
+            {
+              "key": "access-control-allow-methods",
+              "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+            },
+            {
+              "key": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "key": "content-security-policy",
+              "value": "default-src 'none'"
+            },
+            {
+              "key": "content-type",
+              "value": "text/html; charset=utf-8"
+            },
+            {
+              "key": "x-content-type-options",
+              "value": "nosniff"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": false,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    },
+    {
+      "uuid": "2065e78c-856f-4ed5-9638-1be80c667602",
+      "type": "http",
+      "documentation": "",
+      "method": "get",
+      "endpoint": "containers/containerId/stats",
+      "responses": [
+        {
+          "uuid": "69d39aeb-c49b-414a-b3a3-24771b63c55f",
+          "body": "{\n  \"read\": \"2026-01-30T10:59:33.461577844Z\",\n  \"preread\": \"0001-01-01T00:00:00Z\",\n  \"pids_stats\": {\n    \"current\": 49\n  },\n  \"blkio_stats\": {\n    \"io_service_bytes_recursive\": [\n      {\n        \"major\": 252,\n        \"minor\": 12,\n        \"op\": \"Read\",\n        \"value\": 233472\n      },\n      {\n        \"major\": 252,\n        \"minor\": 12,\n        \"op\": \"Write\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 12,\n        \"op\": \"Sync\",\n        \"value\": 233472\n      },\n      {\n        \"major\": 252,\n        \"minor\": 12,\n        \"op\": \"Async\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 12,\n        \"op\": \"Discard\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 12,\n        \"op\": \"Total\",\n        \"value\": 233472\n      },\n      {\n        \"major\": 252,\n        \"minor\": 1,\n        \"op\": \"Read\",\n        \"value\": 3751530496\n      },\n      {\n        \"major\": 252,\n        \"minor\": 1,\n        \"op\": \"Write\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 1,\n        \"op\": \"Sync\",\n        \"value\": 3751530496\n      },\n      {\n        \"major\": 252,\n        \"minor\": 1,\n        \"op\": \"Async\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 1,\n        \"op\": \"Discard\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 1,\n        \"op\": \"Total\",\n        \"value\": 3751530496\n      },\n      {\n        \"major\": 8,\n        \"minor\": 0,\n        \"op\": \"Read\",\n        \"value\": 3797504000\n      },\n      {\n        \"major\": 8,\n        \"minor\": 0,\n        \"op\": \"Write\",\n        \"value\": 0\n      },\n      {\n        \"major\": 8,\n        \"minor\": 0,\n        \"op\": \"Sync\",\n        \"value\": 3797504000\n      },\n      {\n        \"major\": 8,\n        \"minor\": 0,\n        \"op\": \"Async\",\n        \"value\": 0\n      },\n      {\n        \"major\": 8,\n        \"minor\": 0,\n        \"op\": \"Discard\",\n        \"value\": 0\n      },\n      {\n        \"major\": 8,\n        \"minor\": 0,\n        \"op\": \"Total\",\n        \"value\": 3797504000\n      },\n      {\n        \"major\": 252,\n        \"minor\": 11,\n        \"op\": \"Read\",\n        \"value\": 45740032\n      },\n      {\n        \"major\": 252,\n        \"minor\": 11,\n        \"op\": \"Write\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 11,\n        \"op\": \"Sync\",\n        \"value\": 45740032\n      },\n      {\n        \"major\": 252,\n        \"minor\": 11,\n        \"op\": \"Async\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 11,\n        \"op\": \"Discard\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 11,\n        \"op\": \"Total\",\n        \"value\": 45740032\n      },\n      {\n        \"major\": 8,\n        \"minor\": 16,\n        \"op\": \"Read\",\n        \"value\": 10327704064\n      },\n      {\n        \"major\": 8,\n        \"minor\": 16,\n        \"op\": \"Write\",\n        \"value\": 0\n      },\n      {\n        \"major\": 8,\n        \"minor\": 16,\n        \"op\": \"Sync\",\n        \"value\": 10327704064\n      },\n      {\n        \"major\": 8,\n        \"minor\": 16,\n        \"op\": \"Async\",\n        \"value\": 0\n      },\n      {\n        \"major\": 8,\n        \"minor\": 16,\n        \"op\": \"Discard\",\n        \"value\": 0\n      },\n      {\n        \"major\": 8,\n        \"minor\": 16,\n        \"op\": \"Total\",\n        \"value\": 10327704064\n      },\n      {\n        \"major\": 252,\n        \"minor\": 3,\n        \"op\": \"Read\",\n        \"value\": 10327704064\n      },\n      {\n        \"major\": 252,\n        \"minor\": 3,\n        \"op\": \"Write\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 3,\n        \"op\": \"Sync\",\n        \"value\": 10327704064\n      },\n      {\n        \"major\": 252,\n        \"minor\": 3,\n        \"op\": \"Async\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 3,\n        \"op\": \"Discard\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 3,\n        \"op\": \"Total\",\n        \"value\": 10327704064\n      }\n    ],\n    \"io_serviced_recursive\": [\n      {\n        \"major\": 252,\n        \"minor\": 12,\n        \"op\": \"Read\",\n        \"value\": 15\n      },\n      {\n        \"major\": 252,\n        \"minor\": 12,\n        \"op\": \"Write\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 12,\n        \"op\": \"Sync\",\n        \"value\": 15\n      },\n      {\n        \"major\": 252,\n        \"minor\": 12,\n        \"op\": \"Async\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 12,\n        \"op\": \"Discard\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 12,\n        \"op\": \"Total\",\n        \"value\": 15\n      },\n      {\n        \"major\": 252,\n        \"minor\": 1,\n        \"op\": \"Read\",\n        \"value\": 915901\n      },\n      {\n        \"major\": 252,\n        \"minor\": 1,\n        \"op\": \"Write\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 1,\n        \"op\": \"Sync\",\n        \"value\": 915901\n      },\n      {\n        \"major\": 252,\n        \"minor\": 1,\n        \"op\": \"Async\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 1,\n        \"op\": \"Discard\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 1,\n        \"op\": \"Total\",\n        \"value\": 915901\n      },\n      {\n        \"major\": 8,\n        \"minor\": 0,\n        \"op\": \"Read\",\n        \"value\": 916567\n      },\n      {\n        \"major\": 8,\n        \"minor\": 0,\n        \"op\": \"Write\",\n        \"value\": 0\n      },\n      {\n        \"major\": 8,\n        \"minor\": 0,\n        \"op\": \"Sync\",\n        \"value\": 916567\n      },\n      {\n        \"major\": 8,\n        \"minor\": 0,\n        \"op\": \"Async\",\n        \"value\": 0\n      },\n      {\n        \"major\": 8,\n        \"minor\": 0,\n        \"op\": \"Discard\",\n        \"value\": 0\n      },\n      {\n        \"major\": 8,\n        \"minor\": 0,\n        \"op\": \"Total\",\n        \"value\": 916567\n      },\n      {\n        \"major\": 252,\n        \"minor\": 11,\n        \"op\": \"Read\",\n        \"value\": 651\n      },\n      {\n        \"major\": 252,\n        \"minor\": 11,\n        \"op\": \"Write\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 11,\n        \"op\": \"Sync\",\n        \"value\": 651\n      },\n      {\n        \"major\": 252,\n        \"minor\": 11,\n        \"op\": \"Async\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 11,\n        \"op\": \"Discard\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 11,\n        \"op\": \"Total\",\n        \"value\": 651\n      },\n      {\n        \"major\": 8,\n        \"minor\": 16,\n        \"op\": \"Read\",\n        \"value\": 79559\n      },\n      {\n        \"major\": 8,\n        \"minor\": 16,\n        \"op\": \"Write\",\n        \"value\": 0\n      },\n      {\n        \"major\": 8,\n        \"minor\": 16,\n        \"op\": \"Sync\",\n        \"value\": 79559\n      },\n      {\n        \"major\": 8,\n        \"minor\": 16,\n        \"op\": \"Async\",\n        \"value\": 0\n      },\n      {\n        \"major\": 8,\n        \"minor\": 16,\n        \"op\": \"Discard\",\n        \"value\": 0\n      },\n      {\n        \"major\": 8,\n        \"minor\": 16,\n        \"op\": \"Total\",\n        \"value\": 79559\n      },\n      {\n        \"major\": 252,\n        \"minor\": 3,\n        \"op\": \"Read\",\n        \"value\": 79559\n      },\n      {\n        \"major\": 252,\n        \"minor\": 3,\n        \"op\": \"Write\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 3,\n        \"op\": \"Sync\",\n        \"value\": 79559\n      },\n      {\n        \"major\": 252,\n        \"minor\": 3,\n        \"op\": \"Async\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 3,\n        \"op\": \"Discard\",\n        \"value\": 0\n      },\n      {\n        \"major\": 252,\n        \"minor\": 3,\n        \"op\": \"Total\",\n        \"value\": 79559\n      }\n    ],\n    \"io_queue_recursive\": [],\n    \"io_service_time_recursive\": [],\n    \"io_wait_time_recursive\": [],\n    \"io_merged_recursive\": [],\n    \"io_time_recursive\": [],\n    \"sectors_recursive\": []\n  },\n  \"num_procs\": 0,\n  \"storage_stats\": {},\n  \"cpu_stats\": {\n    \"cpu_usage\": {\n      \"total_usage\": 1950723284902,\n      \"percpu_usage\": [\n        979658989188,\n        971064295714\n      ],\n      \"usage_in_kernelmode\": 617990000000,\n      \"usage_in_usermode\": 1294250000000\n    },\n    \"system_cpu_usage\": 4141020320000000,\n    \"online_cpus\": 2,\n    \"throttling_data\": {\n      \"periods\": 0,\n      \"throttled_periods\": 0,\n      \"throttled_time\": 0\n    }\n  },\n  \"precpu_stats\": {\n    \"cpu_usage\": {\n      \"total_usage\": 0,\n      \"usage_in_kernelmode\": 0,\n      \"usage_in_usermode\": 0\n    },\n    \"throttling_data\": {\n      \"periods\": 0,\n      \"throttled_periods\": 0,\n      \"throttled_time\": 0\n    }\n  },\n  \"memory_stats\": {\n    \"usage\": 458633216,\n    \"max_usage\": 641589248,\n    \"stats\": {\n      \"active_anon\": 19209912320,\n      \"active_file\": 10183770112,\n      \"cache\": 350861918208,\n      \"dirty\": 16777216,\n      \"hierarchical_memory_limit\": 9223372036854772000,\n      \"hierarchical_memsw_limit\": 9223372036854772000,\n      \"inactive_anon\": 1490638864384,\n      \"inactive_file\": 340678148096,\n      \"mapped_file\": 84590723072,\n      \"pgfault\": 1669709,\n      \"pgmajfault\": 454943,\n      \"pgpgin\": 3961601,\n      \"pgpgout\": 4101595,\n      \"rss\": 1469835116544,\n      \"rss_huge\": 1005022347264,\n      \"total_active_anon\": 4689920,\n      \"total_active_file\": 2486272,\n      \"total_cache\": 85659648,\n      \"total_dirty\": 4096,\n      \"total_inactive_anon\": 363925504,\n      \"total_inactive_file\": 83173376,\n      \"total_mapped_file\": 20652032,\n      \"total_pgfault\": 1669709,\n      \"total_pgmajfault\": 454943,\n      \"total_pgpgin\": 3961601,\n      \"total_pgpgout\": 4101595,\n      \"total_rss\": 358846464,\n      \"total_rss_huge\": 245366784,\n      \"total_unevictable\": 0,\n      \"total_writeback\": 0,\n      \"unevictable\": 0,\n      \"writeback\": 0\n    },\n    \"limit\": 8025042944\n  },\n  \"name\": \"/xxxxxxxxxxx\",\n  \"id\": \" xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx \",\n  \"networks\": {\n    \"eth0\": {\n      \"rx_bytes\": 5940812,\n      \"rx_packets\": 97854,\n      \"rx_errors\": 0,\n      \"rx_dropped\": 0,\n      \"tx_bytes\": 61768820,\n      \"tx_packets\": 107664,\n      \"tx_errors\": 0,\n      \"tx_dropped\": 0\n    }\n  }\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ],
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
+    }
+  ],
+  "rootChildren": [
+    {
+      "type": "route",
+      "uuid": "4f1c750c-6f0d-4add-b1ed-405c6d1293df"
+    },
+    {
+      "type": "route",
+      "uuid": "2065e78c-856f-4ed5-9638-1be80c667602"
+    }
+  ],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "application/json"
+    },
+    {
+      "key": "Access-Control-Allow-Origin",
+      "value": "*"
+    },
+    {
+      "key": "Access-Control-Allow-Methods",
+      "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+    },
+    {
+      "key": "Access-Control-Allow-Headers",
+      "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": [],
+  "callbacks": []
+}

--- a/tests/cloud/docker/restapi/docker.json
+++ b/tests/cloud/docker/restapi/docker.json
@@ -1,6 +1,6 @@
 {
   "uuid": "123def66-79b3-46a6-a645-ba1aa0fab6c2",
-  "lastMigration": 32,
+  "lastMigration": 33,
   "name": "Docker",
   "endpointPrefix": "",
   "latency": 0,
@@ -35,7 +35,9 @@
           "callbacks": []
         }
       ],
-      "responseMode": null
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
     },
     {
       "uuid": "e7e4e95d-f5d8-4e40-ba95-ffd76264b8ca",
@@ -64,7 +66,9 @@
           "callbacks": []
         }
       ],
-      "responseMode": null
+      "responseMode": null,
+      "streamingMode": null,
+      "streamingInterval": 0
     }
   ],
   "rootChildren": [


### PR DESCRIPTION
## Description

Handle cgroup v1 and v2 hosts

**Fixes** # CTOR-2192

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Changed skipped_code handling to use NO_VALUE() for absent metrics.

**🔧 Refactors**
* Replaced Digest::MD5 with Digest::SHA and added constants import.
* Converted numeric counter types to named COUNTER_* constants.

**📚 Documentation**
* Updated copyright year range in file header.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/104985957?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->