### PR TITLE
enh(ci): add bookworm-arm64 and trixie-arm64 CPAN libraries packaging

### DIFF
--- a/.github/packaging/cpan-libraries.json
+++ b/.github/packaging/cpan-libraries.json
@@ -417,7 +417,7 @@
         "rpm_dependencies": "zeromq"
       },
       "deb": {
-        "build_names": "bullseye-amd64,bookworm,trixie,jammy,noble,bullseye-arm64",
+        "build_names": "bullseye-amd64,bookworm,trixie,jammy,noble,bullseye-arm64,bookworm-arm64,trixie-arm64",
         "use_dh_make_perl": "false",
         "version": "0.01",
         "deb_dependencies": "libzmq5"


### PR DESCRIPTION
### Description
JIRA: [MON-201662](https://centreon.atlassian.net/browse/MON-201662)

While working on MON-201662, the linux/arm64 build of the centreon-engine bookworm Docker image had to be disabled because the engine Dockerfile installs centreon-plugin-applications-monitoring-centreon-poller, whose dependencylibzmq-libzmq4 (XS-native CPAN module ZMQ::LibZMQ4) is not produced for bookworm-arm64 in apt-plugins-stable. The plugin .deb itself is arch: all, so once the native libs exist for arm64, the plugin installs cleanly.

This PR extends the existing bullseye-arm64 packaging pattern to bookworm-arm64 and trixie-arm64 (anticipating the next Debian stable at no extra cost) for CPAN libs:

ZMQ::LibZMQ4: centreon-plugin-virtualization-vmware-daemon

### Changes
.github/packaging/cpan-libraries.json:  append bookworm-arm64,trixie-arm64 to the deb.build_names of the three libs.

get-packaging-images matrix: include the two new arm64 images.
test-packages matrix: add bookworm/arm64 and trixie/arm64 install tests.
No changes are required to merge-package-deb-artifacts, download-and-cache-deb or deliver-packages — their distrib-only matrices already absorb arm64 artifacts via the per-distrib merge pattern (proven by bullseye-arm64).

[MON-201662]: https://centreon.atlassian.net/browse/MON-201662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ