### PR TITLE
enh(network::paloalto::snmp): Add sensor mode

### DIFF
--- a/src/network/paloalto/snmp/plugin.pm
+++ b/src/network/paloalto/snmp/plugin.pm
@@ -39,6 +39,7 @@ sub new {
         'list-interfaces' => 'snmp_standard::mode::listinterfaces',
         'memory'          => 'network::paloalto::snmp::mode::memory',
         'panorama'        => 'network::paloalto::snmp::mode::panorama',
+        'sensors'         => 'snmp_standard::mode::entity',
         'sessions'        => 'network::paloalto::snmp::mode::sessions',
         'signatures'      => 'network::paloalto::snmp::mode::signatures'
     };


### PR DESCRIPTION
# Community contributors

## Description

Monitors the PA sensors
`sensor.celsius_Temperature @ U48'=40C;;;; 'sensor.celsius_Temperature @ U49'=39C;;;; 'sensor.celsius_Temperature @ Cavium Core'=44C;;;; 'count_sensor'=3;;;;
`