### PR TITLE
fix(ci-tests): add missing python lib for snmpsim

### DIFF
--- a/.github/docker/testing/Dockerfile.testing-plugins-alma10
+++ b/.github/docker/testing/Dockerfile.testing-plugins-alma10
@@ -22,7 +22,7 @@ dnf clean all
 dnf install -y python3.13 python3.13-pip
 pip3.13 install robotframework robotframework-examples
 # Install snmpsim
-pip3.13 install snmpsim
+pip3.13 install snmpsim pysmi
 
 dnf install -y nodejs24
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} bash -

--- a/.github/docker/testing/Dockerfile.testing-plugins-alma8
+++ b/.github/docker/testing/Dockerfile.testing-plugins-alma8
@@ -17,7 +17,7 @@ dnf clean all
 dnf install -y python3.11 python3.11-pip
 pip3.11 install robotframework robotframework-examples
 # Install snmpsim
-pip3.11 install snmpsim
+pip3.11 install snmpsim pysmi
 
 dnf module enable -y nodejs:24
 dnf install -y nodejs

--- a/.github/docker/testing/Dockerfile.testing-plugins-alma9
+++ b/.github/docker/testing/Dockerfile.testing-plugins-alma9
@@ -22,7 +22,7 @@ dnf clean all
 dnf install -y python3.11 python3.11-pip
 pip3.11 install robotframework robotframework-examples
 # Install snmpsim
-pip3.11 install snmpsim
+pip3.11 install snmpsim pysmi
 
 dnf module enable -y nodejs:24
 dnf install -y nodejs

--- a/.github/docker/testing/Dockerfile.testing-plugins-bookworm
+++ b/.github/docker/testing/Dockerfile.testing-plugins-bookworm
@@ -38,7 +38,7 @@ apt-get install -y python3-dev python3-pip
 rm -rf /usr/lib/python3.11/EXTERNALLY-MANAGED
 pip3 install robotframework robotframework-examples
 # Install snmpsim
-pip3 install snmpsim
+pip3 install snmpsim pysmi
 
 curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
 apt-get install -y nodejs

--- a/.github/docker/testing/Dockerfile.testing-plugins-bullseye
+++ b/.github/docker/testing/Dockerfile.testing-plugins-bullseye
@@ -38,7 +38,7 @@ apt-get install -y python3 python3-dev python3-pip
 rm -rf /usr/lib/python3.11/EXTERNALLY-MANAGED
 pip3 install robotframework robotframework-examples
 # Install snmpsim
-pip3 install snmpsim
+pip3 install snmpsim pysmi
 
 curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
 apt-get install -y nodejs

--- a/.github/docker/testing/Dockerfile.testing-plugins-jammy
+++ b/.github/docker/testing/Dockerfile.testing-plugins-jammy
@@ -38,7 +38,7 @@ apt-get install -y python3 python3-dev python3-pip
 rm -rf /usr/lib/python3.11/EXTERNALLY-MANAGED
 pip3 install robotframework robotframework-examples
 # Install snmpsim
-pip3 install snmpsim
+pip3 install snmpsim pysmi
 
 set -x
 curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -

--- a/.github/docker/testing/Dockerfile.testing-plugins-noble
+++ b/.github/docker/testing/Dockerfile.testing-plugins-noble
@@ -41,7 +41,7 @@ python3 -m venv .venv
 apt-get install -y python3 python3-dev python3-pip
 pip3 install robotframework robotframework-examples
 # Install snmpsim
-pip3 install snmpsim
+pip3 install snmpsim pysmi
 
 curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
 apt-get install -y nodejs

--- a/.github/docker/testing/Dockerfile.testing-plugins-trixie
+++ b/.github/docker/testing/Dockerfile.testing-plugins-trixie
@@ -41,7 +41,7 @@ python3 -m venv .venv
 apt-get install -y python3 python3-dev python3-pip
 pip3 install robotframework robotframework-examples
 # Install snmpsim
-pip3 install snmpsim
+pip3 install snmpsim pysmi
 
 curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash -
 apt-get install -y nodejs

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -258,7 +258,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: Prepare FatPacker
-        uses: shogo82148/actions-setup-perl@dea55ec1f85d42d13106b8e8263b9b7199eaef09 # v1.39.0
+        uses: shogo82148/actions-setup-perl@9f8c263975569ff3b4e510cb1f8813115749e146 # v1.41.0
         with:
           perl-version: '5.34'
           install-modules-with: cpm

--- a/.github/workflows/spellchecker.yml
+++ b/.github/workflows/spellchecker.yml
@@ -34,7 +34,7 @@ jobs:
               - added|modified: 'src/**/*.pm'
 
       - name: Install CPAN Libraries
-        uses: shogo82148/actions-setup-perl@dea55ec1f85d42d13106b8e8263b9b7199eaef09 # v1.39.0
+        uses: shogo82148/actions-setup-perl@9f8c263975569ff3b4e510cb1f8813115749e146 # v1.41.0
         with:
           perl-version: '5.34'
           install-modules-with: cpm


### PR DESCRIPTION
## Description

After the last update of snmpsim (1.2.2) there is a missing python library: pysmi.

**Fixes** CTOR-2317

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.


<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Updated shogo82148/actions-setup-perl action to a newer patch version

**🐛 Bugfixes**
* Added missing pysmi Python library to snmpsim installations across images


<sup>[More info](https://app.aikido.dev/featurebranch/scan/110301378?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->