### PR TITLE
doc(network::nortel::standard::snmp): add missing component

### DIFF
--- a/src/network/nortel/standard/snmp/mode/hardware.pm
+++ b/src/network/nortel/standard/snmp/mode/hardware.pm
@@ -117,7 +117,7 @@ Check hardware.
 =item B<--component>
 
 Which component to check (default: '.*').
-Can be: 'fan', 'psu', 'card', 'entity', 'led'.
+Can be: 'fan', 'psu', 'card', 'entity', 'led', 'temperature'.
 
 =item B<--filter>
 


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

add missing component

