### PR TITLE
fix(hooks): only check robocop when .robot files are committed

### DIFF
--- a/.githooks/pre-commit.d/20_plugins.sh
+++ b/.githooks/pre-commit.d/20_plugins.sh
@@ -59,9 +59,6 @@ function check_md5() {
 }
 
 jq=$(type -p jq) || fatal "Could not locate jq command"
-# Determining the robotidy command
-robocop_path=$(type -p robocop) || fatal "Could not locate robocop. Cannot check robot lint"
-robocop_exe="${robocop_path##*/}"
 
 # Get list of committed files
 mapfile -t committed_files < <(git diff --cached --name-only --diff-filter=ACMR)
@@ -103,7 +100,8 @@ for file in "${committed_files[@]}"; do
         robot)
             info "--> Checking robot format"
             check_tabs_crlf "$file"
-            cp "$file" "$tmpfile" && $robocop_path format "$tmpfile" >/dev/null 2>&1
+            robocop_path=$(type -p robocop) || fatal "Could not locate robocop. Cannot check robot lint"
+            cp "$file" "$tmpfile" && "$robocop_path" format "$tmpfile" >/dev/null 2>&1
             diff -q "$file" "$tmpfile" >/dev/null 2>&1
             rc=$?
             if [ $rc -ne 0 ] ; then


### PR DESCRIPTION
## Summary

The `robocop` check was running unconditionally at the top of the script, causing a fatal error even when no `.robot` files are being committed (e.g. a simple version bump).

Moved the `robocop` detection inside the `robot)` case block so it only runs when actually needed.

## Root cause

Introduced in commit `b9fef835d` — the upfront check was added alongside the `robot)` case but was placed at the top level.