### PR TITLE
fix(perl-filesys-smbclient) Insecure use of strcpy function

### DIFF
--- a/dependencies/perl-filesys-smbclient/src/libauthSamba.c
+++ b/dependencies/perl-filesys-smbclient/src/libauthSamba.c
@@ -20,7 +20,7 @@ void set_fn(char *workgroup,
   snprintf(User, sizeof(User), "%s", username);
   snprintf(Password, sizeof(Password), "%s", password);
   /* set workgroup only when set */
-  if (workgroup[0] && workgroup[0] != 0) {
+  if (workgroup && *workgroup) {
 #ifdef VERBOSE
     printf("Workgroup is set to %s\n", workgroup);
 #endif
@@ -40,21 +40,20 @@ void auth_fn(const char *server,
 #ifdef VERBOSE
   printf("auth_fn\n");
 #endif
-
   /* set workgroup only when set */
-  if (Workgroup[0] && Workgroup[0] != 0) {
+  if (*Workgroup && workgroup) {
 #ifdef VERBOSE
     printf("Workgroup is set to %s\n", Workgroup);
 #endif
     snprintf(workgroup, wgmaxlen, "%s", Workgroup);
   }
-  snprintf(username, unmaxlen, "%s", User);
-  snprintf(password, pwmaxlen, "%s", Password);
+  if (username) snprintf(username, unmaxlen, "%s", User);
+  if (password) snprintf(password, pwmaxlen, "%s", Password);
 
 #ifdef VERBOSE
-  fprintf(stdout, "username: [%s]\n", username);
-  fprintf(stdout, "password: [%s]\n", password);
-  fprintf(stdout, "workgroup: [%s]\n", workgroup);
+  fprintf(stdout, "username: [%s]\n", username ? username : "(null)");
+  fprintf(stdout, "password: [%s]\n", password ? password : "(null)");
+  fprintf(stdout, "workgroup: [%s]\n", workgroup ? workgroup : "(null)");
 #endif
 
 

--- a/dependencies/perl-filesys-smbclient/src/libauthSamba.c
+++ b/dependencies/perl-filesys-smbclient/src/libauthSamba.c
@@ -17,14 +17,14 @@ void set_fn(char *workgroup,
   printf("set_fn\n");
 #endif
 
-  strcpy(User, username);
-  strcpy(Password, password);
+  snprintf(User, sizeof(User), "%s", username);
+  snprintf(Password, sizeof(Password), "%s", password);
   /* set workgroup only when set */
   if (workgroup[0] && workgroup[0] != 0) {
 #ifdef VERBOSE
     fprintf("Workgroup is set to %s", workgroup);
 #endif
-    strcpy(Workgroup, workgroup);
+    snprintf(Workgroup, sizeof(Workgroup), "%s", workgroup);
   }
 }
 
@@ -47,12 +47,12 @@ void auth_fn(const char *server,
     fprintf("Workgroup is set to %s", Workgroup);
 #endif
     strcpy(workgroup, Workgroup);
-    wgmaxlen = 100;
+    wgmaxlen = sizeof(Workgroup);
   }
   strcpy(username, User);
-  unmaxlen = 100;
+  unmaxlen = sizeof(User);
   strcpy(password, Password);
-  pwmaxlen = 100;
+  pwmaxlen = sizeof(Password);
 
 #ifdef VERBOSE
   fprintf(stdout, "username: [%s]\n", username);

--- a/dependencies/perl-filesys-smbclient/src/libauthSamba.c
+++ b/dependencies/perl-filesys-smbclient/src/libauthSamba.c
@@ -22,7 +22,7 @@ void set_fn(char *workgroup,
   /* set workgroup only when set */
   if (workgroup[0] && workgroup[0] != 0) {
 #ifdef VERBOSE
-    fprintf("Workgroup is set to %s", workgroup);
+    printf("Workgroup is set to %s\n", workgroup);
 #endif
     snprintf(Workgroup, sizeof(Workgroup), "%s", workgroup);
   }
@@ -44,15 +44,12 @@ void auth_fn(const char *server,
   /* set workgroup only when set */
   if (Workgroup[0] && Workgroup[0] != 0) {
 #ifdef VERBOSE
-    fprintf("Workgroup is set to %s", Workgroup);
+    printf("Workgroup is set to %s\n", Workgroup);
 #endif
-    strcpy(workgroup, Workgroup);
-    wgmaxlen = sizeof(Workgroup);
+    snprintf(workgroup, wgmaxlen, "%s", Workgroup);
   }
-  strcpy(username, User);
-  unmaxlen = sizeof(User);
-  strcpy(password, Password);
-  pwmaxlen = sizeof(Password);
+  snprintf(username, unmaxlen, "%s", User);
+  snprintf(password, pwmaxlen, "%s", Password);
 
 #ifdef VERBOSE
   fprintf(stdout, "username: [%s]\n", username);


### PR DESCRIPTION
# Community contributors

## Description

Insecure use of strcpy function

**Fixes** # CTOR-2146

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 | ✅ Resolved Issues: 3 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Added null checks and safer logging to prevent dereferencing null pointers.

**🔧 Refactors**
* Replaced insecure strcpy usages with bounded snprintf calls throughout.


<sup>[More info](https://app.aikido.dev/featurebranch/scan/111891630?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->