### PR TITLE
fix(apps::backup::veeam::local): fixed regression on job-status mode

### DIFF
--- a/src/apps/backup/veeam/local/mode/jobstatus.pm
+++ b/src/apps/backup/veeam/local/mode/jobstatus.pm
@@ -256,8 +256,8 @@ sub manage_selection {
             is_continuous => $job->{isContinuous},
             is_running => $job->{isRunning} =~ /True|1/ ? 1 : ($session->{creationTimeUTC} !~ /[0-9]/ ? 2 : 0),
             scheduled => $job->{scheduled} =~ /True|1/i ? 1 : 0, 
-            status => defined($session->{result}) && $session->{result} ne '' ?
-                $session->{result} : '-'
+            status => defined($session->{result}) && $session->{result} ne '' && $job_result->{ $session->{result} } ?
+                $job_result->{ $session->{result} } : '-'
         };
         $self->{global}->{total}++;
     }


### PR DESCRIPTION
Refs: CTOR-2269
Fixing regression reported here https://github.com/centreon/centreon-nsclient-build/issues/109

Refs: CTOR-2269

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added veeam-version option and improved PowerShell command handling 🤖 🚭 

**🐛 Bugfixes**
* Fixed regression in job-status mode causing incorrect job status handling


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107518591?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->