### PR TITLE
fix(ci): remove robot tests for el10 and trixie (perl connector not available)

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -388,6 +388,7 @@ jobs:
             image: testing:alma10
             distrib: el10
             arch: amd64
+            skip_robot_tests: true
           - package_extension: deb
             image: testing:bullseye
             distrib: bullseye
@@ -400,6 +401,7 @@ jobs:
             image: testing:trixie
             distrib: trixie
             arch: amd64
+            skip_robot_tests: true
           - package_extension: deb
             image: testing:jammy
             distrib: jammy


### PR DESCRIPTION
## Description

Robot tests are not ok on el10 and debian trixie because the perl connector is not available yet on these distribs.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
