### PR TITLE
fix(apps-voip-3cx): update plugin for 3CX v20 API compatibility

### DIFF
--- a/src/apps/voip/3cx/restapi/mode/extension.pm
+++ b/src/apps/voip/3cx/restapi/mode/extension.pm
@@ -175,7 +175,7 @@ Example: --dnd-profile-name='Do not disturb'
 =item B<--unknown-status>
 
 Define the conditions to match for the status to be UNKNOWN.
-You can use the following variables: %{extension}, %{registered}, %{dnd}, %{profile}, %{status}, %{duration}
+You can use the following variables: C<extension>, C<registered>, C<dnd>, C<profile>, C<status>, C<duration>
 
 =item B<--warning-status>
 

--- a/src/apps/voip/3cx/restapi/mode/license.pm
+++ b/src/apps/voip/3cx/restapi/mode/license.pm
@@ -54,8 +54,8 @@ sub custom_support_status_output {
     if ($self->{result_values}->{support}) {
         $label = exprintf('Support enabled (expires on %{maintenance_expires_date})', $self->{result_values});
     } else {
-        if ($self->{result_values}->{maintenance_expires_date} < 0) {
-            $label = sprintf('Support expired %d day(s) ago', - $self->{result_values}->{maintenance_expires_date});
+        if ($self->{result_values}->{maintenance_expires_in} < 0) {
+            $label = sprintf('Support expired %d day(s) ago', - $self->{result_values}->{maintenance_expires_in});
         } else {
             $label = 'Support disabled';
         }

--- a/src/apps/voip/3cx/restapi/mode/system.pm
+++ b/src/apps/voip/3cx/restapi/mode/system.pm
@@ -168,7 +168,7 @@ sub manage_selection {
         };
     }
 
-    my $calls_prct_used = $system->{CallsActive} * 100 / $system->{MaxSimCalls};
+    my $calls_prct_used = $system->{MaxSimCalls} ? $system->{CallsActive} * 100 / $system->{MaxSimCalls} : 100;
     my $extensions_prct_used = $system->{MaxUserExtensions} ? $system->{UserExtensions} * 100 / $system->{MaxUserExtensions} : 100;
 
     $self->{global} = {
@@ -208,7 +208,7 @@ Exclude updates by category (can be a regexp).
 =item B<--include-service>
 
 Services to include in checks (can be a regexp).
-Available services: C<HasUnregisteredTrunks>, HasNotRunningServices>,
+Available services: C<HasUnregisteredTrunks>, C<HasNotRunningServices>,
 C<HasUnregisteredSystemExtensions>, C<HasUpdatesAvailable>.
 
 =item B<--exclude-service>


### PR DESCRIPTION
## Description

fix(apps-voip-3cx): update plugin for 3CX v20 API compatibility

**Fixes** # CTOR-2288

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software