### PR TITLE
enh(ci): add bookworm-arm64 and trixie-arm64 CPAN libraries packaging

### DIFF
--- a/.github/docker/packaging/Dockerfile.packaging-plugins-java-alma10
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-java-alma10
@@ -11,10 +11,10 @@ dnf install -y \
   zstd
 
 cd /usr/local/src
-wget https://dlcdn.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz
-tar zxf apache-maven-3.8.9-bin.tar.gz
-ln -s /usr/local/src/apache-maven-3.8.9/bin/mvn /usr/bin/mvn
-rm -f apache-maven-3.8.9-bin.tar.gz
+wget https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
+tar zxf apache-maven-3.9.15-bin.tar.gz
+ln -s /usr/local/src/apache-maven-3.9.15/bin/mvn /usr/bin/mvn
+rm -f apache-maven-3.9.15-bin.tar.gz
 
 echo '[goreleaser]
 name=GoReleaser

--- a/.github/docker/packaging/Dockerfile.packaging-plugins-java-alma8
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-java-alma8
@@ -11,10 +11,10 @@ dnf install -y \
   zstd
 
 cd /usr/local/src
-wget https://dlcdn.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz
-tar zxf apache-maven-3.8.9-bin.tar.gz
-ln -s /usr/local/src/apache-maven-3.8.9/bin/mvn /usr/bin/mvn
-rm -f apache-maven-3.8.9-bin.tar.gz
+wget https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
+tar zxf apache-maven-3.9.15-bin.tar.gz
+ln -s /usr/local/src/apache-maven-3.9.15/bin/mvn /usr/bin/mvn
+rm -f apache-maven-3.9.15-bin.tar.gz
 
 echo '[goreleaser]
 name=GoReleaser

--- a/.github/docker/packaging/Dockerfile.packaging-plugins-java-alma9
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-java-alma9
@@ -11,10 +11,10 @@ dnf install -y \
   zstd
 
 cd /usr/local/src
-wget https://dlcdn.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz
-tar zxf apache-maven-3.8.9-bin.tar.gz
-ln -s /usr/local/src/apache-maven-3.8.9/bin/mvn /usr/bin/mvn
-rm -f apache-maven-3.8.9-bin.tar.gz
+wget https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
+tar zxf apache-maven-3.9.15-bin.tar.gz
+ln -s /usr/local/src/apache-maven-3.9.15/bin/mvn /usr/bin/mvn
+rm -f apache-maven-3.9.15-bin.tar.gz
 
 echo '[goreleaser]
 name=GoReleaser

--- a/.github/docker/packaging/Dockerfile.packaging-plugins-java-jammy
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-java-jammy
@@ -13,10 +13,10 @@ apt-get install -y \
   zstd
 
 cd /usr/local/src
-wget https://dlcdn.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz
-tar zxf apache-maven-3.8.9-bin.tar.gz
-ln -s /usr/local/src/apache-maven-3.8.9/bin/mvn /usr/bin/mvn
-rm -f apache-maven-3.8.9-bin.tar.gz
+wget https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
+tar zxf apache-maven-3.9.15-bin.tar.gz
+ln -s /usr/local/src/apache-maven-3.9.15/bin/mvn /usr/bin/mvn
+rm -f apache-maven-3.9.15-bin.tar.gz
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 

--- a/.github/docker/packaging/Dockerfile.packaging-plugins-java-noble
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-java-noble
@@ -13,10 +13,10 @@ apt-get install -y \
   zstd
 
 cd /usr/local/src
-wget https://dlcdn.apache.org/maven/maven-3/3.8.9/binaries/apache-maven-3.8.9-bin.tar.gz
-tar zxf apache-maven-3.8.9-bin.tar.gz
-ln -s /usr/local/src/apache-maven-3.8.9/bin/mvn /usr/bin/mvn
-rm -f apache-maven-3.8.9-bin.tar.gz
+wget https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
+tar zxf apache-maven-3.9.15-bin.tar.gz
+ln -s /usr/local/src/apache-maven-3.9.15/bin/mvn /usr/bin/mvn
+rm -f apache-maven-3.9.15-bin.tar.gz
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 

--- a/.github/packaging/cpan-libraries.json
+++ b/.github/packaging/cpan-libraries.json
@@ -72,7 +72,7 @@
         "build_distribs": "el8,el9"
       },
       "deb": {
-        "build_names": "bullseye-amd64,bookworm,trixie,jammy,noble,bullseye-arm64",
+        "build_names": "bullseye-amd64,bookworm,trixie,jammy,noble,bullseye-arm64,bookworm-arm64,trixie-arm64",
         "use_dh_make_perl": "false",
         "no-auto-depends": "true",
         "deb_dependencies": "libexporter-tiny-perl libxs-install-perl"
@@ -210,7 +210,7 @@
         "revision": "3"
       },
       "deb": {
-        "build_names": "bullseye-amd64,bookworm,trixie,jammy,noble,bullseye-arm64",
+        "build_names": "bullseye-amd64,bookworm,trixie,jammy,noble,bullseye-arm64,bookworm-arm64,trixie-arm64",
         "use_dh_make_perl": "false",
         "no-auto-depends": "true",
         "deb_dependencies": "libcarp-assert-perl libdynaloader-functions-perl libexporter-tiny-perl libdevel-overloadinfo-perl libssh-4 libc6",
@@ -260,7 +260,7 @@
         "revision": "3"
       },
       "deb": {
-        "build_names": "bullseye-amd64,bookworm,trixie,jammy,noble,bullseye-arm64",
+        "build_names": "bullseye-amd64,bookworm,trixie,jammy,noble,bullseye-arm64,bookworm-arm64,trixie-arm64",
         "use_dh_make_perl": "false",
         "no-auto-depends": "true",
         "deb_dependencies": "libcarp-assert-perl libdynaloader-functions-perl libexporter-tiny-perl libdevel-overloadinfo-perl libcurl4",

--- a/.github/scripts/perl-cpan-libraries/cpan_matrix_lib.py
+++ b/.github/scripts/perl-cpan-libraries/cpan_matrix_lib.py
@@ -65,6 +65,22 @@ DEB_BUILD_NAME_INCLUDES = [
         "arch": "arm64",
         "runner_name": "ubuntu-24.04-arm",
     },
+    {
+        "build_name": "bookworm-arm64",
+        "distrib":    "bookworm",
+        "package_extension": "deb",
+        "image": "packaging-plugins-bookworm-arm64",
+        "arch": "arm64",
+        "runner_name": "ubuntu-24.04-arm",
+    },
+    {
+        "build_name": "trixie-arm64",
+        "distrib":    "trixie",
+        "package_extension": "deb",
+        "image": "packaging-plugins-trixie-arm64",
+        "arch": "arm64",
+        "runner_name": "ubuntu-24.04-arm",
+    },
 ]
 
 # ── Derived constants (single source of truth: the include lists above) ────────

--- a/.github/workflows/docker-builder-packaging-plugins.yml
+++ b/.github/workflows/docker-builder-packaging-plugins.yml
@@ -61,9 +61,15 @@ jobs:
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-bookworm
             image: packaging-plugins-bookworm
+          - runner: ubuntu-24.04-arm
+            dockerfile: packaging-plugins-bookworm
+            image: packaging-plugins-bookworm-arm64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-trixie
             image: packaging-plugins-trixie
+          - runner: ubuntu-24.04-arm
+            dockerfile: packaging-plugins-trixie
+            image: packaging-plugins-trixie-arm64
           - runner: ubuntu-24.04
             dockerfile: packaging-plugins-java-bullseye
             image: packaging-plugins-java-bullseye

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -163,6 +163,8 @@ jobs:
           - image: packaging-plugins-jammy
           - image: packaging-plugins-noble
           - image: packaging-plugins-bullseye-arm64
+          - image: packaging-plugins-bookworm-arm64
+          - image: packaging-plugins-trixie-arm64
     runs-on: ${{ contains(matrix.image, 'arm') && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     steps:
       - name: Login to Registry
@@ -539,6 +541,16 @@ jobs:
           - package_extension: deb
             image: debian:bullseye
             distrib: bullseye
+            arch: arm64
+            runner_name: ubuntu-24.04-arm
+          - package_extension: deb
+            image: debian:bookworm
+            distrib: bookworm
+            arch: arm64
+            runner_name: ubuntu-24.04-arm
+          - package_extension: deb
+            image: debian:trixie
+            distrib: trixie
             arch: arm64
             runner_name: ubuntu-24.04-arm
 


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

**JIRA: [MON-198411](https://centreon.atlassian.net/browse/MON-198411)** — relates to MON-196927 (Engine docker-compose installation script).

While working on MON-196927, the `linux/arm64` build of the `centreon-engine` bookworm Docker image had to be disabled because the engine Dockerfile installs `centreon-plugin-applications-monitoring-centreon-poller`, whose dependency `libssh-session-perl` (XS-native CPAN module `Libssh::Session`) is not produced for `bookworm-arm64` in `apt-plugins-stable`. The plugin `.deb` itself is `arch: all`, so once the native libs exist for arm64, the plugin installs cleanly.

This PR extends the existing `bullseye-arm64` packaging pattern to **bookworm-arm64** and **trixie-arm64** (anticipating the next Debian stable at no extra cost) for three CPAN libs:

- `Libssh::Session` — direct dep of centreon-poller (the immediate blocker).
- `Net::Curl` — used by many HTTP plugins.
- `Crypt::OpenSSL::AES` — used by plugins relying on AES encryption.

### Changes

1. `.github/packaging/cpan-libraries.json` — append `bookworm-arm64,trixie-arm64` to the `deb.build_names` of the three libs.
2. `.github/workflows/docker-builder-packaging-plugins.yml` — add two matrix entries (`packaging-plugins-bookworm-arm64`, `packaging-plugins-trixie-arm64`) reusing the existing bookworm/trixie Dockerfiles on the `ubuntu-24.04-arm` runner (same pattern as `bullseye-arm64`).
3. `.github/workflows/perl-cpan-libraries.yml`:
   - `get-packaging-images` matrix: include the two new arm64 images.
   - `test-packages` matrix: add bookworm/arm64 and trixie/arm64 install tests.

No changes are required to `merge-package-deb-artifacts`, `download-and-cache-deb` or `deliver-packages` — their distrib-only matrices already absorb arm64 artifacts via the per-distrib merge pattern (proven by bullseye-arm64).

**Fixes** MON-198411

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested?

### Sequencing note

\`docker-builder-packaging-plugins.yml\` and \`perl-cpan-libraries.yml\` both fire on this PR. The first push triggers them in parallel — \`perl-cpan-libraries.yml\` (job \`get-packaging-images\`) does a \`docker pull packaging-plugins-bookworm-arm64:latest\` without retry, so it will fail until the docker-builder workflow has finished pushing the new image to Harbor. After the docker-builder run is green, click **Re-run failed jobs** on the failed perl-cpan-libraries run.

### What to verify

1. \`docker-builder-packaging-plugins.yml\` — two new green matrix entries: \`packaging-plugins-bookworm-arm64\` and \`packaging-plugins-trixie-arm64\`. Both images published to the internal Harbor at \`:latest\`.
2. \`perl-cpan-libraries.yml\` — re-run after (1):
   - \`get-packaging-images\`: arm64 entries for bookworm and trixie green.
   - \`package-deb\`: 6 new green entries (bookworm-arm64 and trixie-arm64 × 3 libs).
   - \`test-packages\`: bookworm/arm64 and trixie/arm64 install OK.
3. Inspect artifacts: \`packages-deb-bookworm-arm64-*\` and \`packages-deb-trixie-arm64-*\` must contain \`libssh-session-perl_*_arm64.deb\`, \`libnet-curl-perl_*_arm64.deb\`, \`libcrypt-openssl-aes-perl_*_arm64.deb\`.
4. After merge, \`deliver-packages\` publishes for \`bookworm\` and \`trixie\` (cache merge contains arm64). Final sanity check from a \`debian:bookworm\` arm64 container:
   \`\`\`bash
   apt-get update
   apt-get install -y libssh-session-perl libnet-curl-perl libcrypt-openssl-aes-perl
   perl -MLibssh::Session -e 'print Libssh::Session->VERSION'
   \`\`\`

## Checklist

- [x] I have followed the coding style guidelines.
- [x] I have rebased my development branch on \`develop\`.
- [ ] CI tests will be re-run after the docker builder run finishes (see Sequencing note).

## Follow-up (separate ticket)

After publication of the arm64 \`.deb\`s on \`apt-plugins-stable\`, on the \`MON-196927\` branch in \`centreon-collect\`:
- Drop the \`[arch=amd64]\` constraint on the apt-plugins source list in the engine Dockerfile and remove the \`cpanm\` ARM fallback.
- Re-enable \`platforms: linux/amd64,linux/arm64\` for \`dockerize-engine-broker\` and produce engine \`.deb\`s for arm64.

[MON-198411]: https://centreon.atlassian.net/browse/MON-198411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added bookworm-arm64 and trixie-arm64 CPAN packaging, workflows, images
* Bumped Apache Maven to 3.9.15 in Java Dockerfiles


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110311654?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->