### PR TITLE
fix(apps::centreon::sql): fix hardcoded centreon_storage database name - CTOR 2477

### DIFF
--- a/src/apps/centreon/sql/mode/countnotifications.pm
+++ b/src/apps/centreon/sql/mode/countnotifications.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -118,8 +118,9 @@ __END__
 
 =head1 MODE
 
-Check the number of notifications (works only with centreon-broker).
-The mode should be used with mysql plugin and dyn-mode option.
+Check the number of notifications sent (works only with centreon-broker).
+The mode should be used with the database::mysql::plugin plugin and C<--dyn-mode> option.
+Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=apps::centreon::sql::mode::countnotifications ...>.
 
 =over 8
 

--- a/src/apps/centreon/sql/mode/countnotifications.pm
+++ b/src/apps/centreon/sql/mode/countnotifications.pm
@@ -46,6 +46,11 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::init(%options);
 
+    if ($self->{option_results}->{centreon_storage_database} !~ /^[a-zA-Z0-9_\-]+$/) {
+        $self->{output}->add_option_msg(short_msg => "Wrong value for --centreon-storage-database option (only alphanumeric characters, underscores and dashes are allowed).");
+        $self->{output}->option_exit();
+    }
+
     if (($self->{perfdata}->threshold_validate(label => 'warning', value => $self->{option_results}->{warning})) == 0) {
         $self->{output}->add_option_msg(short_msg => "Wrong warning threshold '" . $self->{option_results}->{warning} . "'.");
         $self->{output}->option_exit();
@@ -62,7 +67,7 @@ sub execute {
     my ($self, %options) = @_;
 
     $self->{sql}->connect();
-    $self->{sql}->query(query => "SELECT name, count(NULLIF(log_id, 0)) as num FROM " . $self->{option_results}->{centreon_storage_database} . ".instances LEFT JOIN " . $self->{option_results}->{centreon_storage_database} . ".logs ON logs.ctime > " . $options{time} . " AND logs.msg_type IN ('2', '3') AND logs.instance_name = instances.name WHERE deleted = '0' GROUP BY name");
+    $self->{sql}->query(query => "SELECT name, count(NULLIF(log_id, 0)) as num FROM `" . $self->{option_results}->{centreon_storage_database} . "`.instances LEFT JOIN `" . $self->{option_results}->{centreon_storage_database} . "`.logs ON logs.ctime > " . $options{time} . " AND logs.msg_type IN ('2', '3') AND logs.instance_name = instances.name WHERE deleted = '0' GROUP BY name");
     my $total_notifications = 0;
     while ((my $row = $self->{sql}->fetchrow_hashref())) {
         $self->{output}->output_add(long_msg => sprintf("%d sent notifications from %s", $row->{num}, $row->{name}));
@@ -126,7 +131,7 @@ Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=
 
 =item B<--centreon-storage-database>
 
-Centreon storage database name (default: 'centreon_storage').
+Set the Centreon storage database name, only alphanumeric characters and underscores are allowed (default: 'centreon_storage').
 
 =item B<--warning>
 

--- a/src/apps/centreon/sql/mode/countproblems.pm
+++ b/src/apps/centreon/sql/mode/countproblems.pm
@@ -45,6 +45,11 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::init(%options);
 
+    if ($self->{option_results}->{centreon_storage_database} !~ /^[a-zA-Z0-9_\-]+$/) {
+        $self->{output}->add_option_msg(short_msg => "Wrong value for --centreon-storage-database option (only alphanumeric characters, underscores and dashes are allowed).");
+        $self->{output}->option_exit();
+    }
+
     if (($self->{perfdata}->threshold_validate(label => 'warning', value => $self->{option_results}->{warning})) == 0) {
         $self->{output}->add_option_msg(short_msg => "Wrong warning threshold '" . $self->{option_results}->{warning} . "'.");
         $self->{output}->option_exit();
@@ -61,7 +66,7 @@ sub execute {
     my ($self, %options) = @_;
 
     $self->{sql}->connect();
-    $self->{sql}->query(query => "SELECT name, msg_type, status, count(NULLIF(log_id, 0)) as num FROM " . $self->{option_results}->{centreon_storage_database} . ".instances LEFT JOIN " . $self->{option_results}->{centreon_storage_database} . ".logs ON logs.ctime > " . $options{time} . " AND logs.msg_type IN ('0', '1') AND type = '1' AND status NOT IN ('0') AND logs.instance_name = instances.name WHERE deleted = '0' GROUP BY name, msg_type, status");
+    $self->{sql}->query(query => "SELECT name, msg_type, status, count(NULLIF(log_id, 0)) as num FROM `" . $self->{option_results}->{centreon_storage_database} . "`.instances LEFT JOIN `" . $self->{option_results}->{centreon_storage_database} . "`.logs ON logs.ctime > " . $options{time} . " AND logs.msg_type IN ('0', '1') AND type = '1' AND status NOT IN ('0') AND logs.instance_name = instances.name WHERE deleted = '0' GROUP BY name, msg_type, status");
 
     my $total_problems = { total => 0, hosts => 0, services => 0 };
     my $total_problems_by_poller = {};
@@ -169,7 +174,7 @@ Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=
 
 =item B<--centreon-storage-database>
 
-Centreon storage database name (default: 'centreon_storage').
+Set the Centreon storage database name, only alphanumeric characters and underscores are allowed (default: 'centreon_storage').
 
 =item B<--warning>
 

--- a/src/apps/centreon/sql/mode/countproblems.pm
+++ b/src/apps/centreon/sql/mode/countproblems.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -162,7 +162,8 @@ __END__
 =head1 MODE
 
 Check the number of problems (works only with centreon-broker).
-The mode should be used with mysql plugin and dyn-mode option.
+The mode should be used with the database::mysql::plugin plugin and C<--dyn-mode> option.
+Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=apps::centreon::sql::mode::countproblems ...>.
 
 =over 8
 

--- a/src/apps/centreon/sql/mode/countservices.pm
+++ b/src/apps/centreon/sql/mode/countservices.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -21,6 +21,7 @@
 package apps::centreon::sql::mode::countservices;
 
 use base qw(centreon::plugins::templates::counter);
+use centreon::plugins::constants qw(:values :counters);
 
 use strict;
 use warnings;
@@ -60,10 +61,10 @@ sub set_counters {
 
      $self->{maps_counters_type} = [
         {
-            name => 'pollers', type => 3, cb_prefix_output => 'prefix_poller_output', cb_long_output => 'poller_long_output', indent_long_output => '    ', message_multiple => 'All pollers are ok',
+            name => 'pollers', type => COUNTER_TYPE_MULTIPLE, cb_prefix_output => 'prefix_poller_output', cb_long_output => 'poller_long_output', indent_long_output => '    ', message_multiple => 'All pollers are ok',
             group => [
-                { name => 'host', type => 0, cb_prefix_output => 'prefix_host_output', skipped_code => { -10 => 1 } },
-                { name => 'service', type => 0, cb_prefix_output => 'prefix_service_output', skipped_code => { -10 => 1 } }
+                { name => 'host', type => COUNTER_MULTIPLE_INSTANCE, prefix_output => 'number of hosts ', skipped_code => { NO_VALUE() => 1 } },
+                { name => 'service', type => COUNTER_MULTIPLE_INSTANCE, prefix_output => 'number of services ', skipped_code => { NO_VALUE() => 1 } }
             ]
         }
     ];
@@ -201,6 +202,8 @@ __END__
 =head1 MODE
 
 Check the number of hosts/services by poller.
+The mode should be used with the database::mysql::plugin plugin and C<--dyn-mode> option.
+Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=apps::centreon::sql::mode::countservices ...>.
 
 =over 8
 
@@ -217,11 +220,94 @@ Centreon storage database name (default: 'centreon_storage').
 
 Filter by poller name (regexp can be used).
 
-=item B<--warning-*> B<--critical-*>
 
-Thresholds.
-Can be: 'service', 'services-ok', 'services-warning', 'services-critical', 'services-unknown', 'services-pending',
-'host', 'hosts-up', 'hosts-down', 'hosts-unreachable', 'hosts-pending'.
+=item B<--warning-host>
+
+Threshold.
+
+=item B<--critical-host>
+
+Threshold.
+
+=item B<--warning-hosts-down>
+
+Threshold.
+
+=item B<--critical-hosts-down>
+
+Threshold.
+
+=item B<--warning-hosts-pending>
+
+Threshold.
+
+=item B<--critical-hosts-pending>
+
+Threshold.
+
+=item B<--warning-hosts-unreachable>
+
+Threshold.
+
+=item B<--critical-hosts-unreachable>
+
+Threshold.
+
+=item B<--warning-hosts-up>
+
+Threshold.
+
+=item B<--critical-hosts-up>
+
+Threshold.
+
+=item B<--warning-service>
+
+Threshold.
+
+=item B<--critical-service>
+
+Threshold.
+
+=item B<--warning-services-critical>
+
+Threshold.
+
+=item B<--critical-services-critical>
+
+Threshold.
+
+=item B<--warning-services-ok>
+
+Threshold.
+
+=item B<--critical-services-ok>
+
+Threshold.
+
+=item B<--warning-services-pending>
+
+Threshold.
+
+=item B<--critical-services-pending>
+
+Threshold.
+
+=item B<--warning-services-unknown>
+
+Threshold.
+
+=item B<--critical-services-unknown>
+
+Threshold.
+
+=item B<--warning-services-warning>
+
+Threshold.
+
+=item B<--critical-services-warning>
+
+Threshold.
 
 =back
 

--- a/src/apps/centreon/sql/mode/countservices.pm
+++ b/src/apps/centreon/sql/mode/countservices.pm
@@ -210,7 +210,7 @@ Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=
 =item B<--filter-counters>
 
 Only display some counters (regexp can be used).
-Example: --filter-counters='service'
+Example: --filter-counters='service'.
 
 =item B<--centreon-storage-database>
 

--- a/src/apps/centreon/sql/mode/countservices.pm
+++ b/src/apps/centreon/sql/mode/countservices.pm
@@ -127,11 +127,21 @@ sub new {
     return $self;
 }
 
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if ($self->{option_results}->{centreon_storage_database} !~ /^[a-zA-Z0-9_\-]+$/) {
+        $self->{output}->add_option_msg(short_msg => "Wrong value for --centreon-storage-database option (only alphanumeric characters, underscores and dashes are allowed).");
+        $self->{output}->option_exit();
+    }
+}
+
 sub manage_selection {
     my ($self, %options) = @_;
 
     my $query = "SELECT instances.name, COUNT(DISTINCT hosts.host_id) as num_hosts, count(DISTINCT services.host_id, services.service_id) as num_services
-        FROM " . $self->{option_results}->{centreon_storage_database} .  ".instances, " . $self->{option_results}->{centreon_storage_database} . ".hosts, " . $self->{option_results}->{centreon_storage_database} . ".services WHERE instances.running = '1' AND instances.instance_id = hosts.instance_id AND hosts.enabled = '1' AND hosts.host_id = services.host_id AND services.enabled = '1' GROUP BY hosts.instance_id";
+        FROM `" . $self->{option_results}->{centreon_storage_database} . "`.instances, `" . $self->{option_results}->{centreon_storage_database} . "`.hosts, `" . $self->{option_results}->{centreon_storage_database} . "`.services WHERE instances.running = '1' AND instances.instance_id = hosts.instance_id AND hosts.enabled = '1' AND hosts.host_id = services.host_id AND services.enabled = '1' GROUP BY hosts.instance_id";
     $options{sql}->connect();
     $options{sql}->query(
         query => 'SELECT
@@ -214,7 +224,7 @@ Example: --filter-counters='service'.
 
 =item B<--centreon-storage-database>
 
-Centreon storage database name (default: 'centreon_storage').
+Set the Centreon storage database name, only alphanumeric characters and underscores are allowed (default: 'centreon_storage').
 
 =item B<--filter-poller>
 

--- a/src/apps/centreon/sql/mode/dsmqueue.pm
+++ b/src/apps/centreon/sql/mode/dsmqueue.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -21,6 +21,7 @@
 package apps::centreon::sql::mode::dsmqueue;
 
 use base qw(centreon::plugins::templates::counter);
+use centreon::plugins::constants qw(:counters);
 
 use strict;
 use warnings;
@@ -29,8 +30,8 @@ sub set_counters {
     my ($self, %options) = @_;
     
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0 },
-        { name => 'host', type => 1, cb_prefix_output => 'prefix_host_output', message_multiple => 'All host queues are ok' },
+        { name => 'global', type => COUNTER_TYPE_GLOBAL },
+        { name => 'host', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_host_output', message_multiple => 'All host queues are ok' },
     ];
     
     $self->{maps_counters}->{global} = [
@@ -128,6 +129,8 @@ __END__
 =head1 MODE
 
 Check Centreon DSM queue usage.
+The mode should be used with the database::mysql::plugin plugin and C<--dyn-mode> option.
+Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=apps::centreon::sql::mode::dsmqueue ...>.
 
 =over 8
 
@@ -142,22 +145,36 @@ Centreon storage database name (default: 'centreon').
 =item B<--filter-counters>
 
 Only display some counters (regexp can be used).
-Example: --filter-counters='^total-queue-cache$'
-
-=item B<--warning-*>
-
-Warning threshold.
-Can be: Can be: 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'.
-
-=item B<--critical-*>
-
-Critical threshold.
-Can be: Can be: 'total-queue-cache', 'total-queue-lock', 'host-queue-cache'.
+Example: C<--filter-counters='^total-queue-cache$'>
 
 =item B<--filter-host-queue>
 
 Filter by host and pool prefix name (regexp can be used).
-Example: host1.queue1
+Example: C<host1.queue1>.
+
+=item B<--warning-host-queue-cache>
+
+Threshold.
+
+=item B<--critical-host-queue-cache>
+
+Threshold.
+
+=item B<--warning-total-queue-cache>
+
+Threshold.
+
+=item B<--critical-total-queue-cache>
+
+Threshold.
+
+=item B<--warning-total-queue-lock>
+
+Threshold.
+
+=item B<--critical-total-queue-lock>
+
+Threshold.
 
 =back
 

--- a/src/apps/centreon/sql/mode/dsmqueue.pm
+++ b/src/apps/centreon/sql/mode/dsmqueue.pm
@@ -77,13 +77,25 @@ sub new {
     bless $self, $class;
     
     $options{options}->add_options(arguments =>
-                                { 
-                                  "filter-host-queue:s"         => { name => 'filter_host_queue' },
-                                  "centreon-storage-database:s" => { name => 'centreon_storage_database', default => 'centreon_storage' },
-                                  "centreon-database:s"         => { name => 'centreon_database', default => 'centreon' },
-                                });
-    
+        { 
+            "filter-host-queue:s"         => { name => 'filter_host_queue' },
+            "centreon-storage-database:s" => { name => 'centreon_storage_database', default => 'centreon_storage' },
+            "centreon-database:s"         => { name => 'centreon_database', default => 'centreon' },
+        });
+
     return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    foreach my $option_name ('centreon_database', 'centreon_storage_database') {
+        if ($self->{option_results}->{$option_name} !~ /^[a-zA-Z0-9_\-]+$/) {
+            $self->{output}->add_option_msg(short_msg => "Wrong value for --" . $option_name =~ s/_/-/r . " option (only alphanumeric characters and underscores and dashes are allowed).");
+            $self->{output}->option_exit();
+        }
+    }
 }
 
 sub manage_selection {
@@ -92,13 +104,13 @@ sub manage_selection {
     $options{sql}->connect();
 
     $self->{global} = { total_queue_cache => 0, total_queue_lock => 0 };    
-    my $query = "SELECT COUNT(*) as nb FROM " . $self->{option_results}->{centreon_storage_database} . ".mod_dsm_cache";
+    my $query = "SELECT COUNT(*) as nb FROM `" . $self->{option_results}->{centreon_storage_database} . "`.mod_dsm_cache";
     $options{sql}->query(query => $query);
     if ((my $row = $options{sql}->fetchrow_hashref())) {
         $self->{global}->{total_queue_cache} = $row->{nb};
     }
     
-    $query = "SELECT COUNT(*) as nb FROM " . $self->{option_results}->{centreon_storage_database} . ".mod_dsm_locks";
+    $query = "SELECT COUNT(*) as nb FROM `" . $self->{option_results}->{centreon_storage_database} . "`.mod_dsm_locks";
     $options{sql}->query(query => $query);
     if ((my $row = $options{sql}->fetchrow_hashref())) {
         $self->{global}->{total_queue_lock} = $row->{nb};
@@ -107,7 +119,7 @@ sub manage_selection {
     # check by poller
     $self->{host} = {};
     $query = "SELECT mod_dsm_pool.pool_host_id, mod_dsm_pool.pool_prefix, COUNT(*) as nb FROM " .  $self->{option_results}->{centreon_database} . ".mod_dsm_pool" . 
-        " LEFT JOIN " . $self->{option_results}->{centreon_storage_database} . ".mod_dsm_cache ON mod_dsm_pool.pool_host_id = mod_dsm_cache.host_id AND mod_dsm_pool.pool_prefix = mod_dsm_cache.pool_prefix" .
+        " LEFT JOIN `" . $self->{option_results}->{centreon_storage_database} . "`.mod_dsm_cache ON mod_dsm_pool.pool_host_id = mod_dsm_cache.host_id AND mod_dsm_pool.pool_prefix = mod_dsm_cache.pool_prefix" .
         " GROUP BY mod_dsm_pool.pool_host_id, mod_dsm_pool.pool_prefix";
     $options{sql}->query(query => $query);
     while ((my $row = $options{sql}->fetchrow_hashref())) {
@@ -136,7 +148,7 @@ Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=
 
 =item B<--centreon-storage-database>
 
-Centreon storage database name (default: 'centreon_storage').
+Set the Centreon storage database name, only alphanumeric characters and underscores are allowed (default: 'centreon_storage').
 
 =item B<--centreon-database>
 

--- a/src/apps/centreon/sql/mode/executiontime.pm
+++ b/src/apps/centreon/sql/mode/executiontime.pm
@@ -81,13 +81,23 @@ sub new {
     return $self;
 }
 
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if ($self->{option_results}->{centreon_storage_database} !~ /^[a-zA-Z0-9_\-]+$/) {
+        $self->{output}->add_option_msg(short_msg => "Wrong value for --centreon-storage-database option (only alphanumeric characters, underscores and dashes are allowed).");
+        $self->{output}->option_exit();
+    }
+}
+
 sub manage_selection {
     my ($self, %options) = @_;
 
     $options{sql}->connect();
     $options{sql}->query(
         query => 'SELECT h.name, s.description, s.execution_time
-            FROM ' . $self->{option_results}->{centreon_storage_database} .  '.services s, ' . $self->{option_results}->{centreon_storage_database} .  '.hosts h
+            FROM `' . $self->{option_results}->{centreon_storage_database} .  '`.services s, `' . $self->{option_results}->{centreon_storage_database} .  '`.hosts h
             WHERE s.execution_time > ' . $self->{option_results}->{execution_time} .  '
                 AND h.enabled = 1
                 AND (h.name NOT LIKE "\_Module\_%" OR h.name LIKE "\_Module\_Meta%")
@@ -127,12 +137,11 @@ limit of execution time (default: '20').
 
 =item B<--centreon-storage-database>
 
-Centreon storage database name (default: 'centreon_storage').
+Set the Centreon storage database name, only alphanumeric characters and underscores are allowed (default: 'centreon_storage').
 
 =item B<--filter-poller>
 
 Filter by poller name (regexp can be used).
-
 
 =item B<--warning-count>
 

--- a/src/apps/centreon/sql/mode/executiontime.pm
+++ b/src/apps/centreon/sql/mode/executiontime.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -21,6 +21,7 @@
 package apps::centreon::sql::mode::executiontime;
 
 use base qw(centreon::plugins::templates::counter);
+use centreon::plugins::constants qw(:counters);
 
 use strict;
 use warnings;
@@ -41,8 +42,8 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0 },
-        { name => 'services', type => 1 }
+        { name => 'global', type => COUNTER_TYPE_GLOBAL },
+        { name => 'services', type => COUNTER_TYPE_INSTANCE }
     ];
     
     $self->{maps_counters}->{global} = [
@@ -114,6 +115,8 @@ __END__
 =head1 MODE
 
 Check the number of services exceeding defined execution time.
+The mode should be used with the database::mysql::plugin plugin and C<--dyn-mode> option.
+Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=apps::centreon::sql::mode::executiontime ...>.
 
 =over 8
 
@@ -130,10 +133,22 @@ Centreon storage database name (default: 'centreon_storage').
 
 Filter by poller name (regexp can be used).
 
-=item B<--warning-count> B<--critical-count>
 
-Thresholds on the number of services exceeding
-defined execution time.
+=item B<--warning-count>
+
+Threshold.
+
+=item B<--critical-count>
+
+Threshold.
+
+=item B<--warning-list>
+
+Threshold.
+
+=item B<--critical-list>
+
+Threshold.
 
 =back
 

--- a/src/apps/centreon/sql/mode/multiservices.pm
+++ b/src/apps/centreon/sql/mode/multiservices.pm
@@ -278,6 +278,11 @@ sub check_options {
     my ($self, %options) = @_;
     $self->SUPER::check_options(%options);
 
+    if ($self->{option_results}->{centreon_storage_database} !~ /^[a-zA-Z0-9_\-]+$/) {
+        $self->{output}->add_option_msg(short_msg => "Wrong value for --centreon-storage-database option (only alphanumeric characters, underscores and dashes are allowed).");
+        $self->{output}->option_exit();
+    }
+
     if (!defined($self->{option_results}->{config}) || $self->{option_results}->{config} eq '') {
         $self->{output}->add_option_msg(short_msg => "Please define --config option");
         $self->{output}->option_exit();
@@ -357,7 +362,7 @@ sub manage_query {
     my ($self, %options) = @_;
 
     my $query = "SELECT hosts.name, services.description, hosts.state as hstate, services.state as sstate, services.output as soutput
-                FROM " . $self->{option_results}->{centreon_storage_database} . ".hosts," . $self->{option_results}->{centreon_storage_database} . ".services WHERE hosts.host_id=services.host_id
+                FROM `" . $self->{option_results}->{centreon_storage_database} . "`.hosts,`" . $self->{option_results}->{centreon_storage_database} . "`.services WHERE hosts.host_id=services.host_id
                 AND hosts.name NOT LIKE 'Module%' AND hosts.enabled=1 AND services.enabled=1
                 AND hosts.name = '" . $options{host} . "'
                 AND services.description = '" . $options{service} . "'";
@@ -422,7 +427,7 @@ sub manage_selection {
             };
 
             my $query = "SELECT hosts.name, services.description, hosts.state as hstate, services.state as sstate, services.output as soutput
-                         FROM " . $self->{option_results}->{centreon_storage_database} . ".hosts," . $self->{option_results}->{centreon_storage_database} . ".services WHERE hosts.host_id=services.host_id
+                         FROM `" . $self->{option_results}->{centreon_storage_database} . "`.hosts,`" . $self->{option_results}->{centreon_storage_database} . "`.services WHERE hosts.host_id=services.host_id
                          AND hosts.name NOT LIKE 'Module%' AND hosts.enabled=1 AND services.enabled=1
                          AND hosts.name LIKE '" . $config_data->{selection}->{$group}->{'host_name_filter'} . "'
                          AND services.description LIKE '" . $config_data->{selection}->{$group}->{'service_name_filter'} . "'";
@@ -490,7 +495,7 @@ Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=
 
 =item B<--centreon-storage-database>
 
-Centreon storage database name (default: 'centreon_storage').
+Set the Centreon storage database name, only alphanumeric characters and underscores are allowed (default: 'centreon_storage').
 
 =item B<--filter-counters>
 

--- a/src/apps/centreon/sql/mode/multiservices.pm
+++ b/src/apps/centreon/sql/mode/multiservices.pm
@@ -494,7 +494,7 @@ Centreon storage database name (default: 'centreon_storage').
 
 =item B<--filter-counters>
 
-Can be C<totalhost>, C<totalservice>, 'groups'. Better to manage it in config file
+Can be C<totalhost>, C<totalservice>, 'groups'. Better to manage it in config file.
 
 =item B<--warning-total>
 

--- a/src/apps/centreon/sql/mode/multiservices.pm
+++ b/src/apps/centreon/sql/mode/multiservices.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -21,6 +21,7 @@
 package apps::centreon::sql::mode::multiservices;
 
 use base qw(centreon::plugins::templates::counter);
+use centreon::plugins::constants qw(:counters);
 
 use strict;
 use warnings;
@@ -137,7 +138,7 @@ sub custom_groups_output {
     my $msg_host = '';
     my $msg_svc = '';
 
-    if ($config_data->{formatting}->{display_details} eq 'true') {
+    if ($config_data->{formatting}->{display_details} eq 'true' || $config_data->{formatting}->{display_details} == 1) {
         $msg_host .= (defined($self->{instance_mode}->{inventory}->{groups}->{$self->{result_values}->{instance}}->{list_up}))
                         ? "HOSTS: [up: $self->{result_values}->{up} (" . join(' - ', @{$self->{instance_mode}->{inventory}->{groups}->{$self->{result_values}->{instance}}->{list_up}}) . ")]"
                         : "HOSTS: [up: $self->{result_values}->{up}]";
@@ -265,7 +266,9 @@ sub new {
         'warning-groups:s'  => { name => 'warning_groups' },
         'critical-groups:s' => { name => 'critical_groups' },
         'warning-total:s'   => { name => 'warning_total' },
-        'critical-total:s'  => { name => 'critical_total' }
+        'critical-total:s'  => { name => 'critical_total' },
+        'centreon-storage-database:s' => { name => 'centreon_storage_database', default => 'centreon_storage' }
+
     });
 
     return $self;
@@ -306,24 +309,6 @@ sub check_options {
     }
     
     $self->change_macros(macros => ['warning_groups', 'critical_groups', 'warning_total', 'critical_total']);
-}
-
-sub prefix_totalh_output {
-    my ($self, %options) = @_;
-
-    return "Hosts state summary ";
-}
-
-sub prefix_totals_output {
-    my ($self, %options) = @_;
-
-    return "Services state summary ";
-}
-
-sub prefix_groups_output {
-    my ($self, %options) = @_;
-
-    return "Group '" . $options{instance_value}->{display} . "': ";
 }
 
 sub parse_json_config {
@@ -372,7 +357,7 @@ sub manage_query {
     my ($self, %options) = @_;
 
     my $query = "SELECT hosts.name, services.description, hosts.state as hstate, services.state as sstate, services.output as soutput
-                FROM centreon_storage.hosts, centreon_storage.services WHERE hosts.host_id=services.host_id
+                FROM " . $self->{option_results}->{centreon_storage_database} . ".hosts," . $self->{option_results}->{centreon_storage_database} . ".services WHERE hosts.host_id=services.host_id
                 AND hosts.name NOT LIKE 'Module%' AND hosts.enabled=1 AND services.enabled=1
                 AND hosts.name = '" . $options{host} . "'
                 AND services.description = '" . $options{service} . "'";
@@ -406,21 +391,21 @@ sub manage_selection {
     $self->{groups} = {};
     $self->{hosts} = {};
 
-    if ($config_data->{counters}->{totalhosts} eq 'true') {
+    if ($config_data->{counters}->{totalhosts} eq 'true' || $config_data->{counters}->{totalhosts} == 1) {
         push @{$self->{maps_counters_type}}, {
-            name => 'totalhost', type => 0, cb_prefix_output => 'prefix_totalh_output',
+            name => 'totalhost', type => COUNTER_TYPE_GLOBAL, prefix_output => 'Hosts state summary  ',
         };
         $self->{totalhost} = { up => 0, down => 0, unreachable => 0 };
     }
-    if ($config_data->{counters}->{totalservices} eq 'true') {
+    if ($config_data->{counters}->{totalservices} eq 'true' == $config_data->{counters}->{totalservices} == 1) {
         push @{$self->{maps_counters_type}}, {
-            name => 'totalservice', type => 0, cb_prefix_output => 'prefix_totals_output',
+            name => 'totalservice', type => COUNTER_TYPE_GLOBAL, prefix_output => 'Services state summary ',
         };
         $self->{totalservice} = { ok => 0, warning => 0, critical => 0, unknown => 0 };
     }
-    if ($config_data->{counters}->{groups} eq 'true') {
+    if ($config_data->{counters}->{groups} eq 'true' || $config_data->{counters}->{groups} == 1) {
         push @{$self->{maps_counters_type}}, {
-            name => 'logicalgroups', type => 1, cb_prefix_output => 'prefix_groups_output', message_multiple => $config_data->{formatting}->{groups_global_msg}
+            name => 'logicalgroups', type => COUNTER_TYPE_INSTANCE, prefix_output => "Group '%{display}' ", message_multiple => $config_data->{formatting}->{groups_global_msg}
         };
     }
 
@@ -437,7 +422,7 @@ sub manage_selection {
             };
 
             my $query = "SELECT hosts.name, services.description, hosts.state as hstate, services.state as sstate, services.output as soutput
-                         FROM centreon_storage.hosts, centreon_storage.services WHERE hosts.host_id=services.host_id
+                         FROM " . $self->{option_results}->{centreon_storage_database} . ".hosts," . $self->{option_results}->{centreon_storage_database} . ".services WHERE hosts.host_id=services.host_id
                          AND hosts.name NOT LIKE 'Module%' AND hosts.enabled=1 AND services.enabled=1
                          AND hosts.name LIKE '" . $config_data->{selection}->{$group}->{'host_name_filter'} . "'
                          AND services.description LIKE '" . $config_data->{selection}->{$group}->{'service_name_filter'} . "'";
@@ -500,19 +485,44 @@ __END__
 =item B<--config>
 
 Specify the config (can be a file or a json string directly).
+The mode should be used with the database::mysql::plugin plugin and C<--dyn-mode> option.
+Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=apps::centreon::sql::mode::multiservices ...>.
+
+=item B<--centreon-storage-database>
+
+Centreon storage database name (default: 'centreon_storage').
 
 =item B<--filter-counters>
 
-Can be 'totalhost','totalservice','groups'. Better to manage it in config file
+Can be C<totalhost>, C<totalservice>, 'groups'. Better to manage it in config file
 
-=item B<--warning-*>
+=item B<--warning-total>
+
+Threshold for hosts and services.
+You can use the following variables: 
+- for hosts: %{total_up}, %{total_down}, %{total_unreachable} for hosts
+- for services: %{ok_total}, %{ok_warning}, %{ok_critical}, %{ok_unknown}.
+Example: C<< --warning-total='%{total_unreachable} > 4' >>.
+
+=item B<--critical-total>
+
+Threshold for hosts and services.
+You can use the following variables: 
+- for hosts: %{total_up}, %{total_down}, %{total_unreachable} for hosts
+- for services: %{ok_total}, %{ok_warning}, %{ok_critical}, %{ok_unknown}.
+Example: C<< --critical-total='%{critical_total} > 4' >>.
+
+=item B<--warning-groups>
+
+Threshold for groups.
+You can use the following variables: %{instance}, %{up}, %{down}, %{unreachable},
+%{ok}, %{warning}, %{critical}, %{unknown}.
+Example: C<< --warning-groups='%{instance} eq 'ESX' && %{down} > 2' >>.
+
+=item B<--critical-groups>
 
 Can be 'total' for host and service, 'groups' for groups.
-Example: --warning-total '%{total_unreachable} > 4' --warning-groups '%{instance} eq 'ESX' && %{total_down} > 2 && %{critical_total} > 4'
-
-=item B<--critical-*>
-
-Can be 'total' for host and service, 'groups' for groups
+Example: C<< --critical-groups='%{instance} eq 'ESX' && %{total_down} > 2 && %{critical_total} > 4' >>.
 
 =back
 

--- a/src/apps/centreon/sql/mode/partitioning.pm
+++ b/src/apps/centreon/sql/mode/partitioning.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -122,7 +122,8 @@ __END__
 =head1 MODE
 
 Check that partitions for MySQL/MariaDB tables are correctly created.
-The mode should be used with mysql plugin and dyn-mode option.
+The mode should be used with the database::mysql::plugin plugin and C<--dyn-mode> option.
+Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=apps::centreon::sql::mode::partitioning ...>.
 
 =over 8
 

--- a/src/apps/centreon/sql/mode/partitioning.pm
+++ b/src/apps/centreon/sql/mode/partitioning.pm
@@ -130,19 +130,19 @@ Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=
 =item B<--tablename>
 
 This option is mandatory (can be multiple).
-Example: centreon_storage.data_bin
+Example: centreon_storage.data_bin.
 
 =item B<--warning>
 
-Warning threshold (number of retention forward days)
+Warning threshold (number of retention forward days).
 
 =item B<--critical>
 
-Critical threshold (number of retention forward days)
+Critical threshold (number of retention forward days).
 
 =item B<--timezone>
 
-Timezone use for partitioning (if not set, we use current server execution timezone)
+Timezone use for partitioning (if not set, we use current server execution timezone).
 
 =back
 

--- a/src/apps/centreon/sql/mode/pollerdelay.pm
+++ b/src/apps/centreon/sql/mode/pollerdelay.pm
@@ -59,11 +59,21 @@ sub new {
     return $self;
 }
 
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::check_options(%options);
+
+    if ($self->{option_results}->{centreon_storage_database} !~ /^[a-zA-Z0-9_\-]+$/) {
+        $self->{output}->add_option_msg(short_msg => "Wrong value for --centreon-storage-database option (only alphanumeric characters, underscores and dashes are allowed).");
+        $self->{output}->option_exit();
+    }
+}
+
 sub manage_selection {
     my ($self, %options) = @_;
 
     $options{sql}->connect();
-    $options{sql}->query(query => 'SELECT instance_id, name, last_alive, running FROM ' . $self->{option_results}->{centreon_storage_database} . ".instances WHERE deleted = '0'");
+    $options{sql}->query(query => "SELECT instance_id, name, last_alive, running FROM `" . $self->{option_results}->{centreon_storage_database} . "`.instances WHERE deleted = '0'");
 
     my $result = $options{sql}->fetchall_arrayref();
     $self->{poller} = {};
@@ -106,7 +116,7 @@ Filter by poller name (can be a regexp).
 
 =item B<--centreon-storage-database>
 
-Centreon storage database name (default: 'centreon_storage').
+Set the Centreon storage database name, only alphanumeric characters and underscores are allowed (default: 'centreon_storage').
 
 =item B<--warning-delay>
 

--- a/src/apps/centreon/sql/mode/pollerdelay.pm
+++ b/src/apps/centreon/sql/mode/pollerdelay.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -21,6 +21,7 @@
 package apps::centreon::sql::mode::pollerdelay;
 
 use base qw(centreon::plugins::templates::counter);
+use centreon::plugins::constants qw(:values :counters);
 
 use strict;
 use warnings;
@@ -29,7 +30,7 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'poller', type => 1, cb_prefix_output => 'prefix_poller_output', message_multiple => 'All poller delay for last update are ok', skipped_code => { -10 => 1 } }
+        { name => 'poller', type => COUNTER_TYPE_INSTANCE, prefix_output => "Poller '%{display}' ", message_multiple => 'All poller delay for last update are ok', skipped_code => { NO_VALUE() => 1 } }
     ];
 
     $self->{maps_counters}->{poller} = [
@@ -45,19 +46,14 @@ sub set_counters {
     ];
 }
 
-sub prefix_poller_output {
-    my ($self, %options) = @_;
-
-    return "Poller '" . $options{instance_value}->{display} . "' : ";
-}
-
 sub new {
     my ($class, %options) = @_;
     my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
     bless $self, $class;
     
     $options{options}->add_options(arguments => {
-        "filter-name:s" => { name => 'filter_name' },
+        'filter-name:s'               => { name => 'filter_name' },
+        'centreon-storage-database:s' => { name => 'centreon_storage_database', default => 'centreon_storage' },
     });
 
     return $self;
@@ -67,9 +63,7 @@ sub manage_selection {
     my ($self, %options) = @_;
 
     $options{sql}->connect();
-    $options{sql}->query(query => q{
-        SELECT instance_id, name, last_alive, running FROM centreon_storage.instances WHERE deleted = '0';
-    });
+    $options{sql}->query(query => 'SELECT instance_id, name, last_alive, running FROM ' . $self->{option_results}->{centreon_storage_database} . ".instances WHERE deleted = '0'");
 
     my $result = $options{sql}->fetchall_arrayref();
     $self->{poller} = {};
@@ -100,14 +94,19 @@ __END__
 
 =head1 MODE
 
-Check the delay of the last update from a poller to the Central server.
-The mode should be used with mysql plugin and dyn-mode option.
+Check the delay of the last data update sent from a poller to the Central server.
+The mode should be used with the database::mysql::plugin plugin and C<--dyn-mode> option.
+Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=apps::centreon::sql::mode::pollerdelay ...>.
 
 =over 8
 
 =item B<--filter-name>
 
 Filter by poller name (can be a regexp).
+
+=item B<--centreon-storage-database>
+
+Centreon storage database name (default: 'centreon_storage').
 
 =item B<--warning-delay>
 

--- a/src/apps/centreon/sql/mode/virtualservice.pm
+++ b/src/apps/centreon/sql/mode/virtualservice.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -21,6 +21,7 @@
 package apps::centreon::sql::mode::virtualservice;
 
 use base qw(centreon::plugins::templates::counter);
+use centreon::plugins::constants qw(:counters);
 
 use strict;
 use warnings;
@@ -288,14 +289,14 @@ sub manage_selection {
 
     if (exists($config_data->{virtualcurve})) {
         push @{$self->{maps_counters_type}}, {
-            name => 'global', type => 1, message_separator => $config_data->{formatting}->{message_separator}, message_multiple => $config_data->{formatting}->{custom_message_global},
+            name => 'global', type => COUNTER_TYPE_INSTANCE, message_separator => $config_data->{formatting}->{message_separator}, message_multiple => $config_data->{formatting}->{custom_message_global},
         };
     }
 
     # Selection is prefered can't mix selection and sql matching
     if (exists($config_data->{selection})) {
         push @{$self->{maps_counters_type}}, {
-            name => 'metric', type => 1, message_separator => $config_data->{formatting}->{message_separator}, message_multiple => $config_data->{formatting}->{custom_message_metric},
+            name => 'metric', type => COUNTER_TYPE_INSTANCE, message_separator => $config_data->{formatting}->{message_separator}, message_multiple => $config_data->{formatting}->{custom_message_metric},
         };
         foreach my $id (keys %{$config_data->{selection}}) {
             my $query = "SELECT index_data.host_name, index_data.service_description, metrics.metric_name, metrics.current_value, metrics.unit_name, metrics.min, metrics.max ";
@@ -317,7 +318,7 @@ sub manage_selection {
         }
     } elsif (exists($config_data->{filters})) {
         push @{$self->{maps_counters_type}}, {
-            name => 'metric', type => 1, message_separator => $config_data->{formatting}->{message_separator}, message_multiple => $config_data->{formatting}->{custom_message_metric},
+            name => 'metric', type => COUNTER_TYPE_INSTANCE, message_separator => $config_data->{formatting}->{message_separator}, message_multiple => $config_data->{formatting}->{custom_message_metric},
         };
         my $query = "SELECT index_data.host_name, index_data.service_description, metrics.metric_name, metrics.current_value, metrics.unit_name, metrics.min, metrics.max ";
         $query .= "FROM $self->{option_results}->{database}index_data, $self->{option_results}->{database}metrics, $self->{option_results}->{database}services WHERE index_data.id = metrics.index_id AND services.service_id = index_data.service_id AND services.host_id = index_data.host_id ";
@@ -417,6 +418,8 @@ __END__
 Mode to play with centreon metrics.
 Example: display two curves of different service on the same graph.
 Example: aggregate multiple metrics (min,max,avg,sum) or custom operation.
+The mode should be used with the database::mysql::plugin plugin and C<--dyn-mode> option.
+Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=apps::centreon::sql::mode::virtualservice ...>.
 
 =over 8
 
@@ -434,19 +437,25 @@ Specify the full path to a json config file
 
 =item B<--filter-counters>
 
-Filter some counter (can be 'unique' or 'global')
+Filter some counter (can be 'metric' or 'global')
 Useless, if you use selection/filter but not
 global/virtual curves
 
-=item B<--warning-*>
+=item B<--warning-global>
 
-Warning threshold (can be 'unique' or 'global')
-(Override config_file if set)
+Threshold.
 
-=item B<--critical-*>
+=item B<--critical-global>
 
-Critical threshold (can be 'unique' or 'global')
-(Override config_file if set)
+Threshold.
+
+=item B<--warning-metric>
+
+Threshold.
+
+=item B<--critical-metric>
+
+Threshold.
 
 =back
 

--- a/src/apps/centreon/sql/mode/virtualservice.pm
+++ b/src/apps/centreon/sql/mode/virtualservice.pm
@@ -425,21 +425,21 @@ Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=
 
 =item B<--database>
 
-Specify the database (default: 'centreon_storage')
+Specify the database (default: 'centreon_storage').
 
 =item B<--config-file>
 
-Specify the full path to a json config file
+Specify the full path to a json config file.
 
 =item B<--json-data>
 
-Specify the full path to a json config file
+Specify the full path to a json config file.
 
 =item B<--filter-counters>
 
 Filter some counter (can be 'metric' or 'global')
 Useless, if you use selection/filter but not
-global/virtual curves
+global/virtual curves.
 
 =item B<--warning-global>
 

--- a/src/apps/centreon/sql/mode/virtualservice.pm
+++ b/src/apps/centreon/sql/mode/virtualservice.pm
@@ -214,7 +214,7 @@ sub new {
     $options{options}->add_options(arguments => {
         'config-file:s' => { name => 'config_file' },
         'json-data:s'   => { name => 'json_data' },
-        'database:s'    => { name => 'database' }
+        'database:s'    => { name => 'database', default => 'centreon_storage' }
     });
 
     return $self;
@@ -250,9 +250,10 @@ sub check_options {
     $config_data->{formatting}->{change_bytes} = 0 if (!exists($config_data->{formatting}->{change_bytes}));
     $config_data->{formatting}->{change_bytes_network} = 0 if (!exists($config_data->{formatting}->{change_bytes_network}));
 
-    $self->{option_results}->{database} = 
-        (defined($self->{option_results}->{database}) && $self->{option_results}->{database} ne '') ?
-            $self->{option_results}->{database} . '.' : 'centreon_storage.';
+    if ($self->{option_results}->{database} !~ /^[a-zA-Z0-9_\-]+$/) {
+        $self->{output}->add_option_msg(short_msg => "Wrong value for --database option (only alphanumeric characters, underscores and dashes are allowed).");
+        $self->{output}->option_exit();
+    }
 }
 
 sub parse_json_config {
@@ -298,9 +299,10 @@ sub manage_selection {
         push @{$self->{maps_counters_type}}, {
             name => 'metric', type => COUNTER_TYPE_INSTANCE, message_separator => $config_data->{formatting}->{message_separator}, message_multiple => $config_data->{formatting}->{custom_message_metric},
         };
+
         foreach my $id (keys %{$config_data->{selection}}) {
             my $query = "SELECT index_data.host_name, index_data.service_description, metrics.metric_name, metrics.current_value, metrics.unit_name, metrics.min, metrics.max ";
-            $query .= "FROM $self->{option_results}->{database}index_data, $self->{option_results}->{database}metrics WHERE index_data.id = metrics.index_id ";
+            $query .= "FROM `$self->{option_results}->{database}`.index_data, `$self->{option_results}->{database}`.metrics WHERE index_data.id = metrics.index_id ";
             $query .= "AND index_data.service_description = '" . $config_data->{selection}->{$id}->{service_name} . "'";
             $query .= "AND index_data.host_name = '" . $config_data->{selection}->{$id}->{host_name} . "'" ;
             $query .= "AND metrics.metric_name = '" . $config_data->{selection}->{$id}->{metric_name} . "'";
@@ -321,7 +323,7 @@ sub manage_selection {
             name => 'metric', type => COUNTER_TYPE_INSTANCE, message_separator => $config_data->{formatting}->{message_separator}, message_multiple => $config_data->{formatting}->{custom_message_metric},
         };
         my $query = "SELECT index_data.host_name, index_data.service_description, metrics.metric_name, metrics.current_value, metrics.unit_name, metrics.min, metrics.max ";
-        $query .= "FROM $self->{option_results}->{database}index_data, $self->{option_results}->{database}metrics, $self->{option_results}->{database}services WHERE index_data.id = metrics.index_id AND services.service_id = index_data.service_id AND services.host_id = index_data.host_id ";
+        $query .= "FROM `$self->{option_results}->{database}`.index_data, `$self->{option_results}->{database}`.metrics, $self->{option_results}->{database}.services WHERE index_data.id = metrics.index_id AND services.service_id = index_data.service_id AND services.host_id = index_data.host_id ";
         $query .= "AND index_data.service_description LIKE '" . $config_data->{filters}->{service} . "' " if (defined($config_data->{filters}->{service}) && ($config_data->{filters}->{service} ne ''));
         $query .= "AND index_data.host_name LIKE '" . $config_data->{filters}->{host} . "' " if (defined($config_data->{filters}->{host}) && ($config_data->{filters}->{host} ne ''));
         $query .= "AND metrics.metric_name LIKE '" . $config_data->{filters}->{metric} . "' " if (defined($config_data->{filters}->{metric}) && ($config_data->{filters}->{metric} ne ''));
@@ -425,7 +427,7 @@ Example: C<perl centreon_plugins.pl --plugin=database::mysql::plugin --dyn-mode=
 
 =item B<--database>
 
-Specify the database (default: 'centreon_storage').
+Set the Centreon storage database name, only alphanumeric characters and underscores are allowed (default: 'centreon_storage').
 
 =item B<--config-file>
 

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -87,6 +87,7 @@ dfsrevent
 --display-transform-dst
 --display-transform-src
 dns-resolve-time
+DSM
 --dyn-mode
 Ekara
 -EncodedCommand


### PR DESCRIPTION
Refs:CTOR-2477

# Centreon team (internal PR)

## Description

Some modes have an centreon_storage hardcoded database name. This PR fixes that.

**Fixes** [CTOR-2477](https://centreon.atlassian.net/browse/CTOR-2477)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [X] I have reviewed all the help messages in all the .pm files I have modified.
  - [X] All sentences begin with a capital letter.
  - [X] All sentences end with a period.
  - [X] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.


[CTOR-2477]: https://centreon.atlassian.net/browse/CTOR-2477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ