### PR TITLE
fix(apps/vmware/connector): change esx-hostname pod because it can't be null CTOR-1375

### DIFF
--- a/src/apps/vmware/connector/mode/alarmhost.pm
+++ b/src/apps/vmware/connector/mode/alarmhost.pm
@@ -263,7 +263,7 @@ Check ESX host alarms (red an yellow).
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 

--- a/src/apps/vmware/connector/mode/countvmhost.pm
+++ b/src/apps/vmware/connector/mode/countvmhost.pm
@@ -174,7 +174,7 @@ Check number of vm running/off on ESX hosts.
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 

--- a/src/apps/vmware/connector/mode/cpuhost.pm
+++ b/src/apps/vmware/connector/mode/cpuhost.pm
@@ -180,7 +180,7 @@ Check ESX CPU usage.
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 

--- a/src/apps/vmware/connector/mode/datastorehost.pm
+++ b/src/apps/vmware/connector/mode/datastorehost.pm
@@ -163,7 +163,7 @@ Check ESX datastore latency.
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 

--- a/src/apps/vmware/connector/mode/healthhost.pm
+++ b/src/apps/vmware/connector/mode/healthhost.pm
@@ -307,7 +307,7 @@ Check health of ESX hosts.
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 

--- a/src/apps/vmware/connector/mode/maintenancehost.pm
+++ b/src/apps/vmware/connector/mode/maintenancehost.pm
@@ -128,7 +128,7 @@ Check maintenance mode of ESX hosts.
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 

--- a/src/apps/vmware/connector/mode/memoryhost.pm
+++ b/src/apps/vmware/connector/mode/memoryhost.pm
@@ -237,7 +237,7 @@ Check ESX memory usage.
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 

--- a/src/apps/vmware/connector/mode/nethost.pm
+++ b/src/apps/vmware/connector/mode/nethost.pm
@@ -364,7 +364,7 @@ Check ESX net usage.
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 

--- a/src/apps/vmware/connector/mode/servicehost.pm
+++ b/src/apps/vmware/connector/mode/servicehost.pm
@@ -159,7 +159,7 @@ Check ESX services.
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 

--- a/src/apps/vmware/connector/mode/statushost.pm
+++ b/src/apps/vmware/connector/mode/statushost.pm
@@ -131,7 +131,7 @@ Check ESX global status.
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 

--- a/src/apps/vmware/connector/mode/storagehost.pm
+++ b/src/apps/vmware/connector/mode/storagehost.pm
@@ -332,7 +332,7 @@ Check ESX storage infos.
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 

--- a/src/apps/vmware/connector/mode/swaphost.pm
+++ b/src/apps/vmware/connector/mode/swaphost.pm
@@ -134,7 +134,7 @@ Check ESX swap rate usage.
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 

--- a/src/apps/vmware/connector/mode/timehost.pm
+++ b/src/apps/vmware/connector/mode/timehost.pm
@@ -140,7 +140,7 @@ Check ESX time.
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 

--- a/src/apps/vmware/connector/mode/uptimehost.pm
+++ b/src/apps/vmware/connector/mode/uptimehost.pm
@@ -140,7 +140,7 @@ Check ESX uptime.
 =item B<--esx-hostname>
 
 ESX hostname to check.
-If not set, we check all ESX.
+You can check all ESX using .* and --filter option.
 
 =item B<--filter>
 


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID**

change esx-hostname pod because it can't be null

**Fixes** # (issue)
CTOR-1375

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Documentation

## How this pull request can be tested ?

```
su centreon-engine -c "/usr/lib/centreon/plugins//centreon_vmware_connector_client.pl --plugin=apps::vmware::connector::plugin --mode=health-host --custommode=connector --connector-hostname='localhost' --connector-port='5700' --container='vc-server'  --esx-hostname='' --unknown-status='' --warning-status='' --critical-status=''  --warning-total-problems='' --critical-total-problems='' --warning-problems='' --critical-problems='' --warning-problems-yellow='' --critical-problems-yellow='' --warning-problems-red='' --critical-problems-red='' --verbose"
UNKNOWN: Argument error: esx hostname cannot be null
```

## Checklist

- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
