### PR TITLE
Fix Commvault token refresh handling

### DIFF
--- a/src/apps/backup/commvault/commserve/restapi/custom/api.pm
+++ b/src/apps/backup/commvault/commserve/restapi/custom/api.pm
@@ -187,7 +187,7 @@ sub refresh_authent_token
     if ($code != 200) {
         $self->{cache_authent_token}->remove_file() if $code == 450 || $code == 500;
         return ('', '') unless $exit_on_failed;
-        my $message = $content && $content =~ /Message\":\"([^\"]+)\"/ ? $1 : $self->{http}->get_message();
+        my $message = $content && $content =~ /Message":"([^\"]+)"/ ? $1 : $self->{http}->get_message();
         $self->{output}->option_exit(short_msg => "Cannot refresh token [code: '" . $self->{http}->get_code() . "'] [message: '$message']");
     }
     my ($accessToken, $refreshToken, $expiryTime) = ('', '', '');
@@ -198,8 +198,19 @@ sub refresh_authent_token
             if $content =~ /accessToken\":\s*\"([^\"]+)\"/m;
         $refreshToken = $1
             if $content =~ /refreshToken\":\s*\"([^\"]+)\"/m;
-        $expiryTime = $1
-            if $content =~ /tokenExpiryTimes.amp\":\s*(\d+)/m; # Commvault returns Times}amp instead of Timestamp
+
+        my $token_expiry_timestamp = $1
+            if $content =~ /"tokenExpiryTimestamp"\s*:\s*(-?\d+)/m;
+        my $expires_in = $1
+            if $content =~ /"expiresIn"\s*:\s*(\d+)/m;
+        if (defined($token_expiry_timestamp) && $token_expiry_timestamp ne '') {
+            $expiryTime = $token_expiry_timestamp;
+        } elsif (defined($expires_in) && $expires_in ne '') {
+            $expiryTime = time() + $expires_in;
+        } else {
+            $expiryTime = $1
+                if $content =~ /tokenExpiryTimes\.amp"\s*:\s*(\d+)/m; # Commvault returns Times}amp instead of Timestamp
+        }
     }
 
     $self->{output}->option_exit(short_msg => "Cannot extract tokens !")
@@ -284,6 +295,7 @@ sub request_internal {
         $self->{output}->option_exit(short_msg => 'Tokens where not found. This check can be run after next execution of "token" mode')
             if $authent_token eq '';
 
+        $expiry_time = 0 if !defined($expiry_time) || $expiry_time !~ /^\d+$/;
         $expiry_time -= time;
         $self->{output}->output_add(long_msg => $expiry_time > 0 ? "Token will expire in $expiry_time seconds" : "Token has expired", debug => 1);
 

--- a/src/apps/backup/commvault/commserve/restapi/custom/api.pm
+++ b/src/apps/backup/commvault/commserve/restapi/custom/api.pm
@@ -25,7 +25,7 @@ use warnings;
 use centreon::plugins::http;
 use centreon::plugins::statefile;
 use Digest::SHA qw(sha256_hex);
-use centreon::plugins::misc qw/json_encode/;
+use centreon::plugins::misc qw/json_encode is_not_empty/;
 use MIME::Base64;
 
 sub new {
@@ -203,9 +203,9 @@ sub refresh_authent_token
             if $content =~ /"tokenExpiryTimestamp"\s*:\s*(-?\d+)/m;
         my $expires_in = $1
             if $content =~ /"expiresIn"\s*:\s*(\d+)/m;
-        if (defined($token_expiry_timestamp) && $token_expiry_timestamp ne '') {
+        if ( is_not_empty($token_expiry_timestamp) ) {
             $expiryTime = $token_expiry_timestamp;
-        } elsif (defined($expires_in) && $expires_in ne '') {
+        } elsif ( is_not_empty($expires_in) ) {
             $expiryTime = time() + $expires_in;
         } else {
             $expiryTime = $1

--- a/src/apps/backup/commvault/commserve/restapi/custom/api.pm
+++ b/src/apps/backup/commvault/commserve/restapi/custom/api.pm
@@ -187,7 +187,7 @@ sub refresh_authent_token
     if ($code != 200) {
         $self->{cache_authent_token}->remove_file() if $code == 450 || $code == 500;
         return ('', '') unless $exit_on_failed;
-        my $message = $content && $content =~ /Message":"([^\"]+)"/ ? $1 : $self->{http}->get_message();
+        my $message = $content && $content =~ /Message\":\"([^\"]+)\"/ ? $1 : $self->{http}->get_message();
         $self->{output}->option_exit(short_msg => "Cannot refresh token [code: '" . $self->{http}->get_code() . "'] [message: '$message']");
     }
     my ($accessToken, $refreshToken, $expiryTime) = ('', '', '');

--- a/src/apps/backup/commvault/commserve/restapi/mode/token.pm
+++ b/src/apps/backup/commvault/commserve/restapi/mode/token.pm
@@ -96,7 +96,8 @@ sub run {
     my $msg = 'Token available';
     my $severity = 'OK';
     if ($self->{option_results}->{api_token} ne '') {
-        if ($expiry_time < $self->{option_results}->{refresh_before} || $self->{option_results}->{force_refresh}) {
+        my $time_remaining = $expiry_time - time();
+        if ($time_remaining < $self->{option_results}->{refresh_before} || $self->{option_results}->{force_refresh}) {
             if ($authent_token eq '') {
                 $authent_token = $self->{option_results}->{api_token};
                 $refresh_token = $self->{option_results}->{refresh_token};


### PR DESCRIPTION
## Description

Fix the check of the token expiration. Before, we compared a timestamp to a delay.
Also get the good value of expiry time.

**Fixes** # CTOR-2443

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Please describe the **procedure** to verify that the goal of the PR is matched. 
Provide clear instructions so that it can be **correctly tested**.
Mention the automated tests included in this FOR (what they test like mode/option combinations).

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).

