### PR TITLE
fix(apps::vmware::vsphere8): can now recover from a corrupted cache

### DIFF
--- a/src/apps/vmware/vsphere8/custom/api.pm
+++ b/src/apps/vmware/vsphere8/custom/api.pm
@@ -293,7 +293,10 @@ sub get_all_acq_specs {
 
     # store it in the cache for future runs
     $self->{acq_specs_cache}->write(data => { updated => time(), acq_specs => $self->{all_acq_specs} });
-    return $self->{all_acq_specs};
+    # in some cases the statefile was corrupted and the plugin was stuck
+    # only return a result if it looks ok, else we store an empty array
+    return $self->{all_acq_specs} if ref($self->{all_acq_specs} = 'ARRAY') && @{$self->{all_acq_specs}};
+    $self->{all_acq_specs} = [];
 }
 
 sub compose_type_from_rsrc_id {

--- a/src/apps/vmware/vsphere8/custom/api.pm
+++ b/src/apps/vmware/vsphere8/custom/api.pm
@@ -295,8 +295,8 @@ sub get_all_acq_specs {
     $self->{acq_specs_cache}->write(data => { updated => time(), acq_specs => $self->{all_acq_specs} });
     # in some cases the statefile was corrupted and the plugin was stuck
     # only return a result if it looks ok, else we store an empty array
-    return $self->{all_acq_specs} if ref($self->{all_acq_specs} = 'ARRAY') && @{$self->{all_acq_specs}};
-    $self->{all_acq_specs} = [];
+    $self->{all_acq_specs} = [] unless ref($self->{all_acq_specs}) eq 'ARRAY' && @{$self->{all_acq_specs}};
+    return $self->{all_acq_specs};
 }
 
 sub compose_type_from_rsrc_id {


### PR DESCRIPTION
## Description

In some cases the statefile was corrupted and the plugin was stuck.

Issue exposed here https://thewatch.centreon.com/infra-monitoring-data-collection-6/esx-8-api-get-esx-stats-function-failed-to-retrieve-stats-5551

Refs: CTOR-2291



## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**🐛 Bugfixes**
* Recovered from corrupted cache by forcing token re-authentication and cleanup


<sup>[More info](https://app.aikido.dev/featurebranch/scan/108919600?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->