### PR TITLE
fix(ci): force Net::DHCP version

### DIFF
--- a/.github/packaging/cpan-libraries.json
+++ b/.github/packaging/cpan-libraries.json
@@ -271,6 +271,8 @@
     {
       "name": "Net::DHCP",
       "rpm": {
+        "version": "0.8",
+        "comment": "Force version 0.8 because of a problem with the packaging job on version 0.9",
         "rpm_provides": "perl(Net::DHCP::Constants) perl(Net::DHCP::Packet)"
       }
     },

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -388,7 +388,6 @@ jobs:
             image: testing:alma10
             distrib: el10
             arch: amd64
-            skip_robot_tests: true
           - package_extension: deb
             image: testing:bullseye
             distrib: bullseye
@@ -401,7 +400,6 @@ jobs:
             image: testing:trixie
             distrib: trixie
             arch: amd64
-            skip_robot_tests: true
           - package_extension: deb
             image: testing:jammy
             distrib: jammy


### PR DESCRIPTION
## Description

Error on packaging of Net::DHCP version 0.9 => use version 0.8

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
