### PR TITLE
fix(apps::centreon::logmanagement): fix counting method after more testing

### DIFF
--- a/src/apps/centreon/logmanagement/restapi/mode/logcount.pm
+++ b/src/apps/centreon/logmanagement/restapi/mode/logcount.pm
@@ -91,9 +91,14 @@ sub manage_selection {
     $self->{output}->option_exit("curves array is missing from response")
         unless $result->{curves} && ref($result->{curves}) eq 'ARRAY';
 
-    my $count = value_of($result, '->{curves}->[0]->{data}->[0]', 'none');
-    $self->{output}->option_exit("Path .response.curves[0].data[0] could not be found or is '" . $count . "'")
-        unless $count =~ /^[\.\d]+$/;
+    # under `data` should be an array reference with the count values grouped by time slices
+    my $data = value_of($result, '->{curves}->[0]->{data}', '');
+    $self->{output}->option_exit("Could not get the count result (.response.curves[0].data is not an array).")
+        unless ref $data eq 'ARRAY';
+
+    # we now have to sum all the slices to get the total number
+    my $count = 0;
+    $count += $_ foreach @{$data};
 
     $self->{logcount} = {
         count => $count

--- a/src/apps/centreon/logmanagement/restapi/mode/logcount.pm
+++ b/src/apps/centreon/logmanagement/restapi/mode/logcount.pm
@@ -93,7 +93,7 @@ sub manage_selection {
 
     # under `data` should be an array reference with the count values grouped by time slices
     my $data = value_of($result, '->{curves}->[0]->{data}', '');
-    $self->{output}->option_exit("Could not get the count result (.response.curves[0].data is not an array).")
+    $self->{output}->option_exit(short_msg => "Could not get the count result (.response.curves[0].data is not an array).")
         unless ref $data eq 'ARRAY';
 
     # we now have to sum all the slices to get the total number

--- a/src/apps/centreon/logmanagement/restapi/mode/logcount.pm
+++ b/src/apps/centreon/logmanagement/restapi/mode/logcount.pm
@@ -88,7 +88,7 @@ sub manage_selection {
 
     # Extract the log count from the API response
     # API response format: {"curves":[{"metric":"count","times":[...],"data":[count_value,...],"attributes":[]}]}
-    $self->{output}->option_exit("curves array is missing from response")
+    $self->{output}->option_exit(short_msg => "curves array is missing from response")
         unless $result->{curves} && ref($result->{curves}) eq 'ARRAY';
 
     # under `data` should be an array reference with the count values grouped by time slices


### PR DESCRIPTION
## Description

Log counts are splitted into slices of time, so we have to sum them to get the actual number of logs.

Refs: CTOR-2294

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

