### PR TITLE
fix(docker-connector-vmware): drop arm64 ZMQ::LibZMQ4 compile shim

### DIFF
--- a/.github/docker/connector/Dockerfile.connector-vmware
+++ b/.github/docker/connector/Dockerfile.connector-vmware
@@ -162,38 +162,6 @@ RUN mkdir -p /usr/local/share/perl/5.36.0/VMware /usr/local/share/perl5/VMware
 FROM sdk-${WITH_SDK} AS sdk-installer
 
 #############################################
-# Stage 2c: arm64 Perl modules builder
-# Compiles CPAN modules unavailable as arm64 packages.
-# amd64: uses Centreon apt repo packages instead (see cpanm-deps-amd64 below).
-#############################################
-FROM debian:13-slim AS cpanm-builder
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    --mount=type=cache,target=/root/.cpanm \
-    bash -e <<'EOF'
-apt-get update
-apt-get install -y --no-install-recommends \
-    cpanminus \
-    build-essential \
-    libzmq3-dev \
-    perl
-cpanm --notest --configure-timeout 300 -L /opt/perl-modules \
-    ZMQ::LibZMQ4
-EOF
-
-# arm64: inject pre-compiled modules into runtime
-FROM scratch AS cpanm-deps-arm64
-COPY --from=cpanm-builder /opt/perl-modules/ /opt/perl-modules/
-
-# amd64: packages come from Centreon apt repo — nothing to copy from builder
-FROM scratch AS cpanm-deps-amd64
-
-ARG TARGETARCH
-# hadolint ignore=DL3006
-FROM cpanm-deps-${TARGETARCH} AS cpanm-deps-selected
-
-#############################################
 # Stage 3: Runtime - Debian 13 slim image (trixie)
 #############################################
 FROM debian:13-slim AS centreon-vmware
@@ -224,12 +192,10 @@ usermod -aG centreon-engine centreon
 usermod -aG centreon-gorgone centreon
 EOF
 
-# Install runtime dependencies — one update, arch-conditional Centreon repo + packages
-ARG TARGETARCH
+# Install runtime dependencies — one update, same packages on every arch
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     bash -e <<'EOF'
-ARCH=$(dpkg --print-architecture)
 apt-get update
 apt-get install -y --no-install-recommends gnupg wget ca-certificates
 . /etc/os-release
@@ -253,19 +219,13 @@ apt-get install -y --no-install-recommends \
     libuuid-perl \
     libzmq5 \
     libzmq-constants-perl \
+    libzmq-libzmq4-perl \
     libxml-libxml-perl \
     libjson-perl \
     inotify-tools \
     netcat-openbsd
-if [ "$ARCH" = "amd64" ]; then
-    apt-get install -y --no-install-recommends \
-        libzmq-libzmq4-perl
-fi
 rm -rf /tmp/* /var/tmp/* /usr/share/doc/* /usr/share/man/*
 EOF
-
-# arm64: inject pre-compiled Perl modules from cpanm-builder (amd64: FROM scratch — no-op)
-COPY --link --from=cpanm-deps-selected / /
 
 # Create directory structure
 RUN bash -e <<'EOF'
@@ -312,7 +272,7 @@ EOF
 
 COPY --chmod=755 .github/docker/connector/entrypoint /usr/local/lib/centreon-vmware/
 
-ENV PERL5LIB=/opt/perl-modules/lib/perl5:/usr/local/share/perl5:/usr/share/perl5:/usr/lib/perl5
+ENV PERL5LIB=/usr/local/share/perl5:/usr/share/perl5:/usr/lib/perl5
 
 EXPOSE 5700
 


### PR DESCRIPTION
## Summary
- `libzmq-libzmq4-perl` is now published for arm64 on `packages.centreon.com` (`apt-plugins-stable`), same version as amd64 (`0.01-1+deb13u1`, published 2026-07-21). `.github/packaging/cpan-libraries.json` already lists `trixie-arm64` as a build target for `ZMQ::LibZMQ4`.
- The `Dockerfile.connector-vmware` no longer needs the arm64-only `cpanm-builder` shim that compiled `ZMQ::LibZMQ4` from source — the package now installs from the Centreon apt repo on both architectures, just like amd64 already did.
- Removed: `cpanm-builder` / `cpanm-deps-arm64` / `cpanm-deps-amd64` / `cpanm-deps-selected` stages, the arch-conditional apt install branch, the shim `COPY --from=cpanm-deps-selected`, and the now-unused `/opt/perl-modules` entry in `PERL5LIB`.

## Test plan
- [x] Built the image locally with `docker buildx build --platform linux/arm64 --build-arg PACKAGE_SOURCE=repo --build-arg VERSION=20260700 --build-arg STABILITY=stable` — succeeds, `libzmq-libzmq4-perl 0.01-1+deb13u1 arm64` installs from apt, and `perl -e 'use ZMQ::LibZMQ4'` loads correctly inside the arm64 (aarch64, via qemu) container.
- [x] Same check on `linux/amd64` — no regression, `ZMQ::LibZMQ4` still loads.
- [x] CI `docker-build` job in `connector-vmware.yml` (multi-arch buildx) green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)