### PR TITLE
fix(java): update maven version for el and ubuntu - release

### DIFF
--- a/.github/docker/packaging/Dockerfile.packaging-plugins-java-alma10
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-java-alma10
@@ -11,10 +11,10 @@ dnf install -y \
   zstd
 
 cd /usr/local/src
-wget https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
-tar zxf apache-maven-3.9.15-bin.tar.gz
-ln -s /usr/local/src/apache-maven-3.9.15/bin/mvn /usr/bin/mvn
-rm -f apache-maven-3.9.15-bin.tar.gz
+wget https://dlcdn.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz
+tar zxf apache-maven-3.9.16-bin.tar.gz
+ln -s /usr/local/src/apache-maven-3.9.16/bin/mvn /usr/bin/mvn
+rm -f apache-maven-3.9.16-bin.tar.gz
 
 echo '[goreleaser]
 name=GoReleaser

--- a/.github/docker/packaging/Dockerfile.packaging-plugins-java-alma8
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-java-alma8
@@ -11,10 +11,10 @@ dnf install -y \
   zstd
 
 cd /usr/local/src
-wget https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
-tar zxf apache-maven-3.9.15-bin.tar.gz
-ln -s /usr/local/src/apache-maven-3.9.15/bin/mvn /usr/bin/mvn
-rm -f apache-maven-3.9.15-bin.tar.gz
+wget https://dlcdn.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz
+tar zxf apache-maven-3.9.16-bin.tar.gz
+ln -s /usr/local/src/apache-maven-3.9.16/bin/mvn /usr/bin/mvn
+rm -f apache-maven-3.9.16-bin.tar.gz
 
 echo '[goreleaser]
 name=GoReleaser

--- a/.github/docker/packaging/Dockerfile.packaging-plugins-java-alma9
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-java-alma9
@@ -11,10 +11,10 @@ dnf install -y \
   zstd
 
 cd /usr/local/src
-wget https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
-tar zxf apache-maven-3.9.15-bin.tar.gz
-ln -s /usr/local/src/apache-maven-3.9.15/bin/mvn /usr/bin/mvn
-rm -f apache-maven-3.9.15-bin.tar.gz
+wget https://dlcdn.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz
+tar zxf apache-maven-3.9.16-bin.tar.gz
+ln -s /usr/local/src/apache-maven-3.9.16/bin/mvn /usr/bin/mvn
+rm -f apache-maven-3.9.16-bin.tar.gz
 
 echo '[goreleaser]
 name=GoReleaser

--- a/.github/docker/packaging/Dockerfile.packaging-plugins-java-jammy
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-java-jammy
@@ -13,10 +13,10 @@ apt-get install -y \
   zstd
 
 cd /usr/local/src
-wget https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
-tar zxf apache-maven-3.9.15-bin.tar.gz
-ln -s /usr/local/src/apache-maven-3.9.15/bin/mvn /usr/bin/mvn
-rm -f apache-maven-3.9.15-bin.tar.gz
+wget https://dlcdn.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz
+tar zxf apache-maven-3.9.16-bin.tar.gz
+ln -s /usr/local/src/apache-maven-3.9.16/bin/mvn /usr/bin/mvn
+rm -f apache-maven-3.9.16-bin.tar.gz
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 

--- a/.github/docker/packaging/Dockerfile.packaging-plugins-java-noble
+++ b/.github/docker/packaging/Dockerfile.packaging-plugins-java-noble
@@ -13,10 +13,10 @@ apt-get install -y \
   zstd
 
 cd /usr/local/src
-wget https://dlcdn.apache.org/maven/maven-3/3.9.15/binaries/apache-maven-3.9.15-bin.tar.gz
-tar zxf apache-maven-3.9.15-bin.tar.gz
-ln -s /usr/local/src/apache-maven-3.9.15/bin/mvn /usr/bin/mvn
-rm -f apache-maven-3.9.15-bin.tar.gz
+wget https://dlcdn.apache.org/maven/maven-3/3.9.16/binaries/apache-maven-3.9.16-bin.tar.gz
+tar zxf apache-maven-3.9.16-bin.tar.gz
+ln -s /usr/local/src/apache-maven-3.9.16/bin/mvn /usr/bin/mvn
+rm -f apache-maven-3.9.16-bin.tar.gz
 
 echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
 


### PR DESCRIPTION
## Description

Maven version 3.9.15 is not available anymore => update to maven 3.9.16.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
