### PR TITLE
CTOR-2503 - fix Can't locate object method "is_rman" for Oracle plugin

### DIFF
--- a/src/database/oracle/sqlpluscmd.pm
+++ b/src/database/oracle/sqlpluscmd.pm
@@ -110,6 +110,7 @@ sub check_options {
     $self->{local_connexion} = $self->{option_results}->{local_connexion};
     $self->{sqlplus_cmd} = $self->{option_results}->{sqlplus_cmd};
     $self->{container} = defined($self->{option_results}->{container}[0]) ? $self->{option_results}->{container}[0] : undef;
+    $self->{type} = $self->{option_results}->{type} ? shift(@{$self->{option_results}->{type}}) : '';
 
     $self->{timeout} = 30;
     if (defined($self->{option_results}->{timeout}) && $self->{option_results}->{timeout} =~ /^\d+$/ &&
@@ -188,6 +189,12 @@ sub check_options {
         return 0;
     }
     return 1;
+}
+
+sub is_rman {
+      my ($self, %options) = @_;                                               
+
+      return ($self->{type} // '') eq 'rman_catalog';
 }
 
 sub is_version_minimum {


### PR DESCRIPTION
## Description

With the latest version, the is_rman function is only available for dbi but not for sqlpluscmd.
We need to add it.

**Fixes** # CTOR-2503

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).