### PR TITLE
enh(storage::dell::me4::restapi): Add tier distribution and page allocation metrics to volume-statistics mode

### DIFF
--- a/src/storage/dell/me4/restapi/mode/volumestatistics.pm
+++ b/src/storage/dell/me4/restapi/mode/volumestatistics.pm
@@ -28,7 +28,7 @@ use Digest::MD5 qw(md5_hex);
 
 sub prefix_output {
     my ($self, %options) = @_;
-    
+
     return "Volume '" . $options{instance_value}->{display} . "' ";
 }
 
@@ -130,6 +130,54 @@ sub set_counters {
                     { template => '%s', min => 0, label_extra_instance => 1 }
                 ]
             }
+        },
+        { label => 'tier-ssd-percent', nlabel => 'volume.tier.ssd.percentage', set => {
+                key_values => [ { name => 'percent-tier-ssd' } ],
+                output_template => 'tier SSD: %s%%',
+                perfdatas => [
+                    { template => '%d', min => 0, max => 100, label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'tier-sata-percent', nlabel => 'volume.tier.archive.percentage', set => {
+                key_values => [ { name => 'percent-tier-sata' } ],
+                output_template => 'tier Archive (SATA): %s%%',
+                perfdatas => [
+                    { template => '%d', min => 0, max => 100, label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'tier-sas-percent', nlabel => 'volume.tier.sas.percentage', set => {
+                key_values => [ { name => 'percent-tier-sas' } ],
+                output_template => 'tier SAS: %s%%',
+                perfdatas => [
+                    { template => '%d', min => 0, max => 100, label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'tier-rfc-percent', nlabel => 'volume.tier.rfc.percentage', set => {
+                key_values => [ { name => 'percent-allocated-rfc' } ],
+                output_template => 'tier RFC: %s%%',
+                perfdatas => [
+                    { template => '%d', min => 0, max => 100, label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'pages-alloc', nlabel => 'volume.pages.allocated.perminute', set => {
+                key_values => [ { name => 'pages-alloc-per-minute' } ],
+                output_template => 'pages alloc/min: %s',
+                perfdatas => [
+                    { template => '%d', min => 0, label_extra_instance => 1 }
+                ]
+            }
+        },
+        { label => 'pages-dealloc', nlabel => 'volume.pages.deallocated.perminute', set => {
+                key_values => [ { name => 'pages-dealloc-per-minute' } ],
+                output_template => 'pages dealloc/min: %s',
+                perfdatas => [
+                    { template => '%d', min => 0, label_extra_instance => 1 }
+                ]
+            }
         }
     ];
 }
@@ -155,7 +203,7 @@ sub manage_selection {
     foreach my $volume (@{$results->{'volume-statistics'}}) {
         next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
             && $volume->{'volume-name'} !~ /$self->{option_results}->{filter_name}/);
-        
+
         $self->{volumes}->{$volume->{'volume-name'}} = { display => $volume->{'volume-name'}, %{$volume} };
     }
 
@@ -191,7 +239,9 @@ Can be: 'data-read', 'data-written',
 'reads', 'writes',
 'data-transfer', 'iops',
 'write-cache-percent', 'write-cache-hits', 'write-cache-misses',
-'read-cache-hits', 'read-cache-misses'.
+'read-cache-hits', 'read-cache-misses',
+'tier-ssd-percent', 'tier-sata-percent', 'tier-sas-percent',
+'tier-rfc-percent', 'pages-alloc', 'pages-dealloc'.
 
 =back
 


### PR DESCRIPTION
feat(storage/dell/me4): add tier distribution and page allocation metrics

# Community contributors

## Description

The current volume-statistics mode does not export tier distribution metrics that are already available in the /api/show/volume-statistics API response. This is a enhancement

## New metrics added
- percent-tier-ssd → volume.tier.ssd.percentage (%)
- percent-tier-sata → volume.tier.archive.percentage (%)
- percent-tier-sas → volume.tier.sas.percentage (%)
- percent-allocated-rfc → volume.tier.rfc.percentage (%)
- pages-alloc-per-minute → volume.pages.allocated.perminute
- pages-dealloc-per-minute → volume.pages.deallocated.perminute


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?
Monitor data tiering behavior per volume. Useful for capacity planning and detecting SSD tier saturation (hot data spilling to slower tiers).

If some information is confidential, such as logins or IP addresses, obfuscate them in what is sent 
publicly and we'll get in touch with you by private message if this information is needed.

## Testing
Tested on Dell PowerVault ME5084 (~300 volumes) with Centreon 25.10.14 Community Edition


**Output example:**
sudo -u centreon-engine /usr/lib/centreon/plugins/centreon-plugins/src/centreon_plugins.pl --plugin=storage::dell::me4::restapi::plugin --mode=volume-statistics --hostname=localhost --api-username=user--api-password=*** --port=443 --proto=https --insecure --digest-sha256 --filter-name='DISK_CLIENTE'
OK: All volumes statistics are ok | 'DISK_CLIENTE#volume.data.transfer.bytespersecond'=0B/s;;;0; 'DISK_CLIENTE#volume.iops.ops'=0ops;;;0; 'DISK_CLIENTE#volume.cache.write.usage.percentage'=0;;;0; 'DISK_CLIENTE#volume.tier.ssd.percentage'=11;;;0;100 'DISK_CLIENTE#volume.tier.archive.percentage'=88;;;0;100 'DISK_CLIENTE#volume.tier.sas.percentage'=0;;;0;100 'DISK_CLIENTE#volume.tier.rfc.percentage'=0;;;0;100 'DISK_CLIENTE#volume.pages.allocated.perminute'=0;;;0; 'DISK_CLIENTE#volume.pages.deallocated.perminute'=0;;;0; 


## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] I have provide data or shown output displaying the result of this code in the plugin area concerned.
