### PR TITLE
fix(apps::backup::veeam): fix job-type and session values - CTOR-2490

### DIFF
--- a/src/centreon/common/powershell/veeam/jobstatus.pm
+++ b/src/centreon/common/powershell/veeam/jobstatus.pm
@@ -78,7 +78,7 @@ Try {
 
             $item = @{}
             $item.name = $_.Name
-            $item.type = $_.JobType.value
+            $item.type = $_.JobType.value__
             $item.isRunning = $_.isRunning
             $item.scheduled = $_.IsScheduleEnabled
             $item.isContinuous = 0
@@ -90,7 +90,7 @@ Try {
             $item.sessions = New-Object System.Collections.Generic.List[Hashtable];
             [Veeam.Backup.Core.CBackupSession]::GetByJob($guid) | Sort-Object CreationTimeUTC -Descending | Select-Object -First 2 | ForEach-Object {
                 $session = @{}
-                $session.result = $_.Result.value
+                $session.result = $_.Result.value__
                 $session.creationTimeUTC = (get-date -date $_.CreationTimeUTC.ToUniversalTime() -Uformat ' . "'%s'" . ')
                 $session.endTimeUTC = (get-date -date $_.EndTimeUTC.ToUniversalTime() -Uformat ' . "'%s'" . ')
                 $item.sessions.Add($session)


### PR DESCRIPTION
Refs:CTOR-2490
------------------------------------------------------------------------------------------------------
# Centreon team (internal PR)

## Description

With Veeam Backup & Replication 13 or inferior, the job-status mode of apps::backup::veeam::local::plugin returns type: `unknown `and status: `-` for every job, and therefore reports CRITICAL on all of them regardless of the actual backup outcome.

The PowerShell script embedded in the plugin reads the job type and the session result through the .value accessor:
```
$item.type = $_.JobType.value
$session.result = $_.Result.value
```

This should be (as before last change)
```
$item.type = $_.JobType.value__
$session.result = $_.Result.value__
```

**Fixes** [CTOR-2490](https://centreon.atlassian.net/browse/CTOR-2490)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Please describe the **procedure** to verify that the goal of the PR is matched. 
Provide clear instructions so that it can be **correctly tested**.
Mention the automated tests included in this FOR (what they test like mode/option combinations).

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [ ] In case of a new plugin, I have created the new packaging directory accordingly.
- [ ] I have implemented automated tests related to my commits.
  - [ ] Data used for automated tests are anonymized.
- [ ] I have reviewed all the help messages in all the .pm files I have modified.
  - [ ] All sentences begin with a capital letter.
  - [ ] All sentences end with a period.
  - [ ] I am able to understand all the help messages, if not, exchange with the PO or TW to rewrite them.
- [ ] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.


[CTOR-2490]: https://centreon.atlassian.net/browse/CTOR-2490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ