### PR TITLE
fix(docker-connector-vmware): dockerfile-review fixes

### DIFF
--- a/.github/docker/connector/Dockerfile.connector-vmware
+++ b/.github/docker/connector/Dockerfile.connector-vmware
@@ -45,7 +45,7 @@ ARG STABILITY=stable
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    STABILITY=${STABILITY} bash -eo pipefail <<'EOF'
+    STABILITY=${STABILITY} PKG_VERSION=${VERSION} bash -eo pipefail <<'EOF'
 apt-get update
 apt-get install -y --no-install-recommends dpkg gnupg wget ca-certificates
 . /etc/os-release
@@ -55,7 +55,11 @@ wget -O- https://apt-key.centreon.com | gpg --dearmor \
 apt-get update
 mkdir -p /extracted
 cd /tmp
-apt-get download centreon-plugin-virtualization-vmware-daemon
+# PKG_VERSION pins an exact release (e.g. 20260300-1+deb13u1); unset/empty
+# downloads whatever is currently latest in the ${STABILITY} channel.
+# (named PKG_VERSION, not VERSION: `. /etc/os-release` above already defines
+# its own VERSION="13 (trixie)", which would silently clobber an ARG VERSION.)
+apt-get download "centreon-plugin-virtualization-vmware-daemon${PKG_VERSION:+=$PKG_VERSION}"
 for deb in centreon-plugin-virtualization-vmware-daemon*.deb; do
     echo "Extracting $deb..."
     dpkg-deb -x "$deb" /extracted/

--- a/.github/docker/connector/Dockerfile.connector-vmware
+++ b/.github/docker/connector/Dockerfile.connector-vmware
@@ -269,12 +269,6 @@ EOF
 
 COPY --chmod=755 .github/docker/connector/entrypoint /usr/local/lib/centreon-vmware/
 
-# Required at runtime by entrypoint/container.d/10-engine-context.sh (poller mode).
-# DEBUG (true/1) enables verbose entrypoint logging — see container.sh / 00-init.sh.
-ENV APP_SECRET= \
-    SALT= \
-    DEBUG=
-
 ENV PERL5LIB=/usr/local/share/perl5:/usr/share/perl5:/usr/lib/perl5
 
 EXPOSE 5700

--- a/.github/docker/connector/Dockerfile.connector-vmware
+++ b/.github/docker/connector/Dockerfile.connector-vmware
@@ -1,11 +1,14 @@
 # syntax=docker/dockerfile:1
 
-# PACKAGE_SOURCE=mount (default, CI): extract from .deb bind-mounted via packages-centreon/
-# PACKAGE_SOURCE=repo  (prod):        download from Centreon apt repo (requires VERSION + STABILITY)
-# PACKAGE_SOURCE=local (dev):         copy from local repo source (connectors/vmware/src/)
-ARG PACKAGE_SOURCE=mount
-# Build arg to include VMware Perl SDK (requires proprietary files in sdks-vmware/ — see sdks-vmware/README.md)
-ARG WITH_SDK=false
+# PACKAGE_SOURCE=repo  (default, local dev): download from Centreon apt repo (VERSION pins a release, STABILITY picks the channel)
+# PACKAGE_SOURCE=mount (CI):                 extract from .deb bind-mounted via packages-centreon/
+# PACKAGE_SOURCE=local (Dockerfile-only CI): copy from local repo source (connectors/vmware/src/)
+ARG PACKAGE_SOURCE=repo
+# Build arg to include VMware Perl SDK (requires proprietary files in sdks-vmware/ — see sdks-vmware/README.md).
+# Defaults to true: without the SDK the daemon can't do anything useful (see the
+# sdk-false stage below) — CI always passes WITH_SDK=false explicitly to validate
+# the Dockerfile builds without the licensed SDK, it doesn't rely on this default.
+ARG WITH_SDK=true
 
 #############################################
 # Stage 1a: Extract from bind-mounted .deb (PACKAGE_SOURCE=mount)
@@ -85,7 +88,7 @@ COPY --link --from=extractor-repo /extracted/usr/share/perl5/centreon /centreon-
 FROM scratch AS vmware-perl-local
 COPY connectors/vmware/src/centreon/ /centreon-modules/
 
-ARG PACKAGE_SOURCE=mount
+ARG PACKAGE_SOURCE=repo
 # hadolint ignore=DL3006
 FROM vmware-perl-${PACKAGE_SOURCE} AS vmware-perl-selected
 
@@ -104,7 +107,7 @@ FROM scratch AS vmware-bin-local
 COPY connectors/vmware/src/centreon_vmware.pl /centreon_vmware.pl
 COPY connectors/vmware/src/centreon/script/centreon_vmware_convert_config_file /centreon_vmware_convert_config_file
 
-ARG PACKAGE_SOURCE=mount
+ARG PACKAGE_SOURCE=repo
 # hadolint ignore=DL3006
 FROM vmware-bin-${PACKAGE_SOURCE} AS vmware-bin-selected
 
@@ -170,7 +173,7 @@ FROM debian:13-slim AS centreon-vmware
 
 ARG VERSION
 ARG STABILITY
-ARG WITH_SDK=false
+ARG WITH_SDK=true
 
 LABEL org.opencontainers.image.title="centreon-vmware" \
       org.opencontainers.image.source="https://github.com/centreon/centreon-plugins" \

--- a/.github/docker/connector/Dockerfile.connector-vmware
+++ b/.github/docker/connector/Dockerfile.connector-vmware
@@ -45,14 +45,9 @@ ARG STABILITY=stable
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    bash -e <<'EOF'
+    STABILITY=${STABILITY} bash -eo pipefail <<'EOF'
 apt-get update
 apt-get install -y --no-install-recommends dpkg gnupg wget ca-certificates
-EOF
-
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    STABILITY=${STABILITY} bash -e <<'EOF'
 . /etc/os-release
 echo "deb https://packages.centreon.com/apt-plugins-${STABILITY}/ ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/centreon-plugins.list
 wget -O- https://apt-key.centreon.com | gpg --dearmor \
@@ -183,11 +178,11 @@ EOF
 RUN bash -e <<'EOF'
 groupadd -g 33 www-data 2>/dev/null || true
 groupadd -g 900 centreon
-useradd -u 900 -g centreon -m -r -d /var/spool/centreon -s /bin/bash centreon
+useradd -u 900 -g centreon -m -r -l -d /var/spool/centreon -s /bin/bash centreon
 groupadd -g 901 centreon-engine
-useradd -u 901 -g centreon-engine -m -r -d /var/lib/centreon-engine -s /bin/bash centreon-engine
+useradd -u 901 -g centreon-engine -m -r -l -d /var/lib/centreon-engine -s /bin/bash centreon-engine
 groupadd -g 903 centreon-gorgone
-useradd -u 903 -g centreon-gorgone -m -r -d /var/lib/centreon-gorgone -s /bin/bash centreon-gorgone
+useradd -u 903 -g centreon-gorgone -m -r -l -d /var/lib/centreon-gorgone -s /bin/bash centreon-gorgone
 usermod -aG centreon-engine centreon
 usermod -aG centreon-gorgone centreon
 EOF
@@ -195,7 +190,7 @@ EOF
 # Install runtime dependencies — one update, same packages on every arch
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
-    bash -e <<'EOF'
+    bash -eo pipefail <<'EOF'
 apt-get update
 apt-get install -y --no-install-recommends gnupg wget ca-certificates
 . /etc/os-release
@@ -224,6 +219,8 @@ apt-get install -y --no-install-recommends \
     libjson-perl \
     inotify-tools \
     netcat-openbsd
+apt-get remove -y --purge gnupg wget
+apt-get autoremove -y
 rm -rf /tmp/* /var/tmp/* /usr/share/doc/* /usr/share/man/*
 EOF
 
@@ -271,6 +268,12 @@ echo "=== Files verified ==="
 EOF
 
 COPY --chmod=755 .github/docker/connector/entrypoint /usr/local/lib/centreon-vmware/
+
+# Required at runtime by entrypoint/container.d/10-engine-context.sh (poller mode).
+# DEBUG (true/1) enables verbose entrypoint logging — see container.sh / 00-init.sh.
+ENV APP_SECRET= \
+    SALT= \
+    DEBUG=
 
 ENV PERL5LIB=/usr/local/share/perl5:/usr/share/perl5:/usr/lib/perl5
 

--- a/.github/docker/connector/Dockerfile.connector-vmware
+++ b/.github/docker/connector/Dockerfile.connector-vmware
@@ -150,8 +150,11 @@ EOF
 
 #############################################
 # Stage 2b: VMware SDK — without SDK (WITH_SDK=false, default)
-# Used by CI and public image builds. The daemon starts but encrypted
-# credentials won't be decryptable without the SDK.
+# Used by CI and public image builds. The daemon requires the VMware Perl
+# SDK to run at all — centreon::script::centreon_vmware unconditionally
+# `use`s VMware::VIRuntime/VILib — so without it the daemon logs a clear
+# "you will need the Perl VMware SDK" error and exits immediately, rather
+# than starting in some degraded/plain-text-only mode.
 #############################################
 FROM debian:13-slim AS sdk-false
 
@@ -167,6 +170,7 @@ FROM debian:13-slim AS centreon-vmware
 
 ARG VERSION
 ARG STABILITY
+ARG WITH_SDK=false
 
 LABEL org.opencontainers.image.title="centreon-vmware" \
       org.opencontainers.image.source="https://github.com/centreon/centreon-plugins" \
@@ -260,20 +264,37 @@ COPY --chown=centreon-gorgone:centreon --chmod=660 \
     connectors/vmware/packaging/config/centreon_vmware-conf.json \
     /etc/centreon/centreon_vmware.json
 
-# Verify critical files exist
-RUN bash -e <<'EOF'
+# Needed before the verification step below so `perl -c`/`perl` can resolve
+# the copied centreon:: and VMware:: modules.
+ENV PERL5LIB=/usr/local/share/perl5:/usr/share/perl5:/usr/lib/perl5
+
+# Verify critical files exist, and that the daemon behaves as documented
+# for the current WITH_SDK setting
+RUN WITH_SDK=${WITH_SDK} bash -eo pipefail <<'EOF'
 echo "=== Verification ==="
 ls -lah /usr/bin/centreon_vmware.pl
 ls -lah /usr/bin/centreon_vmware_convert_config_file
 ls -lah /usr/share/perl5/centreon/
 ls -lah /usr/local/share/perl5/VMware/
 ls -lah /etc/centreon/
+if [ "$WITH_SDK" = "true" ]; then
+    # centreon_vmware.pl unconditionally `use`s VMware::VIRuntime/VILib
+    # (via centreon::script::centreon_vmware) — only compiles when the
+    # licensed SDK is actually present.
+    perl -c /usr/bin/centreon_vmware.pl
+else
+    # Without the SDK, a BEGIN-time requirements check deliberately makes
+    # the daemon refuse to start and log this exact message instead of a
+    # raw "Can't locate VMware/VIRuntime.pm in @INC" error. Assert that
+    # graceful failure still fires, rather than silently accepting any
+    # other kind of breakage.
+    OUTPUT=$(perl /usr/bin/centreon_vmware.pl --config-extra=/etc/centreon/centreon_vmware.json 2>&1) || true
+    echo "$OUTPUT" | grep -q 'you will need the Perl VMware SDK'
+fi
 echo "=== Files verified ==="
 EOF
 
 COPY --chmod=755 .github/docker/connector/entrypoint /usr/local/lib/centreon-vmware/
-
-ENV PERL5LIB=/usr/local/share/perl5:/usr/share/perl5:/usr/lib/perl5
 
 EXPOSE 5700
 

--- a/.github/docker/connector/entrypoint/container.d/10-engine-context.sh
+++ b/.github/docker/connector/entrypoint/container.d/10-engine-context.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
+# This file is sourced (not executed) by container.sh, so DEBUG=true's
+# `set -x` is inherited here. Disable it before touching the secrets: with
+# tracing on, the shell would print APP_SECRET/SALT's actual values inline
+# (e.g. "+ APP_SECRET=...", "+ printf ... <secret>"). Restore it afterwards
+# so later container.d scripts still get traced when DEBUG is enabled.
+case "$-" in *x*) trace_was_on=1 ;; esac
+set +x
+
 echo "=== Writing Engine Secrets ==="
 
 APP_SECRET="${APP_SECRET:?ERROR: APP_SECRET must be set for poller mode}"
@@ -12,6 +20,9 @@ chmod 640 "$ENGINE_CONTEXT"
 
 echo "✓ Engine secrets written to $ENGINE_CONTEXT"
 if [ "${DEBUG}" = "true" ] || [ "${DEBUG}" = "1" ]; then
-    echo "Debug: $(cat "$ENGINE_CONTEXT")"
+    echo "Debug: $(ls -l "$ENGINE_CONTEXT")"
 fi
 echo ""
+
+[ "$trace_was_on" = "1" ] && set -x
+:

--- a/.github/docker/connector/entrypoint/container.d/10-engine-context.sh
+++ b/.github/docker/connector/entrypoint/container.d/10-engine-context.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
-# This file is sourced (not executed) by container.sh, so DEBUG=true's
-# `set -x` is inherited here. Disable it before touching the secrets: with
-# tracing on, the shell would print APP_SECRET/SALT's actual values inline
-# (e.g. "+ APP_SECRET=...", "+ printf ... <secret>"). Restore it afterwards
-# so later container.d scripts still get traced when DEBUG is enabled.
-case "$-" in *x*) trace_was_on=1 ;; esac
-set +x
+# This file is sourced (not executed) by container.sh, so container.sh's
+# `set -x` (enabled when DEBUG=true/1) is inherited here. Disable it before
+# touching the secrets: with tracing on, the shell would print
+# APP_SECRET/SALT's actual values inline (e.g. "+ APP_SECRET=...",
+# "+ printf ... <secret>"). Restore it afterwards so later container.d
+# scripts still get traced when DEBUG is enabled.
+if [ "${DEBUG}" = "true" ] || [ "${DEBUG}" = "1" ]; then
+    set +x
+fi
 
 echo "=== Writing Engine Secrets ==="
 
@@ -24,5 +26,6 @@ if [ "${DEBUG}" = "true" ] || [ "${DEBUG}" = "1" ]; then
 fi
 echo ""
 
-[ "$trace_was_on" = "1" ] && set -x
-:
+if [ "${DEBUG}" = "true" ] || [ "${DEBUG}" = "1" ]; then
+    set -x
+fi

--- a/.github/workflows/connector-vmware.yml
+++ b/.github/workflows/connector-vmware.yml
@@ -319,6 +319,8 @@ jobs:
           build-args: |
             PACKAGE_SOURCE=mount
             WITH_SDK=false
+            VERSION=${{ needs.get-environment.outputs.version }}
+            STABILITY=${{ needs.get-environment.outputs.stability }}
           push: false
 
   set-skip-label:

--- a/sdks-vmware/README.md
+++ b/sdks-vmware/README.md
@@ -45,14 +45,11 @@ you want the built image labeled with the repo's current plugins-wide version an
 
 ## Local build with SDK — from Centreon stable repo
 
-This is now the default — both flags below match the Dockerfile's own defaults, so a
-plain `docker build -f .github/docker/connector/Dockerfile.connector-vmware .` from the
-repo root does the same thing. Kept explicit here for clarity:
+`PACKAGE_SOURCE=repo` and `WITH_SDK=true` are the Dockerfile's own defaults, so this is
+just:
 
 ```bash
 docker build \
-  --build-arg PACKAGE_SOURCE=repo \
-  --build-arg WITH_SDK=true \
   --file .github/docker/connector/Dockerfile.connector-vmware \
   --tag connector-vmware:local \
   .
@@ -66,12 +63,12 @@ reflects whatever `VERSION` you passed (empty if you didn't pin one).
 
 ## Local build with SDK — from local .deb packages
 
-Place the `.deb` package in a `packages-centreon/` directory at the repo root, then:
+Place the `.deb` package in a `packages-centreon/` directory at the repo root, then
+(`WITH_SDK=true` is the default, only `PACKAGE_SOURCE` needs overriding):
 
 ```bash
 docker build \
   --build-arg PACKAGE_SOURCE=mount \
-  --build-arg WITH_SDK=true \
   --file .github/docker/connector/Dockerfile.connector-vmware \
   --tag connector-vmware:local \
   .
@@ -88,7 +85,6 @@ immediately.
 
 ```bash
 docker build \
-  --build-arg PACKAGE_SOURCE=repo \
   --build-arg WITH_SDK=false \
   --file .github/docker/connector/Dockerfile.connector-vmware \
   --tag connector-vmware:local \

--- a/sdks-vmware/README.md
+++ b/sdks-vmware/README.md
@@ -35,6 +35,10 @@ Two workflows handle Docker image validation:
 | `mount` | `packages-centreon/` bind mount | CI (from cache) or local build with `.deb` |
 | `repo` | `packages.centreon.com` apt repo | Ad-hoc build — downloads from stable repo |
 
+`local` and `mount` copy files directly (no `.deb` download), so there's no packaged
+version for the image to pick up. Pass `--build-arg VERSION=$(cat .version.plugins)` if
+you want the built image labeled with the repo's current plugins-wide version anyway.
+
 ## Local build with SDK — from Centreon stable repo
 
 Downloads the stable `.deb` from the Centreon apt repository.
@@ -49,7 +53,11 @@ docker build \
   .
 ```
 
-Specify a version with `--build-arg VERSION=20260300-1+deb13u1` to pin a specific release.
+By default this downloads whatever is currently latest in the `${STABILITY}` channel
+(`STABILITY` defaults to `stable`). Pass `--build-arg VERSION=20260300-1+deb13u1` to pin
+an exact release instead — the build fails clearly if that version isn't published in
+the selected channel. Either way, `org.opencontainers.image.version` on the built image
+reflects whatever `VERSION` you passed (empty if you didn't pin one).
 
 ## Local build with SDK — from local .deb packages
 

--- a/sdks-vmware/README.md
+++ b/sdks-vmware/README.md
@@ -18,22 +18,26 @@ The SDK files are **not included** in this repository due to Broadcom licensing 
 2. Download **VMware vSphere Perl SDK 7.0** and **vSAN SDK for Perl**
 3. Place the downloaded archives in this directory
 
-## CI workflows
+## CI workflow
 
-Two workflows handle Docker image validation:
-
-| Workflow | Trigger | `PACKAGE_SOURCE` | Description |
-|---|---|---|---|
-| `connector-vmware.yml` | Source / packaging changes | `mount` | Builds real `.deb`, stages it, builds Docker image |
-| `docker-builder-connector-vmware.yml` | Dockerfile / entrypoint changes only | `local` | Validates Dockerfile structure without packages |
+`connector-vmware.yml` builds the real `.deb`, stages it into `packages-centreon/`, and
+builds the Docker image with `PACKAGE_SOURCE=mount` and `WITH_SDK=false` — both passed
+explicitly as build-args, so it doesn't depend on this Dockerfile's own `ARG` defaults.
+It never publishes the image (`push: false`); its only job is proving the Dockerfile
+builds. It's triggered by changes under `connectors/vmware/`, this Dockerfile, or the
+entrypoint scripts.
 
 ## PACKAGE_SOURCE build modes
 
 | `PACKAGE_SOURCE` | Source | Use case |
 |---|---|---|
-| `local` | `connectors/vmware/src/` | Dockerfile-only CI validation |
-| `mount` | `packages-centreon/` bind mount | CI (from cache) or local build with `.deb` |
-| `repo` | `packages.centreon.com` apt repo | Ad-hoc build — downloads from stable repo |
+| `repo` (default) | `packages.centreon.com` apt repo | Local/dev build — downloads from the stable repo |
+| `mount` | `packages-centreon/` bind mount | CI (from cache) or local build with a `.deb` you already have |
+| `local` | `connectors/vmware/src/` | Dockerfile-only structure validation, no real package |
+
+`WITH_SDK` also defaults to `true`: this image is primarily meant for local/dev use,
+where the SDK is required for the daemon to do anything at all (see below) — CI passes
+`WITH_SDK=false` explicitly to validate the Dockerfile without the licensed SDK.
 
 `local` and `mount` copy files directly (no `.deb` download), so there's no packaged
 version for the image to pick up. Pass `--build-arg VERSION=$(cat .version.plugins)` if
@@ -41,8 +45,9 @@ you want the built image labeled with the repo's current plugins-wide version an
 
 ## Local build with SDK — from Centreon stable repo
 
-Downloads the stable `.deb` from the Centreon apt repository.
-`encrypted::` credentials require the SDK.
+This is now the default — both flags below match the Dockerfile's own defaults, so a
+plain `docker build -f .github/docker/connector/Dockerfile.connector-vmware .` from the
+repo root does the same thing. Kept explicit here for clarity:
 
 ```bash
 docker build \
@@ -74,12 +79,17 @@ docker build \
 
 ## Local build without SDK
 
-The image works for plain-text credentials in `centreon_vmware.json`.
-`encrypted::` credentials require the SDK.
+Mainly useful to validate the Dockerfile/repo-download path builds without the licensed
+SDK on hand — matches what CI does. The resulting image **cannot actually run the
+daemon**: `centreon::script::centreon_vmware` unconditionally requires
+`VMware::VIRuntime`/`VMware::VILib` (for both plain-text and `encrypted::` credentials),
+so without the SDK it logs a clear "you will need the Perl VMware SDK" error and exits
+immediately.
 
 ```bash
 docker build \
   --build-arg PACKAGE_SOURCE=repo \
+  --build-arg WITH_SDK=false \
   --file .github/docker/connector/Dockerfile.connector-vmware \
   --tag connector-vmware:local \
   .


### PR DESCRIPTION
## Summary

`/dockerfile-review` audit of `.github/docker/connector/Dockerfile.connector-vmware`, plus follow-up fixes from review discussion. Every change below was verified with a real local `docker build`/`docker run` (and, where noted, against the real licensed VMware SDK), not just read statically.

### Security / correctness fixes
- **`useradd` missing `-l`** for `centreon`/`centreon-engine`/`centreon-gorgone` — added.
- **Pipes without `pipefail`**: two `wget | gpg --dearmor | tee` apt-key fetches (in `extractor-repo` and the runtime stage) ran under `bash -e`, which only checks the last command's exit code — a failed `wget` would silently produce a broken/empty keyring instead of failing the build. Switched to `bash -eo pipefail`.
- **`gnupg`/`wget` never removed**: installed to bootstrap the Centreon apt repo, but shipped permanently in the production image. Now purged in the same `RUN` (confirmed via `dpkg -l` they're gone, and nothing in the entrypoint scripts needs them).
- **Merged `extractor-repo`'s two separate `apt-get update && install` blocks** into one.

### Secret handling
- Removed a redundant `ENV APP_SECRET=/SALT=/DEBUG=` documentation block from the Dockerfile — the entrypoint's own `:?` requirement checks already document this, and the empty-valued ENV was tripping Docker's own `SecretsUsedInArgOrEnv` build warning.
- Found and fixed a real leak while testing that removal: `container.d/10-engine-context.sh` is *sourced* (not executed) by `container.sh`, so `DEBUG=true`'s `set -x` was inherited into it and printed `APP_SECRET`/`SALT`'s actual values in the trace (`+ APP_SECRET=...`, `+ printf ... <secret>`) — on top of an explicit `cat` of the secrets file it also did. Both fixed: tracing is disabled around the secret-handling block (keyed directly off the same `DEBUG` check `container.sh` uses) and restored afterward so later scripts still trace normally; the debug line now shows file permissions instead of content.

### VERSION handling
- `ARG VERSION`/`ARG STABILITY` fed `LABEL org.opencontainers.image.version`, but the CI workflow's `build-args` never passed them — the label was always empty. Wired `VERSION`/`STABILITY` from `get-environment` outputs into `connector-vmware.yml`'s `docker-build` job.
- The README already documented `--build-arg VERSION=...` as pinning a specific release, but the Dockerfile never actually used it for anything except the label — `apt-get download` always grabbed latest-in-channel regardless. Now `apt-get download "pkg${PKG_VERSION:+=$PKG_VERSION}"` actually pins when set, falls back to latest when empty.
- Caught a real bug while wiring that up: naming the shell variable `VERSION` broke the *unpinned* build (`E: Version '13 (trixie)' ... was not found`) because `. /etc/os-release` in the same block defines its own `VERSION="13 (trixie)"`, silently clobbering the ARG-sourced one. Renamed to `PKG_VERSION`.

### Verification stage
- Added a `WITH_SDK`-conditional functional check instead of just checking file existence: `perl -c /usr/bin/centreon_vmware.pl` when `WITH_SDK=true` (real compile/dependency check — catches a broken `PERL5LIB`, a bad SDK patch, a missing runtime Perl dep); an assertion that the daemon's own graceful "you will need the Perl VMware SDK" message still fires when `WITH_SDK=false`, instead of silently accepting any other failure mode.
- This surfaced a stale/incorrect comment: the `sdk-false` stage claimed "the daemon starts but encrypted credentials won't be decryptable without the SDK." Empirically false — `centreon::script::centreon_vmware` unconditionally `use`s `VMware::VIRuntime`/`VMware::VILib`, so the daemon can't even compile without the SDK, plain-text or encrypted. Comment corrected, and the same wrong claim in `sdks-vmware/README.md`'s "Local build without SDK" section fixed too.

### Local dev defaults
- `connector-vmware.yml` always passes `PACKAGE_SOURCE`/`WITH_SDK` explicitly, so the Dockerfile's own `ARG` defaults only ever affected a plain `docker build` with no flags. The old defaults (`mount` + `false`) produced either a build error (`packages-centreon/` doesn't exist on a fresh clone) or a technically-valid but functionally useless image (daemon can't run at all without the SDK). Flipped defaults to `PACKAGE_SOURCE=repo`, `WITH_SDK=true` (all declaration sites) so a plain `docker build -f Dockerfile.connector-vmware .` either builds a fully working image or fails immediately pointing at the missing SDK files.
- Updated `sdks-vmware/README.md` to match: corrected a stale reference to a `docker-builder-connector-vmware.yml` workflow that doesn't exist, dropped now-redundant `--build-arg` flags from the example commands, and documented `--build-arg VERSION=$(cat .version.plugins)` for `local`/`mount` builds (which don't download a `.deb`, so there's no packaged version to read from).

### Not changed (reported, not fixed)
- **Unpinned package versions**: come from live Debian/Centreon apt repos; pinning needs a resolved-version snapshot first, not a guess.
- **Apt source-list `echo > file` lines**: left as `RUN echo` rather than a COPY heredoc — content depends on `VERSION_CODENAME` sourced from `/etc/os-release` at build time, so a static heredoc isn't a direct swap.
- **docker-compose `build:` support** for `centreon-vmware` in `centreon/centreon`'s `install-poller` (different repo) — tracked separately in [MON-208038](https://centreon.atlassian.net/browse/MON-208038).

## Test plan

- [x] Built locally end-to-end with `PACKAGE_SOURCE=local`/`mount`/`repo` and both `WITH_SDK=true` (real licensed SDK) and `WITH_SDK=false`
- [x] Confirmed via `dpkg -l` that `gnupg`/`wget` are absent from the final image
- [x] Confirmed `useradd -l` took effect (`/etc/passwd` entries correct, UIDs/GIDs unchanged: 900/901/903)
- [x] Confirmed `DEBUG=true` no longer prints `APP_SECRET`/`SALT` anywhere in the trace; normal and missing-secret paths unchanged
- [x] Confirmed `VERSION` pinning: real version → build succeeds and label matches exactly; bogus version → build fails clearly; unpinned → downloads latest
- [x] Confirmed the verification check passes on `WITH_SDK=true` (`perl -c` "syntax OK") and `WITH_SDK=false` (graceful-failure assertion), and genuinely fails when the expected message is missing (isolated repro)
- [x] Confirmed a plain `docker build` with zero flags now either builds a fully working image or fails immediately pointing at the missing SDK
- [x] Tested on both amd64 and arm64 (QEMU emulation) with the real SDK
- [x] Real CI (`connector-vmware.yml`, `docker build connector-vmware trixie`) passed against the final state of this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MON-208038]: https://centreon.atlassian.net/browse/MON-208038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ