### PR TITLE
enh(apps::proxmox::ve::restapi): convert tags to array in discovery mode

### DIFF
--- a/src/apps/proxmox/ve/restapi/custom/api.pm
+++ b/src/apps/proxmox/ve/restapi/custom/api.pm
@@ -26,7 +26,7 @@ use strict;
 use warnings;
 use centreon::plugins::http;
 use centreon::plugins::statefile;
-use centreon::plugins::misc qw(is_excluded);
+use centreon::plugins::misc qw(is_excluded is_local_ip);
 use JSON::XS;
 use Digest::SHA qw(sha256_hex);
 
@@ -422,7 +422,7 @@ sub api_get_network_interfaces {
 
             my $ip_loopback = ($ip->{'ip-address'} =~ /^127\./ || $name =~ /^lo$/i) ? 1 : 0;
 
-            my $ip_local = $ip_loopback || centreon::plugins::misc::is_local_ip($ip->{'ip-address'});
+            my $ip_local = $ip_loopback || is_local_ip($ip->{'ip-address'});
 
             $hash_ips_by_interface{$name} = { address => $ip->{'ip-address'}, local => $ip_local, loopback => $ip_loopback }
                 unless $hash_ips_by_interface{$name};

--- a/src/apps/proxmox/ve/restapi/mode/discovery.pm
+++ b/src/apps/proxmox/ve/restapi/mode/discovery.pm
@@ -32,7 +32,11 @@ sub new {
     bless $self, $class;
     
     $options{options}->add_options(arguments => {
-        'resource-type:s' => { name => 'resource_type' },
+        'resource-type:s' => {
+            name => 'resource_type',
+            default => 'node',
+            regexp_match => '^node|vm$',
+            error_message => 'Unknown resource type. Accepted values: node, vm.' },
         'prettify'        => { name => 'prettify' }
     });
 
@@ -42,14 +46,6 @@ sub new {
 sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::init(%options);
-
-    if (!defined($self->{option_results}->{resource_type}) || $self->{option_results}->{resource_type} eq '') {
-        $self->{option_results}->{resource_type} = 'nodes';
-    }
-    if ($self->{option_results}->{resource_type} !~ /^node|vm$/) {
-        $self->{output}->add_option_msg(short_msg => 'unknown resource type');
-        $self->{output}->option_exit();
-    }
 }
 
 sub discovery_vm {
@@ -64,7 +60,7 @@ sub discovery_vm {
         $vm->{name} = $vms->{$vm_id}->{Name};
         $vm->{state} = $vms->{$vm_id}->{State};
         $vm->{node_name} = $vms->{$vm_id}->{Node};
-        $vm->{tags} = $vms->{$vm_id}->{Tags};
+        $vm->{tags} = [ sort split(/;/, $vms->{$vm_id}->{Tags}) ];
 
         my ($network_ips, $network_interfaces, $osinfo);
 

--- a/tests/apps/proxmox/ve/restapi/discovery.robot
+++ b/tests/apps/proxmox/ve/restapi/discovery.robot
@@ -41,7 +41,7 @@ Discovery ${tc}
     ...    "discovered_items":3
     ...    2
     ...    --resource-type=vm
-    ...    .*"tags":"production;linux".*"ip_addresses":\\\\["123.321.123.321","127.0.0.1"\\\\].*"os_info_name":"XXXXX GNU/Linux"
+    ...    .*"ip_addresses":\\\\["123.321.123.321","127.0.0.1"\\\\].*"os_info_name":"XXXXX GNU/Linux".*"tags":\\\\["dev","linux"\\\\]
     ...    3
     ...    --resource-type=node
     ...    ^(?!.*(ip_addresses|os_info_name)).*$


### PR DESCRIPTION
## Description

- convert tags to array in discovery mode
- move validity check of options to add_options instead of check_options

Refs: CTOR-2259

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
