### PR TITLE
fix(database-oracle): correct controlfile typos

### DIFF
--- a/src/database/oracle/mode/rmanbackupage.pm
+++ b/src/database/oracle/mode/rmanbackupage.pm
@@ -232,11 +232,11 @@ Warning threshold in seconds.
 
 Critical threshold in seconds.
 
-=item B<--warning-crontrolfile>
+=item B<--warning-controlfile>
 
 Warning threshold in seconds.
 
-=item B<--critical-crontrolfile>
+=item B<--critical-controlfile>
 
 Critical threshold in seconds.
 
@@ -252,7 +252,7 @@ Skip error if never executed.
 
 Skip error if never executed.
 
-=item B<--no-crontrolfile>
+=item B<--no-controlfile>
 
 Skip error if never executed.
 


### PR DESCRIPTION
# Community contributors

## Description

Corrected the Oracle RMAN backup age mode help messages so the existing controlfile options are displayed with the correct spelling. No runtime behavior was changed.

**Fixes** #N/A

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

Verify that the Oracle RMAN backup age mode help messages use `controlfile` consistently:

```bash
grep -R "crontrolfile" rmanbackupage.pm
```
## Checklist

- [X] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (develop).
- [X] I have provide data or shown output displaying the result of this code in the plugin area concerned.