### PR TITLE
fix(databases::mssql): fix locks counts for named instances

### DIFF
--- a/src/database/mssql/mode/deadlocks.pm
+++ b/src/database/mssql/mode/deadlocks.pm
@@ -84,7 +84,7 @@ sub manage_selection {
         FROM
             sys.dm_os_performance_counters
         WHERE
-            object_name LIKE '%:Locks%'
+            object_name LIKE '%Locks%'
         AND
             counter_name LIKE 'Number of Deadlocks/sec%'
     });

--- a/src/database/mssql/mode/deadlocks.pm
+++ b/src/database/mssql/mode/deadlocks.pm
@@ -32,7 +32,7 @@ sub set_counters {
 
     $self->{maps_counters_type} = [
         { name => 'total', type => COUNTER_TYPE_GLOBAL },
-        { name => 'by_instance', type => COUNTER_TYPE_INSTANCE, prefix_output => "instance '%{display}': " }
+        { name => 'by_instance', type => COUNTER_TYPE_INSTANCE, prefix_output => "instance %{display}: " }
     ];
 
     $self->{maps_counters}->{total} = [

--- a/src/database/mssql/mode/deadlocks.pm
+++ b/src/database/mssql/mode/deadlocks.pm
@@ -27,12 +27,6 @@ use centreon::plugins::constants qw(:counters);
 use centreon::plugins::misc qw(is_excluded trim);
 use Digest::SHA qw(sha256_hex);
 
-sub prefix_by_instance_output {
-    my ($self, %options) = @_;
-
-    return "instance '" . $options{instance_value}->{display} . "' ";
-}
-
 sub set_counters {
     my ($self, %options) = @_;
 
@@ -57,7 +51,7 @@ sub set_counters {
             label => 'deadlocks-by-instance', type => COUNTER_KIND_METRIC, nlabel => 'mssql.deadlocks.perminute',
             set   => {
                 key_values      => [ { name => 'value', per_minute => 1 }, { name => 'display' } ],
-                output_template => '%.2f dead locks/min',
+                output_template => 'instance %{display}: %.2f dead locks/min',
                 perfdatas       => [
                     { template => '%.2f', min => 0, label_extra_instance => 1, instance_use => 'display' },
                 ],
@@ -90,7 +84,7 @@ sub manage_selection {
         FROM
             sys.dm_os_performance_counters
         WHERE
-            object_name = 'SQLServer:Locks'
+            object_name LIKE '%:Locks%'
         AND
             counter_name LIKE 'Number of Deadlocks/sec%'
     });

--- a/src/database/mssql/mode/deadlocks.pm
+++ b/src/database/mssql/mode/deadlocks.pm
@@ -32,7 +32,7 @@ sub set_counters {
 
     $self->{maps_counters_type} = [
         { name => 'total', type => COUNTER_TYPE_GLOBAL },
-        { name => 'by_instance', type => COUNTER_TYPE_INSTANCE}
+        { name => 'by_instance', type => COUNTER_TYPE_INSTANCE, prefix_output => "instance '%{display}': " }
     ];
 
     $self->{maps_counters}->{total} = [
@@ -51,7 +51,7 @@ sub set_counters {
             label => 'deadlocks-by-instance', type => COUNTER_KIND_METRIC, nlabel => 'mssql.deadlocks.perminute',
             set   => {
                 key_values      => [ { name => 'value', per_minute => 1 }, { name => 'display' } ],
-                output_template => 'instance %{display}: %.2f dead locks/min',
+                output_template => '%.2f dead locks/min',
                 perfdatas       => [
                     { template => '%.2f', min => 0, label_extra_instance => 1, instance_use => 'display' },
                 ],

--- a/src/database/mssql/mode/lockswaits.pm
+++ b/src/database/mssql/mode/lockswaits.pm
@@ -32,7 +32,7 @@ sub set_counters {
 
     $self->{maps_counters_type} = [
         { name => 'total', type => COUNTER_TYPE_GLOBAL },
-        { name => 'by_instance', type => COUNTER_TYPE_INSTANCE, prefix_output => "instance '%{display}': "}
+        { name => 'by_instance', type => COUNTER_TYPE_INSTANCE, prefix_output => "instance %{display}: "}
     ];
 
     $self->{maps_counters}->{total} = [

--- a/src/database/mssql/mode/lockswaits.pm
+++ b/src/database/mssql/mode/lockswaits.pm
@@ -86,7 +86,7 @@ sub manage_selection {
         FROM
             sys.dm_os_performance_counters
         WHERE
-            object_name LIKE '%:Locks%'
+            object_name LIKE '%Locks%'
         AND
             counter_name LIKE 'Lock Waits/sec%'
     });

--- a/src/database/mssql/mode/lockswaits.pm
+++ b/src/database/mssql/mode/lockswaits.pm
@@ -32,7 +32,7 @@ sub set_counters {
 
     $self->{maps_counters_type} = [
         { name => 'total', type => COUNTER_TYPE_GLOBAL },
-        { name => 'by_instance', type => COUNTER_TYPE_INSTANCE}
+        { name => 'by_instance', type => COUNTER_TYPE_INSTANCE, prefix_output => "instance '%{display}': "}
     ];
 
     $self->{maps_counters}->{total} = [
@@ -53,7 +53,7 @@ sub set_counters {
             label => 'lockswaits-by-instance', type => COUNTER_KIND_METRIC, nlabel => 'mssql.lockswaits.perminute',
             set   => {
                 key_values      => [ { name => 'value', per_minute => 1 }, { name => 'display' } ],
-                output_template => 'instance %{display}: %.2f locks waits/min',
+                output_template => '%.2f locks waits/min',
                 perfdatas       => [
                     { template => '%.2f', min => 0, label_extra_instance => 1, instance_use => 'display' },
                 ],

--- a/src/database/mssql/mode/lockswaits.pm
+++ b/src/database/mssql/mode/lockswaits.pm
@@ -27,12 +27,6 @@ use centreon::plugins::constants qw(:counters);
 use centreon::plugins::misc qw(is_excluded trim);
 use Digest::SHA qw(sha256_hex);
 
-sub prefix_by_instance_output {
-    my ($self, %options) = @_;
-
-    return "instance '" . $options{instance_value}->{display} . "' ";
-}
-
 sub set_counters {
     my ($self, %options) = @_;
 
@@ -59,7 +53,7 @@ sub set_counters {
             label => 'lockswaits-by-instance', type => COUNTER_KIND_METRIC, nlabel => 'mssql.lockswaits.perminute',
             set   => {
                 key_values      => [ { name => 'value', per_minute => 1 }, { name => 'display' } ],
-                output_template => '%.2f locks waits/min',
+                output_template => 'instance %{display}: %.2f locks waits/min',
                 perfdatas       => [
                     { template => '%.2f', min => 0, label_extra_instance => 1, instance_use => 'display' },
                 ],
@@ -92,7 +86,7 @@ sub manage_selection {
         FROM
             sys.dm_os_performance_counters
         WHERE
-            object_name = 'SQLServer:Locks'
+            object_name LIKE '%:Locks%'
         AND
             counter_name LIKE 'Lock Waits/sec%'
     });

--- a/tests/database/mssql/dead-locks.robot
+++ b/tests/database/mssql/dead-locks.robot
@@ -46,19 +46,19 @@ Dead-locks ${tc}
     ...    OK: 124.00 total dead locks/min | 'total#mssql.deadlocks.perminute'=124.00;;;0; 'AllocUnit#mssql.deadlocks.perminute'=8.00;;;0; 'Application#mssql.deadlocks.perminute'=1.00;;;0; 'Database#mssql.deadlocks.perminute'=5.00;;;0; 'Extent#mssql.deadlocks.perminute'=3.00;;;0; 'File#mssql.deadlocks.perminute'=30.00;;;0; 'HoBT#mssql.deadlocks.perminute'=2.00;;;0; 'Key#mssql.deadlocks.perminute'=51.00;;;0; 'Metadata#mssql.deadlocks.perminute'=7.00;;;0; 'OIB#mssql.deadlocks.perminute'=4.00;;;0; 'Object#mssql.deadlocks.perminute'=1.00;;;0; 'Page#mssql.deadlocks.perminute'=1.00;;;0; 'RID#mssql.deadlocks.perminute'=4.00;;;0; 'RowGroup#mssql.deadlocks.perminute'=4.00;;;0; 'Xact#mssql.deadlocks.perminute'=3.00;;;0;
     ...    2
     ...    --filter-database=Database
-    ...    OK: 45.00 total dead locks/min - 5.00 dead locks/min | 'total#mssql.deadlocks.perminute'=45.00;;;0; 'Database#mssql.deadlocks.perminute'=5.00;;;0;
+    ...    OK: 45.00 total dead locks/min - instance Database: 5.00 dead locks/min | 'total#mssql.deadlocks.perminute'=45.00;;;0; 'Database#mssql.deadlocks.perminute'=5.00;;;0;
     ...    3
     ...    --include-instance=Database
-    ...    OK: 45.00 total dead locks/min - 5.00 dead locks/min | 'total#mssql.deadlocks.perminute'=45.00;;;0; 'Database#mssql.deadlocks.perminute'=5.00;;;0;
+    ...    OK: 45.00 total dead locks/min - instance Database: 5.00 dead locks/min | 'total#mssql.deadlocks.perminute'=45.00;;;0; 'Database#mssql.deadlocks.perminute'=5.00;;;0;
     ...    4
     ...    --exclude-instance=Database
     ...    OK: 79.00 total dead locks/min | 'total#mssql.deadlocks.perminute'=79.00;;;0; 'AllocUnit#mssql.deadlocks.perminute'=8.00;;;0; 'Application#mssql.deadlocks.perminute'=1.00;;;0; 'Extent#mssql.deadlocks.perminute'=3.00;;;0; 'File#mssql.deadlocks.perminute'=30.00;;;0; 'HoBT#mssql.deadlocks.perminute'=2.00;;;0; 'Key#mssql.deadlocks.perminute'=51.00;;;0; 'Metadata#mssql.deadlocks.perminute'=7.00;;;0; 'OIB#mssql.deadlocks.perminute'=4.00;;;0; 'Object#mssql.deadlocks.perminute'=1.00;;;0; 'Page#mssql.deadlocks.perminute'=1.00;;;0; 'RID#mssql.deadlocks.perminute'=4.00;;;0; 'RowGroup#mssql.deadlocks.perminute'=4.00;;;0; 'Xact#mssql.deadlocks.perminute'=3.00;;;0;
     ...    5
     ...    --include-instance=Database --warning-deadlocks-by-instance=1
-    ...    WARNING: 5.00 dead locks/min | 'total#mssql.deadlocks.perminute'=45.00;;;0; 'Database#mssql.deadlocks.perminute'=5.00;0:1;;0;
+    ...    WARNING: instance Database: 5.00 dead locks/min | 'total#mssql.deadlocks.perminute'=45.00;;;0; 'Database#mssql.deadlocks.perminute'=5.00;0:1;;0;
     ...    6
     ...    --include-instance=Database --critical-deadlocks-by-instance=1
-    ...    CRITICAL: 5.00 dead locks/min | 'total#mssql.deadlocks.perminute'=45.00;;;0; 'Database#mssql.deadlocks.perminute'=5.00;;0:1;0;
+    ...    CRITICAL: instance Database: 5.00 dead locks/min | 'total#mssql.deadlocks.perminute'=45.00;;;0; 'Database#mssql.deadlocks.perminute'=5.00;;0:1;0;
     ...    7
     ...    --include-instance=unexisting
     ...    UNKNOWN: No locks counter found with given filters

--- a/tests/database/mssql/locks-waits.robot
+++ b/tests/database/mssql/locks-waits.robot
@@ -46,19 +46,19 @@ Locks-waits ${tc}
     ...    OK: 124.00 total locks waits/min | 'total#mssql.lockswaits.perminute'=124.00;;;0; 'AllocUnit#mssql.lockswaits.perminute'=8.00;;;0; 'Application#mssql.lockswaits.perminute'=1.00;;;0; 'Database#mssql.lockswaits.perminute'=5.00;;;0; 'Extent#mssql.lockswaits.perminute'=3.00;;;0; 'File#mssql.lockswaits.perminute'=30.00;;;0; 'HoBT#mssql.lockswaits.perminute'=2.00;;;0; 'Key#mssql.lockswaits.perminute'=51.00;;;0; 'Metadata#mssql.lockswaits.perminute'=7.00;;;0; 'OIB#mssql.lockswaits.perminute'=4.00;;;0; 'Object#mssql.lockswaits.perminute'=1.00;;;0; 'Page#mssql.lockswaits.perminute'=1.00;;;0; 'RID#mssql.lockswaits.perminute'=4.00;;;0; 'RowGroup#mssql.lockswaits.perminute'=4.00;;;0; 'Xact#mssql.lockswaits.perminute'=3.00;;;0;
     ...    2
     ...    --filter-database=Database
-    ...    OK: 45.00 total locks waits/min - 5.00 locks waits/min | 'total#mssql.lockswaits.perminute'=45.00;;;0; 'Database#mssql.lockswaits.perminute'=5.00;;;0;
+    ...    OK: 45.00 total locks waits/min - instance Database: 5.00 locks waits/min | 'total#mssql.lockswaits.perminute'=45.00;;;0; 'Database#mssql.lockswaits.perminute'=5.00;;;0;
     ...    3
     ...    --include-instance=Database
-    ...    OK: 45.00 total locks waits/min - 5.00 locks waits/min | 'total#mssql.lockswaits.perminute'=45.00;;;0; 'Database#mssql.lockswaits.perminute'=5.00;;;0;
+    ...    OK: 45.00 total locks waits/min - instance Database: 5.00 locks waits/min | 'total#mssql.lockswaits.perminute'=45.00;;;0; 'Database#mssql.lockswaits.perminute'=5.00;;;0;
     ...    4
     ...    --exclude-instance=Database
     ...    OK: 79.00 total locks waits/min | 'total#mssql.lockswaits.perminute'=79.00;;;0; 'AllocUnit#mssql.lockswaits.perminute'=8.00;;;0; 'Application#mssql.lockswaits.perminute'=1.00;;;0; 'Extent#mssql.lockswaits.perminute'=3.00;;;0; 'File#mssql.lockswaits.perminute'=30.00;;;0; 'HoBT#mssql.lockswaits.perminute'=2.00;;;0; 'Key#mssql.lockswaits.perminute'=51.00;;;0; 'Metadata#mssql.lockswaits.perminute'=7.00;;;0; 'OIB#mssql.lockswaits.perminute'=4.00;;;0; 'Object#mssql.lockswaits.perminute'=1.00;;;0; 'Page#mssql.lockswaits.perminute'=1.00;;;0; 'RID#mssql.lockswaits.perminute'=4.00;;;0; 'RowGroup#mssql.lockswaits.perminute'=4.00;;;0; 'Xact#mssql.lockswaits.perminute'=3.00;;;0;
     ...    5
     ...    --include-instance=Database --warning-lockswaits-by-instance=1
-    ...    WARNING: 5.00 locks waits/min | 'total#mssql.lockswaits.perminute'=45.00;;;0; 'Database#mssql.lockswaits.perminute'=5.00;0:1;;0;
+    ...    WARNING: instance Database: 5.00 locks waits/min | 'total#mssql.lockswaits.perminute'=45.00;;;0; 'Database#mssql.lockswaits.perminute'=5.00;0:1;;0;
     ...    6
     ...    --include-instance=Database --critical-lockswaits-by-instance=1
-    ...    CRITICAL: 5.00 locks waits/min | 'total#mssql.lockswaits.perminute'=45.00;;;0; 'Database#mssql.lockswaits.perminute'=5.00;;0:1;0;
+    ...    CRITICAL: instance Database: 5.00 locks waits/min | 'total#mssql.lockswaits.perminute'=45.00;;;0; 'Database#mssql.lockswaits.perminute'=5.00;;0:1;0;
     ...    7
     ...    --include-instance=unexisting
     ...    UNKNOWN: No locks waits counter found with given filters


### PR DESCRIPTION
## Description

For some users, the `object_name = 'SQLServer:Locks'` condition did not work (probably because they use named instances) and `object_name LIKE '%Locks%'` has to be used instead.

Refs: CTOR-2402

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
