### PR TITLE
enh(postgres): Add lock filtering capability

### DIFF
--- a/.github/docker/testing/Dockerfile.testing-plugins-alma10
+++ b/.github/docker/testing/Dockerfile.testing-plugins-alma10
@@ -22,7 +22,7 @@ dnf clean all
 dnf install -y python3.13 python3.13-pip
 pip3.13 install robotframework robotframework-examples
 # Install snmpsim
-pip3.13 install snmpsim pysmi
+pip3.13 install snmpsim pysmi cryptography
 
 dnf install -y nodejs24
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=${PNPM_VERSION} bash -

--- a/src/centreon/plugins/dbi.pm
+++ b/src/centreon/plugins/dbi.pm
@@ -304,10 +304,25 @@ sub fetchrow_hashref {
     return $self->{statement_handle}->fetchrow_hashref();
 }
 
+=head2 $self->query(\%options)
+
+Constructor of the vault object.
+
+%options must provide:
+
+- C<query>: An SQL query to execute on the already connected database (ex: SELECT * FROM table WHERE col like ?)
+
+%options might provide:
+
+- C<continue_error>: either 1 or 0. if 1 and the query preparation fail, plugin exit. if 0, method return 1 if query fail.
+
+- C<param>: array of parameter to use as bind_param. the number of element in the array should match the number of bind made in the query (number of '?')
+
+=cut
 sub query {
     my ($self, %options) = @_;
     my $continue_error   = defined($options{continue_error}) && $options{continue_error} == 1 ? 1 : 0;
-
+    my $param = $options{param};
     $self->{statement_handle} = $self->{instance}->prepare($options{query});
     if (!defined($self->{statement_handle})) {
         return 1 if ($continue_error == 1);
@@ -316,6 +331,12 @@ sub query {
         $self->{output}->option_exit(exit_litteral => $self->{sql_errors_exit});
     }
 
+    if ($param and ref($param) eq 'ARRAY' && scalar(@$param) > 0){
+        for (my $i = 1; $i <= @$param; $i++) {
+        $self->{statement_handle}->bind_param($i, @$param[$i-1]);
+        }
+
+    }
     my $rv;
     if (defined($self->{exec_timeout})) {
         my $mask   = POSIX::SigSet->new(SIGALRM);

--- a/src/database/postgres/mode/locks.pm
+++ b/src/database/postgres/mode/locks.pm
@@ -26,7 +26,7 @@ use strict;
 use warnings;
 
 use centreon::plugins::constants qw(:values);
-use centreon::plugins::misc qw/is_excluded/;
+use centreon::plugins::misc qw/is_excluded is_empty/;
 
 sub new {
     my ($class, %options) = @_;
@@ -39,7 +39,8 @@ sub new {
         'include-database:s'  => { name => 'include_database', default => '' },
         'exclude-database:s'  => { name => 'exclude_database', default => '' },
         'include:s'           => { name => 'include_database' },
-        'exclude:s'           => { name => 'exclude_database' }
+        'exclude:s'           => { name => 'exclude_database' },
+        'include-locktype:s'  => {name => 'include_locktype', default => '%'},
     });
 
     return $self;
@@ -83,7 +84,7 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'locks', type => 1, cb_prefix_output => 'custom_locks_prefix_output', message_multiple => 'All databases locks are ok',  skipped_code => { NO_VALUE() => 1 }  },
+        { name => 'locks', type => COUNTER_TYPE_INSTANCE(), cb_prefix_output => 'custom_locks_prefix_output', message_multiple => 'All databases locks are ok',  skipped_code => { NO_VALUE() => 1 }  },
     ];
 
     $self->{items} = { 'total', 'warning' };
@@ -136,6 +137,10 @@ sub check_options {
         $self->{output}->option_exit(short_msg => "Critical warning ('$label' locks) threshold '" . $value . "'.")
             unless $self->{perfdata}->threshold_validate(label => 'crit-' . $label, value => $value);
     }
+    # the add_options 'default' property do not transform an empty string to the default value, so we do it here too
+    if (is_empty($self->{option_results}->{include_locktype})) {
+        $self->{option_results}->{include_locktype} = '%';
+    }
 }
 
 sub manage_selection {
@@ -144,10 +149,13 @@ sub manage_selection {
     $options{sql}->connect();
 
     $options{sql}->query(query => q{
-        SELECT granted, mode, datname FROM pg_database d LEFT JOIN pg_locks l ON (d.oid=l.database) WHERE d.datallowconn
-    });
+        SELECT granted, mode, datname FROM pg_database d LEFT JOIN pg_locks l ON (d.oid=l.database AND locktype like ?) WHERE d.datallowconn
+    },
+        param=> [$self->{option_results}->{include_locktype}]);
 
     my $result = $options{sql}->fetchall_arrayref();
+    $self->{output}->option_exit(short_msg => "No databases found. Do you have sufficient permissions ?") if scalar(@{$result}) == 0;
+
     my $dblocks = {};
     foreach my $row (@{$result}) {        
         my ($granted, $mode, $dbname) = ($$row[0], $$row[1], $$row[2]);
@@ -182,6 +190,8 @@ sub manage_selection {
             push @{$self->{maps_counters}->{locks}}, $new_counter;
         }
     }
+    $self->{output}->option_exit(short_msg => "No metrics found. please check the include and exclude filter.")
+        if !%$dblocks;
 
     $self->{locks} = $dblocks;
 }
@@ -213,6 +223,10 @@ Filter databases using a regular expression.
 =item B<--exclude-database>
 
 Exclude databases using a regular expression.
+
+=item B<--include-locktype>
+
+Include lock type using a SQL 'like' format. by default all lock type are included (default: '%').
 
 =back
 

--- a/src/database/postgres/mode/locks.pm
+++ b/src/database/postgres/mode/locks.pm
@@ -25,7 +25,7 @@ use base qw(centreon::plugins::templates::counter);
 use strict;
 use warnings;
 
-use centreon::plugins::constants qw(:values);
+use centreon::plugins::constants qw(:values :counters);
 use centreon::plugins::misc qw/is_excluded is_empty/;
 
 sub new {
@@ -40,7 +40,8 @@ sub new {
         'exclude-database:s'  => { name => 'exclude_database', default => '' },
         'include:s'           => { name => 'include_database' },
         'exclude:s'           => { name => 'exclude_database' },
-        'include-locktype:s'  => {name => 'include_locktype', default => '%'},
+        'include-locktype:s'  => {name => 'include_locktype', default => 'relation'},
+        'exclude-locktype:s'  => {name => 'exclude_locktype', default => ''},
     });
 
     return $self;
@@ -137,10 +138,7 @@ sub check_options {
         $self->{output}->option_exit(short_msg => "Critical warning ('$label' locks) threshold '" . $value . "'.")
             unless $self->{perfdata}->threshold_validate(label => 'crit-' . $label, value => $value);
     }
-    # the add_options 'default' property do not transform an empty string to the default value, so we do it here too
-    if (is_empty($self->{option_results}->{include_locktype})) {
-        $self->{option_results}->{include_locktype} = '%';
-    }
+
 }
 
 sub manage_selection {
@@ -149,17 +147,17 @@ sub manage_selection {
     $options{sql}->connect();
 
     $options{sql}->query(query => q{
-        SELECT granted, mode, datname FROM pg_database d LEFT JOIN pg_locks l ON (d.oid=l.database AND locktype like ?) WHERE d.datallowconn
-    },
-        param=> [$self->{option_results}->{include_locktype}]);
+        SELECT granted, mode, datname, locktype FROM pg_database d LEFT JOIN pg_locks l ON (d.oid=l.database) WHERE d.datallowconn
+    });
 
     my $result = $options{sql}->fetchall_arrayref();
     $self->{output}->option_exit(short_msg => "No databases found. Do you have sufficient permissions ?") if scalar(@{$result}) == 0;
 
     my $dblocks = {};
     foreach my $row (@{$result}) {        
-        my ($granted, $mode, $dbname) = ($$row[0], $$row[1], $$row[2]);
+        my ($granted, $mode, $dbname, $locktype) = ($$row[0], $$row[1], $$row[2], $$row[3]);
         next if is_excluded($dbname, $self->{option_results}->{include_database}, $self->{option_results}->{exclude_database});
+        next if is_excluded($locktype, $self->{option_results}->{include_locktype}, $self->{option_results}->{exclude_locktype});
         if (!defined($dblocks->{$dbname})) {
             $dblocks->{$dbname} = {total => 0, waiting => 0, database => $dbname };
             # Empty. no lock (left join)
@@ -226,7 +224,11 @@ Exclude databases using a regular expression.
 
 =item B<--include-locktype>
 
-Include lock type using a SQL 'like' format. by default all lock type are included (default: '%').
+Filter lock type by C<pg_locks.locktype> column. (default: 'relation').
+
+=item B<--exclude-locktype>
+
+Filter lock type by C<pg_locks.locktype> column.
 
 =back
 


### PR DESCRIPTION
postgresql use lock internally to process SQL query. this monitoring mode was not filtering lock by type.
This PR add a new argument allowing to filter the lock monitored by locktype

**Fixes** # CTOR-2319

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Create a pg container and execute the plugin on it. both the default database and the postgres internal database should show metrics


- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [X] I have reviewed all the help messages in all the .pm files I have modified.
  - [X] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [X] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [X] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
