### PR TITLE
fix(ci): remove version pin for UUID CPAN package

### DIFF
--- a/.github/packaging/cpan-libraries.json
+++ b/.github/packaging/cpan-libraries.json
@@ -379,9 +379,7 @@
     },
     {
       "name": "UUID",
-      "rpm": {
-        "version": "0.31"
-      }
+      "rpm": {}
     },
     {
       "name": "UUID::URandom",


### PR DESCRIPTION
## Description

JIRA: [MON-201736](https://centreon.atlassian.net/browse/MON-201736)

The CI packaging job `Package el* UUID` fails with a 404 error because `www.cpan.org` no longer serves `UUID-0.31.tar.gz`.

Remove the version pin so the packaging toolchain always resolves the latest available version.

## Changes

`.github/packaging/cpan-libraries.json`: remove `"version": "0.31"` from the `UUID` RPM entry.

## References

- Failed CI run: https://github.com/centreon/centreon-plugins/actions/runs/28036159265/job/83144839176

[MON-201736]: https://centreon.atlassian.net/browse/MON-201736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ