### PR TITLE
enh(ci): fix as400 daemon java dependency

### DIFF
--- a/.github/workflows/as400.yml
+++ b/.github/workflows/as400.yml
@@ -41,27 +41,35 @@ jobs:
           - package_extension: rpm
             image: packaging-plugins-java-alma8
             distrib: el8
+            java_major_version: "17"
           - package_extension: rpm
             image: packaging-plugins-java-alma9
             distrib: el9
+            java_major_version: "17"
           - package_extension: rpm
             image: packaging-plugins-java-alma10
             distrib: el10
+            java_major_version: "21"
           - package_extension: deb
             image: packaging-plugins-java-bullseye
             distrib: bullseye
+            java_major_version: "17"
           - package_extension: deb
             image: packaging-plugins-java-bookworm
             distrib: bookworm
+            java_major_version: "17"
           - package_extension: deb
             image: packaging-plugins-java-trixie
             distrib: trixie
+            java_major_version: "21"
           - package_extension: deb
             image: packaging-plugins-java-jammy
             distrib: jammy
+            java_major_version: "17"
           - package_extension: deb
             image: packaging-plugins-java-noble
             distrib: noble
+            java_major_version: "17"
 
     container:
       image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}
@@ -92,8 +100,11 @@ jobs:
           {} ';'
         shell: bash
 
-      - name: Set JAVA_HOME
-        run: export JAVA_HOME=$( java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | tr -s ' ' | cut -d ' ' -f 4)
+      - name: Set JAVA_HOME and set Java major version for packaging
+        run: |
+          export JAVA_HOME=$( java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | tr -s ' ' | cut -d ' ' -f 4)
+          echo "JAVA_MAJOR_VERSION=${{ matrix.java_major_version }}" >> "$GITHUB_ENV"
+        shell: bash
 
       - name: Build JAR using maven
         run: mvn -version && mvn clean install -f as400/connector.as400/pom.xml

--- a/as400/packaging/centreon-as400-daemon.yaml
+++ b/as400/packaging/centreon-as400-daemon.yaml
@@ -60,10 +60,10 @@ scripts:
 overrides:
   rpm:
     depends:
-      - "java-17-openjdk-headless"
+      - "java-${JAVA_MAJOR_VERSION}-openjdk-headless"
   deb:
     depends:
-      - "openjdk-17-jre-headless"
+      - "openjdk-${JAVA_MAJOR_VERSION}-jre-headless"
 
 rpm:
   summary: Centreon AS 400 Plugin daemon


### PR DESCRIPTION
## Description

Correction de la version de java en dépendance de el10 et trixie, qui n'ont plus java17 mais java21.

**Fixes** CTOR-2464

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Test manuel en récupérant les packages en artifact (fait lors de la création de la PR)

## Checklist

- [ ] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
