### PR TITLE
enh(cloud::kubernetes::plugin) Mode(node-usage): CPU/Memory requests inflated due to non-Running and unscheduled pods included in allocation calculation

### DIFF
--- a/packaging/centreon-plugin-Cloud-Kubernetes-Api/deb.json
+++ b/packaging/centreon-plugin-Cloud-Kubernetes-Api/deb.json
@@ -1,4 +1,5 @@
 {
     "dependencies": [
+        "libfile-homedir-perl"
     ]
 }

--- a/packaging/centreon-plugin-Cloud-Kubernetes-Api/rpm.json
+++ b/packaging/centreon-plugin-Cloud-Kubernetes-Api/rpm.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-        "perl(DateTime)"
+        "perl(DateTime)",
+        "perl-File-HomeDir"
     ]
 }

--- a/src/cloud/kubernetes/mode/nodeusage.pm
+++ b/src/cloud/kubernetes/mode/nodeusage.pm
@@ -348,6 +348,7 @@ Threshold in percentage.
 =item B<--critical-memory-requests>
 
 Threshold in percentage.
+
 =item B<--warning-allocated-pods>
 
 Threshold in percentage.

--- a/src/cloud/kubernetes/mode/nodeusage.pm
+++ b/src/cloud/kubernetes/mode/nodeusage.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -21,6 +21,8 @@
 package cloud::kubernetes::mode::nodeusage;
 
 use base qw(centreon::plugins::templates::counter);
+use centreon::plugins::constants qw/:values :counters/;
+use centreon::plugins::misc qw/is_excluded/;
 
 use strict;
 use warnings;
@@ -108,8 +110,8 @@ sub set_counters {
     my ($self, %options) = @_;
     
     $self->{maps_counters_type} = [
-        { name => 'nodes', type => 1, cb_prefix_output => 'prefix_node_output',
-            message_multiple => 'All Nodes usage are ok', skipped_code => { -11 => 1 } },
+        { name => 'nodes', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_node_output',
+            message_multiple => 'All Nodes usage are ok', skipped_code => { NO_VALUE() => 1 } },
     ];
 
     $self->{maps_counters}->{nodes} = [
@@ -183,8 +185,12 @@ sub new {
     bless $self, $class;
     
     $options{options}->add_options(arguments => {
-        'filter-name:s' => { name => 'filter_name' },
-        'units:s'       => { name => 'units', default => '%' } # Keep compat
+        'filter-name:s'    => { redirect => 'include_name' },
+        'include-name:s'   => { name => 'include_name', default => '' },
+        'exclude-name:s'   => { name => 'exclude_name', default => '' },
+        'include-status:s' => { name => 'include_status', default => 'running' },
+        'exclude-status:s' => { name => 'exclude_status', default => '' },
+        'units:s'          => { name => 'units', default => '%' } # Keep compat
     });
    
     return $self;
@@ -202,12 +208,9 @@ sub manage_selection {
 
     my $nodes = $options{custom}->kubernetes_list_nodes();
     
+    my $found = 0;
     foreach my $node (@{$nodes}) {
-        if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne '' &&
-            $node->{metadata}->{name} !~ /$self->{option_results}->{filter_name}/) {
-            $self->{output}->output_add(long_msg => "skipping '" . $node->{metadata}->{name} . "': no matching filter name.", debug => 1);
-            next;
-        }
+        next if is_excluded($node->{metadata}->{name}, $self->{option_results}->{include_name}, $self->{option_results}->{exclude_name}, output => $self->{output});
 
         $self->{nodes}->{$node->{metadata}->{name}} = {
             display => $node->{metadata}->{name},
@@ -217,15 +220,18 @@ sub manage_selection {
         }            
     }
     
-    if (scalar(keys %{$self->{nodes}}) <= 0) {
-        $self->{output}->add_option_msg(short_msg => "No Nodes found.");
-        $self->{output}->option_exit();
-    }
+    $self->{output}->option_exit(short_msg => "No Nodes found.")
+        unless keys %{$self->{nodes}};
     
     my $pods = $options{custom}->kubernetes_list_pods();
 
     foreach my $pod (@{$pods}) {
-        next if (defined($pod->{spec}->{nodeName}) && !defined($self->{nodes}->{$pod->{spec}->{nodeName}}));
+        next unless defined $pod->{spec}->{nodeName} &&
+                    defined $pod->{status}->{phase} &&
+                    defined $self->{nodes}->{$pod->{spec}->{nodeName}};
+        $pod->{status}->{phase} = lc $pod->{status}->{phase};
+        next if is_excluded($pod->{status}->{phase}, $self->{option_results}->{include_status}, $self->{option_results}->{exclude_status}, output => $self->{output});
+
         $self->{nodes}->{$pod->{spec}->{nodeName}}->{pods_allocated}++;
         foreach my $container (@{$pod->{spec}->{containers}}) {
             $self->{nodes}->{$pod->{spec}->{nodeName}}->{cpu_requests} += $self->to_core(value => $container->{resources}->{requests}->{cpu}) if (defined($container->{resources}->{requests}->{cpu}));
@@ -233,7 +239,11 @@ sub manage_selection {
             $self->{nodes}->{$pod->{spec}->{nodeName}}->{memory_requests} += $self->to_bytes(value => $container->{resources}->{requests}->{memory}) if (defined($container->{resources}->{requests}->{memory}));
             $self->{nodes}->{$pod->{spec}->{nodeName}}->{memory_limits} += $self->to_bytes(value => $container->{resources}->{limits}->{memory}) if (defined($container->{resources}->{limits}->{memory}));
         }
+        $found++
     }
+
+    $self->{output}->option_exit(short_msg => "No Pods found.")
+        unless $found;
 }
 
 sub to_bytes {
@@ -280,15 +290,103 @@ Check node usage.
 
 =over 8
 
-=item B<--filter-name>
+=item B<--include-name>
 
 Filter node name (can be a regexp).
 
-=item B<--warning-*> B<--critical-*> 
+=item B<--exclude-name>
 
-Thresholds (in percentage).
-Can be: 'cpu-requests', 'cpu-limits', 'memory-requests', 'memory-limits',
-'allocated-pods'.
+Exclude by node name (can be a regexp).
+
+=item B<--include-status>
+
+Filter by node status (can be a regexp).
+Default: 'running'
+Status can be 'pending', 'running', 'succeeded', 'failed', 'unknown'
+
+=item B<--exclude-status>
+
+Exclude by node status (can be a regexp).
+Status can be 'pending', 'running', 'succeeded', 'failed', 'unknown'
+
+=item B<--warning-allocated-pods>
+
+Threshold in percentage.
+
+=item B<--critical-allocated-pods>
+
+Threshold in percentage.
+
+=item B<--warning-cpu-limits>
+
+Threshold in percentage.
+
+=item B<--critical-cpu-limits>
+
+Threshold in percentage.
+
+=item B<--warning-cpu-requests>
+
+Threshold in percentage.
+
+=item B<--critical-cpu-requests>
+
+Threshold in percentage.
+
+=item B<--warning-memory-limits>
+
+Threshold in percentage.
+
+=item B<--critical-memory-limits>
+
+Threshold in percentage.
+
+=item B<--warning-memory-requests>
+
+Threshold in percentage.
+
+=item B<--critical-memory-requests>
+
+Threshold in percentage.
+=item B<--warning-allocated-pods>
+
+Threshold in percentage.
+
+=item B<--critical-allocated-pods>
+
+Threshold in percentage.
+
+=item B<--warning-cpu-limits>
+
+Threshold in percentage.
+
+=item B<--critical-cpu-limits>
+
+Threshold in percentage.
+
+=item B<--warning-cpu-requests>
+
+Threshold in percentage.
+
+=item B<--critical-cpu-requests>
+
+Threshold in percentage.
+
+=item B<--warning-memory-limits>
+
+Threshold in percentage.
+
+=item B<--critical-memory-limits>
+
+Threshold in percentage.
+
+=item B<--warning-memory-requests>
+
+Threshold in percentage.
+
+=item B<--critical-memory-requests>
+
+Threshold in percentage.
 
 =back
 

--- a/tests/cloud/kubernetes/kubectl_bin/kubectl
+++ b/tests/cloud/kubernetes/kubectl_bin/kubectl
@@ -1,0 +1,441 @@
+#!/bin/sh
+
+if [ "$1" = "get" ] && [ "$2" = "nodes" ]; then
+cat<<EOF
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Node",
+            "metadata": {
+                "annotations": {
+                    "kubeadm.alpha.kubernetes.io/cri-socket": "unix:///run/containerd/containerd.sock",
+                    "node.alpha.kubernetes.io/ttl": "0",
+                    "volumes.kubernetes.io/controller-managed-attach-detach": "true"
+                },
+                "creationTimestamp": "2026-04-22T11:59:51Z",
+                "labels": {
+                    "beta.kubernetes.io/arch": "amd64",
+                    "beta.kubernetes.io/os": "linux",
+                    "kubernetes.io/arch": "amd64",
+                    "kubernetes.io/hostname": "kind-control-plane",
+                    "kubernetes.io/os": "linux",
+                    "node-role.kubernetes.io/control-plane": ""
+                },
+                "name": "kind-control-plane",
+                "resourceVersion": "2829",
+                "uid": "c478b092-6a40-46b7-98fc-AAAAAAAAAAA2"
+            },
+            "spec": {
+                "podCIDR": "10.244.0.0/24",
+                "podCIDRs": [
+                    "10.244.0.0/24"
+                ],
+                "providerID": "kind://docker/kind/kind-control-plane"
+            },
+            "status": {
+                "addresses": [
+                    {
+                        "address": "172.18.0.2",
+                        "type": "InternalIP"
+                    },
+                    {
+                        "address": "kind-control-plane",
+                        "type": "Hostname"
+                    }
+                ],
+                "allocatable": {
+                    "cpu": "8",
+                    "ephemeral-storage": "486903968Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32580872Ki",
+                    "pods": "110"
+                },
+                "capacity": {
+                    "cpu": "8",
+                    "ephemeral-storage": "486903968Ki",
+                    "hugepages-1Gi": "0",
+                    "hugepages-2Mi": "0",
+                    "memory": "32580872Ki",
+                    "pods": "110"
+                },
+                "conditions": [
+                    {
+                        "lastHeartbeatTime": "2026-04-22T12:30:49Z",
+                        "lastTransitionTime": "2026-04-22T11:59:49Z",
+                        "message": "kubelet has sufficient memory available",
+                        "reason": "KubeletHasSufficientMemory",
+                        "status": "False",
+                        "type": "MemoryPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-04-22T12:30:49Z",
+                        "lastTransitionTime": "2026-04-22T11:59:49Z",
+                        "message": "kubelet has no disk pressure",
+                        "reason": "KubeletHasNoDiskPressure",
+                        "status": "False",
+                        "type": "DiskPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-04-22T12:30:49Z",
+                        "lastTransitionTime": "2026-04-22T11:59:49Z",
+                        "message": "kubelet has sufficient PID available",
+                        "reason": "KubeletHasSufficientPID",
+                        "status": "False",
+                        "type": "PIDPressure"
+                    },
+                    {
+                        "lastHeartbeatTime": "2026-04-22T12:30:49Z",
+                        "lastTransitionTime": "2026-04-22T12:00:09Z",
+                        "message": "kubelet is posting ready status",
+                        "reason": "KubeletReady",
+                        "status": "True",
+                        "type": "Ready"
+                    }
+                ],
+                "daemonEndpoints": {
+                    "kubeletEndpoint": {
+                        "Port": 10250
+                    }
+                },
+                "images": [
+                    {
+                        "names": [
+                            "docker.io/library/import-2024-05-13@sha256:d147453847b7c5b8c33045e54d6e0301edea08b5ae152e84b9b5cab377e20321",
+                            "registry.k8s.io/kube-apiserver-amd64:v1.30.0",
+                            "registry.k8s.io/kube-apiserver:v1.30.0"
+                        ],
+                        "sizeBytes": 89436130
+                    }
+                ],
+                "nodeInfo": {
+                    "architecture": "amd64",
+                    "bootID": "0f789f7a-1ba9-4bb9-9dd7-a52984ba2267",
+                    "containerRuntimeVersion": "containerd://1.7.15",
+                    "kernelVersion": "6.8.0-107-generic",
+                    "kubeProxyVersion": "v1.30.0",
+                    "kubeletVersion": "v1.30.0",
+                    "machineID": "f92bfe0ec4384fc3852bde51437b329d",
+                    "operatingSystem": "linux",
+                    "osImage": "Debian GNU/Linux 12 (bookworm)",
+                    "systemUUID": "9689d3c2-c2ae-4b94-9ba6-7c54a6e39b35"
+                }
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": ""
+    }
+}
+EOF
+fi
+
+if [ "$1" = "get" ] && [ "$2" = "pods" ]; then
+cat<<EOF
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {
+                "creationTimestamp": "2026-04-22T12:00:08Z",
+                "generateName": "coredns-7db6d8ff4d-",
+                "labels": {
+                    "k8s-app": "kube-dns",
+                    "pod-template-hash": "7db6d8ff4d"
+                },
+                "name": "coredns-7db6d8ff4d-lhw8x",
+                "namespace": "kube-system",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": true,
+                        "controller": true,
+                        "kind": "ReplicaSet",
+                        "name": "coredns-7db6d8ff4d",
+                        "uid": "e9146919-3443-4b28-8709-7339ca946a10"
+                    }
+                ],
+                "resourceVersion": "427",
+                "uid": "c49b22ee-936b-4bfb-8b09-f69b36736ec8"
+            },
+            "spec": {
+                "affinity": {
+                    "podAntiAffinity": {
+                        "preferredDuringSchedulingIgnoredDuringExecution": [
+                            {
+                                "podAffinityTerm": {
+                                    "labelSelector": {
+                                        "matchExpressions": [
+                                            {
+                                                "key": "k8s-app",
+                                                "operator": "In",
+                                                "values": [
+                                                    "kube-dns"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "topologyKey": "kubernetes.io/hostname"
+                                },
+                                "weight": 100
+                            }
+                        ]
+                    }
+                },
+                "containers": [
+                    {
+                        "args": [
+                            "-conf",
+                            "/etc/coredns/Corefile"
+                        ],
+                        "image": "registry.k8s.io/coredns/coredns:v1.11.1",
+                        "imagePullPolicy": "IfNotPresent",
+                        "livenessProbe": {
+                            "failureThreshold": 5,
+                            "httpGet": {
+                                "path": "/health",
+                                "port": 8080,
+                                "scheme": "HTTP"
+                            },
+                            "initialDelaySeconds": 60,
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 5
+                        },
+                        "name": "coredns",
+                        "ports": [
+                            {
+                                "containerPort": 53,
+                                "name": "dns",
+                                "protocol": "UDP"
+                            },
+                            {
+                                "containerPort": 53,
+                                "name": "dns-tcp",
+                                "protocol": "TCP"
+                            },
+                            {
+                                "containerPort": 9153,
+                                "name": "metrics",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "readinessProbe": {
+                            "failureThreshold": 3,
+                            "httpGet": {
+                                "path": "/ready",
+                                "port": 8181,
+                                "scheme": "HTTP"
+                            },
+                            "periodSeconds": 10,
+                            "successThreshold": 1,
+                            "timeoutSeconds": 1
+                        },
+                        "resources": {
+                            "limits": {
+                                "memory": "170Mi"
+                            },
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "70Mi"
+                            }
+                        },
+                        "securityContext": {
+                            "allowPrivilegeEscalation": false,
+                            "capabilities": {
+                                "add": [
+                                    "NET_BIND_SERVICE"
+                                ],
+                                "drop": [
+                                    "ALL"
+                                ]
+                            },
+                            "readOnlyRootFilesystem": true
+                        },
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/etc/coredns",
+                                "name": "config-volume",
+                                "readOnly": true
+                            },
+                            {
+                                "mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+                                "name": "kube-api-access-4fsnw",
+                                "readOnly": true
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "Default",
+                "enableServiceLinks": true,
+                "nodeName": "kind-control-plane",
+                "nodeSelector": {
+                    "kubernetes.io/os": "linux"
+                },
+                "preemptionPolicy": "PreemptLowerPriority",
+                "priority": 2000000000,
+                "priorityClassName": "system-cluster-critical",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "serviceAccount": "coredns",
+                "serviceAccountName": "coredns",
+                "terminationGracePeriodSeconds": 30,
+                "tolerations": [
+                    {
+                        "key": "CriticalAddonsOnly",
+                        "operator": "Exists"
+                    },
+                    {
+                        "effect": "NoSchedule",
+                        "key": "node-role.kubernetes.io/control-plane"
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/not-ready",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    },
+                    {
+                        "effect": "NoExecute",
+                        "key": "node.kubernetes.io/unreachable",
+                        "operator": "Exists",
+                        "tolerationSeconds": 300
+                    }
+                ],
+                "volumes": [
+                    {
+                        "configMap": {
+                            "defaultMode": 420,
+                            "items": [
+                                {
+                                    "key": "Corefile",
+                                    "path": "Corefile"
+                                }
+                            ],
+                            "name": "coredns"
+                        },
+                        "name": "config-volume"
+                    },
+                    {
+                        "name": "kube-api-access-4fsnw",
+                        "projected": {
+                            "defaultMode": 420,
+                            "sources": [
+                                {
+                                    "serviceAccountToken": {
+                                        "expirationSeconds": 3607,
+                                        "path": "token"
+                                    }
+                                },
+                                {
+                                    "configMap": {
+                                        "items": [
+                                            {
+                                                "key": "ca.crt",
+                                                "path": "ca.crt"
+                                            }
+                                        ],
+                                        "name": "kube-root-ca.crt"
+                                    }
+                                },
+                                {
+                                    "downwardAPI": {
+                                        "items": [
+                                            {
+                                                "fieldRef": {
+                                                    "apiVersion": "v1",
+                                                    "fieldPath": "metadata.namespace"
+                                                },
+                                                "path": "namespace"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-04-22T12:00:11Z",
+                        "status": "True",
+                        "type": "PodReadyToStartContainers"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-04-22T12:00:09Z",
+                        "status": "True",
+                        "type": "Initialized"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-04-22T12:00:11Z",
+                        "status": "True",
+                        "type": "Ready"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-04-22T12:00:11Z",
+                        "status": "True",
+                        "type": "ContainersReady"
+                    },
+                    {
+                        "lastProbeTime": null,
+                        "lastTransitionTime": "2026-04-22T12:00:09Z",
+                        "status": "True",
+                        "type": "PodScheduled"
+                    }
+                ],
+                "containerStatuses": [
+                    {
+                        "containerID": "containerd://1618229d9d17134662ba462a091719fe9ec9b6d9d0c8158a702ebca3a7a5797b",
+                        "image": "registry.k8s.io/coredns/coredns:v1.11.1",
+                        "imageID": "sha256:cbb01a7bd410dc08ba382018ab909a674fb0e48687f0c00797ed5bc34fcc6bb4",
+                        "lastState": {},
+                        "name": "coredns",
+                        "ready": true,
+                        "restartCount": 0,
+                        "started": true,
+                        "state": {
+                            "running": {
+                                "startedAt": "2026-04-22T12:00:10Z"
+                            }
+                        }
+                    }
+                ],
+                "hostIP": "172.18.0.2",
+                "hostIPs": [
+                    {
+                        "ip": "172.18.0.2"
+                    }
+                ],
+                "phase": "Running",
+                "podIP": "10.244.0.3",
+                "podIPs": [
+                    {
+                        "ip": "10.244.0.3"
+                    }
+                ],
+                "qosClass": "Burstable",
+                "startTime": "2026-04-22T12:00:09Z"
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": ""
+    }
+}
+EOF
+fi

--- a/tests/cloud/kubernetes/nodeusage.robot
+++ b/tests/cloud/kubernetes/nodeusage.robot
@@ -1,0 +1,47 @@
+*** Settings ***
+Documentation       Cloud Kubernetes kubectl node-usage
+
+Resource            ${CURDIR}${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Ctn Generic Suite Setup
+Suite Teardown      Ctn Generic Suite Teardown
+Test Timeout        120s
+
+
+*** Variables ***
+${CMD}      ${CENTREON_PLUGINS}
+...         --plugin=cloud::kubernetes::plugin
+...         --mode=node-usage
+...         --custommode=kubectl
+...         --command=${CURDIR}${/}kubectl_bin${/}kubectl
+
+
+*** Test Cases ***
+Node Usage ${tc}
+    [Tags]    cloud    kubernetes
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extraoptions}
+
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:
+    ...    tc
+    ...    extraoptions
+    ...    expected_result
+    ...    --
+    ...    1
+    ...    ${EMPTY}
+    ...    OK: Node 'kind-control-plane' CPU requests: 1.25% (0.1/8), Memory requests: 0.22% (70.00MB/31.07GB), Memory limits: 0.53% (170.00MB/31.07GB), Pods allocation: 0.91% (1/110) | 'kind-control-plane#cpu.requests.percentage'=1.25%;;;0;100 'kind-control-plane#memory.requests.percentage'=0.22%;;;0;100 'kind-control-plane#memory.limits.percentage'=0.53%;;;0;100 'kind-control-plane#pods.allocation.percentage'=0.91%;;;0;100
+    ...    2
+    ...    --include-status='unknown'
+    ...    UNKNOWN: No Pods found.
+    ...    3
+    ...    --exclude-status='running'
+    ...    UNKNOWN: No Pods found.
+    ...    4
+    ...    --include-name='none'
+    ...    UNKNOWN: No Nodes found.
+    ...    5
+    ...    --exclude-name='kind-control-plane'
+    ...    UNKNOWN: No Nodes found.


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

Plugin(cloud::kubernetes) - Mode(node-usage): CPU/Memory requests inflated due to non-Running and unscheduled pods included in allocation calculation

**Fixes** # CTOR-2252

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 | 🔍 Quality Issues: 1 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added File::HomeDir package dependencies to Debian and RPM packaging

**🔧 Refactors**
* Replaced numeric counter constants with named CENTREON constants in nodeusage

**📚 Documentation**
* Updated copyright header year to 2026-Present in nodeusage.pm


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107367052?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->