### PR TITLE
fix(mssql): fix empty output for mssql database-size mode

### DIFF
--- a/src/database/mssql/mode/databasessize.pm
+++ b/src/database/mssql/mode/databasessize.pm
@@ -1,5 +1,5 @@
 #
-# Copyright 2024 Centreon (http://www.centreon.com/)
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
 #
 # Centreon is a full-fledged industry-strength solution that meets
 # the needs in IT infrastructure and application monitoring for
@@ -25,6 +25,7 @@ use base qw(centreon::plugins::templates::counter);
 use strict;
 use warnings;
 use database::mssql::mode::resources::types qw($database_state);
+use centreon::plugins::constants qw(:counters :values);
 
 sub custom_space_usage_perfdata {
     my ($self, %options) = @_;
@@ -146,10 +147,10 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'databases', type => 3, cb_prefix_output => 'prefix_database_output', cb_long_output => 'database_long_output', indent_long_output => '    ', message_multiple => 'All databases are ok',
+        { name => 'databases', type => COUNTER_TYPE_MULTIPLE, cb_prefix_output => 'prefix_database_output', cb_long_output => 'database_long_output', indent_long_output => '    ', message_multiple => 'All databases are ok',
             group => [
-                { name => 'datafiles', type => 0, cb_prefix_output => 'prefix_datafiles_output', skipped_code => { -10 => 1 } },
-                { name => 'logfiles', type => 0, cb_prefix_output => 'prefix_logfiles_output', skipped_code => { -10 => 1 } }
+                { name => 'datafiles', type => COUNTER_MULTIPLE_INSTANCE, cb_prefix_output => 'prefix_datafiles_output', skipped_code => { NO_VALUE => 1 } },
+                { name => 'logfiles', type => COUNTER_MULTIPLE_INSTANCE, cb_prefix_output => 'prefix_logfiles_output', skipped_code => { NO_VALUE => 1 } }
             ]
         }
     ];
@@ -348,6 +349,9 @@ sub manage_selection {
         }
     }
 
+    if (scalar(keys %{$self->{databases}}) <= 0 ) {
+        $self->{output}->option_exit(short_msg => "No database found, check filter parameter.");
+    }
     foreach my $dbname (keys %{$self->{databases}}) {
         foreach my $type (('data', 'log')) {
             my $options = [$type . 'files_maxsize'];
@@ -399,11 +403,11 @@ Overload all log files max size (in MB).
 
 =item B<--datafiles-maxsize-unlimited>
 
-Overload only unlimited autogrowth data files max size (in MB).
+Overload only unlimited auto growth data files max size (in MB).
 
 =item B<--logfiles-maxsize-unlimited>
 
-Overload only unlimited autogrowth log files max size (in MB).
+Overload only unlimited auto growth log files max size (in MB).
 
 =item B<--check-underlying-disk>
 
@@ -411,13 +415,55 @@ Check and consider underlying disk space for data and log files.
 
 =item B<--ignore-unlimited>
 
-Thresholds not applied on unlimited autogrowth data and log files.
+Thresholds not applied on unlimited auto growth data and log files.
 
-=item B<--warning-*> B<--critical-*>
+=item B<--warning-datafiles-space-usage>
 
 Thresholds.
-Can be: 'datafiles-space-usage', 'datafiles-space-usage-free', 'datafiles-space-usage-prct'
-'logfiles-space-usage', 'logfiles-space-usage-free', 'logfiles-space-usage-prct'.
+
+=item B<--critical-datafiles-space-usage>
+
+Thresholds.
+
+=item B<--warning-datafiles-space-usage-free>
+
+Thresholds.
+
+=item B<--critical-datafiles-space-usage-free>
+
+Thresholds.
+
+=item B<--warning-datafiles-space-usage-prct>
+
+Thresholds.
+
+=item B<--critical-datafiles-space-usage-prct>
+
+Thresholds.
+
+=item B<--warning-logfiles-space-usage>
+
+Thresholds.
+
+=item B<--critical-logfiles-space-usage>
+
+Thresholds.
+
+=item B<--warning-logfiles-space-usage-free>
+
+Thresholds.
+
+=item B<--critical-logfiles-space-usage-free>
+
+Thresholds.
+
+=item B<--warning-logfiles-space-usage-prct>
+
+Thresholds.
+
+=item B<--critical-logfiles-space-usage-prct>
+
+Thresholds.
 
 =back
 

--- a/tests/database/mssql/databasessize.robot
+++ b/tests/database/mssql/databasessize.robot
@@ -1,0 +1,44 @@
+*** Settings ***
+Documentation       Database MSSQL plugin
+...                 To execute this test, run an MSSQL Docker container with:
+...                 docker run -e ACCEPT_EULA=Y -e MSSQL_SA_PASSWORD='Str0ngPass!' -p 1433:1433 mcr.microsoft.com/mssql/server:2022-latest
+...                 Then add a # on '[Setup] Skip' line below and execute the test.
+
+Resource            ${CURDIR}${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Ctn Generic Suite Setup
+Test Timeout        120s
+
+
+*** Variables ***
+${HOSTNAME}     127.0.0.1
+${PORT}         1433
+${USERNAME}     sa
+${PASSWORD}     Str0ngPass!
+${CMD}          ${CENTREON_PLUGINS}
+...             --plugin=database::mssql::plugin
+...             --mode=databases-size
+...             --hostname=${HOSTNAME}
+...             --username=${USERNAME}
+...             --password=${PASSWORD}
+...             --port=${PORT}
+
+
+*** Test Cases ***
+database size ${tc}
+    [Documentation]    Check MSSQL connected users
+    [Tags]    database    mssql
+    [Setup]    Skip    Reason: This test can only be executed manually
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+
+    Ctn Run Command Without Connector And Check Result As Regexp    ${command}    ${expected_regexp}
+
+    Examples:    tc    extraoptions    expected_regexp    --
+    ...    1
+    ...    ${EMPTY}
+    ...    OK: All databases are ok | 'master#datafiles.space.usage.bytes'=\\\\d+;;;0;.*
+    ...    2
+    ...    --filter-database='NoTeXiSt'
+    ...    UNKNOWN: No database found, check filter parameter.

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -71,6 +71,7 @@ CXF
 Cyberoam
 DaemonSet
 Datacore
+datafiles
 datasource
 datastore
 Datastore


### PR DESCRIPTION
# Community contributors

## Description

fix empty output for mssql database size plugin

**Fixes** # CTOR-778

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

See manual automated test, you need to setup a docker mssql container and run the plugin on it.

## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [X] I have implemented automated tests related to my commits.
  - [X] Data used for automated tests are anonymized.
- [X] I have reviewed all the help messages in all the .pm files I have modified.
  - [X] All sentences begin with a capital letter.
  - [X] All sentences end with a period.
  - [X] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
