### PR TITLE
Specify --snmp-errors-exit option accepts OK as possible value CTOR-2253

### DIFF
--- a/src/centreon/plugins/snmp.pm
+++ b/src/centreon/plugins/snmp.pm
@@ -1264,7 +1264,7 @@ Security engine ID, given as a hexadecimal string.
 =item B<--snmp-errors-exit>
 
 Expected status in case of SNMP error or timeout.
-Possible values are warning, critical and unknown (default).
+Possible values are ok, warning, critical and unknown (default).
 
 =item B<--snmp-tls-transport>
 


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

Specify --snmp-errors-exit option accepts OK as possible value

**Fixes** # (issue)
CTOR-2253

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Documentation

## How this pull request can be tested ?

```
/usr/lib/centreon/plugins//centreon_generic_snmp.pl --plugin=apps::protocols::snmp::plugin --mode string-value --hostname= *************--snmp-version='3' --snmp-community='public' --output-ignore-perfdata --snmp-errors-exit=ok --snmp-username hx_sup --authprotocol SHA --authpassphrase *************--privprotocol AES --privpassphrase " *************" --oid-table .1.3.6.1.4.1.25597.11.5.1.7 --format-ok %{details_ok}
OK: SNMP Table Request: Timeout
```

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added --snmp-errors-exit CLI option with default 'unknown' value
* Validated --snmp-errors-exit value and emitted explicit error on invalid


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110313962?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->