### PR TITLE
enh(rust-plugins): Display floats with only 2 decimal

### DIFF
--- a/rust-plugins/src/output/mod.rs
+++ b/rust-plugins/src/output/mod.rs
@@ -208,7 +208,7 @@ impl<'a> OutputFormatter<'a> {
         for m in self.metrics.iter() {
             if let Some(status) = m.status {
                 if status.is_worse_than(self.status) {
-                    v.push(std::format!("{} is {}{}", m.name, m.value, m.uom));
+                    v.push(std::format!("{} is {}{}", m.name, float_string(&m.value), m.uom));
                 }
             }
         }

--- a/tests/os/linux/snmp/swap.robot
+++ b/tests/os/linux/snmp/swap.robot
@@ -130,10 +130,10 @@ cgs-swap ${tc}
     ...    CRITICAL: swap.usage.bytes is 499420B | swap.usage.bytes=499420B;;0.1;0; swap.usage.percent=49.97%;;;0;100
     ...    4
     ...    --warning-swap-prct=0.1
-    ...    WARNING: swap.usage.percent is 49.97098317023874% | swap.usage.bytes=499420B;;;0; swap.usage.percent=49.97%;0.1;;0;100
+    ...    WARNING: swap.usage.percent is 49.97% | swap.usage.bytes=499420B;;;0; swap.usage.percent=49.97%;0.1;;0;100
     ...    5
     ...    --critical-swap-prct=0.1
-    ...    CRITICAL: swap.usage.percent is 49.97098317023874% | swap.usage.bytes=499420B;;;0; swap.usage.percent=49.97%;;0.1;0;100
+    ...    CRITICAL: swap.usage.percent is 49.97% | swap.usage.bytes=499420B;;;0; swap.usage.percent=49.97%;;0.1;0;100
 
 
 cgs-swap-64 ${tc}
@@ -165,8 +165,8 @@ cgs-swap-64 ${tc}
     ...    CRITICAL: swap.usage.bytes is 499420B | swap.usage.bytes=499420B;;0.1;0; swap.usage.percent=49.97%;;;0;100
     ...    4
     ...    --warning-swap-prct=0.1
-    ...    WARNING: swap.usage.percent is 49.97098317023874% | swap.usage.bytes=499420B;;;0; swap.usage.percent=49.97%;0.1;;0;100
+    ...    WARNING: swap.usage.percent is 49.97% | swap.usage.bytes=499420B;;;0; swap.usage.percent=49.97%;0.1;;0;100
     ...    5
     ...    --critical-swap-prct=0.1
-    ...    CRITICAL: swap.usage.percent is 49.97098317023874% | swap.usage.bytes=499420B;;;0; swap.usage.percent=49.97%;;0.1;0;100
+    ...    CRITICAL: swap.usage.percent is 49.97% | swap.usage.bytes=499420B;;;0; swap.usage.percent=49.97%;;0.1;0;100
 


### PR DESCRIPTION
## Description

Rust-plugins - Afficher les float avec seulement 2 chiffres après la virgule dans l'output

**Fixes** # CTOR-2256

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Formatted floating-point metric values to two decimals in outputs


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107827119?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->