### PR TITLE
enh(hooks): enhance pre-commit hooks

### DIFF
--- a/.githooks/pre-commit.d/20_plugins.sh
+++ b/.githooks/pre-commit.d/20_plugins.sh
@@ -123,7 +123,7 @@ for file in "${committed_files[@]}"; do
             ;;
     esac
 done
-test -f "$tmpfile" && rm "$tmpfile"
+rm -f "$tmpfile"
 
 (( errors > 0 )) && fatal "$errors errors found in pre-commit checks"
 info "All plugins pre-commit checks passed"

--- a/.githooks/pre-commit.d/20_plugins.sh
+++ b/.githooks/pre-commit.d/20_plugins.sh
@@ -27,7 +27,7 @@ function fatal() {
     exit 1
 }
 
-function check_tabs() {
+function check_tabs_crlf() {
     local file="$1"
     info "--> Checking BASH indentation"
     grep -P '^\t' "$file" >/dev/null 2>&1 && warning "--> File $file contains leading tab character (suspected bad indentation)."
@@ -88,7 +88,7 @@ for file in "${committed_files[@]}"; do
                 error "Spellcheck error on file $file"
                 tail -n 2 $tmpfile | head -n 1 | sed 's/^[^:]*:/Invalid words:/' 2>/dev/null
             fi
-            check_tabs "$file"
+            check_tabs_crlf "$file"
             check_constants "$file"
             check_md5 "$file"
             ;;
@@ -102,7 +102,7 @@ for file in "${committed_files[@]}"; do
             ;;
         robot)
             info "--> Checking robot format"
-            check_tabs "$file"
+            check_tabs_crlf "$file"
             cp "$file" "$tmpfile" && $robocop_path format "$tmpfile" >/dev/null 2>&1
             diff -q "$file" "$tmpfile" >/dev/null 2>&1
             rc=$?
@@ -111,12 +111,12 @@ for file in "${committed_files[@]}"; do
             fi
             ;;
         sh)
-            check_tabs "$file"
+            check_tabs_crlf "$file"
           ;;
         json)
             info "--> Checking JSON validity"
             jq '' "$file" >/dev/null 2>&1 || error "JSON file $file is not valid"
-            check_tabs "$file"
+            check_tabs_crlf "$file"
           ;;
         *)
             info "File extension '.${file_extension}' has no checks"

--- a/.githooks/pre-commit.d/20_plugins.sh
+++ b/.githooks/pre-commit.d/20_plugins.sh
@@ -7,6 +7,7 @@ NC='\033[0m' # No Color
 
 # global errors counter
 errors=0
+tmpfile="/tmp/check$$"
 
 function info() {
     echo -e "${GREEN}INFO${NC}: $*"
@@ -30,15 +31,38 @@ function check_tabs() {
     local file="$1"
     info "--> Checking BASH indentation"
     grep -P '^\t' "$file" >/dev/null 2>&1 && warning "--> File $file contains leading tab character (suspected bad indentation)."
+    info "--> Checking carriage returns"
+    grep $'\r' "$file" >/dev/null 2>&1 && warning "--> File $file contains CRLF line terminators."
+}
+
+function check_constants() {
+    local file="$1"
+
+    info "--> Checking constants utilization"
+
+    grep -nH -- "-\(1\|2\|10\)[[:space:]]*=>[[:space:]]*1" "$file" > "$tmpfile"
+    grep -nH "\<type[[:space:]]*=>[[:space:]]*[0-9]" "$file" >> "$tmpfile"
+    if [ -s "$tmpfile" ] ; then
+        error "It seems that some counters are not using constants defined in centreon/plugins/constants.pm."
+        cat $tmpfile
+    fi
+}
+
+function check_md5() {
+    local file="$1"
+
+    info "--> Checking MD5 utilization"
+    grep -q md5_hex "$file"
+    if [ $? -eq 0 ] ; then
+        error "$file: It seems that md5_hexa is used. Use sha256_hex (with Digest::SHA) instead."
+    fi
 }
 
 jq=$(type -p jq) || fatal "Could not locate jq command"
 # Determining the robotidy command
-robotidy_path=$(type -p robocop) || robotidy_path=$(type -p robotidy) || fatal "Could not locate either robocop nor robotidy. Cannot check robot lint"
-robotidy_exe="${robotidy_path##*/}"
-info "Robot lint tool is $robotidy_exe"
-# Options depend on the use binary
-declare -A robotidy_opts=([robotidy]="-->-check --skip-keyword-call Examples:" [robocop]="check --ignore DOC02 --ignore LEN08 --ignore LEN04 --ignore DOC03 --ignore NAME07" )
+robocop_path=$(type -p robocop) || fatal "Could not locate robocop. Cannot check robot lint"
+robocop_exe="${robocop_path##*/}"
+
 # Get list of committed files
 mapfile -t committed_files < <(git diff --cached --name-only --diff-filter=ACMR)
 info "Starting plugins pre-commit hooks for ${#committed_files[@]} files"
@@ -58,8 +82,15 @@ for file in "${committed_files[@]}"; do
             grep -- '--warning-\*\|--critical-\*' "$file"  >/dev/null && error "File $file contains help that is written as --warning-* or --critical-*"
             # check spelling
             info "--> Checking that spelling in file is OK"
-            perl .github/scripts/pod_spell_check.t "$file" ./tests/resources/spellcheck/stopwords.txt >/dev/null 2>&1 || error "Spellcheck error on file $file"
+            perl .github/scripts/pod_spell_check.t "$file" ./tests/resources/spellcheck/stopwords.txt >$tmpfile 2>&1
+            rc=$?
+            if [ $rc -ne 0 ] ; then
+                error "Spellcheck error on file $file"
+                tail -n 2 $tmpfile | head -n 1 | sed 's/^[^:]*:/Invalid words:/' 2>/dev/null
+            fi
             check_tabs "$file"
+            check_constants "$file"
+            check_md5 "$file"
             ;;
         txt)
             if [[ "${file##*/}" == "stopwords.txt" ]]; then
@@ -70,9 +101,14 @@ for file in "${committed_files[@]}"; do
             fi
             ;;
         robot)
-            info "--> Checking robot lint"
-            $robotidy_path ${robotidy_opts[$robotidy_exe]} "$file" >/dev/null 2>&1 || warning "--> Robot lint errors found in $file"
+            info "--> Checking robot format"
             check_tabs "$file"
+            cp "$file" "$tmpfile" && $robocop_path format "$tmpfile" >/dev/null 2>&1
+            diff -q "$file" "$tmpfile" >/dev/null 2>&1
+            rc=$?
+            if [ $rc -ne 0 ] ; then
+                error "$file not is properly formatted, please use 'robocop format'"
+            fi
             ;;
         sh)
             check_tabs "$file"
@@ -87,5 +123,7 @@ for file in "${committed_files[@]}"; do
             ;;
     esac
 done
+test -f "$tmpfile" && rm "$tmpfile"
+
 (( errors > 0 )) && fatal "$errors errors found in pre-commit checks"
 info "All plugins pre-commit checks passed"


### PR DESCRIPTION
- Check robot files with robocop format
- Check that perl files use constants and don't use md5_hex
- Check files carriage returns
- Display invalid words in spell check results

**Fixes** # CTOR-2271

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added robocop formatting check for robot files with diff
* Added Perl checks for constants usage and forbidden md5_hex
* Added checks for leading tabs and CRLF carriage returns
* Displayed invalid words from spellcheck output on failures
* Introduced temporary file handling and removed it after checks


<sup>[More info](https://app.aikido.dev/featurebranch/scan/107991705?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->