### PR TITLE
enh(snmp_standard::mode::interface) Implement locking when accessing the cache

### DIFF
--- a/.github/scripts/fatpack-plugins.pl
+++ b/.github/scripts/fatpack-plugins.pl
@@ -106,6 +106,7 @@ foreach my $plugin (@plugins) {
             'centreon/plugins/perfdata.pm',
             'centreon/plugins/script.pm',
             'centreon/plugins/statefile.pm',
+            'centreon/plugins/lockfile.pm',
             'centreon/plugins/values.pm',
             'centreon/plugins/backend/http/curl.pm',
             'centreon/plugins/backend/http/curlconstants.pm',

--- a/packaging/centreon-plugin-Applications-Commvault-Commserve-Restapi/pkg.json
+++ b/packaging/centreon-plugin-Applications-Commvault-Commserve-Restapi/pkg.json
@@ -4,7 +4,6 @@
     "plugin_name": "centreon_commvault_commserve_restapi.pl",
     "files": [
         "centreon/plugins/script_custom.pm",
-        "centreon/plugins/lockfile.pm",
         "apps/backup/commvault/commserve/restapi/"
     ]
 }

--- a/src/centreon/plugins/lockfile.pm
+++ b/src/centreon/plugins/lockfile.pm
@@ -53,13 +53,17 @@ sub check_options {
 
     $self->{option_results} = $options{option_results};
 
-    $self->{output}->exit_options(short_msg => "Missing lock filename !")
-         unless $self->{option_results}->{lockfile};
+    $self->{option_results}->{lockfile} //= 'global.lck';
 
     $self->{output}->exit_options(short_msg => "Missing lockfile_dir !")
          unless $self->{option_results}->{lockfile_dir};
 }
 
+sub set_lockfile_name {
+    my ($self, $name) = @_;
+
+    $self->{option_results}->{lockfile} = $name;
+}
 
 sub try_lock {
     my ($self, %options) = @_;
@@ -69,6 +73,8 @@ sub try_lock {
             if $self->{output};
         return 0;
     }
+
+    $self->{option_results}->{lockfile} = $options{lockfile} if defined $options{lockfile};
 
     $self->{filename} = $self->{option_results}->{lockfile_dir} . '/' . $self->{option_results}->{lockfile};
 
@@ -208,8 +214,6 @@ Creates a new instance of the C<lockfile> object.
 
 =back
 
-=back
-
 =head2 try_lock
 
     $obj->try_lock();
@@ -219,6 +223,18 @@ Try to acquire a lock by creating a lock file. If the lock file already exists, 
 =over 4
 
 =item * C<%options> - A hash of options.
+
+=back
+
+=head2 set_lockfile_name
+
+    $obj->set_lockfile_name($name);
+
+Set lock file name to use.
+
+=over 4
+
+=item * C<$name> - Lock file name to use ( default is C<global.lck> )
 
 =back
 

--- a/src/centreon/plugins/statefile.pm
+++ b/src/centreon/plugins/statefile.pm
@@ -281,8 +281,19 @@ sub slurp {
     return $content;
 }
 
+sub read_from {
+    my ($self, %options) = @_;
+
+    if ($options{datas}) {
+        $self->{datas} = $options{datas};
+        return
+    }
+    $self->read(%options);
+}
+
 sub read {
     my ($self, %options) = @_;
+
     $self->{statefile_suffix} = defined($options{statefile_suffix}) ? $options{statefile_suffix} : $self->{statefile_suffix};
     $self->{statefile_dir} = defined($options{statefile_dir}) ? $options{statefile_dir} : $self->{statefile_dir};
     $self->{statefile} = defined($options{statefile}) ? $options{statefile} . $self->{statefile_suffix} : $self->{statefile};
@@ -423,9 +434,7 @@ sub write {
             $serialized,
             $self->{memexpiration}
         );
-        if (defined($self->{memcached}->errstr) && $self->{memcached}->errstr =~ /^SUCCESS$/i) {
-            return ;
-        }
+        return if defined($self->{memcached}->errstr) && $self->{memcached}->errstr =~ /^SUCCESS$/i;
     }
     if (defined($self->{redis_cnx})) {
         return if (defined($self->{redis_cnx}->set(
@@ -434,9 +443,17 @@ sub write {
             'EX', $self->{memexpiration}))
         );
     }
-    open FILE, '>', $self->{statefile_dir} . '/' . $self->{statefile};
-    print FILE $serialized;
-    close FILE;
+
+    # We write data to a temporary file to ensure that other plugin instances can access a valid cache during the write operation
+    my $filename = $self->{statefile_dir} . '/' . $self->{statefile};
+    if (open(my $file, '>', "$filename.tmp")) {
+        print $file $serialized;
+        $self->{output}->add_option_msg(short_msg => "Cannot close or rename statefile '$filename.tmp' to '$filename': $!")
+            unless close($file) && rename ("$filename.tmp", $filename);
+
+    } else {
+        $self->{output}->add_option_msg(short_msg => "Cannot write statefile '$filename': $!");
+    }
 }
 
 sub remove_file{

--- a/src/centreon/plugins/templates/counter.pm
+++ b/src/centreon/plugins/templates/counter.pm
@@ -129,7 +129,7 @@ sub new {
         'list-counters'           => { name => 'list_counters' }
     });
     $self->{statefile_value} = undef;
-    if (defined($options{statefile}) && $options{statefile}) {
+    if ($options{statefile}) {
         centreon::plugins::misc::mymodule_load(
             output => $self->{output},
             module => 'centreon::plugins::statefile',
@@ -249,9 +249,7 @@ sub check_options {
 
     $self->change_macros(macros => $change_macros_opt) if (scalar(@$change_macros_opt) > 0);
 
-    if (defined($self->{statefile_value})) {
-        $self->{statefile_value}->check_options(%options);
-    }
+    $self->{statefile_value}->check_options(%options) if $self->{statefile_value};
 }
 
 sub run_global {

--- a/src/snmp_standard/mode/interfaces.pm
+++ b/src/snmp_standard/mode/interfaces.pm
@@ -25,7 +25,8 @@ use base qw(centreon::plugins::templates::counter);
 use strict;
 use warnings;
 use centreon::plugins::statefile;
-use Digest::MD5 qw(md5_hex);
+use centreon::plugins::lockfile;
+use Digest::SHA qw(sha256_hex);
 use Safe;
 use File::Copy qw(copy);
 use centreon::plugins::misc qw(is_empty);
@@ -1040,6 +1041,7 @@ sub new {
         'force-counters32'         => { name => 'force_counters32' },
         'force-counters64'         => { name => 'force_counters64' },
         'map-speed-dsl:s@'         => { name => 'map_speed_dsl' },
+        'no-cache-lock'            => { name => 'no_cache_lock' },
         'trace'                    => { name => 'trace' }
     });
     if ($self->{no_traffic} == 0) {
@@ -1071,6 +1073,7 @@ sub new {
     }
 
     $self->{statefile_cache} = centreon::plugins::statefile->new(%options);
+    $self->{lockfile_cache} = centreon::plugins::lockfile->new(%options);
 
     $self->{safe} = Safe->new();
     $self->{safe}->share('$assign_var');
@@ -1087,6 +1090,7 @@ sub check_options {
     $self->check_oids_label();
 
     $self->{statefile_cache}->check_options(%options);
+    $self->{lockfile_cache}->check_options(%options);
     if (defined($self->{option_results}->{add_traffic})) {
         $self->{option_results}->{units_traffic} = 'percent_delta' if (is_empty($self->{option_results}->{units_traffic}) || $self->{option_results}->{units_traffic} eq '%');
         $self->{option_results}->{units_traffic} = 'bps' if ($self->{option_results}->{units_traffic} eq 'absolute'); # compat
@@ -1203,7 +1207,7 @@ sub reload_get_simple {
 }
 
 sub reload_cache {
-    my ($self) = @_;
+    my ($self, %options) = @_;
 
     my $datas = {};
     $datas->{oid_filter} = $self->{option_results}->{oid_filter};
@@ -1223,7 +1227,6 @@ sub reload_cache {
         ($func = $self->can($self->{oids_label}->{ $self->{option_results}->{oid_extra_display} }->{get}))) {
         $func->($self, snmp_get => $snmp_get, name => $self->{option_results}->{oid_extra_display});
     }
-
     my $result = $self->{snmp}->get_multiple_table(oids => [ values %$snmp_get ]);
 
     $func = $self->can($self->{oids_label}->{ $self->{option_results}->{oid_filter} }->{cache});
@@ -1233,10 +1236,7 @@ sub reload_cache {
         $custom->($self, datas => $datas);
     }
 
-    if (scalar(@{$datas->{all_ids}}) <= 0) {
-        $self->{output}->add_option_msg(short_msg => "Can't construct cache...");
-        $self->{output}->option_exit();
-    }
+    $self->{output}->option_exit(short_msg => "Can't construct cache...") unless @{$datas->{all_ids}};
 
     if ($self->{option_results}->{oid_filter} ne $self->{option_results}->{oid_display}) {
         $func = $self->can($self->{oids_label}->{$self->{option_results}->{oid_display}}->{cache});
@@ -1248,7 +1248,9 @@ sub reload_cache {
         $func->($self, result => $result, datas => $datas, name => $self->{option_results}->{oid_extra_display});
     }
 
-    $self->{statefile_cache}->write(data => $datas);
+    $self->{statefile_cache}->write(data => $datas) unless %options && $options{do_not_write};
+
+    return $datas;
 }
 
 sub add_selected_interface {
@@ -1257,28 +1259,36 @@ sub add_selected_interface {
     $self->{int}->{$options{id}} = { display => $self->get_display_value(id => $options{id}), extra_display => '' };
     if (defined($self->{option_results}->{oid_extra_display})) {
         my $name = $self->{statefile_cache}->get(name => $self->{option_results}->{oid_extra_display} . '_' . $options{id});
-        $self->{int}->{$options{id}}->{extra_display} = ' [ ' . (defined($name) ? $name : '') . ' ]';
+        $self->{int}->{$options{id}}->{extra_display} = ' [ ' . ($name // '') . ' ]';
     }
 }
 
 sub get_selection {
     my ($self, %options) = @_;
 
+    my $file_name = 'cache_snmpstandard_' . $self->{snmp}->get_hostname() . '_' . $self->{snmp}->get_port() . '_' . $self->{mode};
+
+    # Lock file have same name that statfile with .lck extension
+    my $have_lock = $self->{option_results}->{no_cache_lock} || $self->{lockfile_cache}->try_lock( lockfile => $file_name.'.lck' );
+
     # init cache file
-    my $has_cache_file = $self->{statefile_cache}->read(statefile => 'cache_snmpstandard_' . $self->{snmp}->get_hostname() . '_' . $self->{snmp}->get_port() . '_' . $self->{mode});
-    if (defined($self->{option_results}->{show_cache})) {
-        $self->{output}->add_option_msg(long_msg => $self->{statefile_cache}->get_string_content());
-        $self->{output}->option_exit();
-    }
+    my $has_cache_file = $self->{statefile_cache}->read(statefile => $file_name);
+    $self->{output}->option_exit(long_msg => $self->{statefile_cache}->get_string_content())
+        if defined $self->{option_results}->{show_cache};
 
     $self->{int} = {};
     my $timestamp_cache = $self->{statefile_cache}->get(name => 'last_timestamp');
 
     if ($has_cache_file == 0 || $self->check_oids_options_change() ||
-        !defined($timestamp_cache) || ((time() - $timestamp_cache) > (($self->{option_results}->{reload_cache_time}) * 60))) {
-        $self->reload_cache();
-        $self->{statefile_cache}->read();
+        !defined($timestamp_cache) || ($have_lock && ((time() - $timestamp_cache) > (($self->{option_results}->{reload_cache_time}) * 60)))) {
+        # We retrieve new data when:
+        # - the cache is empty
+        # - the cache is expired and we have the lock
+        # We only rewrite the cache when we hold the lock
+        my $datas = $self->reload_cache(do_not_write => !$have_lock);
+        $self->{statefile_cache}->read_from(datas => $datas);
     }
+    $self->{lockfile_cache}->unlock();
 
     my $all_ids = $self->{statefile_cache}->get(name => 'all_ids');
     if (!defined($self->{option_results}->{use_name}) && defined($self->{option_results}->{interface})
@@ -1312,7 +1322,7 @@ sub get_selection {
         $self->{map_speed_dsl} = [];
         foreach (@{$self->{option_results}->{map_speed_dsl}}) {
             my ($src, $dst) = split /,/;
-            next if (is_empty($dst) || is_empty($src));
+            next if is_empty($dst) || is_empty($src);
             push @{$self->{map_speed_dsl}}, { src => $src, dst => $dst };
         }
         foreach (@{$all_ids}) {
@@ -1324,10 +1334,7 @@ sub get_selection {
         }
     }
 
-    if (scalar(keys %{$self->{int}}) <= 0) {
-        $self->{output}->add_option_msg(short_msg => "No entry found (maybe you should reload cache file)");
-        $self->{output}->option_exit();
-    }
+    $self->{output}->option_exit(short_msg => "No entry found (maybe you should reload cache file)") unless keys %{$self->{int}};
 }
 
 sub load_status {
@@ -1466,9 +1473,7 @@ sub manage_selection {
     }
 
     $self->{cache_name} = 'snmpstandard_' . $options{snmp}->get_hostname() . '_' . $options{snmp}->get_port() . '_' . $self->{mode} . '_' .
-                          (defined($self->{option_results}->{filter_counters}) ? md5_hex($self->{option_results}->{filter_counters}) : md5_hex('all')) . '_' .
-                          (defined($self->{option_results}->{interface}) ? md5_hex($self->{option_results}->{interface}) : md5_hex('all')) . '_' .
-                          md5_hex($self->{checking});
+                          sha256_hex(($self->{option_results}->{filter_counters} // 'all') . '_' . sha256_hex($self->{option_results}->{interface} // 'all') . '_' .  $self->{checking});
 }
 
 sub add_result_global {
@@ -1967,6 +1972,10 @@ Example: adding --display-transform-src='eth' --display-transform-dst='ens'  wil
 =item B<--show-cache>
 
 Display cache interface data.
+
+=item B<--no-cache-lock>
+
+Set to disable locking when accessing cache.
 
 =back
 


### PR DESCRIPTION
## Description

Implement lockfile into interfaces.pm

**Fixes** # CTOR-2298

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🚀 New Features**
* Added new centreon::plugins::lockfile module for lockfile management.

**⚡ Enhancements**
* Integrated lockfile handling into snmp_standard::mode::interfaces for cache access.
* Included lockfile.pm in fatpack packaging common_files for bundled plugins.

**🔧 Refactors**
* Removed explicit lockfile entry from plugin pkg.json files list.
* Replaced Digest::MD5 usage with Digest::SHA sha256_hex in interfaces.
* Adjusted statefile initialization condition in templates::counter for clarity.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107801083?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->