### PR TITLE
fix(ci): cleanup a useless comment to trigger new build & release on unstable

### DIFF
--- a/.github/workflows/generic-plugins.yml
+++ b/.github/workflows/generic-plugins.yml
@@ -11,8 +11,6 @@ on:
       - '.github/workflows/generic-plugins.yml'
       - 'rust-plugins/**'
       - 'packaging/centreon-plugin-*-snmp-rs/**'
-      # The robot suites of the rust plugin live in the perl test tree: they must retrigger this
-      # workflow, as plugins.yml excludes the centreon-plugin-rust-snmp tag.
       - 'tests/resources/**'
       - 'tests/os/linux/snmp/**'
       - 'tests/os/windows/snmp/**'


### PR DESCRIPTION
## Description

The monitoring connectors tests require the plugin to be available in version >= 20260900

Refs: CTOR-2413

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

