### PR TITLE
enh(packaging): no dependency towards nmap anymore

### DIFF
--- a/packaging/centreon-plugin-Applications-Nmap-Cli/deb.json
+++ b/packaging/centreon-plugin-Applications-Nmap-Cli/deb.json
@@ -1,8 +1,6 @@
 {
     "dependencies": [
         "centreon-plugins-sudoers",
-        "perl",
-        "nmap",
         "libxml-simple-perl"
     ]
 }

--- a/packaging/centreon-plugin-Applications-Nmap-Cli/rpm.json
+++ b/packaging/centreon-plugin-Applications-Nmap-Cli/rpm.json
@@ -1,8 +1,6 @@
 {
     "dependencies": [
         "centreon-plugins-sudoers",
-        "perl",
-        "nmap",
         "plink",
         "perl(Libssh::Session)",
         "perl(XML::Simple)"

--- a/tests/apps/nmap/cli/bin/nmap1
+++ b/tests/apps/nmap/cli/bin/nmap1
@@ -1,0 +1,35 @@
+cat <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<?xml-stylesheet href="file:///usr/bin/../share/nmap/nmap.xsl" type="text/xsl"?>
+<!-- Nmap 7.94SVN scan initiated Tue May 19 17:37:16 2026 as: nmap -sS -sU -R -O -&#45;osscan-limit -&#45;osscan-guess -p U:161,162,T:21-25,80,139,443,3306,8080,8443 -oX - 127.0.0.1/32 -->
+<nmaprun scanner="nmap" args="nmap -sS -sU -R -O -&#45;osscan-limit -&#45;osscan-guess -p U:161,162,T:21-25,80,139,443,3306,8080,8443 -oX - 127.0.0.1/32" start="1779205036" startstr="Tue May 19 17:37:16 2026" version="7.94SVN" xmloutputversion="1.05">
+<scaninfo type="syn" protocol="tcp" numservices="11" services="21-25,80,139,443,3306,8080,8443"/>
+<scaninfo type="udp" protocol="udp" numservices="2" services="161-162"/>
+<verbose level="0"/>
+<debugging level="0"/>
+<host starttime="1779205036" endtime="1779205036"><status state="up" reason="localhost-response" reason_ttl="0"/>
+<address addr="127.0.0.1" addrtype="ipv4"/>
+<hostnames>
+<hostname name="localhost" type="PTR"/>
+</hostnames>
+<ports><port protocol="tcp" portid="21"><state state="closed" reason="reset" reason_ttl="64"/><service name="ftp" method="table" conf="3"/></port>
+<port protocol="tcp" portid="22"><state state="closed" reason="reset" reason_ttl="64"/><service name="ssh" method="table" conf="3"/></port>
+<port protocol="tcp" portid="23"><state state="closed" reason="reset" reason_ttl="64"/><service name="telnet" method="table" conf="3"/></port>
+<port protocol="tcp" portid="24"><state state="closed" reason="reset" reason_ttl="64"/><service name="priv-mail" method="table" conf="3"/></port>
+<port protocol="tcp" portid="25"><state state="closed" reason="reset" reason_ttl="64"/><service name="smtp" method="table" conf="3"/></port>
+<port protocol="tcp" portid="80"><state state="closed" reason="reset" reason_ttl="64"/><service name="http" method="table" conf="3"/></port>
+<port protocol="tcp" portid="139"><state state="closed" reason="reset" reason_ttl="64"/><service name="netbios-ssn" method="table" conf="3"/></port>
+<port protocol="tcp" portid="443"><state state="closed" reason="reset" reason_ttl="64"/><service name="https" method="table" conf="3"/></port>
+<port protocol="tcp" portid="3306"><state state="closed" reason="reset" reason_ttl="64"/><service name="mysql" method="table" conf="3"/></port>
+<port protocol="tcp" portid="8080"><state state="closed" reason="reset" reason_ttl="64"/><service name="http-proxy" method="table" conf="3"/></port>
+<port protocol="tcp" portid="8443"><state state="closed" reason="reset" reason_ttl="64"/><service name="https-alt" method="table" conf="3"/></port>
+<port protocol="udp" portid="161"><state state="open" reason="udp-response" reason_ttl="64"/><service name="snmp" method="table" conf="3"/></port>
+<port protocol="udp" portid="162"><state state="closed" reason="port-unreach" reason_ttl="64"/><service name="snmptrap" method="table" conf="3"/></port>
+</ports>
+<times srtt="62" rttvar="243" to="100000"/>
+</host>
+<runstats><finished time="1779205036" timestr="Tue May 19 17:37:16 2026" summary="Nmap done at Tue May 19 17:37:16 2026; 1 IP address (1 host up) scanned in 0.26 seconds" elapsed="0.26" exit="success"/><hosts up="1" down="0" total="1"/>
+</runstats>
+</nmaprun>
+EOF

--- a/tests/apps/nmap/cli/bin/nmap2
+++ b/tests/apps/nmap/cli/bin/nmap2
@@ -1,0 +1,37 @@
+cat <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<?xml-stylesheet href="file:///usr/bin/../share/nmap/nmap.xsl" type="text/xsl"?>
+<!-- Nmap 7.94SVN scan initiated Tue May 19 17:47:05 2026 as: nmap -sS -sU -R -O -&#45;osscan-limit -&#45;osscan-guess -p U:161,162,T:21-25,80,139,443,3306,5985,5986,8080,8443 -oX - 127.0.0.1 -->
+<nmaprun scanner="nmap" args="nmap -sS -sU -R -O -&#45;osscan-limit -&#45;osscan-guess -p U:161,162,T:21-25,80,139,443,3306,5985,5986,8080,8443 -oX - 127.0.0.1" start="1779205625" startstr="Tue May 19 17:47:05 2026" version="7.94SVN" xmloutputversion="1.05">
+<scaninfo type="syn" protocol="tcp" numservices="13" services="21-25,80,139,443,3306,5985-5986,8080,8443"/>
+<scaninfo type="udp" protocol="udp" numservices="2" services="161-162"/>
+<verbose level="0"/>
+<debugging level="0"/>
+<host starttime="1779205625" endtime="1779205625"><status state="up" reason="localhost-response" reason_ttl="0"/>
+<address addr="127.0.0.1" addrtype="ipv4"/>
+<hostnames>
+<hostname name="localhost" type="PTR"/>
+</hostnames>
+<ports><port protocol="tcp" portid="21"><state state="closed" reason="reset" reason_ttl="64"/><service name="ftp" method="table" conf="3"/></port>
+<port protocol="tcp" portid="22"><state state="closed" reason="reset" reason_ttl="64"/><service name="ssh" method="table" conf="3"/></port>
+<port protocol="tcp" portid="23"><state state="closed" reason="reset" reason_ttl="64"/><service name="telnet" method="table" conf="3"/></port>
+<port protocol="tcp" portid="24"><state state="closed" reason="reset" reason_ttl="64"/><service name="priv-mail" method="table" conf="3"/></port>
+<port protocol="tcp" portid="25"><state state="closed" reason="reset" reason_ttl="64"/><service name="smtp" method="table" conf="3"/></port>
+<port protocol="tcp" portid="80"><state state="closed" reason="reset" reason_ttl="64"/><service name="http" method="table" conf="3"/></port>
+<port protocol="tcp" portid="139"><state state="closed" reason="reset" reason_ttl="64"/><service name="netbios-ssn" method="table" conf="3"/></port>
+<port protocol="tcp" portid="443"><state state="closed" reason="reset" reason_ttl="64"/><service name="https" method="table" conf="3"/></port>
+<port protocol="tcp" portid="3306"><state state="closed" reason="reset" reason_ttl="64"/><service name="mysql" method="table" conf="3"/></port>
+<port protocol="tcp" portid="5985"><state state="closed" reason="reset" reason_ttl="64"/><service name="wsman" method="table" conf="3"/></port>
+<port protocol="tcp" portid="5986"><state state="closed" reason="reset" reason_ttl="64"/><service name="wsmans" method="table" conf="3"/></port>
+<port protocol="tcp" portid="8080"><state state="closed" reason="reset" reason_ttl="64"/><service name="http-proxy" method="table" conf="3"/></port>
+<port protocol="tcp" portid="8443"><state state="closed" reason="reset" reason_ttl="64"/><service name="https-alt" method="table" conf="3"/></port>
+<port protocol="udp" portid="161"><state state="open" reason="udp-response" reason_ttl="64"/><service name="snmp" method="table" conf="3"/></port>
+<port protocol="udp" portid="162"><state state="closed" reason="port-unreach" reason_ttl="64"/><service name="snmptrap" method="table" conf="3"/></port>
+</ports>
+<times srtt="49" rttvar="150" to="100000"/>
+</host>
+<runstats><finished time="1779205625" timestr="Tue May 19 17:47:05 2026" summary="Nmap done at Tue May 19 17:47:05 2026; 1 IP address (1 host up) scanned in 0.30 seconds" elapsed="0.30" exit="success"/><hosts up="1" down="0" total="1"/>
+</runstats>
+</nmaprun>
+EOF

--- a/tests/apps/nmap/cli/bin/nmap3
+++ b/tests/apps/nmap/cli/bin/nmap3
@@ -1,0 +1,37 @@
+cat <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE nmaprun>
+<?xml-stylesheet href="file:///usr/bin/../share/nmap/nmap.xsl" type="text/xsl"?>
+<!-- Nmap 7.94SVN scan initiated Tue May 19 17:34:15 2026 as: nmap -sS -sU -R -O -&#45;osscan-limit -&#45;osscan-guess -p U:161,162,T:21-25,80,139,443,3306,5985,5986,8080,8443 -oX - 127.0.0.1/32 -->
+<nmaprun scanner="nmap" args="nmap -sS -sU -R -O -&#45;osscan-limit -&#45;osscan-guess -p U:161,162,T:21-25,80,139,443,3306,5985,5986,8080,8443 -oX - 127.0.0.1/32" start="1779204855" startstr="Tue May 19 17:34:15 2026" version="7.94SVN" xmloutputversion="1.05">
+<scaninfo type="syn" protocol="tcp" numservices="13" services="21-25,80,139,443,3306,5985-5986,8080,8443"/>
+<scaninfo type="udp" protocol="udp" numservices="2" services="161-162"/>
+<verbose level="0"/>
+<debugging level="0"/>
+<host starttime="1779204855" endtime="1779204855"><status state="up" reason="localhost-response" reason_ttl="0"/>
+<address addr="127.0.0.1" addrtype="ipv4"/>
+<hostnames>
+<hostname name="localhost" type="PTR"/>
+</hostnames>
+<ports><port protocol="tcp" portid="21"><state state="closed" reason="reset" reason_ttl="64"/><service name="ftp" method="table" conf="3"/></port>
+<port protocol="tcp" portid="22"><state state="closed" reason="reset" reason_ttl="64"/><service name="ssh" method="table" conf="3"/></port>
+<port protocol="tcp" portid="23"><state state="closed" reason="reset" reason_ttl="64"/><service name="telnet" method="table" conf="3"/></port>
+<port protocol="tcp" portid="24"><state state="closed" reason="reset" reason_ttl="64"/><service name="priv-mail" method="table" conf="3"/></port>
+<port protocol="tcp" portid="25"><state state="closed" reason="reset" reason_ttl="64"/><service name="smtp" method="table" conf="3"/></port>
+<port protocol="tcp" portid="80"><state state="closed" reason="reset" reason_ttl="64"/><service name="http" method="table" conf="3"/></port>
+<port protocol="tcp" portid="139"><state state="closed" reason="reset" reason_ttl="64"/><service name="netbios-ssn" method="table" conf="3"/></port>
+<port protocol="tcp" portid="443"><state state="closed" reason="reset" reason_ttl="64"/><service name="https" method="table" conf="3"/></port>
+<port protocol="tcp" portid="3306"><state state="closed" reason="reset" reason_ttl="64"/><service name="mysql" method="table" conf="3"/></port>
+<port protocol="tcp" portid="5985"><state state="closed" reason="reset" reason_ttl="64"/><service name="wsman" method="table" conf="3"/></port>
+<port protocol="tcp" portid="5986"><state state="closed" reason="reset" reason_ttl="64"/><service name="wsmans" method="table" conf="3"/></port>
+<port protocol="tcp" portid="8080"><state state="closed" reason="reset" reason_ttl="64"/><service name="http-proxy" method="table" conf="3"/></port>
+<port protocol="tcp" portid="8443"><state state="closed" reason="reset" reason_ttl="64"/><service name="https-alt" method="table" conf="3"/></port>
+<port protocol="udp" portid="161"><state state="open" reason="udp-response" reason_ttl="64"/><service name="snmp" method="table" conf="3"/></port>
+<port protocol="udp" portid="162"><state state="closed" reason="port-unreach" reason_ttl="64"/><service name="snmptrap" method="table" conf="3"/></port>
+</ports>
+<times srtt="54" rttvar="164" to="100000"/>
+</host>
+<runstats><finished time="1779204855" timestr="Tue May 19 17:34:15 2026" summary="Nmap done at Tue May 19 17:34:15 2026; 1 IP address (1 host up) scanned in 0.29 seconds" elapsed="0.29" exit="success"/><hosts up="1" down="0" total="1"/>
+</runstats>
+</nmaprun>
+EOF

--- a/tests/apps/nmap/cli/discovery.robot
+++ b/tests/apps/nmap/cli/discovery.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation       Test the Podman container-usage mode
+Documentation       Check nmap discovery
 
 Library             Collections
 Resource            ${CURDIR}${/}..${/}..${/}..${/}resources/import.resource
@@ -10,26 +10,34 @@ Test Timeout        120s
 
 
 *** Variables ***
-${MOCKOON_JSON}     ${CURDIR}${/}podman.json
-
-${cmd}              ${CENTREON_PLUGINS}
-...                 --plugin=apps::nmap::cli::plugin
-...                 --mode=discovery
+${cmd}      ${CENTREON_PLUGINS}
+...         --plugin=apps::nmap::cli::plugin
+...         --mode=discovery
 
 
 *** Test Cases ***
-Container usage ${tc}
-    [Documentation]    Check nmap discovery
+nmap ${tc}
     [Tags]    apps    nmap
-    Log To Console    \n
     ${command}    Catenate
     ...    ${cmd}
     ...    --subnet='127.0.0.1/32'
+    ...    --command-path=${CURDIR}${/}bin
+    ...    --command=nmap${tc}
     ...    ${extraoptions}
 
     Ctn Run Command And Check Result As Json    ${command}    ${expected_result}
 
-    Examples:         tc    extraoptions          expected_result    --
-    ...       1     ${EMPTY}                       {"end_time":1747232859,"discovered_items":1,"results":[{"hostname":"localhost","ip":"127.0.0.1","hostnames":[{"type":"PTR","name":"localhost"}],"vendor":null,"status":"up","addresses":[{"address":"127.0.0.1","type":"ipv4"}],"os_accuracy":null,"os":null,"services":null,"type":"unknown"}],"duration":0,"start_time":1747232859}
-    ...       2     --nmap-options='-sS -sU -R -O --osscan-limit --osscan-guess -p U:161,162,T:21-25,80,139,443,3306,5985,5986,8080,8443 -oX - '                   {"end_time":1747232859,"discovered_items":1,"results":[{"hostname":"localhost","ip":"127.0.0.1","hostnames":[{"type":"PTR","name":"localhost"}],"vendor":null,"status":"up","addresses":[{"address":"127.0.0.1","type":"ipv4"}],"os_accuracy":null,"os":null,"services":null,"type":"unknown"}],"duration":1,"start_time":1747232859}
-    ...       3     --nmap-options='-sS -oX - '    {"results":[{"ip":"127.0.0.1","type":"unknown","os_accuracy":null,"status":"up","services":null,"hostnames":[{"type":"PTR","name":"localhost"}],"os":null,"hostname":"localhost","vendor":null,"addresses":[{"address":"127.0.0.1","type":"ipv4"}]}],"duration":0,"discovered_items":1,"start_time":1747234100,"end_time":1747234100}
+    Examples:
+    ...    tc
+    ...    extraoptions
+    ...    expected_result
+    ...    --
+    ...    1
+    ...    ${EMPTY}
+    ...    {"discovered_items":1,"end_time":1779205487,"results":[{"os":null,"vendor":null,"hostnames":[{"type":"PTR","name":"localhost"}],"type":"unknown","services":[{"port":"161/udp","name":"snmp"}],"status":"up","hostname":"localhost","addresses":[{"type":"ipv4","address":"127.0.0.1"}],"os_accuracy":null,"ip":"127.0.0.1"}],"duration":0,"start_time":1779205487}
+    ...    2
+    ...    --nmap-options='-sS -sU -R -O --osscan-limit --osscan-guess -p U:161,162,T:21-25,80,139,443,3306,5985,5986,8080,8443 -oX - '
+    ...    {"end_time":1779205703,"discovered_items":1,"start_time":1779205703,"results":[{"ip":"127.0.0.1","type":"unknown","hostnames":[{"type":"PTR","name":"localhost"}],"hostname":"localhost","addresses":[{"address":"127.0.0.1","type":"ipv4"}],"os":null,"services":[{"port":"161/udp","name":"snmp"}],"vendor":null,"status":"up","os_accuracy":null}],"duration":0}
+    ...    3
+    ...    --nmap-options='-sS -oX - '
+    ...    {"start_time":1779205487,"results":[{"type":"unknown","services":[{"name":"snmp","port":"161/udp"}],"hostnames":[{"type":"PTR","name":"localhost"}],"vendor":null,"os":null,"hostname":"localhost","addresses":[{"type":"ipv4","address":"127.0.0.1"}],"ip":"127.0.0.1","os_accuracy":null,"status":"up"}],"end_time":1779205488,"discovered_items":1,"duration":1}

--- a/tests/resources/resources.resource
+++ b/tests/resources/resources.resource
@@ -216,7 +216,11 @@ Ctn Run Command And Check Result As Json
     Dictionaries Should Be Equal
     ...    ${json_output}
     ...    ${json_expected}
+    ...    Wrong JSON result for command:\n${command}\n\nObtained:\n${output}\n\nExpected JSON:\n${expected}\n
+    ...    values=False
     ...    ignore_keys=['end_time', 'start_time', 'duration']
+    ...    ignore_value_order=true
+
     Log Dictionary    ${json_output}
 
 Ctn Run Command And Return Parsed XML


### PR DESCRIPTION
## Description

License subscription is about to expire, so we likely no longer can ship the plugin with this dependency.

Refs: CTOR-2327

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

