### PR TITLE
enh(delivery): target jfrog artifactory through its native hostname

### DIFF
--- a/.github/actions/package-delivery/action.yml
+++ b/.github/actions/package-delivery/action.yml
@@ -175,7 +175,7 @@ runs:
         (inputs.stability == 'stable' && github.event_name == 'push')
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       env:
-        JF_URL: https://packages.centreon.com
+        JF_URL: https://centreon.jfrog.io
         JF_ACCESS_TOKEN: ${{ inputs.artifactory_token }}
       with:
         script: |

--- a/.github/scripts/perl-cpan-libraries/cpan_matrix_lib.py
+++ b/.github/scripts/perl-cpan-libraries/cpan_matrix_lib.py
@@ -290,7 +290,7 @@ _DEB_VERSION_RE = re.compile(r"^([0-9v][0-9.]*)(?:[+\-]|$)")
 _deb_packages_cache: dict = {}  # (repo, distrib, arch) → {pkg_name: version}
 
 
-_ALLOWED_ARTIFACTORY_HOSTS = {"packages.centreon.com"}
+_ALLOWED_ARTIFACTORY_HOSTS = {"centreon.jfrog.io"}
 
 
 def _artifactory_list_folder(base_url, repo_path):

--- a/.github/scripts/perl-cpan-libraries/generate-matrices.py
+++ b/.github/scripts/perl-cpan-libraries/generate-matrices.py
@@ -12,7 +12,7 @@ Usage:
     # CI (after all check-official-repos jobs)
     python3 generate-matrices.py \\
         --partial-matrices-dir official-repos/ \\
-        --artifactory-url https://packages.centreon.com \\
+        --artifactory-url https://centreon.jfrog.io \\
         .github/packaging/cpan-libraries.json
 
     # Local debug (no filtering, cpanm used for version info if available)
@@ -218,7 +218,7 @@ def main():
     parser.add_argument(
         "--artifactory-url", metavar="URL",
         help="Base URL of the public Artifactory instance "
-             "(e.g. https://packages.centreon.com). When provided, packages already "
+             "(e.g. https://centreon.jfrog.io). When provided, packages already "
              "present in the Centreon repository at the expected version are "
              "skipped (not rebuilt).",
     )

--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           python3 .github/scripts/perl-cpan-libraries/generate-matrices.py \
             --partial-matrices-dir official-repos \
-            --artifactory-url https://packages.centreon.com \
+            --artifactory-url https://centreon.jfrog.io \
             --stability "$STABILITY" \
             .github/packaging/cpan-libraries.json
         shell: bash


### PR DESCRIPTION
Fixes: [MON-207928](https://centreon.atlassian.net/browse/MON-207928)

Everything that **writes to or reads from jfrog artifactory in CI** now targets its native hostname `https://centreon.jfrog.io` instead of `https://packages.centreon.com`, so artifactory deliveries keep working when `packages.centreon.com` is switched over to the pulp stack (epic [MON-199319](https://centreon.atlassian.net/browse/MON-199319)) — both stacks can then run in parallel:

- `JF_URL` of the jfrog CLI setups (delivery, promote, feature-repository cleanup) — the API calls built on it (`yum` recalculate, `deb` reindex, AQL) follow;
- direct artifactory content/API reads by scripts and actions;
- the apt public key fetch moves from the artifactory-specific `/api/security/keypair/APT-GPG-KEY/public` endpoint to the dedicated `https://apt-key.centreon.com/` host (same key bundle, survives the cutover).

**Client-facing URLs are untouched** (repo file templates, sources.list lines, apt auth.conf machines): they keep `packages.centreon.com`, which is precisely what will switch to pulp.

[MON-207928]: https://centreon.atlassian.net/browse/MON-207928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-199319]: https://centreon.atlassian.net/browse/MON-199319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ