### PR TITLE
fix(network::cisco::meraki::cloudcontroller::restapi): fix typo in api custom CTOR-2478

### DIFF
--- a/src/network/cisco/meraki/cloudcontroller/restapi/custom/api.pm
+++ b/src/network/cisco/meraki/cloudcontroller/restapi/custom/api.pm
@@ -502,7 +502,7 @@ sub get_network_wireless_usage_history {
     return $self->request_api(
         endpoint => '/networks/' . $options{network_id} . '/wireless/usageHistory',
         get_param => [ 
-            'deviceSerial ='. $options{serial}, 
+            'deviceSerial='. $options{serial}, 
             'timespan=' . $self->{timespan} ],
         hostname => $self->get_shard_hostname(serial => $options{serial})
     )


### PR DESCRIPTION
# Centreon team (internal PR)

## Description

**Fixes** # (issue)
Fix [Error Cisco Meraki Plugin : centreon_cisco_meraki_restapi.pl](https://thewatch.centreon.com/centreon-monitoring-agent-61/error-cisco-meraki-plugin-centreon-cisco-meraki-restapi-pl-5834?tid=5834)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

N/A
