### PR TITLE
enh(database::oracle::plugin) Add RMAN external catalog support

### DIFF
--- a/src/database/oracle/common.pm
+++ b/src/database/oracle/common.pm
@@ -1,0 +1,38 @@
+#
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package database::oracle::common;
+
+use strict;
+use warnings;
+
+use Exporter 'import';
+
+our @EXPORT_OK = qw/convert_to_rman/;
+
+# Naively converts an Oracle query into an RMAN query by replacing v$ with rc_
+sub convert_to_rman($)
+{
+    my ($sql) = @_;
+
+    $sql =~ s/v\$/rc_/gr
+}
+
+1;

--- a/src/database/oracle/dbi.pm
+++ b/src/database/oracle/dbi.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -45,6 +45,7 @@ sub connect_oracle {
 sub check_options {
     my ($self, %options) = @_;
 
+    $self->{type} = $self->{option_results}->{type} ? shift(@{$self->{option_results}->{type}}) : '';
     $self->{container} = defined($self->{option_results}->{container}[0]) ? $self->{option_results}->{container}[0] : undef;
     return $self->SUPER::check_options(%options);
 }
@@ -107,6 +108,12 @@ sub connect {
         $self->query(query => "alter session set container=$self->{container}");
     }
     return 0;
+}
+
+sub is_rman() {
+    my ($self, %options) = @_;
+
+    return ($self->{type} // '') eq 'rman_catalog';
 }
 
 1;

--- a/src/database/oracle/mode/rmanbackupage.pm
+++ b/src/database/oracle/mode/rmanbackupage.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -24,6 +24,8 @@ use base qw(centreon::plugins::mode);
 
 use strict;
 use warnings;
+
+use database::oracle::common qw/convert_to_rman/;
 use DateTime;
 
 sub new {
@@ -99,6 +101,9 @@ sub run {
             GROUP BY object_type
         };
     }
+
+    $query = convert_to_rman($query) if $options{sql}->is_rman();
+
     $options{sql}->query(query => $query);
     my $result = $options{sql}->fetchall_arrayref();
     $options{sql}->disconnect();
@@ -165,7 +170,7 @@ sub run {
                 min => 0
             );
             my $exit_code = $self->{perfdata}->threshold_check(value => $backup_age, threshold => [ { label => 'critical-' . $label, exit_litteral => 'critical' }, { label => 'warning-' . $label, exit_litteral => 'warning' } ]);
-            
+
             if (!$self->{output}->is_status(value => $exit_code, compare => 'ok', litteral => 1)) {
                 $self->{output}->output_add(
                     severity => $exit_code,
@@ -173,7 +178,7 @@ sub run {
                 );
             }
         }
-        
+
         if ($executed == 0 && !defined($self->{option_results}->{'no-' . $label})) {
             $self->{output}->output_add(
                 severity => 'CRITICAL',
@@ -199,29 +204,62 @@ __END__
 
 =head1 MODE
 
-Check Oracle rman backup age.
+Check Oracle RMAN backup age.
 
 =over 8
 
-=item B<--warning-*>
+=item B<--warning-db-incr>
 
 Warning threshold in seconds.
-Can be: 'db-incr', 'db-full', 'archivelog', 'controlfile'.
 
-=item B<--critical-*>
+=item B<--critical-db-incr>
 
 Critical threshold in seconds.
-Can be: 'db-incr', 'db-full', 'archivelog', 'controlfile'.
 
-=item B<  --no-*>
+=item B<--warning-db-full>
+
+Warning threshold in seconds.
+
+=item B<--critical-db-full>
+
+Critical threshold in seconds.
+
+=item B<--warning-archivelog>
+
+Warning threshold in seconds.
+
+=item B<--critical-archivelog>
+
+Critical threshold in seconds.
+
+=item B<--warning-crontrolfile>
+
+Warning threshold in seconds.
+
+=item B<--critical-crontrolfile>
+
+Critical threshold in seconds.
+
+=item B<--no-db-incr>
 
 Skip error if never executed.
-Can be: 'db-incr', 'db-full', 'archivelog', 'controlfile'.
+
+=item B<--no-db-full>
+
+Skip error if never executed.
+
+=item B<--no-archivelog*>
+
+Skip error if never executed.
+
+=item B<--no-crontrolfile>
+
+Skip error if never executed.
 
 =item B<--filter-type>
 
 Filter backup type.
-(type can be : 'DB INCR', 'DB FULL', 'ARCHIVELOG')
+(type can be : C<DB INCR>, C<DB FULL>, C<ARCHIVELOG>)
 
 =item B<--skip-no-backup>
 

--- a/src/database/oracle/mode/rmanbackupproblems.pm
+++ b/src/database/oracle/mode/rmanbackupproblems.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -25,6 +25,9 @@ use base qw(centreon::plugins::templates::counter);
 use strict;
 use warnings;
 
+use centreon::plugins::constants qw/:counters :values/;
+use database::oracle::common qw/convert_to_rman/;
+
 sub prefix_global_output {
     my ($self, %options) = @_;
     
@@ -38,7 +41,7 @@ sub set_counters {
     my ($self, %options) = @_;
     
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output', skipped_code => { -10 => 1 } },
+        { name => 'global', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_global_output', skipped_code => { NO_VALUE() => 1 } },
     ];
     
     $self->{maps_counters}->{global} = [
@@ -101,6 +104,8 @@ sub manage_selection {
         GROUP BY status
     };
 
+    $query = convert_to_rman($query) if $options{sql}->is_rman();
+
     $options{sql}->query(query => $query);
     my $result = $options{sql}->fetchall_arrayref();
     $options{sql}->disconnect();
@@ -125,7 +130,7 @@ __END__
 
 =head1 MODE
 
-Check Oracle rman backup problems.
+Check Oracle RMAN backup problems.
 
 =over 8
 
@@ -133,10 +138,37 @@ Check Oracle rman backup problems.
 
 Retention in days (default: 3).
 
-=item B<--warning-*> B<--critical-*>
+=item B<--warning-completed>
 
-Thresholds.
-Can be: 'completed', 'failed', 'completed-warnings', 'completed-errors'.
+Threshold.
+
+=item B<--critical-completed>
+
+Threshold.
+
+=item B<--warning-completed-errors>
+
+Threshold.
+
+=item B<--critical-completed-errors>
+
+Threshold.
+
+=item B<--warning-completed-warnings>
+
+Threshold.
+
+=item B<--critical-completed-warnings>
+
+Threshold.
+
+=item B<--warning-failed>
+
+Threshold.
+
+=item B<--critical-failed>
+
+Threshold.
 
 =back
 

--- a/src/database/oracle/plugin.pm
+++ b/src/database/oracle/plugin.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -63,8 +63,8 @@ sub new {
     };
 
     $self->{sql_modes}->{dbi} = 'database::oracle::dbi';
-    $self->{sql_modes}->{sqlpluscmd} = 'database::oracle::sqlpluscmd';						 
-						 
+    $self->{sql_modes}->{sqlpluscmd} = 'database::oracle::sqlpluscmd';
+
     return $self;
 }
 
@@ -72,11 +72,12 @@ sub init {
     my ($self, %options) = @_;
 
     $self->{options}->add_options(arguments => {
-        'hostname:s@'   => { name => 'hostname' },
-        'port:s@'       => { name => 'port' },
-        'sid:s'         => { name => 'sid' },
-        'servicename:s' => { name => 'servicename' },
-        'container:s'   => { name => 'container' }
+        'hostname:s@'       => { name => 'hostname' },
+        'port:s@'           => { name => 'port' },
+        'component-type:s@' => { name => 'component_type' },
+        'sid:s'             => { name => 'sid' },
+        'servicename:s'     => { name => 'servicename' },
+        'container:s'       => { name => 'container' },
     });
 
     $self->{options}->parse_options();
@@ -87,19 +88,25 @@ sub init {
         @{$self->{sqldefault}->{dbi}} = ();
         @{$self->{sqldefault}->{sqlpluscmd}} = ();
         for (my $i = 0; $i < scalar(@{$options_result->{hostname}}); $i++) {
-            $self->{sqldefault}->{dbi}[$i] = { data_source => 'Oracle:host=' . $options_result->{hostname}[$i] };
-            $self->{sqldefault}->{sqlpluscmd}[$i] = { hostname => $options_result->{hostname}[$i] };
+            my $type = ref $options_result->{component_type} eq 'ARRAY' && $i < @{$options_result->{component_type}}
+                           ? $options_result->{component_type}->[$i] : 'database';
+            $type = 'database' if $type eq '';
+            $self->{output}->option_exit(short_msg => "--compnent-type should be 'database' or 'rman_catalog'.")
+                unless $type =~ /^(?:database|rman_catalog)$/;
+
+            $self->{sqldefault}->{dbi}[$i] = { type => $type, data_source => 'Oracle:host=' . $options_result->{hostname}[$i] };
+            $self->{sqldefault}->{sqlpluscmd}[$i] = { type => $type, hostname => $options_result->{hostname}[$i] };
             if (defined($options_result->{port}[$i])) {
                 $self->{sqldefault}->{dbi}[$i]->{data_source} .= ';port=' . $options_result->{port}[$i];
                 $self->{sqldefault}->{sqlpluscmd}[$i]->{port} = $options_result->{port}[$i];
             }
             if (defined($options_result->{sid}) && $options_result->{sid} ne '') {
                 $self->{sqldefault}->{dbi}[$i]->{data_source} .= ';sid=' . $options_result->{sid};
-	            $self->{sqldefault}->{sqlpluscmd}[$i]->{sid} = $options_result->{sid};
+                $self->{sqldefault}->{sqlpluscmd}[$i]->{sid} = $options_result->{sid};
             }
             if (defined($options_result->{servicename}) && $options_result->{servicename} ne '') {
                 $self->{sqldefault}->{dbi}[$i]->{data_source} .= ';service_name=' . $options_result->{servicename};
-	            $self->{sqldefault}->{sqlpluscmd}[$i]->{service_name} = $options_result->{servicename};
+                $self->{sqldefault}->{sqlpluscmd}[$i]->{service_name} = $options_result->{servicename};
             }
             $self->{sqldefault}->{dbi}[$i]->{container} = $options_result->{container};
             $self->{sqldefault}->{sqlpluscmd}[$i]->{container} = $options_result->{container};
@@ -133,6 +140,11 @@ Database SID.
 =item B<--servicename>
 
 Database Service Name.
+
+=item B<--component-type>
+
+Define the component to monitor. Can be C<database> or C<rman_catalog> (default: C<database>).
+This enables the use of C<rman-backup-problems> and C<rman-backup-age> modes when an external RMAN catalog is used.
 
 =item B<--container>
 

--- a/tests/database/oracle/rman-catalog.robot
+++ b/tests/database/oracle/rman-catalog.robot
@@ -1,0 +1,87 @@
+*** Settings ***
+Documentation       Database Oracle plugin
+...                 To execute this test, run an Oracle Docker container with:
+...                 docker run -d -p 1522:1521 -e ORACLE_PWD=Oracle123    container-registry.oracle.com/database/free:latest
+...                 To run these tests you need to manually configure an RMAN external catalog, which is not documented here
+
+Resource            ${CURDIR}${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Ctn Generic Suite Setup
+Test Timeout        120s
+
+
+*** Variables ***
+${HOSTNAME}     127.0.0.1
+${USERNAME}     rman
+${PASSWORD}     rman
+${PORT}         1521
+${CMD}          ${CENTREON_PLUGINS}
+...             --plugin=database::oracle::plugin
+...             --hostname=${HOSTNAME}
+...             --port=${PORT}
+...             --username=${USERNAME}
+...             --password=${PASSWORD}
+...             --servicename=FREEPDB1
+
+
+*** Test Cases ***
+RmanBackupAge ${tc}
+    [Tags]    database    oracle    rman    notauto
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    --mode=rman-backup-age
+    ...    ${extra_options}
+
+    Ctn Run Command Without Connector And Check Result As Regexp    ${command}    ${expected_regexp}
+
+    Examples:
+    ...    tc
+    ...    extraoptions
+    ...    expected_regexp
+    ...    --
+    ...    1
+    ...    ${EMPTY}
+    ...    UNKNOWN: Cannot execute query: ORA-00942: table or view "SYS"."V_
+    ...    2
+    ...    --component-type=rman_catalog
+    ...    CRITICAL: Rman 'DB INCR' backups never executed - Rman 'ARCHIVELOG' backups never executed - Rman 'CONTROLFILE' backups never executed | 'DB_FULL_backup_age'=
+    ...    3
+    ...    --component-type=rman_catalog --incremental-level
+    ...    CRITICAL: Rman 'DB INCR' backups never executed - Rman 'ARCHIVELOG' backups never executed | 'DB_FULL_backup_age'=
+    ...    4
+    ...    --incremental-level
+    ...    backup_set_details.incremental_level
+
+RmanBackupProblems ${tc}
+    [Tags]    database    oracle    rman    notauto
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    --mode=rman-backup-problems
+    ...    ${extra_options}
+
+    Ctn Run Command Without Connector And Check Result As Regexp    ${command}    ${expected_regexp}
+
+    Examples:
+    ...    tc
+    ...    extraoptions
+    ...    expected_regexp
+    ...    --
+    ...    1
+    ...    ${EMPTY}
+    ...    UNKNOWN: Cannot execute query: ORA-00942: table or view "SYS"."V_
+    ...    2
+    ...    --component-type=rman_catalog
+    ...    OK: During the last 3 days, number of backups completed: 2, failed: 0, completed with warnings: 0, completed with errors: 0 | 'rman.backups.completed.count'=2;;;0; 'rman.backups.failed.count'=0;;;0; 'rman.backups.completed_with_warnings.count'=0;;;0; 'rman.backups.completed_with_errors.count'=0;;;0;
+
+DisplayHelp ${tc}
+    [Tags]    database    oracle    rman
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    --mode=rman-backup-problems
+    ...    ${extra_options}
+
+    Ctn Run Command Without Connector And Check Result As Regexp    ${command}    ${expected_regexp}
+
+    Examples:    tc    extraoptions    expected_regexp    --
+    ...    1    --mode=rman-backup-problems --help    Plugin Description:
+    ...    2    --mode=rman-backup-age --help    Plugin Description:

--- a/tests/database/oracle/rman-oracle.robot
+++ b/tests/database/oracle/rman-oracle.robot
@@ -1,0 +1,80 @@
+*** Settings ***
+Documentation       Database Oracle plugin
+...                 To execute this test, run an Oracle Docker container with:
+...                 docker run -d -p 1522:1521 -e ORACLE_PWD=Oracle123    container-registry.oracle.com/database/free:latest
+
+Resource            ${CURDIR}${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Ctn Generic Suite Setup
+Test Timeout        120s
+
+
+*** Variables ***
+${HOSTNAME}     127.0.0.1
+${USERNAME}     system
+${PASSWORD}     Oracle123
+${PORT}         1521
+${CMD}          ${CENTREON_PLUGINS}
+...             --plugin=database::oracle::plugin
+...             --hostname=${HOSTNAME}
+...             --port=${PORT}
+...             --username=${USERNAME}
+...             --password=${PASSWORD}
+...             --servicename=FREEPDB1
+
+
+*** Test Cases ***
+RmanBackupAge ${tc}
+    [Tags]    database    oracle    rman    notauto
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    --mode=rman-backup-age
+    ...    ${extra_options}
+
+    Ctn Run Command Without Connector And Check Result As Regexp    ${command}    ${expected_regexp}
+
+    Examples:
+    ...    tc
+    ...    extraoptions
+    ...    expected_regexp
+    ...    --
+    ...    1
+    ...    ${EMPTY}
+    ...    CRITICAL: Rman 'DB FULL' backups never executed - Rman 'DB INCR' backups never executed - Rman 'ARCHIVELOG' backups never executed - Rman 'CONTROLFILE' backups never executed - Rman backups never executed.
+    ...    2
+    ...    --component-type=rman_catalog
+    ...    UNKNOWN: Cannot execute query: ORA-00942: table or view "SYSTEM"."RC_RMAN_STATUS" does not exist
+
+RmanBackupProblems ${tc}
+    [Tags]    database    oracle    rman    notauto
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    --mode=rman-backup-problems
+    ...    ${extra_options}
+
+    Ctn Run Command Without Connector And Check Result As Regexp    ${command}    ${expected_regexp}
+
+    Examples:
+    ...    tc
+    ...    extraoptions
+    ...    expected_regexp
+    ...    --
+    ...    1
+    ...    ${EMPTY}
+    ...    OK: During the last 3 days, number of backups completed: 0, failed: 0, completed with warnings: 0, completed with errors: 0 | 'rman.backups.completed.count'=0;;;0; 'rman.backups.failed.count'=0;;;0; 'rman.backups.completed_with_warnings.count'=0;;;0; 'rman.backups.completed_with_errors.count'=0;;;0;
+    ...    2
+    ...    --component-type=rman_catalog
+    ...    UNKNOWN: Cannot execute query: ORA-00942: table or view "SYSTEM"."RC_RMAN_STATUS" does not exist
+
+DisplayHelp ${tc}
+    [Tags]    database    oracle    rman
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    --mode=rman-backup-problems
+    ...    ${extra_options}
+
+    Ctn Run Command Without Connector And Check Result As Regexp    ${command}    ${expected_regexp}
+
+    Examples:    tc    extraoptions    expected_regexp    --
+    ...    1    --mode=rman-backup-problems --help    Plugin Description:
+    ...    2    --mode=rman-backup-age --help    Plugin Description:

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -306,6 +306,7 @@ redis-cli
 ReplicaJobSession
 RestAPI
 RFC1628
+RMAN
 RRDCached
 rsrp
 rsrq


### PR DESCRIPTION
## Description

Plugin(database::oracle) - Mode(rman-backup): Backup Monitoring Unavailable When Rman Catalog is External

**Fixes** # CTOR-2078

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software