### PR TITLE
fix(notification::orangesms::mode::alerts): fixed incorrect endpoint path

### DIFF
--- a/src/notification/orangesms/mode/alerts.pm
+++ b/src/notification/orangesms/mode/alerts.pm
@@ -127,7 +127,7 @@ sub create_sms_diffusion {
 
     $self->{http}->add_header(key => 'Content-Type', value => 'application/json' );
     my $response = $self->{http}->request(  method => 'POST',
-                                            url_path => $self->{option_results}->{endpoint}.uri_escape($self->{option_results}->{group_id}).'/diffusion-requests',
+                                            url_path => $self->{option_results}->{endpoint}.'groups/'.uri_escape($self->{option_results}->{group_id}).'/diffusion-requests',
                                             header => [ 'Accept: application/json',
                                                         'Content-Type: application/json',
                                                         'Authorization: Bearer ' . $options{token}

--- a/tests/notification/orangesms/orangesms.mockoon.json
+++ b/tests/notification/orangesms/orangesms.mockoon.json
@@ -4,7 +4,7 @@
   "name": "Orangesms.mockoon",
   "endpointPrefix": "",
   "latency": 0,
-  "port": 3003,
+  "port": 3000,
   "hostname": "",
   "folders": [],
   "routes": [
@@ -100,7 +100,7 @@
       "type": "http",
       "documentation": "",
       "method": "post",
-      "endpoint": "api/v1.2/\\d+/diffusion-requests",
+      "endpoint": "api/v1.2/groups/:id/diffusion-requests",
       "responses": [
         {
           "uuid": "b1e555a6-7fd5-4939-beb9-78d214cdafbf",


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

Correction to the API request for sending an SMS in the `create_sms` function

**Fixes** # (issue)
Refs: CTOR-2110

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Please describe the **procedure** to verify that the goal of the PR is matched. 
Provide clear instructions so that it can be **correctly tested**.
Mention the automated tests included in this FOR (what they test like mode/option combinations).

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [x] I have reviewed all the help messages in all the .pm files I have modified.
  - [x] All sentences begin with a capital letter.
  - [x] All sentences end with a period.
  - [x] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
