### PR TITLE
doc(apps/vmware/vsphere8/vcsa/mode/health): fixed VCSA-Health options default value CTOR-2172

### DIFF
--- a/src/apps/vmware/vsphere8/vcsa/mode/health.pm
+++ b/src/apps/vmware/vsphere8/vcsa/mode/health.pm
@@ -125,7 +125,7 @@ C<storage>, C<swap>, C<system>.
 =item B<--warning-status>
 
 Define the condition to match for the status to be WARNING. Available macros: C<%(color)> and C<%(health_check)>.
-Default: C<%{state} ne "green">
+Default: C<%{color} ne "green">
 
 Color can be:
 
@@ -148,8 +148,8 @@ View the details in the Health Messages pane.
 
 =item B<--critical-status>
 
-Define the condition to match for the status to be WARNING. Available macros: C<%(color)> and C<%(health_check)>.
-Default: C<%{state} eq "red">
+Define the condition to match for the status to be CRITICAL. Available macros: C<%(color)> and C<%(health_check)>.
+Default: C<%{color} eq "red">
 
 Status colors are detailed in C<--warning-status> option.
 


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

fixed VCSA-Health options default value 

**Fixes** # (issue)
CTOR-2172

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Documentation

## How this pull request can be tested ?

N/A

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Initialized include/exclude option defaults to empty strings in constructor

**📚 Documentation**
* Corrected warning/critical default expressions and status descriptions in POD


<sup>[More info](https://app.aikido.dev/featurebranch/scan/109955784?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->