### PR TITLE
enh(delivery): legacy suites and front-verified deliveries

### DIFF
--- a/.github/actions/package-delivery-pulp/action.yml
+++ b/.github/actions/package-delivery-pulp/action.yml
@@ -105,6 +105,7 @@ runs:
         REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.repository_prefix }}
         STABLE_REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.stable_repository_prefix }}
         BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.base_path_prefix }}
+        LEGACY_BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.legacy_base_path_prefix }}
         PULP_URL: ${{ inputs.pulp_url }}
         PULP_DOMAIN: ${{ steps.pulp-properties.outputs.domain }}
         PULP_STABLE_DOMAIN: ${{ steps.pulp-properties.outputs.stable_domain }}
@@ -122,6 +123,8 @@ runs:
         STABILITY: ${{ inputs.stability }}
         REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.repository_name }}
         BASE_PATH: ${{ steps.pulp-properties.outputs.base_path }}
+        LEGACY_BASE_PATH: ${{ steps.pulp-properties.outputs.legacy_base_path }}
+        LEGACY_STABLE_BASE_PATH: ${{ steps.pulp-properties.outputs.legacy_stable_base_path }}
         SUITE: ${{ steps.pulp-properties.outputs.suite }}
         STABLE_SUITE: ${{ steps.pulp-properties.outputs.stable_suite }}
         STABLE_BASE_PATH: ${{ steps.pulp-properties.outputs.stable_base_path }}

--- a/.github/actions/package-delivery-pulp/deliver-deb.sh
+++ b/.github/actions/package-delivery-pulp/deliver-deb.sh
@@ -21,7 +21,7 @@ stable_suite_architectures() {
   local release_file http_code
   release_file=$(mktemp)
   http_code=$(content_curl -sSL --retry 3 --retry-delay 5 -o "$release_file" -w '%{http_code}' \
-    "$PULP_CONTENT_URL/$PULP_STABLE_DOMAIN/${STABLE_BASE_PATH:-$BASE_PATH}/dists/$STABLE_SUITE/Release" 2>/dev/null || echo 000)
+    "$PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/${STABLE_BASE_PATH:-$BASE_PATH}}/dists/$STABLE_SUITE/Release" 2>/dev/null || echo 000)
   case "$http_code" in
     404) rm -f "$release_file"; return 0 ;;
     200) awk -F': ' '/^Architectures:/ {print $2}' "$release_file"; rm -f "$release_file" ;;
@@ -39,7 +39,7 @@ fetch_stable_packages_index() {
   local a=$1 pkg_file http_code
   pkg_file=$(mktemp)
   http_code=$(content_curl -sSL --retry 3 --retry-delay 5 -o "$pkg_file" -w '%{http_code}' \
-    "$PULP_CONTENT_URL/$PULP_STABLE_DOMAIN/${STABLE_BASE_PATH:-$BASE_PATH}/dists/$STABLE_SUITE/main/binary-$a/Packages" 2>/dev/null || echo 000)
+    "$PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/${STABLE_BASE_PATH:-$BASE_PATH}}/dists/$STABLE_SUITE/main/binary-$a/Packages" 2>/dev/null || echo 000)
   case "$http_code" in
     404) rm -f "$pkg_file"; return 0 ;;
     200) cat "$pkg_file"; rm -f "$pkg_file" ;;
@@ -444,13 +444,13 @@ for FILE in "${FILES[@]}"; do
   manifest_add "$(jq -cn \
     --arg filename "$FILE" --arg name "$name" --arg version "$version" \
     --arg arch "$arch" --arg sha256 "$sha256" --arg repository "$REPOSITORY_NAME" \
-    --arg base_path "$BASE_PATH" --arg suite "$SUITE" --arg relative_path "$POOL_PATH/$FILE" \
+    --arg base_path "${LEGACY_BASE_PATH:-$PULP_DOMAIN/$BASE_PATH}" --arg suite "$SUITE" --arg relative_path "$POOL_PATH/$FILE" \
     '{filename:$filename,name:$name,version:$version,arch:$arch,sha256:$sha256,repository:$repository,base_path:$base_path,suite:$suite,relative_path:$relative_path}')"
 done
 
 echo "[INFO] Publishing repository $REPOSITORY_NAME"
 create_publication deb "$REPOSITORY_NAME" --structured
 
-echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/$PULP_DOMAIN/$BASE_PATH/ $SUITE main"
+echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/${LEGACY_BASE_PATH:-$PULP_DOMAIN/$BASE_PATH}/ $SUITE main"
 
 manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "${STABILITY:-}" "delivery" "$PULP_CONTENT_URL"

--- a/.github/actions/package-delivery-pulp/deliver-rpm.sh
+++ b/.github/actions/package-delivery-pulp/deliver-rpm.sh
@@ -131,6 +131,8 @@ for ARCH in noarch x86_64; do
 
   REPOSITORY_NAME="$REPOSITORY_PREFIX-$ARCH"
   BASE_PATH="$BASE_PATH_PREFIX/$ARCH"
+  LEGACY_BASE_PATH=""
+  [[ -n "$LEGACY_BASE_PATH_PREFIX" ]] && LEGACY_BASE_PATH="$LEGACY_BASE_PATH_PREFIX/$ARCH"
 
   if ! pulp_resource_exists "repositories/rpm/rpm" "$REPOSITORY_NAME"; then
     echo "::error::rpm repository $REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before delivering."
@@ -194,7 +196,7 @@ for ARCH in noarch x86_64; do
     manifest_add "$(jq -cn \
       --arg filename "$FILENAME" --arg name "$name" --arg version "$version" \
       --arg release "$release" --arg arch "$ARCH" --arg sha256 "$sha256" \
-      --arg repository "$REPOSITORY_NAME" --arg base_path "$BASE_PATH" \
+      --arg repository "$REPOSITORY_NAME" --arg base_path "${LEGACY_BASE_PATH:-$PULP_DOMAIN/$BASE_PATH}" \
       '{filename:$filename,name:$name,version:$version,release:$release,arch:$arch,sha256:$sha256,repository:$repository,base_path:$base_path}')"
   done
   rm -rf "$UPLOAD_DIR"
@@ -249,7 +251,7 @@ for ARCH in noarch x86_64; do
   echo "[INFO] Publishing repository $REPOSITORY_NAME"
   create_publication rpm "$REPOSITORY_NAME"
 
-  echo "::notice::Packages are available at $PULP_CONTENT_URL/$PULP_DOMAIN/$BASE_PATH/"
+  echo "::notice::Packages are available at $PULP_CONTENT_URL/${LEGACY_BASE_PATH:-$PULP_DOMAIN/$BASE_PATH}/"
 done
 
 manifest_write "$MODULE_NAME" "${DISTRIB:-}" "rpm" "${STABILITY:-}" "delivery" "$PULP_CONTENT_URL"

--- a/.github/actions/promote-to-stable-pulp/action.yml
+++ b/.github/actions/promote-to-stable-pulp/action.yml
@@ -86,6 +86,7 @@ runs:
         TESTING_BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.testing_base_path_prefix }}
         STABLE_REPOSITORY_PREFIX: ${{ steps.pulp-properties.outputs.stable_repository_prefix }}
         STABLE_BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.stable_base_path_prefix }}
+        LEGACY_STABLE_BASE_PATH_PREFIX: ${{ steps.pulp-properties.outputs.legacy_stable_base_path_prefix }}
         STABILITY: ${{ inputs.stability }}
         PULP_URL: ${{ inputs.pulp_url }}
         PULP_TOKEN: ${{ env.PULP_TOKEN }}
@@ -106,6 +107,8 @@ runs:
         # stability), not the repository matching the requested stability
         REPOSITORY_NAME: ${{ steps.pulp-properties.outputs.testing_repository_name }}
         BASE_PATH: ${{ steps.pulp-properties.outputs.testing_base_path }}
+        LEGACY_TESTING_BASE_PATH: ${{ steps.pulp-properties.outputs.legacy_testing_base_path }}
+        LEGACY_STABLE_BASE_PATH: ${{ steps.pulp-properties.outputs.legacy_stable_base_path }}
         TESTING_POOL_PATH: ${{ steps.pulp-properties.outputs.testing_pool_path }}
         TESTING_SUITE: ${{ steps.pulp-properties.outputs.testing_suite }}
         STABLE_SUITE: ${{ steps.pulp-properties.outputs.stable_suite }}

--- a/.github/actions/promote-to-stable-pulp/promote-deb.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-deb.sh
@@ -181,40 +181,6 @@ lookup_deb_content() {
   done
 }
 
-# wait for a content-create task and emit its created content href; fall
-# back to a lookup (content already existing on a job re-run)
-resolve_task_content() {
-  local task_href=$1 endpoint=$2 fallback_query=$3
-  local body state content attempt
-  for ((attempt = 0; attempt < 200; attempt++)); do
-    refresh_pulp_token
-    body=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null) || body=""
-    state=$(echo "$body" | jq -r '.state' 2>/dev/null) || state=""
-    case "$state" in
-      completed)
-        content=$(echo "$body" | jq -r '.created_resources[0] // empty')
-        if [[ -n "$content" ]]; then
-          echo "$content"
-          return 0
-        fi
-        break
-        ;;
-      failed | canceled)
-        break
-        ;;
-      *)
-        sleep 3
-        ;;
-    esac
-  done
-  content=$(lookup_deb_content "$endpoint" "$fallback_query")
-  if [[ -z "$content" ]]; then
-    echo "::error::Cannot resolve the created deb content for task $task_href" >&2
-    return 1
-  fi
-  echo "$content"
-}
-
 # emit the release-component hrefs a package is associated with
 lookup_prcs() {
   local package_href=$1
@@ -250,13 +216,12 @@ if ((${#UNPROMOTED_HREFS[@]} == 0)); then
   exit 0
 fi
 
-# batched promote, mirroring the batched delivery. Since the domain merge,
-# testing and stable share their domain (and content): the re-download/
-# re-upload below is deduplicated server-side by sha256, kept only because the
-# battle-tested flow predates the merge — a direct href association would skip
-# the transfers entirely (follow-up optimization). The FIRST package of each
-# arch still goes through the legacy path to establish the release component
-# (see deliver-deb.sh).
+# batched promote, mirroring the batched delivery. Testing and stable share
+# their domain (and content) since the domain merge: the batch below associates
+# the testing package hrefs directly, no re-download/re-upload. Only the FIRST
+# package of each arch goes through the legacy upload path, to establish the
+# release component and deduce its href (see deliver-deb.sh; listing release
+# components requires admin rights).
 declare -A ARCH_SEEN=()
 LEGACY_PACKAGES=()
 BATCH_PACKAGES=()
@@ -367,70 +332,18 @@ if ((${#BATCH_PACKAGES[@]} > 0)); then
   fi
   echo "[INFO] Release component of $STABLE_SUITE/main: $STABLE_RC"
 
-  # remaining packages: parallel re-download+upload (pool of 8, marker-file
-  # based like rpm/deliver-deb), associated with the stable release component below
-  echo "[INFO] Re-uploading ${#BATCH_PACKAGES[@]} package(s) from $BASE_PATH into the stable domain"
-  DOWNLOAD_DIR=$(mktemp -d)
-  MAX_PARALLEL=8
-  for i in "${!BATCH_PACKAGES[@]}"; do
-    if ((i % 40 == 0)); then
-      refresh_pulp_token
-    fi
-    (
-      refresh_pulp_token
-      PACKAGE="${BATCH_PACKAGES[$i]}"
-      RELATIVE_PATH=$(echo "$PACKAGE" | jq -r '.relative_path')
-      SHA256=$(echo "$PACKAGE" | jq -r '.sha256')
-      ARCH=$(echo "$PACKAGE" | jq -r '.architecture')
-      FILE_NAME=$(basename "$RELATIVE_PATH")
-      FILE="$DOWNLOAD_DIR/$i-$FILE_NAME"
-      download_testing_package "$SHA256" "$ARCH" "$FILE"
-      pulp_upload \
-        -F "file=@\"$FILE\"" \
-        -F "relative_path=$RELATIVE_PATH" \
-        -F "pulp_labels=$PULP_LABELS" \
-        "$PULP_URL/$PULP_DOMAIN/api/v3/content/deb/packages/" > "$DOWNLOAD_DIR/$i.task"
-    ) &
-    while (($(jobs -rp | wc -l) >= MAX_PARALLEL)); do
-      wait -n || true
-    done
-  done
-  wait || true
-
-  for i in "${!BATCH_PACKAGES[@]}"; do
-    if [[ ! -s "$DOWNLOAD_DIR/$i.task" ]]; then
-      echo "::error::Re-upload into the stable domain failed for $(echo "${BATCH_PACKAGES[$i]}" | jq -r '.package') ($(echo "${BATCH_PACKAGES[$i]}" | jq -r '.architecture')), see the worker error above"
-      exit 1
-    fi
-  done
-
-  echo "[INFO] Resolving ${#BATCH_PACKAGES[@]} uploaded package(s)"
-  for i in "${!BATCH_PACKAGES[@]}"; do
-    if ((i % 40 == 0)); then
-      refresh_pulp_token
-    fi
-    (
-      resolve_task_content "$(cat "$DOWNLOAD_DIR/$i.task")" "packages" \
-        "--data-urlencode sha256=$(echo "${BATCH_PACKAGES[$i]}" | jq -r '.sha256')" > "$DOWNLOAD_DIR/$i.content"
-    ) &
-    while (($(jobs -rp | wc -l) >= MAX_PARALLEL)); do
-      wait -n || true
-    done
-  done
-  wait || true
+  # remaining packages: the testing content hrefs are associated with the
+  # stable release component directly (same domain, shared content); the
+  # packages keep their delivery-time labels
   PACKAGE_HREFS=()
-  for i in "${!BATCH_PACKAGES[@]}"; do
-    if [[ ! -s "$DOWNLOAD_DIR/$i.content" ]]; then
-      echo "::error::Cannot resolve the promoted content for $(echo "${BATCH_PACKAGES[$i]}" | jq -r '.package') (see the worker error above)"
-      exit 1
-    fi
-    PACKAGE_HREFS+=("$(cat "$DOWNLOAD_DIR/$i.content")")
+  for PACKAGE in "${BATCH_PACKAGES[@]}"; do
+    PACKAGE_HREFS+=("$(echo "$PACKAGE" | jq -r '.pulp_href')")
   done
-  rm -rf "$DOWNLOAD_DIR"
 
   # package_release_components create is synchronous (201 with the unit, no
   # task); a failed create (already existing on a job re-run) falls back to a lookup
   echo "[INFO] Associating ${#PACKAGE_HREFS[@]} package(s) with $STABLE_SUITE/main"
+  MAX_PARALLEL=8
   PRC_DIR=$(mktemp -d)
   for i in "${!PACKAGE_HREFS[@]}"; do
     if ((i % 40 == 0)); then

--- a/.github/actions/promote-to-stable-pulp/promote-deb.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-deb.sh
@@ -42,7 +42,7 @@ suite_sha_file() {
   local base_path=$1 suite=$2 out release_file arches arch pkg_file rc
   out=$(mktemp)
   release_file=$(mktemp)
-  fetch_index "$PULP_CONTENT_URL/$PULP_DOMAIN/$base_path/dists/$suite/Release" "$release_file" && rc=0 || rc=$?
+  fetch_index "$PULP_CONTENT_URL/$base_path/dists/$suite/Release" "$release_file" && rc=0 || rc=$?
   if [[ $rc -eq 2 ]]; then
     echo "$out"
     return 0
@@ -53,7 +53,7 @@ suite_sha_file() {
   arches=$(awk -F': ' '/^Architectures:/ {print $2}' "$release_file")
   for arch in $arches; do
     pkg_file=$(mktemp)
-    if ! fetch_index "$PULP_CONTENT_URL/$PULP_DOMAIN/$base_path/dists/$suite/main/binary-$arch/Packages" "$pkg_file"; then
+    if ! fetch_index "$PULP_CONTENT_URL/$base_path/dists/$suite/main/binary-$arch/Packages" "$pkg_file"; then
       echo "::error::Cannot fetch the $suite binary-$arch Packages index; refusing to promote from a partial view." >&2
       return 1
     fi
@@ -70,17 +70,17 @@ suite_sha_file() {
 download_testing_package() {
   local sha256=$1 arch=$2 dest=$3 filename
   filename=$(
-    content_curl -fsSL --retry 3 --retry-delay 5 "$PULP_CONTENT_URL/$TESTING_DOMAIN/$BASE_PATH/dists/$TESTING_SUITE/main/binary-$arch/Packages" |
+    content_curl -fsSL --retry 3 --retry-delay 5 "$PULP_CONTENT_URL/${LEGACY_TESTING_BASE_PATH:-$TESTING_DOMAIN/$BASE_PATH}/dists/$TESTING_SUITE/main/binary-$arch/Packages" |
       awk -v sha="$sha256" 'BEGIN { RS = ""; FS = "\n" } index($0, "SHA256: " sha) { for (i = 1; i <= NF; i++) if ($i ~ /^Filename: /) { sub(/^Filename: /, "", $i); print $i; exit } }'
   )
   if [[ -z "$filename" ]]; then
     echo "::error::Cannot locate the published file for sha256 $sha256 in $TESTING_SUITE ($arch)" >&2
     return 1
   fi
-  content_curl -fsSL --retry 3 --retry-delay 5 -o "$dest" "$PULP_CONTENT_URL/$TESTING_DOMAIN/$BASE_PATH/$filename"
+  content_curl -fsSL --retry 3 --retry-delay 5 -o "$dest" "$PULP_CONTENT_URL/${LEGACY_TESTING_BASE_PATH:-$TESTING_DOMAIN/$BASE_PATH}/$filename"
 }
 
-TESTING_SHAS_FILE=$(suite_sha_file "$BASE_PATH" "$TESTING_SUITE")
+TESTING_SHAS_FILE=$(suite_sha_file "${LEGACY_TESTING_BASE_PATH:-$TESTING_DOMAIN/$BASE_PATH}" "$TESTING_SUITE")
 
 # paginated: the repository keeps every delivered version across all suites,
 # so the module listing can exceed a single page
@@ -206,12 +206,12 @@ if ((${#UNPROMOTED_HREFS[@]} == 0)); then
   echo "[INFO] All $PACKAGES_COUNT package(s) are already promoted to $STABLE_SUITE; republishing only"
   while read -r PACKAGE; do
     manifest_add "$(echo "$PACKAGE" | jq -c \
-      --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "$STABLE_BASE_PATH" \
+      --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" \
       --arg suite "$STABLE_SUITE" \
       '{filename: (.relative_path | sub(".*/"; "")), name: .package, version, arch: .architecture, sha256, repository: $repository, base_path: $base_path, suite: $suite, relative_path}')"
   done < <(echo "$PACKAGES" | jq -c '.[]')
   create_publication deb "$STABLE_REPOSITORY_NAME" --structured
-  echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH/ $STABLE_SUITE main"
+  echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}/ $STABLE_SUITE main"
   manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "$STABILITY" "promote" "$PULP_CONTENT_URL"
   exit 0
 fi
@@ -309,7 +309,7 @@ if ((${#BATCH_PACKAGES[@]} > 0)); then
     # publication: republish and re-check every candidate before giving up
     echo "[WARN] Cannot deduce the $STABLE_SUITE/main release component (got: ${STABLE_RC_SET:-none}); republishing to check for an interrupted promotion"
     create_publication deb "$STABLE_REPOSITORY_NAME" --structured
-    RECHECK_SHAS_FILE=$(suite_sha_file "$STABLE_BASE_PATH" "$STABLE_SUITE")
+    RECHECK_SHAS_FILE=$(suite_sha_file "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" "$STABLE_SUITE")
     MISSING_COUNT=0
     while read -r sha; do
       grep -qxF "$sha" "$RECHECK_SHAS_FILE" || MISSING_COUNT=$((MISSING_COUNT + 1))
@@ -319,11 +319,11 @@ if ((${#BATCH_PACKAGES[@]} > 0)); then
       echo "[INFO] Every candidate package is published in $STABLE_SUITE; the interrupted promotion only missed the publication"
       while read -r PACKAGE; do
         manifest_add "$(echo "$PACKAGE" | jq -c \
-          --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "$STABLE_BASE_PATH" \
+          --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" \
           --arg suite "$STABLE_SUITE" \
           '{filename: (.relative_path | sub(".*/"; "")), name: .package, version, arch: .architecture, sha256, repository: $repository, base_path: $base_path, suite: $suite, relative_path}')"
       done < <(echo "$PACKAGES" | jq -c '.[]')
-      echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH/ $STABLE_SUITE main"
+      echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}/ $STABLE_SUITE main"
       manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "$STABILITY" "promote" "$PULP_CONTENT_URL"
       exit 0
     fi
@@ -412,7 +412,7 @@ fi
 # verification step verifies exactly this set against the stable suite
 while read -r PACKAGE; do
   manifest_add "$(echo "$PACKAGE" | jq -c \
-    --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "$STABLE_BASE_PATH" \
+    --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" \
     --arg suite "$STABLE_SUITE" \
     '{filename: (.relative_path | sub(".*/"; "")), name: .package, version, arch: .architecture, sha256, repository: $repository, base_path: $base_path, suite: $suite, relative_path}')"
 done < <(echo "$PACKAGES" | jq -c '.[]')
@@ -420,6 +420,6 @@ done < <(echo "$PACKAGES" | jq -c '.[]')
 echo "[INFO] Publishing repository $STABLE_REPOSITORY_NAME"
 create_publication deb "$STABLE_REPOSITORY_NAME" --structured
 
-echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH/ $STABLE_SUITE main"
+echo "::notice::Packages are available with: deb $PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}/ $STABLE_SUITE main"
 
 manifest_write "$MODULE_NAME" "${DISTRIB:-}" "deb" "$STABILITY" "promote" "$PULP_CONTENT_URL"

--- a/.github/actions/promote-to-stable-pulp/promote-rpm.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-rpm.sh
@@ -83,6 +83,8 @@ for ARCH in noarch x86_64; do
 
   STABLE_REPOSITORY_NAME="$STABLE_REPOSITORY_PREFIX-$ARCH"
   STABLE_BASE_PATH="$STABLE_BASE_PATH_PREFIX/$ARCH"
+  LEGACY_STABLE_BASE_PATH=""
+  [[ -n "$LEGACY_STABLE_BASE_PATH_PREFIX" ]] && LEGACY_STABLE_BASE_PATH="$LEGACY_STABLE_BASE_PATH_PREFIX/$ARCH"
 
   if ! pulp_resource_exists "repositories/rpm/rpm" "$STABLE_REPOSITORY_NAME"; then
     echo "::error::stable rpm repository $STABLE_REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before promoting."
@@ -126,11 +128,11 @@ for ARCH in noarch x86_64; do
   # verification step verifies exactly this set against the stable repo
   while read -r PKG; do
     manifest_add "$(echo "$PKG" | jq -c \
-      --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "$STABLE_BASE_PATH" \
+      --arg repository "$STABLE_REPOSITORY_NAME" --arg base_path "${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}" \
       '{filename: (.location_href | sub(".*/"; "")), name, version, release, arch, sha256, repository: $repository, base_path: $base_path}')"
   done < <(echo "${ARCH_RESULTS[$ARCH]}" | jq -c '.[]')
 
-  echo "::notice::Packages are available at $PULP_CONTENT_URL/$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH/"
+  echo "::notice::Packages are available at $PULP_CONTENT_URL/${LEGACY_STABLE_BASE_PATH:-$PULP_STABLE_DOMAIN/$STABLE_BASE_PATH}/"
 done
 
 manifest_write "$MODULE_NAME" "${DISTRIB:-}" "rpm" "$STABILITY" "promote" "$PULP_CONTENT_URL"

--- a/.github/actions/promote-to-stable-pulp/promote-rpm.sh
+++ b/.github/actions/promote-to-stable-pulp/promote-rpm.sh
@@ -13,89 +13,6 @@ PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
 # now equals PULP_DOMAIN); the read/write phase switch is kept as a no-op
 PULP_DOMAIN="${PULP_DOMAIN:-default}"
 PULP_STABLE_DOMAIN="${PULP_STABLE_DOMAIN:-default}"
-# switch_pulp_domain overwrites PULP_DOMAIN itself once the write phase
-# starts; keep our own copy for the testing-domain content-app fetch after that
-TESTING_DOMAIN="$PULP_DOMAIN"
-
-# re-applied on the re-upload into stable (this promote run's own git context,
-# not the original delivery's); check-rpm.sh's verification query needs at
-# least "module" to find the promoted content
-PULP_LABELS=$(jq -cn \
-  --arg mod        "$MODULE_NAME" \
-  --arg git_commit "${GITHUB_SHA:-}" \
-  --arg git_ref    "${GITHUB_REF:-}" \
-  --arg run_id     "${GITHUB_RUN_ID:-}" \
-  --arg actor      "${GITHUB_ACTOR:-}" \
-  --arg workflow   "${GITHUB_WORKFLOW:-}" \
-  '{"module": $mod, "git_commit": $git_commit, "git_ref": $git_ref, "github_run_id": $run_id, "github_actor": $actor, "github_workflow": $workflow}')
-
-# mirrors deliver-rpm.sh's resolve_uploaded_content, scoped to the stable domain
-resolve_promoted_content() {
-  local task_href=$1 sha256=$2
-  local body state content attempt
-  for ((attempt = 0; attempt < 200; attempt++)); do
-    refresh_pulp_token
-    body=$(curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" "$PULP_URL$task_href" 2>/dev/null) || body=""
-    state=$(echo "$body" | jq -r '.state' 2>/dev/null) || state=""
-    case "$state" in
-      completed)
-        content=$(echo "$body" | jq -r '.created_resources[0] // empty')
-        if [[ -n "$content" ]]; then
-          echo "$content"
-          return 0
-        fi
-        break
-        ;;
-      failed | canceled)
-        break
-        ;;
-      *)
-        sleep 3
-        ;;
-    esac
-  done
-  content=$(
-    curl -fsSL -H "Authorization: Bearer $PULP_TOKEN" -G \
-      --data-urlencode "sha256=$sha256" \
-      --data-urlencode "limit=1" \
-      "$PULP_URL/$PULP_STABLE_DOMAIN/api/v3/content/rpm/packages/" | jq -r '.results[0].pulp_href // empty'
-  )
-  if [[ -z "$content" ]]; then
-    echo "::error::Cannot resolve the promoted content for task $task_href (sha256 $sha256)" >&2
-    return 1
-  fi
-  echo "$content"
-}
-
-# resolve a package's served location by sha256 (mirrors check-rpm.sh's
-# resolve_href): pulp_rpm publishes under Packages/<letter>/<file>, which
-# doesn't match the content API's location_href (the upload-time relative path)
-resolve_rpm_href() {
-  local primary_file=$1 sha=$2
-  [[ -s "$primary_file" ]] || return 0
-  awk -v sha="$sha" '
-    BEGIN { RS = "</package>" }
-    index($0, ">" sha "</checksum>") {
-      if (match($0, /<location[^>]*href="[^"]+"/)) {
-        s = substr($0, RSTART, RLENGTH)
-        sub(/.*href="/, "", s); sub(/"$/, "", s)
-        print s; exit
-      }
-    }' "$primary_file"
-}
-
-# fetch the published primary.xml for a base_path into $3 (a single fetch:
-# promote processes one base_path per arch sequentially, unlike check-rpm.sh's
-# many-packages-in-parallel caching)
-fetch_primary_xml() {
-  local domain=$1 base_path=$2 out=$3 repomd primary_href
-  repomd=$(content_curl -fsSL "$PULP_CONTENT_URL/$domain/$base_path/repodata/repomd.xml" 2>/dev/null || true)
-  primary_href=$(printf '%s' "$repomd" | grep -oP '<location href="\K[^"]+primary\.xml[^"]*' | head -1 || true)
-  if [[ -n "$primary_href" ]]; then
-    content_curl -fsSL "$PULP_CONTENT_URL/$domain/$base_path/$primary_href" 2>/dev/null | gunzip -c 2>/dev/null > "$out" || true
-  fi
-}
-
 declare -A ARCH_CONTENT
 declare -A ARCH_RESULTS
 TOTAL_PACKAGES_COUNT=0
@@ -166,7 +83,6 @@ for ARCH in noarch x86_64; do
 
   STABLE_REPOSITORY_NAME="$STABLE_REPOSITORY_PREFIX-$ARCH"
   STABLE_BASE_PATH="$STABLE_BASE_PATH_PREFIX/$ARCH"
-  TESTING_BASE_PATH="$TESTING_BASE_PATH_PREFIX/$ARCH"
 
   if ! pulp_resource_exists "repositories/rpm/rpm" "$STABLE_REPOSITORY_NAME"; then
     echo "::error::stable rpm repository $STABLE_REPOSITORY_NAME does not exist. Pulp repositories and distributions are provisioned centrally by delivery-tooling create-repos; run create-repos for this version before promoting."
@@ -180,59 +96,10 @@ for ARCH in noarch x86_64; do
 
   STABLE_REPOSITORY_HREF=$(pulp rpm repository show --name "$STABLE_REPOSITORY_NAME" | jq -r '.pulp_href')
 
-  # Since the domain merge, testing and stable share their domain (and
-  # content): this re-download/re-upload is deduplicated server-side by
-  # sha256, kept only because the battle-tested flow predates the merge — a
-  # direct href association would skip the transfers entirely (follow-up
-  # optimization). Same shape as the JFrog promote job always had.
-  echo "[INFO] Re-uploading $ARCH_PACKAGES_COUNT package(s) from $TESTING_BASE_PATH into the stable domain"
-  DOWNLOAD_DIR=$(mktemp -d)
-  UPLOAD_DIR=$(mktemp -d)
-  MAX_PARALLEL_UPLOADS=8
-  TESTING_PRIMARY_XML=$(mktemp)
-  fetch_primary_xml "$TESTING_DOMAIN" "$TESTING_BASE_PATH" "$TESTING_PRIMARY_XML"
-  mapfile -t PKG_ROWS < <(echo "$RESULTS" | jq -c '.[]')
-  for i in "${!PKG_ROWS[@]}"; do
-    if ((i % 40 == 0)); then
-      refresh_pulp_token
-    fi
-    (
-      refresh_pulp_token
-      location_href=$(echo "${PKG_ROWS[$i]}" | jq -r '.location_href')
-      sha256=$(echo "${PKG_ROWS[$i]}" | jq -r '.sha256')
-      served_href=$(resolve_rpm_href "$TESTING_PRIMARY_XML" "$sha256")
-      if [[ -z "$served_href" ]]; then
-        echo "::error::Cannot resolve the published location of $(echo "${PKG_ROWS[$i]}" | jq -r '.name') (sha256 $sha256) in $TESTING_BASE_PATH" >&2
-        exit 1
-      fi
-      dest="$DOWNLOAD_DIR/$i-$(basename "$location_href")"
-      content_curl -fsSL --retry 3 --retry-delay 5 -o "$dest" "$PULP_CONTENT_URL/$TESTING_DOMAIN/$TESTING_BASE_PATH/$served_href"
-      pulp_upload -F "file=@\"$dest\"" -F "pulp_labels=$PULP_LABELS" \
-        "$PULP_URL/$PULP_STABLE_DOMAIN/api/v3/content/rpm/packages/" > "$UPLOAD_DIR/$i.task"
-    ) &
-    while (($(jobs -rp | wc -l) >= MAX_PARALLEL_UPLOADS)); do
-      wait -n || true
-    done
-  done
-  wait || true
-
-  NEW_HREFS=()
-  for i in "${!PKG_ROWS[@]}"; do
-    if [[ ! -s "$UPLOAD_DIR/$i.task" ]]; then
-      echo "::error::Re-upload into the stable domain failed for $(echo "${PKG_ROWS[$i]}" | jq -r '.name') ($ARCH), see the worker error above"
-      exit 1
-    fi
-    new_href=$(resolve_promoted_content "$(cat "$UPLOAD_DIR/$i.task")" "$(echo "${PKG_ROWS[$i]}" | jq -r '.sha256')") || new_href=""
-    if [[ -z "$new_href" ]]; then
-      echo "::error::Cannot resolve the promoted content for $(echo "${PKG_ROWS[$i]}" | jq -r '.name') ($ARCH)"
-      exit 1
-    fi
-    NEW_HREFS+=("$new_href")
-  done
-  rm -rf "$DOWNLOAD_DIR" "$UPLOAD_DIR"
-  rm -f "$TESTING_PRIMARY_XML"
-  CONTENT=$(printf '%s\n' "${NEW_HREFS[@]}" | jq -R . | jq -cs .)
-
+  # Same-domain promotion: testing and stable share their domain, so the
+  # testing content hrefs (already collected above) are associated with the
+  # stable repository directly — no re-download/re-upload, the packages keep
+  # their delivery-time labels (check-rpm.sh only needs "module").
   echo "[INFO] Promoting $ARCH_PACKAGES_COUNT packages to $STABLE_REPOSITORY_NAME"
   # pulp-cli repository content modify does not resolve content by pulp_href, use the api directly
   ADD_BODY_FILE=$(mktemp)

--- a/.github/actions/pulp-repository-properties/action.yml
+++ b/.github/actions/pulp-repository-properties/action.yml
@@ -48,12 +48,30 @@ outputs:
   base_path_prefix:
     description: "Base path prefix of rpm distributions (one distribution per architecture)"
     value: ${{ steps.properties.outputs.base_path_prefix }}
+  legacy_base_path_prefix:
+    description: "Legacy (front) rpm base path prefix, used by the content verifications"
+    value: ${{ steps.properties.outputs.legacy_base_path_prefix }}
+  legacy_testing_base_path_prefix:
+    description: "Legacy (front) testing rpm base path prefix"
+    value: ${{ steps.properties.outputs.legacy_testing_base_path_prefix }}
+  legacy_stable_base_path_prefix:
+    description: "Legacy (front) stable rpm base path prefix"
+    value: ${{ steps.properties.outputs.legacy_stable_base_path_prefix }}
   repository_name:
     description: "Repository name of the deb repository"
     value: ${{ steps.properties.outputs.repository_name }}
   base_path:
     description: "Base path of the deb distribution"
     value: ${{ steps.properties.outputs.base_path }}
+  legacy_base_path:
+    description: "Legacy (front) deb base path, used by the content verifications"
+    value: ${{ steps.properties.outputs.legacy_base_path }}
+  legacy_testing_base_path:
+    description: "Legacy (front) testing deb base path"
+    value: ${{ steps.properties.outputs.legacy_testing_base_path }}
+  legacy_stable_base_path:
+    description: "Legacy (front) stable deb base path"
+    value: ${{ steps.properties.outputs.legacy_stable_base_path }}
   suite:
     description: "Apt suite of the deb delivery"
     value: ${{ steps.properties.outputs.suite }}

--- a/.github/actions/pulp-repository-properties/properties.sh
+++ b/.github/actions/pulp-repository-properties/properties.sh
@@ -61,6 +61,12 @@ fi
 
 REPOSITORY_PREFIX=""
 BASE_PATH_PREFIX=""
+LEGACY_BASE_PATH_PREFIX=""
+LEGACY_TESTING_BASE_PATH_PREFIX=""
+LEGACY_STABLE_BASE_PATH_PREFIX=""
+LEGACY_BASE_PATH=""
+LEGACY_TESTING_BASE_PATH=""
+LEGACY_STABLE_BASE_PATH=""
 TESTING_REPOSITORY_PREFIX=""
 TESTING_BASE_PATH_PREFIX=""
 STABLE_REPOSITORY_PREFIX=""
@@ -92,18 +98,37 @@ if [[ "$REPO_BASE" == "plugins" ]]; then
     TESTING_BASE_PATH_PREFIX="rpm/$DISTRIB/$TESTING_SEGMENT"
     STABLE_REPOSITORY_PREFIX="rpm-$DISTRIB-stable"
     STABLE_BASE_PATH_PREFIX="rpm/$DISTRIB/stable"
+    LEGACY_SEGMENT_RPM="$STABILITY_SEGMENT"
+    [[ "$STABILITY_SEGMENT" == "testing-release" ]] && LEGACY_SEGMENT_RPM="testing"
+    LEGACY_TESTING_SEGMENT_RPM="$TESTING_SEGMENT"
+    [[ "$TESTING_SEGMENT" == "testing-release" ]] && LEGACY_TESTING_SEGMENT_RPM="testing"
+    LEGACY_BASE_PATH_PREFIX="rpm-$REPO_BASE/$DISTRIB/$LEGACY_SEGMENT_RPM"
+    LEGACY_TESTING_BASE_PATH_PREFIX="rpm-$REPO_BASE/$DISTRIB/$LEGACY_TESTING_SEGMENT_RPM"
+    LEGACY_STABLE_BASE_PATH_PREFIX="rpm-$REPO_BASE/$DISTRIB/stable"
   else
     # one deb repository per stability (base path = repository name), suites
     # carry the plain codename only
     REPOSITORY_NAME="${DEB_PREFIX}${STABILITY_SEGMENT}"
     BASE_PATH="$REPOSITORY_NAME"
-    SUITE="$DISTRIB"
+    # historical plugins suite names: plain codename for stable,
+    # codename-<stability> otherwise (bare "testing" segment)
+    LEGACY_SEGMENT="$STABILITY_SEGMENT"
+    [[ "$STABILITY_SEGMENT" == "testing-release" ]] && LEGACY_SEGMENT="testing"
+    LEGACY_TESTING_SEGMENT="$TESTING_SEGMENT"
+    [[ "$TESTING_SEGMENT" == "testing-release" ]] && LEGACY_TESTING_SEGMENT="testing"
+    SUITE="$DISTRIB-$LEGACY_SEGMENT"
+    [[ "$STABILITY" == "stable" ]] && SUITE="$DISTRIB"
     TESTING_REPOSITORY_NAME="${DEB_PREFIX}${TESTING_SEGMENT}"
     TESTING_BASE_PATH="$TESTING_REPOSITORY_NAME"
-    TESTING_SUITE="$DISTRIB"
+    TESTING_SUITE="$DISTRIB-$LEGACY_TESTING_SEGMENT"
     STABLE_REPOSITORY_NAME="${DEB_PREFIX}stable"
     STABLE_BASE_PATH="$STABLE_REPOSITORY_NAME"
     STABLE_SUITE="$DISTRIB"
+    # legacy (front) paths used by the content verifications: the CI exercises
+    # the compatibility rewrites on every delivery
+    LEGACY_BASE_PATH="${DEB_PREFIX}${REPO_BASE}"
+    LEGACY_TESTING_BASE_PATH="${DEB_PREFIX}${REPO_BASE}"
+    LEGACY_STABLE_BASE_PATH="${DEB_PREFIX}${REPO_BASE}-stable"
     POOL_PATH="pool/$POOL_SEGMENT/$MODULE_NAME"
     TESTING_POOL_PATH="pool/$TESTING_POOL_SEGMENT/$MODULE_NAME"
     STABLE_POOL_PATH="pool/stable/$MODULE_NAME"
@@ -123,6 +148,7 @@ elif [[ "$DELIVERY_TYPE" == "feature" ]]; then
 
   REPOSITORY_PREFIX="rpm-feature-$FEATURE_TICKET-$VERSION-$DISTRIB-$STABILITY"
   BASE_PATH_PREFIX="rpm-feature/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
+  LEGACY_BASE_PATH_PREFIX="rpm-$REPO_BASE-feature/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
 else
   RPM_ROOT="rpm"
   DEB_INFIX=""
@@ -138,19 +164,35 @@ else
     TESTING_BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/$TESTING_SEGMENT"
     STABLE_REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-stable"
     STABLE_BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/stable"
+    # legacy (front) paths used by the content verifications (the front also
+    # accepts the historical token'd business form)
+    LEGACY_RPM_ROOT="rpm-$REPO_BASE"
+    [[ "$RPM_ROOT" == "rpm-internal" ]] && LEGACY_RPM_ROOT="rpm-$REPO_BASE-internal"
+    LEGACY_BASE_PATH_PREFIX="$LEGACY_RPM_ROOT/$VERSION/$DISTRIB/$STABILITY_SEGMENT"
+    LEGACY_TESTING_BASE_PATH_PREFIX="$LEGACY_RPM_ROOT/$VERSION/$DISTRIB/$TESTING_SEGMENT"
+    LEGACY_STABLE_BASE_PATH_PREFIX="$LEGACY_RPM_ROOT/$VERSION/$DISTRIB/stable"
   else
     # one deb repository per stability (base path = repository name), shared by
     # every major version: the version lives in the suite name only
     # (e.g. "trixie-26.09")
     REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}${STABILITY_SEGMENT}"
     BASE_PATH="$REPOSITORY_NAME"
-    SUITE="$DISTRIB-$VERSION"
+    # suites keep their historical stability-suffixed names so the legacy
+    # client lines (deb .../apt-standard/ trixie-26.10-stable main) work
+    # through the content-front rewrites; each suite lives in its own
+    # per-stability repository regardless
+    SUITE="$DISTRIB-$VERSION-$STABILITY_SEGMENT"
     TESTING_REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}${TESTING_SEGMENT}"
     TESTING_BASE_PATH="$TESTING_REPOSITORY_NAME"
-    TESTING_SUITE="$DISTRIB-$VERSION"
+    TESTING_SUITE="$DISTRIB-$VERSION-$TESTING_SEGMENT"
     STABLE_REPOSITORY_NAME="${DEB_PREFIX}${DEB_INFIX}stable"
     STABLE_BASE_PATH="$STABLE_REPOSITORY_NAME"
-    STABLE_SUITE="$DISTRIB-$VERSION"
+    STABLE_SUITE="$DISTRIB-$VERSION-stable"
+    LEGACY_DEB_ROOT="${DEB_PREFIX}${REPO_BASE}"
+    [[ -n "$DEB_INFIX" ]] && LEGACY_DEB_ROOT="${DEB_PREFIX}${REPO_BASE}-internal"
+    LEGACY_BASE_PATH="$LEGACY_DEB_ROOT"
+    LEGACY_TESTING_BASE_PATH="$LEGACY_DEB_ROOT"
+    LEGACY_STABLE_BASE_PATH="$LEGACY_DEB_ROOT"
     POOL_PATH="pool/$VERSION/$POOL_SEGMENT/$MODULE_NAME"
     TESTING_POOL_PATH="pool/$VERSION/$TESTING_POOL_SEGMENT/$MODULE_NAME"
     STABLE_POOL_PATH="pool/$VERSION/stable/$MODULE_NAME"
@@ -194,12 +236,18 @@ echo "[DEBUG] - stable_domain: $STABLE_DOMAIN"
   echo "skip_delivery=false"
   echo "repository_prefix=$REPOSITORY_PREFIX"
   echo "base_path_prefix=$BASE_PATH_PREFIX"
+  echo "legacy_base_path_prefix=$LEGACY_BASE_PATH_PREFIX"
+  echo "legacy_testing_base_path_prefix=$LEGACY_TESTING_BASE_PATH_PREFIX"
+  echo "legacy_stable_base_path_prefix=$LEGACY_STABLE_BASE_PATH_PREFIX"
   echo "testing_repository_prefix=$TESTING_REPOSITORY_PREFIX"
   echo "testing_base_path_prefix=$TESTING_BASE_PATH_PREFIX"
   echo "stable_repository_prefix=$STABLE_REPOSITORY_PREFIX"
   echo "stable_base_path_prefix=$STABLE_BASE_PATH_PREFIX"
   echo "repository_name=$REPOSITORY_NAME"
   echo "base_path=$BASE_PATH"
+  echo "legacy_base_path=$LEGACY_BASE_PATH"
+  echo "legacy_testing_base_path=$LEGACY_TESTING_BASE_PATH"
+  echo "legacy_stable_base_path=$LEGACY_STABLE_BASE_PATH"
   echo "suite=$SUITE"
   echo "testing_repository_name=$TESTING_REPOSITORY_NAME"
   echo "testing_base_path=$TESTING_BASE_PATH"

--- a/.github/actions/pulp-repository-properties/properties.sh
+++ b/.github/actions/pulp-repository-properties/properties.sh
@@ -43,16 +43,6 @@ case "$DISTRIB_FAMILY" in
     ;;
 esac
 
-# business (paid) rpm content is served under an opaque path segment, mirroring
-# the Artifactory layout; only rpm business repos use it (deb business does not).
-# The segment is path-only: repository NAMES never contain it (they are unique
-# per Domain, and the Domain already identifies the edition).
-BUSINESS_HASH="1a97ff9985262bf3daf7a0919f9c59a6"
-HASH_SEGMENT=""
-if [[ "$REPO_BASE" == "business" && "$DISTRIB_FAMILY" == "el" ]]; then
-  HASH_SEGMENT="/$BUSINESS_HASH"
-fi
-
 # uniform stability segments across every edition (plugins included):
 # unstable, testing-release, testing-hotfix, stable
 TESTING_SEGMENT="testing"
@@ -132,7 +122,7 @@ elif [[ "$DELIVERY_TYPE" == "feature" ]]; then
   fi
 
   REPOSITORY_PREFIX="rpm-feature-$FEATURE_TICKET-$VERSION-$DISTRIB-$STABILITY"
-  BASE_PATH_PREFIX="rpm-feature$HASH_SEGMENT/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
+  BASE_PATH_PREFIX="rpm-feature/$FEATURE_TICKET/$VERSION/$DISTRIB/$STABILITY"
 else
   RPM_ROOT="rpm"
   DEB_INFIX=""
@@ -143,11 +133,11 @@ else
 
   if [[ "$DISTRIB_FAMILY" == "el" ]]; then
     REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-$STABILITY_SEGMENT"
-    BASE_PATH_PREFIX="$RPM_ROOT$HASH_SEGMENT/$VERSION/$DISTRIB/$STABILITY_SEGMENT"
+    BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/$STABILITY_SEGMENT"
     TESTING_REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-$TESTING_SEGMENT"
-    TESTING_BASE_PATH_PREFIX="$RPM_ROOT$HASH_SEGMENT/$VERSION/$DISTRIB/$TESTING_SEGMENT"
+    TESTING_BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/$TESTING_SEGMENT"
     STABLE_REPOSITORY_PREFIX="$RPM_ROOT-$VERSION-$DISTRIB-stable"
-    STABLE_BASE_PATH_PREFIX="$RPM_ROOT$HASH_SEGMENT/$VERSION/$DISTRIB/stable"
+    STABLE_BASE_PATH_PREFIX="$RPM_ROOT/$VERSION/$DISTRIB/stable"
   else
     # one deb repository per stability (base path = repository name), shared by
     # every major version: the version lives in the suite name only

--- a/.github/scripts/pulp/check-common.sh
+++ b/.github/scripts/pulp/check-common.sh
@@ -15,7 +15,6 @@ PULP_URL="${PULP_URL:-https://pulp-api.int.centreon.com}"
 PULP_CONTENT_URL="${PULP_CONTENT_URL:-https://packages.int.centreon.com}"
 
 switch_pulp_domain "$PULP_DOMAIN" || exit 1
-
 # 900s: the published indexes can lag a finished publication by up to the
 # content-app cache TTL (600s), the window must survive that worst case
 METADATA_TIMEOUT="${METADATA_TIMEOUT:-900}"
@@ -105,7 +104,7 @@ check_fetchable_and_record() {
   for i in "${!E_FILENAME[@]}"; do
     fetchable=false
     if [[ "${META_IDX[$i]}" == "true" ]]; then
-      url="${PULP_CONTENT_URL}/${PULP_DOMAIN}/${E_BASEPATH[$i]}/${RESOLVED_IDX[$i]}"
+      url="${PULP_CONTENT_URL}/${E_BASEPATH[$i]}/${RESOLVED_IDX[$i]}"
       # retry: one flaky HEAD out of hundreds (content-app/S3 hiccup) must not
       # fail the whole verification
       for attempt in 1 2 3; do

--- a/.github/scripts/pulp/check-deb.sh
+++ b/.github/scripts/pulp/check-deb.sh
@@ -115,7 +115,7 @@ resolve_pending() {
     if [[ "$arch" == "all" ]]; then
       sk="$base_path|$suite"
       if [[ -z "${arches_cache[$sk]+set}" ]]; then
-        arches_cache[$sk]=$(content_curl -fsSL "$PULP_CONTENT_URL/$PULP_DOMAIN/$base_path/dists/$suite/Release" 2>/dev/null \
+        arches_cache[$sk]=$(content_curl -fsSL "$PULP_CONTENT_URL/$base_path/dists/$suite/Release" 2>/dev/null \
           | awk -F': ' '/^Architectures:/ { print $2; exit }')
       fi
       search_arches="${arches_cache[$sk]:-amd64 arm64 all}"
@@ -126,7 +126,7 @@ resolve_pending() {
       ck="$base_path|$suite|$a"
       if [[ -z "${pkg_cache[$ck]+set}" ]]; then
         cache_file=$(mktemp)
-        content_curl -fsSL "$PULP_CONTENT_URL/$PULP_DOMAIN/$base_path/dists/$suite/main/binary-$a/Packages" 2>/dev/null > "$cache_file" || true
+        content_curl -fsSL "$PULP_CONTENT_URL/$base_path/dists/$suite/main/binary-$a/Packages" 2>/dev/null > "$cache_file" || true
         pkg_cache[$ck]=$cache_file
       fi
       filename=$(resolve_filename "${pkg_cache[$ck]}" "${E_SHA256[$i]}")

--- a/.github/scripts/pulp/check-rpm.sh
+++ b/.github/scripts/pulp/check-rpm.sh
@@ -125,10 +125,10 @@ resolve_pending() {
 
     if [[ -z "${primary_cache[$base_path]+set}" ]]; then
       cache_file=$(mktemp)
-      repomd=$(content_curl -fsSL "$PULP_CONTENT_URL/$PULP_DOMAIN/$base_path/repodata/repomd.xml" 2>/dev/null || true)
+      repomd=$(content_curl -fsSL "$PULP_CONTENT_URL/$base_path/repodata/repomd.xml" 2>/dev/null || true)
       primary_href=$(printf '%s' "$repomd" | grep -oP '<location href="\K[^"]+primary\.xml[^"]*' | head -1 || true)
       if [[ -n "$primary_href" ]]; then
-        content_curl -fsSL "$PULP_CONTENT_URL/$PULP_DOMAIN/$base_path/$primary_href" 2>/dev/null | gunzip -c 2>/dev/null > "$cache_file" || true
+        content_curl -fsSL "$PULP_CONTENT_URL/$base_path/$primary_href" 2>/dev/null | gunzip -c 2>/dev/null > "$cache_file" || true
       fi
       primary_cache[$base_path]=$cache_file
     fi


### PR DESCRIPTION
Related: [MON-202540](https://centreon.atlassian.net/browse/MON-202540) — **draft. This branch merges the two pending trains of this repo (MON-207621 promote-by-href and MON-202540 token removal): review the commits after the merge commit. Merge order: MON-207621 PR → MON-202540 token PR → this one.**

Companion of centreon/delivery-tooling#290 (legacy rewrite front + suffixed suites in create-repos) and centreon/centreon#11415.

1. **Canonical suffixed suites** (`properties.sh`): standard/business deb suites regain their historical names (`trixie-26.10-stable`, `-testing-release`, `-unstable`); plugins/connectors keep the plain codename for stable and `<codename>-testing`/`-unstable` otherwise — each suite living in its per-stability repository.
2. **Verification through the legacy front**: post-deliver/post-promote content checks, stable-guard reads and promote testing reads use the legacy URLs (`rpm-standard/<ver>/…`, `apt-standard/dists/…`, `rpm-connectors/<el>/testing/…`) so the CI exercises the compatibility rewrites on every delivery. Manifests carry the self-sufficient legacy path; all pulp API access stays canonical/domain-scoped; canonical fallback when the legacy output is empty.


[MON-202540]: https://centreon.atlassian.net/browse/MON-202540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ