### PR TITLE
feat(storage): IBM Storage Virtualize (FlashSystem, Storwize, SVC) REST API plugin

### DIFF
--- a/packaging/centreon-plugin-Hardware-Storage-Ibm-Flashsystem-Restapi/deb.json
+++ b/packaging/centreon-plugin-Hardware-Storage-Ibm-Flashsystem-Restapi/deb.json
@@ -1,0 +1,4 @@
+{
+    "dependencies": [
+    ]
+}

--- a/packaging/centreon-plugin-Hardware-Storage-Ibm-Flashsystem-Restapi/pkg.json
+++ b/packaging/centreon-plugin-Hardware-Storage-Ibm-Flashsystem-Restapi/pkg.json
@@ -1,0 +1,9 @@
+{
+    "pkg_name": "centreon-plugin-Hardware-Storage-Ibm-Flashsystem-Restapi",
+    "pkg_summary": "Centreon Plugin",
+    "plugin_name": "centreon_ibm_flashsystem_restapi.pl",
+    "files": [
+        "centreon/plugins/script_custom.pm",
+        "storage/ibm/flashsystem/restapi/"
+    ]
+}

--- a/packaging/centreon-plugin-Hardware-Storage-Ibm-Flashsystem-Restapi/rpm.json
+++ b/packaging/centreon-plugin-Hardware-Storage-Ibm-Flashsystem-Restapi/rpm.json
@@ -1,0 +1,4 @@
+{
+    "dependencies": [
+    ]
+}

--- a/src/storage/ibm/flashsystem/restapi/custom/api.pm
+++ b/src/storage/ibm/flashsystem/restapi/custom/api.pm
@@ -21,14 +21,14 @@
 #
 
 #
-# Mode custom : dialogue avec l'API REST Storage Virtualize.
+# Custom mode: talks to the Storage Virtualize REST API.
 #
-# Trois particularites de cette API dictent la conception :
-#   1. Toutes les commandes sont des POST, y compris les lectures 'ls*'.
-#   2. Le prefixe est /rest/v1 depuis la 8.1.3, /rest avant : on detecte.
-#   3. Une session dure 2 h actives ou 30 min d'inactivite, puis renvoie 403.
-#      Le jeton est donc mis en cache sur le collecteur et reobtenu a la volee
-#      quand la baie le refuse.
+# Three traits of this API drive the design:
+#   1. Every command is a POST, including the 'ls*' reads.
+#   2. The prefix is /rest/v1 since 8.1.3, /rest before: it is auto-detected.
+#   3. A session lasts 2 h active or 30 min idle, then answers 403. The token
+#      is therefore cached on the poller and re-obtained on the fly when the
+#      array rejects it.
 #
 
 package storage::ibm::flashsystem::restapi::custom::api;
@@ -95,16 +95,16 @@ sub check_options {
     $self->{api_username}   = $self->{option_results}->{api_username};
     $self->{api_password}   = $self->{option_results}->{api_password};
     $self->{api_path}       = $self->{option_results}->{api_path};
-    # Duree de reutilisation du jeton. On la veut LONGUE : la baie limite le
-    # nombre d'authentifications et renvoie 429 quand on insiste, alors qu'un
-    # jeton perime se rattrape tout seul par le reessai sur 401/403. Expirer le
-    # jeton par precaution ne protege de rien et coute une authentification.
-    # 6600 s reste sous la limite de 2 h de session active.
+    # How long a token is reused. It has to be LONG: the array rate-limits
+    # authentications and answers 429 when pushed, whereas an expired token
+    # recovers by itself through the retry on 401/403. Expiring the token
+    # early protects against nothing and costs an authentication. 6600 s
+    # stays under the 2 h cap on an active session.
     $self->{token_lifetime} = defined($self->{option_results}->{token_lifetime}) && $self->{option_results}->{token_lifetime} =~ /^\d+$/ ? $self->{option_results}->{token_lifetime} : 6600;
-    # Duree de reutilisation d'une reponse de commande. 55 s par defaut :
-    # assez pour absorber la rafale des controles qui partent dans la meme
-    # minute, court devant la cadence de 5 min — le retard maximal d'une
-    # detection reste sous une minute. 0 desactive le cache.
+    # How long a command response is reused. 55 s by default: enough to
+    # absorb the burst of checks starting within the same minute, short
+    # against the 5 min cadence - the worst detection delay stays under a
+    # minute. 0 disables the cache.
     $self->{command_cache_ttl} = defined($self->{option_results}->{command_cache_ttl}) && $self->{option_results}->{command_cache_ttl} =~ /^\d+$/ ? $self->{option_results}->{command_cache_ttl} : 55;
 
     if (!defined($self->{hostname}) || $self->{hostname} eq '') {
@@ -150,8 +150,8 @@ sub settings {
     $self->{settings_done} = 1;
 }
 
-# Les prefixes a essayer, dans l'ordre. --api-path fige le choix quand on veut
-# eviter la detection (une baie de plus dans le parc, un firmware connu).
+# The prefixes to try, in order. --api-path pins the choice when detection is
+# not wanted (one more array in a known fleet, a known firmware).
 sub api_paths {
     my ($self, %options) = @_;
 
@@ -172,11 +172,10 @@ sub decode_response {
     return $decoded;
 }
 
-# Authentification : POST <prefixe>/auth avec les identifiants en en-tetes.
-# La reponse porte un jeton (JWT sur les firmwares recents, chaine hexadecimale
-# avant). En cas d'echec, le corps porte le code IBM (CMMVCxxxxE) : on le
-# remonte tel quel, c'est lui qui distingue un mot de passe faux d'un compte
-# sans role.
+# Authentication: POST <prefix>/auth with the credentials in headers. The
+# answer carries a token (a JWT on recent firmwares, a hex string before). On
+# failure the body carries the IBM code (CMMVCxxxxE): it is passed through as
+# is, since it is what tells a wrong password from an account with no role.
 sub authenticate {
     my ($self, %options) = @_;
 
@@ -184,10 +183,10 @@ sub authenticate {
 
     my $last_message;
 
-    # La baie limite le rythme des authentifications et repond 429. Plusieurs
-    # controles qui expirent en meme temps suffisent a le declencher, d'ou une
-    # temporisation croissante avant d'abandonner. Le total reste sous le
-    # timeout d'un controle Centreon.
+    # The array rate-limits authentications and answers 429. A few checks
+    # expiring at the same time are enough to trigger it, hence a growing
+    # back-off before giving up. The total stays under a Centreon check
+    # timeout.
     foreach my $attempt (1 .. 3) {
         my $throttled = 0;
 
@@ -215,8 +214,8 @@ sub authenticate {
 
             $last_message = 'HTTP ' . $code . (defined($content) && $content ne '' ? ' - ' . $content : '');
 
-            # Inutile d'essayer l'autre prefixe : c'est le rythme qui est
-            # refuse, pas l'URL.
+            # No point trying the other prefix: the rate is being refused,
+            # not the URL.
             if ($code == 429) {
                 $throttled = 1;
                 last;
@@ -227,8 +226,8 @@ sub authenticate {
         sleep($attempt * 2);
     }
 
-    # Sur 429 on ne sort pas : l'appelant va relire le cache, qu'un controle
-    # voisin a peut-etre rafraichi pendant qu'on patientait.
+    # A 429 does not exit: the caller re-reads the cache, which a neighbouring
+    # check may have refreshed while we waited.
     return (undef, undef, $last_message) if (defined($last_message) && $last_message =~ /^HTTP 429/);
 
     $self->{output}->add_option_msg(
@@ -237,8 +236,8 @@ sub authenticate {
     $self->{output}->option_exit();
 }
 
-# Nom du fichier de cache : une entree par baie et par compte, partagee par
-# tous les controles de cette baie.
+# Cache file name: one entry per array and per account, shared by every check
+# of that array.
 sub statefile_name {
     my ($self, %options) = @_;
 
@@ -247,7 +246,7 @@ sub statefile_name {
         . '_' . md5_hex($self->{api_username});
 }
 
-# Relit le cache et rend le jeton s'il est encore valide, sinon undef.
+# Re-reads the cache and returns the token if still valid, undef otherwise.
 sub cached_token {
     my ($self, %options) = @_;
 
@@ -265,28 +264,28 @@ sub cached_token {
     return $token;
 }
 
-# Le jeton est partage par tous les controles d'une meme baie et d'un meme
-# compte : sans ce cache, chaque service ouvrirait sa propre session.
+# The token is shared by every check of the same array and account: without
+# this cache each service would open its own session.
 sub get_token {
     my ($self, %options) = @_;
 
     my $force = defined($options{force}) && $options{force} == 1;
 
-    # Le jeton qu'on ne veut surtout pas reprendre : celui que la baie vient de
-    # refuser, quand on est ici a cause d'un 401/403.
+    # The one token we must not pick up again: the one the array has just
+    # rejected, when we are here because of a 401/403.
     my $rejected = $force ? $self->{token} : undef;
 
-    # cached_token() lit le fichier, ce qui fixe aussi son nom pour l'ecriture.
+    # cached_token() reads the file, which also sets its name for writing.
     my $cached = $self->cached_token();
     return $cached if (!$force && defined($cached));
 
     my ($token, $path, $throttle_message) = $self->authenticate();
 
-    # Authentification refusee pour cause de rythme. Tous les controles d'une
-    # meme baie constatent l'expiration du jeton au meme moment et se ruent sur
-    # /auth : le temps qu'on ait patiente, l'un d'eux a souvent reussi et ecrit
-    # le cache. On le relit plutot que d'insister — sauf s'il rend le jeton
-    # qu'on vient justement de faire rejeter.
+    # Authentication refused because of the rate. Every check of the same
+    # array notices the token expiry at the same moment and rushes /auth: by
+    # the time we have waited, one of them has usually succeeded and written
+    # the cache. Re-read it rather than insist - unless it hands back the very
+    # token we just got rejected.
     if (!defined($token)) {
         my $refreshed = $self->cached_token();
         if (defined($refreshed) && (!defined($rejected) || $refreshed ne $rejected)) {
@@ -311,24 +310,17 @@ sub get_token {
     return $token;
 }
 
-# request : execute une commande CLI via l'API.
+# RESPONSE cache, shared between the checks of one array through the poller
+# state directory - the same principle as the token cache.
 #
-# $options{command}  nom de la commande, par exemple 'lsvdisk'
-# $options{payload}  parametres, par exemple { filtervalue => 'fixed=no' }
-#
-# Renvoie toujours une reference de tableau : l'API rend tantot un objet seul
-# (lssystem), tantot un tableau. Les modes n'ont donc jamais a tester la forme.
-# Cache de REPONSES, partage entre les controles d'une meme baie via le
-# repertoire d'etat du collecteur — le meme principe que le cache de jeton.
-#
-# Pourquoi : le decoupage en services multiplie les executions du plugin, et
-# plusieurs services relisent les MEMES commandes dans la meme minute — trois
-# services issus du mode performance relisent chacun lssystemstats, les deux
-# services de replication refont les quatre memes appels, et lssystem est lu
-# par la moitie des modes. La baie limite le rythme et repond 429. Le premier
-# controle du cycle remplit le cache, les suivants le relisent : la rafale
-# disparait sans changer la cadence de supervision. Toutes les commandes sont
-# des lectures ls*, la mise en cache est donc semantiquement sure.
+# Why: splitting the monitoring into single-purpose services multiplies plugin
+# runs, and several services re-read the SAME commands within the same minute
+# - three services carved out of the performance mode each re-read
+# lssystemstats, two per-partition replication services redo the same four
+# calls, and lssystem is read by half the modes. The array rate-limits and
+# answers 429. The first check of the cycle fills the cache, the following
+# ones read it: the burst disappears without changing the monitoring cadence.
+# Every command is an ls* read, so caching is semantically safe.
 
 sub response_cache_name {
     my ($self, %options) = @_;
@@ -352,17 +344,24 @@ sub cached_response {
 sub store_response {
     my ($self, %options) = @_;
 
-    # read() d'abord : c'est lui qui fixe le nom du fichier que write() utilise.
+    # read() first: it is what sets the file name write() uses.
     $self->{response_cache}->read(statefile => $self->response_cache_name(key => $options{key}));
     $self->{response_cache}->write(data => { stamp => time(), response => $options{response} });
 }
 
+# request: runs a CLI command through the API.
+#
+# $options{command}  command name, for instance 'lsvdisk'
+# $options{payload}  parameters, for instance { filtervalue => 'fixed=no' }
+#
+# Always returns an array reference: the API answers sometimes with a single
+# object (lssystem), sometimes with an array. Modes never have to test which.
 sub request {
     my ($self, %options) = @_;
 
     my $payload = defined($options{payload}) ? $options{payload} : {};
-    # canonical : le meme payload donne toujours la meme cle, quel que soit
-    # l'ordre interne du hachage.
+    # canonical: the same payload always gives the same key, whatever the
+    # internal hash order.
     my $cache_key = $options{command} . '|' . JSON::XS->new->utf8->canonical->encode($payload);
 
     if ($self->{command_cache_ttl} > 0) {
@@ -393,26 +392,26 @@ sub request {
 
         my $code = $self->{http}->get_code();
 
-        # 401 / 403 : session expiree ou invalidee cote baie. On se
-        # reauthentifie une fois, puis on abandonne pour ne pas boucler.
-        # C'est ce rattrapage qui permet de garder un jeton longtemps en cache
-        # plutot que de le renouveler par precaution.
+        # 401 / 403: session expired or invalidated on the array side.
+        # Re-authenticate once, then give up rather than loop. This recovery
+        # is what allows keeping a token cached for long instead of renewing
+        # it as a precaution.
         if (($code == 401 || $code == 403) && $attempt == 1) {
             $token = $self->get_token(force => 1);
             next;
         }
 
-        # 429 sur une commande : la baie limite le rythme des requetes. On
-        # temporise en allongeant le pas avant d'abandonner.
+        # 429 on a command: the array rate-limits requests. Back off with a
+        # growing step before giving up.
         if ($code == 429 && $attempt <= 3) {
             sleep($attempt * 3);
             next;
         }
 
-        # Rafale persistante malgre les reessais : plutot que de rendre le
-        # controle UNKNOWN, on sert la derniere reponse connue si elle a moins
-        # d'un quart d'heure. Un etat legerement date vaut mieux qu'un trou
-        # dans la supervision pendant une saturation passagere de l'API.
+        # Still throttled after the retries: rather than turning the check
+        # UNKNOWN, serve the last known response if it is under fifteen
+        # minutes old. A slightly stale state beats a hole in the monitoring
+        # during a passing API saturation.
         if ($code == 429 && $self->{command_cache_ttl} > 0) {
             my $stale = $self->cached_response(key => $cache_key, max_age => 900);
             if (defined($stale)) {
@@ -444,15 +443,10 @@ sub request {
     }
 }
 
-# Certaines commandes n'existent pas sur tous les firmwares ni sur tous les
-# modeles : lspartition n'apparait qu'en 8.7, lsrcrelationship disparait des
-# configurations qui n'utilisent que la replication par politique. Un mode
-# generique doit pouvoir demander sans savoir, d'ou cette variante tolerante
-# qui rend une liste vide plutot que de faire echouer le controle.
-# L'API rend les capacites sous forme de chaines unitaires : "310.99TB",
-# "0.00MB", parfois "1.25PB". Les seuils et la perfdata veulent des octets.
-# Rend undef quand la valeur est absente ou non exploitable, pour qu'un mode
-# puisse distinguer "zero" de "pas d'information".
+# The API returns capacities as unit-suffixed strings: "310.99TB", "0.00MB",
+# sometimes "1.25PB". Thresholds and perfdata want bytes. Returns undef when
+# the value is missing or unusable, so a mode can tell "zero" from "no
+# information".
 sub size_to_bytes {
     my ($self, %options) = @_;
 
@@ -467,17 +461,17 @@ sub size_to_bytes {
     return $number * $factor{$unit};
 }
 
-# Joignabilite de la baie, pour le seul usage du controle d'hote.
+# Array reachability, for the sole use of the host check.
 #
-# On ne peut pas se contenter de "l'API a repondu ou non" : un jeton refuse, un
-# 429 ou un certificat casse sont des problemes de supervision, pas des baies
-# mortes. Les confondre ferait passer l'hote DOWN et rendrait TOUS ses services
-# UNREACHABLE — on perdrait la supervision au moment ou elle sert le plus.
+# "Did the API answer" is not enough: a rejected token, a 429 or a broken
+# certificate are monitoring problems, not dead arrays. Mixing them up would
+# take the host DOWN and make ALL its services UNREACHABLE - losing the
+# monitoring right when it matters most.
 #
-# Rend l'une de ces trois valeurs :
-#   'unreachable' l'equipement ne repond pas du tout ;
-#   'degraded'    il repond mais l'API refuse de nous servir ;
-#   'ok'          l'API repond normalement.
+# Returns one of three values:
+#   'unreachable' the device does not answer at all;
+#   'degraded'    it answers but the API refuses to serve us;
+#   'ok'          the API answers normally.
 sub reachability {
     my ($self, %options) = @_;
 
@@ -499,9 +493,9 @@ sub reachability {
     my $code = $self->{http}->get_code();
     return ('ok', 'API responded') if ($code == 200);
 
-    # La bibliotheque HTTP rend un 500 synthetique quand la connexion elle-meme
-    # a echoue : c'est le texte qui distingue "personne au bout du fil" d'une
-    # reponse applicative.
+    # The HTTP library returns a synthetic 500 when the connection itself
+    # failed: the text is what tells "nobody at the other end" from an
+    # application answer.
     my $text = defined($content) ? $content : '';
     return ('unreachable', $text)
         if ($text =~ /can'?t connect|connection refused|no route to host|timeout|timed out/i);
@@ -509,6 +503,11 @@ sub reachability {
     return ('degraded', 'HTTP ' . $code . ($text ne '' ? ' - ' . $text : ''));
 }
 
+# Some commands do not exist on every firmware or model: lspartition only
+# appears in 8.7, lsrcrelationship disappears from setups that only use
+# policy-based replication. A generic mode must be able to ask without
+# knowing, hence this tolerant variant that returns an empty list rather
+# than failing the check.
 sub request_optional {
     my ($self, %options) = @_;
 

--- a/src/storage/ibm/flashsystem/restapi/custom/api.pm
+++ b/src/storage/ibm/flashsystem/restapi/custom/api.pm
@@ -1,0 +1,599 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Mode custom : dialogue avec l'API REST Storage Virtualize.
+#
+# Trois particularites de cette API dictent la conception :
+#   1. Toutes les commandes sont des POST, y compris les lectures 'ls*'.
+#   2. Le prefixe est /rest/v1 depuis la 8.1.3, /rest avant : on detecte.
+#   3. Une session dure 2 h actives ou 30 min d'inactivite, puis renvoie 403.
+#      Le jeton est donc mis en cache sur le collecteur et reobtenu a la volee
+#      quand la baie le refuse.
+#
+
+package storage::ibm::flashsystem::restapi::custom::api;
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use centreon::plugins::statefile;
+use JSON::XS;
+use Digest::MD5 qw(md5_hex);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = {};
+    bless $self, $class;
+
+    if (!defined($options{output})) {
+        print "Class Custom: Need to specify 'output' argument.\n";
+        exit 3;
+    }
+    if (!defined($options{options})) {
+        $options{output}->add_option_msg(short_msg => "Class Custom: Need to specify 'options' argument.");
+        $options{output}->option_exit();
+    }
+
+    if (!defined($options{noptions})) {
+        $options{options}->add_options(arguments => {
+            'hostname:s'       => { name => 'hostname' },
+            'port:s'           => { name => 'port' },
+            'proto:s'          => { name => 'proto' },
+            'api-username:s'   => { name => 'api_username' },
+            'api-password:s'   => { name => 'api_password' },
+            'api-path:s'       => { name => 'api_path' },
+            'timeout:s'        => { name => 'timeout' },
+            'token-lifetime:s' => { name => 'token_lifetime' },
+            'command-cache-ttl:s' => { name => 'command_cache_ttl' }
+        });
+    }
+    $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
+
+    $self->{output} = $options{output};
+    $self->{http} = centreon::plugins::http->new(%options);
+    $self->{cache} = centreon::plugins::statefile->new(%options);
+    $self->{response_cache} = centreon::plugins::statefile->new(%options);
+
+    return $self;
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+
+    $self->{option_results} = $options{option_results};
+}
+
+sub set_defaults {}
+
+sub check_options {
+    my ($self, %options) = @_;
+
+    $self->{hostname}       = $self->{option_results}->{hostname};
+    $self->{port}           = defined($self->{option_results}->{port}) && $self->{option_results}->{port} ne '' ? $self->{option_results}->{port} : 7443;
+    $self->{proto}          = defined($self->{option_results}->{proto}) && $self->{option_results}->{proto} ne '' ? $self->{option_results}->{proto} : 'https';
+    $self->{timeout}        = defined($self->{option_results}->{timeout}) && $self->{option_results}->{timeout} =~ /^\d+$/ ? $self->{option_results}->{timeout} : 30;
+    $self->{api_username}   = $self->{option_results}->{api_username};
+    $self->{api_password}   = $self->{option_results}->{api_password};
+    $self->{api_path}       = $self->{option_results}->{api_path};
+    # Duree de reutilisation du jeton. On la veut LONGUE : la baie limite le
+    # nombre d'authentifications et renvoie 429 quand on insiste, alors qu'un
+    # jeton perime se rattrape tout seul par le reessai sur 401/403. Expirer le
+    # jeton par precaution ne protege de rien et coute une authentification.
+    # 6600 s reste sous la limite de 2 h de session active.
+    $self->{token_lifetime} = defined($self->{option_results}->{token_lifetime}) && $self->{option_results}->{token_lifetime} =~ /^\d+$/ ? $self->{option_results}->{token_lifetime} : 6600;
+    # Duree de reutilisation d'une reponse de commande. 55 s par defaut :
+    # assez pour absorber la rafale des controles qui partent dans la meme
+    # minute, court devant la cadence de 5 min — le retard maximal d'une
+    # detection reste sous une minute. 0 desactive le cache.
+    $self->{command_cache_ttl} = defined($self->{option_results}->{command_cache_ttl}) && $self->{option_results}->{command_cache_ttl} =~ /^\d+$/ ? $self->{option_results}->{command_cache_ttl} : 55;
+
+    if (!defined($self->{hostname}) || $self->{hostname} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify --hostname option.');
+        $self->{output}->option_exit();
+    }
+    if (!defined($self->{api_username}) || $self->{api_username} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify --api-username option.');
+        $self->{output}->option_exit();
+    }
+    if (!defined($self->{api_password}) || $self->{api_password} eq '') {
+        $self->{output}->add_option_msg(short_msg => 'Need to specify --api-password option.');
+        $self->{output}->option_exit();
+    }
+
+    $self->{cache}->check_options(option_results => $self->{option_results});
+    $self->{response_cache}->check_options(option_results => $self->{option_results});
+
+    return 0;
+}
+
+sub get_connection_info {
+    my ($self, %options) = @_;
+
+    return $self->{hostname} . ':' . $self->{port};
+}
+
+sub build_options_for_httplib {
+    my ($self, %options) = @_;
+
+    $self->{option_results}->{hostname} = $self->{hostname};
+    $self->{option_results}->{port}     = $self->{port};
+    $self->{option_results}->{proto}    = $self->{proto};
+    $self->{option_results}->{timeout}  = $self->{timeout};
+}
+
+sub settings {
+    my ($self, %options) = @_;
+
+    return if (defined($self->{settings_done}));
+    $self->build_options_for_httplib();
+    $self->{http}->set_options(%{$self->{option_results}});
+    $self->{settings_done} = 1;
+}
+
+# Les prefixes a essayer, dans l'ordre. --api-path fige le choix quand on veut
+# eviter la detection (une baie de plus dans le parc, un firmware connu).
+sub api_paths {
+    my ($self, %options) = @_;
+
+    return ($self->{api_path}) if (defined($self->{api_path}) && $self->{api_path} ne '');
+    return ('/rest/v1', '/rest');
+}
+
+sub decode_response {
+    my ($self, %options) = @_;
+
+    my $decoded;
+    eval {
+        $decoded = JSON::XS->new->utf8->decode($options{content});
+    };
+    if ($@) {
+        return undef;
+    }
+    return $decoded;
+}
+
+# Authentification : POST <prefixe>/auth avec les identifiants en en-tetes.
+# La reponse porte un jeton (JWT sur les firmwares recents, chaine hexadecimale
+# avant). En cas d'echec, le corps porte le code IBM (CMMVCxxxxE) : on le
+# remonte tel quel, c'est lui qui distingue un mot de passe faux d'un compte
+# sans role.
+sub authenticate {
+    my ($self, %options) = @_;
+
+    $self->settings();
+
+    my $last_message;
+
+    # La baie limite le rythme des authentifications et repond 429. Plusieurs
+    # controles qui expirent en meme temps suffisent a le declencher, d'ou une
+    # temporisation croissante avant d'abandonner. Le total reste sous le
+    # timeout d'un controle Centreon.
+    foreach my $attempt (1 .. 3) {
+        my $throttled = 0;
+
+        foreach my $path ($self->api_paths()) {
+            my $content = $self->{http}->request(
+                method => 'POST',
+                url_path => $path . '/auth',
+                header => [
+                    'X-Auth-Username: ' . $self->{api_username},
+                    'X-Auth-Password: ' . $self->{api_password},
+                    'Accept: application/json'
+                ],
+                unknown_status => '',
+                warning_status => '',
+                critical_status => ''
+            );
+
+            my $code = $self->{http}->get_code();
+            if ($code == 200) {
+                my $decoded = $self->decode_response(content => $content);
+                if (defined($decoded) && defined($decoded->{token}) && $decoded->{token} ne '') {
+                    return ($decoded->{token}, $path);
+                }
+            }
+
+            $last_message = 'HTTP ' . $code . (defined($content) && $content ne '' ? ' - ' . $content : '');
+
+            # Inutile d'essayer l'autre prefixe : c'est le rythme qui est
+            # refuse, pas l'URL.
+            if ($code == 429) {
+                $throttled = 1;
+                last;
+            }
+        }
+
+        last if (!$throttled || $attempt == 3);
+        sleep($attempt * 2);
+    }
+
+    # Sur 429 on ne sort pas : l'appelant va relire le cache, qu'un controle
+    # voisin a peut-etre rafraichi pendant qu'on patientait.
+    return (undef, undef, $last_message) if (defined($last_message) && $last_message =~ /^HTTP 429/);
+
+    $self->{output}->add_option_msg(
+        short_msg => 'Authentication failed: ' . (defined($last_message) ? $last_message : 'no response')
+    );
+    $self->{output}->option_exit();
+}
+
+# Nom du fichier de cache : une entree par baie et par compte, partagee par
+# tous les controles de cette baie.
+sub statefile_name {
+    my ($self, %options) = @_;
+
+    return 'ibm_flashsystem_api_'
+        . md5_hex($self->{hostname} . ':' . $self->{port})
+        . '_' . md5_hex($self->{api_username});
+}
+
+# Relit le cache et rend le jeton s'il est encore valide, sinon undef.
+sub cached_token {
+    my ($self, %options) = @_;
+
+    return undef if ($self->{cache}->read(statefile => $self->statefile_name()) == 0);
+
+    my $token = $self->{cache}->get(name => 'token');
+    my $path = $self->{cache}->get(name => 'api_path');
+    my $expires_on = $self->{cache}->get(name => 'expires_on');
+
+    return undef if (!defined($token) || !defined($path) || !defined($expires_on));
+    return undef if (time() >= $expires_on);
+
+    $self->{token} = $token;
+    $self->{resolved_path} = $path;
+    return $token;
+}
+
+# Le jeton est partage par tous les controles d'une meme baie et d'un meme
+# compte : sans ce cache, chaque service ouvrirait sa propre session.
+sub get_token {
+    my ($self, %options) = @_;
+
+    my $force = defined($options{force}) && $options{force} == 1;
+
+    # Le jeton qu'on ne veut surtout pas reprendre : celui que la baie vient de
+    # refuser, quand on est ici a cause d'un 401/403.
+    my $rejected = $force ? $self->{token} : undef;
+
+    # cached_token() lit le fichier, ce qui fixe aussi son nom pour l'ecriture.
+    my $cached = $self->cached_token();
+    return $cached if (!$force && defined($cached));
+
+    my ($token, $path, $throttle_message) = $self->authenticate();
+
+    # Authentification refusee pour cause de rythme. Tous les controles d'une
+    # meme baie constatent l'expiration du jeton au meme moment et se ruent sur
+    # /auth : le temps qu'on ait patiente, l'un d'eux a souvent reussi et ecrit
+    # le cache. On le relit plutot que d'insister — sauf s'il rend le jeton
+    # qu'on vient justement de faire rejeter.
+    if (!defined($token)) {
+        my $refreshed = $self->cached_token();
+        if (defined($refreshed) && (!defined($rejected) || $refreshed ne $rejected)) {
+            return $refreshed;
+        }
+
+        $self->{output}->add_option_msg(
+            short_msg => 'Authentication failed: ' . $throttle_message
+                . ' The array is rate-limiting authentications and no other check has'
+                . ' refreshed the cached token. Raising --token-lifetime spaces these out.'
+        );
+        $self->{output}->option_exit();
+    }
+
+    $self->{cache}->write(data => {
+        token => $token,
+        api_path => $path,
+        expires_on => time() + $self->{token_lifetime}
+    });
+    $self->{token} = $token;
+    $self->{resolved_path} = $path;
+    return $token;
+}
+
+# request : execute une commande CLI via l'API.
+#
+# $options{command}  nom de la commande, par exemple 'lsvdisk'
+# $options{payload}  parametres, par exemple { filtervalue => 'fixed=no' }
+#
+# Renvoie toujours une reference de tableau : l'API rend tantot un objet seul
+# (lssystem), tantot un tableau. Les modes n'ont donc jamais a tester la forme.
+# Cache de REPONSES, partage entre les controles d'une meme baie via le
+# repertoire d'etat du collecteur — le meme principe que le cache de jeton.
+#
+# Pourquoi : le decoupage en services multiplie les executions du plugin, et
+# plusieurs services relisent les MEMES commandes dans la meme minute — trois
+# services issus du mode performance relisent chacun lssystemstats, les deux
+# services de replication refont les quatre memes appels, et lssystem est lu
+# par la moitie des modes. La baie limite le rythme et repond 429. Le premier
+# controle du cycle remplit le cache, les suivants le relisent : la rafale
+# disparait sans changer la cadence de supervision. Toutes les commandes sont
+# des lectures ls*, la mise en cache est donc semantiquement sure.
+
+sub response_cache_name {
+    my ($self, %options) = @_;
+
+    return 'ibm_flashsystem_api_rsp_' . md5_hex($self->{hostname} . ':' . $self->{port})
+        . '_' . md5_hex($self->{api_username} . '|' . $options{key});
+}
+
+sub cached_response {
+    my ($self, %options) = @_;
+
+    return undef if ($self->{response_cache}->read(statefile => $self->response_cache_name(key => $options{key})) == 0);
+
+    my $stamp = $self->{response_cache}->get(name => 'stamp');
+    my $response = $self->{response_cache}->get(name => 'response');
+    return undef if (!defined($stamp) || $stamp !~ /^\d+$/ || ref($response) ne 'ARRAY');
+    return undef if (time() - $stamp > $options{max_age});
+    return $response;
+}
+
+sub store_response {
+    my ($self, %options) = @_;
+
+    # read() d'abord : c'est lui qui fixe le nom du fichier que write() utilise.
+    $self->{response_cache}->read(statefile => $self->response_cache_name(key => $options{key}));
+    $self->{response_cache}->write(data => { stamp => time(), response => $options{response} });
+}
+
+sub request {
+    my ($self, %options) = @_;
+
+    my $payload = defined($options{payload}) ? $options{payload} : {};
+    # canonical : le meme payload donne toujours la meme cle, quel que soit
+    # l'ordre interne du hachage.
+    my $cache_key = $options{command} . '|' . JSON::XS->new->utf8->canonical->encode($payload);
+
+    if ($self->{command_cache_ttl} > 0) {
+        my $cached = $self->cached_response(key => $cache_key, max_age => $self->{command_cache_ttl});
+        return $cached if (defined($cached));
+    }
+
+    my $token = $self->get_token();
+
+    my $attempt = 0;
+    while (1) {
+        $attempt++;
+        $self->settings();
+
+        my $content = $self->{http}->request(
+            method => 'POST',
+            url_path => $self->{resolved_path} . '/' . $options{command},
+            header => [
+                'X-Auth-Token: ' . $token,
+                'Content-Type: application/json',
+                'Accept: application/json'
+            ],
+            query_form_post => JSON::XS->new->utf8->encode($payload),
+            unknown_status => '',
+            warning_status => '',
+            critical_status => ''
+        );
+
+        my $code = $self->{http}->get_code();
+
+        # 401 / 403 : session expiree ou invalidee cote baie. On se
+        # reauthentifie une fois, puis on abandonne pour ne pas boucler.
+        # C'est ce rattrapage qui permet de garder un jeton longtemps en cache
+        # plutot que de le renouveler par precaution.
+        if (($code == 401 || $code == 403) && $attempt == 1) {
+            $token = $self->get_token(force => 1);
+            next;
+        }
+
+        # 429 sur une commande : la baie limite le rythme des requetes. On
+        # temporise en allongeant le pas avant d'abandonner.
+        if ($code == 429 && $attempt <= 3) {
+            sleep($attempt * 3);
+            next;
+        }
+
+        # Rafale persistante malgre les reessais : plutot que de rendre le
+        # controle UNKNOWN, on sert la derniere reponse connue si elle a moins
+        # d'un quart d'heure. Un etat legerement date vaut mieux qu'un trou
+        # dans la supervision pendant une saturation passagere de l'API.
+        if ($code == 429 && $self->{command_cache_ttl} > 0) {
+            my $stale = $self->cached_response(key => $cache_key, max_age => 900);
+            if (defined($stale)) {
+                $self->{output}->output_add(
+                    long_msg => "HTTP 429 on '" . $options{command} . "': served the cached response instead."
+                );
+                return $stale;
+            }
+        }
+
+        if ($code != 200) {
+            $self->{output}->add_option_msg(
+                short_msg => "API command '" . $options{command} . "' failed (HTTP " . $code . ")"
+                    . (defined($content) && $content ne '' ? ': ' . $content : '')
+            );
+            $self->{output}->option_exit();
+        }
+
+        my $decoded = $self->decode_response(content => $content);
+        if (!defined($decoded)) {
+            $self->{output}->add_option_msg(short_msg => "Cannot decode API response for command '" . $options{command} . "'");
+            $self->{output}->option_exit();
+        }
+
+        my $result = ref($decoded) eq 'ARRAY' ? $decoded : [ $decoded ];
+        $self->store_response(key => $cache_key, response => $result)
+            if ($self->{command_cache_ttl} > 0);
+        return $result;
+    }
+}
+
+# Certaines commandes n'existent pas sur tous les firmwares ni sur tous les
+# modeles : lspartition n'apparait qu'en 8.7, lsrcrelationship disparait des
+# configurations qui n'utilisent que la replication par politique. Un mode
+# generique doit pouvoir demander sans savoir, d'ou cette variante tolerante
+# qui rend une liste vide plutot que de faire echouer le controle.
+# L'API rend les capacites sous forme de chaines unitaires : "310.99TB",
+# "0.00MB", parfois "1.25PB". Les seuils et la perfdata veulent des octets.
+# Rend undef quand la valeur est absente ou non exploitable, pour qu'un mode
+# puisse distinguer "zero" de "pas d'information".
+sub size_to_bytes {
+    my ($self, %options) = @_;
+
+    my $value = $options{value};
+    return undef if (!defined($value) || $value eq '');
+    return undef if ($value !~ /^\s*([0-9]+(?:\.[0-9]+)?)\s*([KMGTPE]?)B?\s*$/i);
+
+    my ($number, $unit) = ($1, uc($2));
+    my %factor = ('' => 1, K => 1024, M => 1024**2, G => 1024**3,
+                  T => 1024**4, P => 1024**5, E => 1024**6);
+
+    return $number * $factor{$unit};
+}
+
+# Joignabilite de la baie, pour le seul usage du controle d'hote.
+#
+# On ne peut pas se contenter de "l'API a repondu ou non" : un jeton refuse, un
+# 429 ou un certificat casse sont des problemes de supervision, pas des baies
+# mortes. Les confondre ferait passer l'hote DOWN et rendrait TOUS ses services
+# UNREACHABLE — on perdrait la supervision au moment ou elle sert le plus.
+#
+# Rend l'une de ces trois valeurs :
+#   'unreachable' l'equipement ne repond pas du tout ;
+#   'degraded'    il repond mais l'API refuse de nous servir ;
+#   'ok'          l'API repond normalement.
+sub reachability {
+    my ($self, %options) = @_;
+
+    $self->settings();
+
+    my $content = $self->{http}->request(
+        method => 'POST',
+        url_path => ($self->api_paths())[0] . '/auth',
+        header => [
+            'X-Auth-Username: ' . $self->{api_username},
+            'X-Auth-Password: ' . $self->{api_password},
+            'Accept: application/json'
+        ],
+        unknown_status => '',
+        warning_status => '',
+        critical_status => ''
+    );
+
+    my $code = $self->{http}->get_code();
+    return ('ok', 'API responded') if ($code == 200);
+
+    # La bibliotheque HTTP rend un 500 synthetique quand la connexion elle-meme
+    # a echoue : c'est le texte qui distingue "personne au bout du fil" d'une
+    # reponse applicative.
+    my $text = defined($content) ? $content : '';
+    return ('unreachable', $text)
+        if ($text =~ /can'?t connect|connection refused|no route to host|timeout|timed out/i);
+
+    return ('degraded', 'HTTP ' . $code . ($text ne '' ? ' - ' . $text : ''));
+}
+
+sub request_optional {
+    my ($self, %options) = @_;
+
+    my $result;
+    eval {
+        local $SIG{__DIE__};
+        $result = $self->request(%options);
+    };
+    return [] if ($@ || !defined($result));
+    return $result;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+IBM Storage Virtualize REST API
+
+=head1 REST API OPTIONS
+
+=over 8
+
+=item B<--hostname>
+
+Management IP address or hostname of the system.
+
+=item B<--port>
+
+API port (default: 7443).
+
+=item B<--proto>
+
+Protocol (default: https).
+
+=item B<--api-username>
+
+Array account used to authenticate. The B<Monitor> role is sufficient and
+recommended: it grants read-only access to the information commands.
+
+=item B<--api-password>
+
+Password of that account. Storage Virtualize has no API key: the credentials
+are exchanged for a session token.
+
+=item B<--api-path>
+
+Pin the API prefix instead of detecting it. Storage Virtualize 8.1.3 and later
+serve C</rest/v1>; earlier releases serve C</rest>. Left empty, both are tried
+in that order.
+
+=item B<--token-lifetime>
+
+Seconds a cached session token is reused (default: 6600, just under the array's
+two-hour cap on an active session).
+
+Keep it long. The array rate-limits authentications and answers B<429 Too Many
+Requests> when pressed, whereas an expired token costs nothing: the plugin
+re-authenticates by itself when a command comes back 401 or 403. Expiring the
+token early protects against nothing and spends an authentication.
+
+=item B<--command-cache-ttl>
+
+Seconds a command B<response> is reused across checks of the same array
+(default: 55; 0 disables).
+
+The array also rate-limits commands. Splitting the monitoring into
+single-purpose services multiplies plugin runs that read the B<same> C<ls*>
+commands within the same minute — the first check of the cycle fills the
+cache, the others read it, and the burst disappears without changing the
+check cadence. Every command is a read, so caching is semantically safe; the
+worst case is a detection delayed by under a minute on a five-minute cadence.
+When a command still gets a 429 after the retries, the last response is served
+if it is less than fifteen minutes old, rather than turning the check UNKNOWN.
+
+The token is cached per array and per account, so every check of the same
+system shares it. If authentications look far too frequent, check that the
+cache directory (C<--statefile-dir>, C</var/lib/centreon/centplugins> by
+default) is writable by the account running the checks.
+
+=item B<--timeout>
+
+HTTP timeout in seconds (default: 30).
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/custom/api.pm
+++ b/src/storage/ibm/flashsystem/restapi/custom/api.pm
@@ -50,8 +50,7 @@ sub new {
         exit 3;
     }
     if (!defined($options{options})) {
-        $options{output}->add_option_msg(short_msg => "Class Custom: Need to specify 'options' argument.");
-        $options{output}->option_exit();
+        $options{output}->option_exit(short_msg => "Class Custom: Need to specify 'options' argument.");
     }
 
     if (!defined($options{noptions})) {
@@ -108,16 +107,13 @@ sub check_options {
     $self->{command_cache_ttl} = defined($self->{option_results}->{command_cache_ttl}) && $self->{option_results}->{command_cache_ttl} =~ /^\d+$/ ? $self->{option_results}->{command_cache_ttl} : 55;
 
     if (!defined($self->{hostname}) || $self->{hostname} eq '') {
-        $self->{output}->add_option_msg(short_msg => 'Need to specify --hostname option.');
-        $self->{output}->option_exit();
+        $self->{output}->option_exit(short_msg => 'Need to specify --hostname option.');
     }
     if (!defined($self->{api_username}) || $self->{api_username} eq '') {
-        $self->{output}->add_option_msg(short_msg => 'Need to specify --api-username option.');
-        $self->{output}->option_exit();
+        $self->{output}->option_exit(short_msg => 'Need to specify --api-username option.');
     }
     if (!defined($self->{api_password}) || $self->{api_password} eq '') {
-        $self->{output}->add_option_msg(short_msg => 'Need to specify --api-password option.');
-        $self->{output}->option_exit();
+        $self->{output}->option_exit(short_msg => 'Need to specify --api-password option.');
     }
 
     $self->{cache}->check_options(option_results => $self->{option_results});
@@ -432,8 +428,7 @@ sub request {
 
         my $decoded = $self->decode_response(content => $content);
         if (!defined($decoded)) {
-            $self->{output}->add_option_msg(short_msg => "Cannot decode API response for command '" . $options{command} . "'");
-            $self->{output}->option_exit();
+            $self->{output}->option_exit(short_msg => "Cannot decode API response for command '" . $options{command} . "'");
         }
 
         my $result = ref($decoded) eq 'ARRAY' ? $decoded : [ $decoded ];

--- a/src/storage/ibm/flashsystem/restapi/custom/api.pm
+++ b/src/storage/ibm/flashsystem/restapi/custom/api.pm
@@ -355,6 +355,9 @@ sub store_response {
 #
 # Always returns an array reference: the API answers sometimes with a single
 # object (lssystem), sometimes with an array. Modes never have to test which.
+# With optional => 1 an HTTP error or an undecodable answer returns undef
+# instead of ending the check: option_exit() leaves the process, an eval()
+# around the call does not catch it - request_optional relies on this flag.
 sub request {
     my ($self, %options) = @_;
 
@@ -422,6 +425,8 @@ sub request {
         }
 
         if ($code != 200) {
+
+            return undef if ($options{optional});
             $self->{output}->add_option_msg(
                 short_msg => "API command '" . $options{command} . "' failed (HTTP " . $code . ")"
                     . (defined($content) && $content ne '' ? ': ' . $content : '')
@@ -431,6 +436,7 @@ sub request {
 
         my $decoded = $self->decode_response(content => $content);
         if (!defined($decoded)) {
+            return undef if ($options{optional});
             $self->{output}->option_exit(short_msg => "Cannot decode API response for command '" . $options{command} . "'");
         }
 
@@ -512,7 +518,7 @@ sub request_optional {
     my $result;
     eval {
         local $SIG{__DIE__};
-        $result = $self->request(%options);
+        $result = $self->request(%options, optional => 1);
     };
     return [] if ($@ || !defined($result));
     return $result;

--- a/src/storage/ibm/flashsystem/restapi/custom/api.pm
+++ b/src/storage/ibm/flashsystem/restapi/custom/api.pm
@@ -55,15 +55,15 @@ sub new {
 
     if (!defined($options{noptions})) {
         $options{options}->add_options(arguments => {
-            'hostname:s'       => { name => 'hostname' },
-            'port:s'           => { name => 'port' },
-            'proto:s'          => { name => 'proto' },
-            'api-username:s'   => { name => 'api_username' },
-            'api-password:s'   => { name => 'api_password' },
-            'api-path:s'       => { name => 'api_path' },
-            'timeout:s'        => { name => 'timeout' },
-            'token-lifetime:s' => { name => 'token_lifetime' },
-            'command-cache-ttl:s' => { name => 'command_cache_ttl' }
+            'hostname:s'          => { name => 'hostname' },
+            'port:s'              => { name => 'port', default => 7443, port => 1 },
+            'proto:s'             => { name => 'proto', default => 'https', protocol_http => 1 },
+            'api-username:s'      => { name => 'api_username' },
+            'api-password:s'      => { name => 'api_password' },
+            'api-path:s'          => { name => 'api_path' },
+            'timeout:s'           => { name => 'timeout', default => 30, numeric => 1 },
+            'token-lifetime:s'    => { name => 'token_lifetime', default => 6600, numeric => 1 },
+            'command-cache-ttl:s' => { name => 'command_cache_ttl', default => 0, numeric => 1 }
         });
     }
     $options{options}->add_help(package => __PACKAGE__, sections => 'REST API OPTIONS', once => 1);
@@ -87,24 +87,27 @@ sub set_defaults {}
 sub check_options {
     my ($self, %options) = @_;
 
-    $self->{hostname}       = $self->{option_results}->{hostname};
-    $self->{port}           = defined($self->{option_results}->{port}) && $self->{option_results}->{port} ne '' ? $self->{option_results}->{port} : 7443;
-    $self->{proto}          = defined($self->{option_results}->{proto}) && $self->{option_results}->{proto} ne '' ? $self->{option_results}->{proto} : 'https';
-    $self->{timeout}        = defined($self->{option_results}->{timeout}) && $self->{option_results}->{timeout} =~ /^\d+$/ ? $self->{option_results}->{timeout} : 30;
-    $self->{api_username}   = $self->{option_results}->{api_username};
-    $self->{api_password}   = $self->{option_results}->{api_password};
-    $self->{api_path}       = $self->{option_results}->{api_path};
+    # Defaults and validations are declared with the options: nothing to
+    # re-check here.
+    $self->{hostname}     = $self->{option_results}->{hostname};
+    $self->{port}         = $self->{option_results}->{port};
+    $self->{proto}        = $self->{option_results}->{proto};
+    $self->{timeout}      = $self->{option_results}->{timeout};
+    $self->{api_username} = $self->{option_results}->{api_username};
+    $self->{api_password} = $self->{option_results}->{api_password};
+    $self->{api_path}     = $self->{option_results}->{api_path};
     # How long a token is reused. It has to be LONG: the array rate-limits
     # authentications and answers 429 when pushed, whereas an expired token
     # recovers by itself through the retry on 401/403. Expiring the token
     # early protects against nothing and costs an authentication. 6600 s
     # stays under the 2 h cap on an active session.
-    $self->{token_lifetime} = defined($self->{option_results}->{token_lifetime}) && $self->{option_results}->{token_lifetime} =~ /^\d+$/ ? $self->{option_results}->{token_lifetime} : 6600;
-    # How long a command response is reused. 55 s by default: enough to
-    # absorb the burst of checks starting within the same minute, short
-    # against the 5 min cadence - the worst detection delay stays under a
-    # minute. 0 disables the cache.
-    $self->{command_cache_ttl} = defined($self->{option_results}->{command_cache_ttl}) && $self->{option_results}->{command_cache_ttl} =~ /^\d+$/ ? $self->{option_results}->{command_cache_ttl} : 55;
+    $self->{token_lifetime} = $self->{option_results}->{token_lifetime};
+    # How long a command response is reused. Disabled by default; 55 s is a
+    # good value when several single-purpose services read the same array:
+    # enough to absorb the burst of checks starting within the same minute,
+    # short against a 5 min cadence - the worst detection delay stays under
+    # a minute.
+    $self->{command_cache_ttl} = $self->{option_results}->{command_cache_ttl};
 
     if (!defined($self->{hostname}) || $self->{hostname} eq '') {
         $self->{output}->option_exit(short_msg => 'Need to specify --hostname option.');
@@ -568,7 +571,8 @@ token early protects against nothing and spends an authentication.
 =item B<--command-cache-ttl>
 
 Seconds a command B<response> is reused across checks of the same array
-(default: 55; 0 disables).
+(default: 0, disabled; 55 is a good value when several services read the same
+array).
 
 The array also rate-limits commands. Splitting the monitoring into
 single-purpose services multiplies plugin runs that read the B<same> C<ls*>

--- a/src/storage/ibm/flashsystem/restapi/mode/capacity.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/capacity.pm
@@ -21,17 +21,17 @@
 #
 
 #
-# Remplissage de la baie.
+# How full the system is.
 #
-# Piege central : sur une baie a FlashCore Modules, la capacite d'un pool est
-# une vue VIRTUELLE sur-allouee au-dessus du materiel. Un pool peut annoncer
-# 630 To libres alors qu'il reste 164 To physiques sur 311. Poser le seuil
-# d'alerte sur l'espace libre du pool revient donc a surveiller un chiffre sans
-# rapport avec le moment ou la baie sera pleine.
+# Central trap: on a system fitted with FlashCore Modules, a pool's capacity is
+# a VIRTUAL, over-allocated view laid over the hardware. A pool can announce
+# 630 TB free while 164 TB remain physically out of 311. Putting the alert
+# threshold on the pool's free space therefore watches a number unrelated to
+# the moment the array fills up.
 #
-# Le seuil par defaut porte donc sur physical_free_capacity, remonte par
-# lssystem. Les chiffres du pool restent exposes en metrique, pour la tendance
-# et pour le taux de sur-allocation, mais ne declenchent rien d'eux-memes.
+# The threshold therefore belongs on physical_free_capacity, reported by
+# lssystem. Pool figures stay published as metrics, for the trend and for the
+# over-allocation ratio, but trigger nothing by themselves.
 #
 
 package storage::ibm::flashsystem::restapi::mode::capacity;
@@ -89,9 +89,9 @@ sub set_counters {
           message_multiple => 'All pools are online', skipped_code => { -10 => 1 } }
     ];
 
-    # C'est ce compteur qui porte l'alerte. Les seuils par defaut restent
-    # volontairement larges : le bon reglage depend du delai d'appro d'une
-    # extension, pas d'une regle generale.
+    # This is the counter that carries the alert. No default is shipped: the
+    # right value depends on how long an extension takes to be delivered, not
+    # on a general rule.
     $self->{maps_counters}->{physical} = [
         { label => 'physical-usage-prct', nlabel => 'system.physical.space.usage.percentage',
           set => {
@@ -100,9 +100,9 @@ sub set_counters {
                 perfdatas => [ { template => '%.2f', unit => '%', min => 0, max => 100 } ]
             }
         },
-        # output_change_bytes convertit la valeur ET rend l'unite : le gabarit
-        # doit donc porter DEUX %s. Avec un seul, l'unite est perdue et la
-        # sortie affiche « used 146.45 » sans dire de quoi.
+        # output_change_bytes converts the value AND returns the unit: the template
+        # must carry TWO %s. With one, the unit is lost and the output reads
+        # "used 146.45" without saying of what.
         { label => 'physical-usage', nlabel => 'system.physical.space.usage.bytes', set => {
                 key_values => [ { name => 'physical_used' }, { name => 'physical_total' } ],
                 output_template => '%s %s',
@@ -142,16 +142,15 @@ sub set_counters {
         }
     ];
 
-    # Ce que la reduction de donnees fait gagner. Le ratio parle mieux que les
-    # octets : « 2.40:1 » se compare d'une baie a l'autre et d'un mois a
-    # l'autre, « 12 To » non.
+    # What data reduction saves. The ratio speaks better than bytes: "2.40:1"
+    # compares from one array to another and from one month to the next,
+    # "12 TB" does not.
     #
-    # Ces deux compteurs vivent dans un groupe A PART, et de type 1, pour une
-    # raison precise : un compteur de type 0 dont la valeur manque n'est pas
-    # tu, il s'affiche « skipped (no value(s)) ». Quand aucun pool n'active la
-    # reduction — le cas ici — cela mettait deux mentions de saut dans une
-    # sortie par ailleurs normale, qui se lisent comme une panne. Un groupe de
-    # type 1 laisse vide ne produit, lui, aucune sortie.
+    # These two counters live in a SEPARATE group, of type 1, for a precise
+    # reason: a type 0 counter whose value is missing is not silent, it prints
+    # "skipped (no value(s))". When no pool enables reduction - a common case -
+    # that put two skip mentions in an otherwise normal output, which read like
+    # a fault. An empty type 1 group prints nothing at all.
     $self->{maps_counters}->{reduction} = [
         { label => 'data-reduction-ratio', nlabel => 'system.data.reduction.ratio.count', set => {
                 key_values => [ { name => 'reduction_ratio' } ],
@@ -228,9 +227,9 @@ sub manage_selection {
     my $physical_total = $options{custom}->size_to_bytes(value => $system->{physical_capacity});
     my $physical_free = $options{custom}->size_to_bytes(value => $system->{physical_free_capacity});
 
-    # Sans capacite physique, on est probablement sur un modele sans FlashCore
-    # Module. Plutot que d'inventer un chiffre, on le dit et on s'en tient aux
-    # pools, dont les seuils restent utilisables.
+    # Without physical capacity we are probably on a model without FlashCore
+    # Modules. Rather than making a figure up, say so and stick to the pools,
+    # whose thresholds remain usable.
     if (!defined($physical_total) || !defined($physical_free) || $physical_total == 0) {
         $self->{output}->output_add(
             long_msg => 'System reports no physical capacity: thresholds on pools only.',
@@ -253,27 +252,25 @@ sub manage_selection {
         logical_free => $options{custom}->size_to_bytes(value => $system->{total_free_space})
     };
 
-    # Taux de reduction : rapport de ce qui a ete ecrit sur ce qui est
-    # reellement stocke. Les deux compteurs valent 0 quand aucun pool n'active
-    # la reduction de donnees — on ne publie alors ni ratio ni gain, plutot que
-    # d'afficher un 1:1 trompeur.
+    # Reduction ratio: what was written over what is really stored. Both
+    # counters are 0 when no pool enables data reduction - then neither ratio
+    # nor saving is published, rather than showing a misleading 1:1.
     my $before = $options{custom}->size_to_bytes(value => $system->{used_capacity_before_reduction});
     my $after = $options{custom}->size_to_bytes(value => $system->{used_capacity_after_reduction});
 
-    # La reduction de donnees peut se produire a DEUX etages, publies par des
-    # champs differents :
+    # Data reduction can happen at TWO layers, published by different fields:
     #
-    #   - la couche logicielle (Data Reduction Pools) : les compteurs
-    #     used_capacity_before/after_reduction de lssystem. Ils valent 0 des
-    #     que les pools sont en data_reduction=no.
-    #   - la compression MATERIELLE des FlashCore Modules, un etage plus bas,
-    #     dans les disques. Elle n'apparait QUE dans la vue detaillee des
-    #     mdisks (effective_used_capacity = ecrit avant compression, contre le
-    #     physique reellement consomme). C'est elle que la GUI appelle
-    #     « Data reduction » sur ces baies : 265.45/146.45 = 1.81:1, verifie
-    #     au dixieme pres contre l'affichage.
+    #   - the software layer (Data Reduction Pools): the
+    #     used_capacity_before/after_reduction counters of lssystem. They are 0
+    #     as soon as the pools are in data_reduction=no.
+    #   - the HARDWARE compression of the FlashCore Modules, one layer below,
+    #     in the drives. It ONLY shows in the detailed view of the mdisks
+    #     (effective_used_capacity = written before compression, against the
+    #     physical capacity really consumed). It is what the GUI calls "Data
+    #     reduction" on such systems: 265.45/146.45 = 1.81:1 on a surveyed
+    #     FlashSystem 5300, verified to the decimal against the display.
     #
-    # On publie la couche active, en disant laquelle en sortie longue.
+    # The active layer is published, and named in the long output.
     $self->{reduction} = {};
     if (defined($before) && defined($after) && $after > 0) {
         $self->{reduction}->{system} = {
@@ -287,16 +284,16 @@ sub manage_selection {
         my ($effective, $used) = (0, 0);
         foreach my $mdisk (@{ $options{custom}->request_optional(command => 'lsmdisk') }) {
             next unless (ref $mdisk eq 'HASH' && defined($mdisk->{id}) && $mdisk->{id} =~ /^\d+$/);
-            # La vue concise ne porte aucun de ces champs : il faut la vue
-            # detaillee, un appel par mdisk. Il y en a un ou deux par baie.
+            # The concise view carries none of these fields: the detailed view is
+            # needed, one call per mdisk. There are one or two per array.
             my $detail = $options{custom}->request_optional(command => 'lsmdisk/' . $mdisk->{id})->[0];
             next unless (ref $detail eq 'HASH');
 
             my $eff   = $options{custom}->size_to_bytes(value => $detail->{effective_used_capacity});
             my $ptot  = $options{custom}->size_to_bytes(value => $detail->{physical_capacity});
             my $pfree = $options{custom}->size_to_bytes(value => $detail->{physical_free_capacity});
-            # Un mdisk sans capacite physique n'est pas porte par des FCM
-            # (baie a disques classiques) : il ne compresse rien.
+            # An mdisk without physical capacity is not backed by FCMs (classic
+            # drives): it compresses nothing.
             next if (!defined($eff) || !defined($ptot) || !defined($pfree) || $ptot == 0);
 
             $effective += $eff;
@@ -312,8 +309,8 @@ sub manage_selection {
                 long_msg => 'Data reduction measured at the drive layer (FlashCore Module compression).'
             );
         } else {
-            # Le dire une fois, en sortie longue, plutot que de laisser deux
-            # compteurs vides encombrer la ligne de resume.
+            # Say it once, in the long output, rather than letting two empty
+            # counters clutter the summary line.
             $self->{output}->output_add(
                 long_msg => 'No data reduction active at any layer: no ratio to report.'
             );

--- a/src/storage/ibm/flashsystem/restapi/mode/capacity.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/capacity.pm
@@ -380,29 +380,95 @@ Example:
 
 Only check pools whose name matches this regular expression.
 
-=item B<--warning-physical-usage-prct> B<--critical-physical-usage-prct>
+=item B<--warning-physical-usage-prct>
+
+Warning threshold.
 
 Thresholds on the percentage of B<physical> capacity used. This is the one to
 set. No default is shipped: the right value depends on how long it takes to get
 an extension delivered, not on a general rule.
 
-=item B<--warning-physical-free> B<--critical-physical-free>
+=item B<--critical-physical-usage-prct>
+
+Critical threshold.
+
+Thresholds on the percentage of B<physical> capacity used. This is the one to
+set. No default is shipped: the right value depends on how long it takes to get
+an extension delivered, not on a general rule.
+
+=item B<--warning-physical-free>
+
+Warning threshold.
 
 Thresholds on the physical space left, in bytes. Useful when the answer is "we
 need N TB of headroom" rather than a percentage.
 
-=item B<--warning-overallocation> B<--critical-overallocation>
+=item B<--critical-physical-free>
+
+Critical threshold.
+
+Thresholds on the physical space left, in bytes. Useful when the answer is "we
+need N TB of headroom" rather than a percentage.
+
+=item B<--warning-overallocation>
+
+Warning threshold.
 
 Threshold on the over-allocation ratio, in percent.
 
-=item B<--unknown-pool-status> B<--warning-pool-status> B<--critical-pool-status>
+=item B<--critical-overallocation>
+
+Critical threshold.
+
+Threshold on the over-allocation ratio, in percent.
+
+=item B<--unknown-pool-status>
+
+Define the conditions to match for the status to be UNKNOWN.
 
 Threshold on each pool. Available macros: C<name>, C<status>,
 C<overallocation>, C<data_reduction>.
 
-Default critical: C<%{status} !~ /^online$/i>
+=item B<--warning-pool-status>
 
-=item B<--warning-pool-usage-prct> B<--critical-pool-usage-prct> B<--warning-pool-free> B<--critical-pool-free>
+Define the conditions to match for the status to be WARNING.
+
+Threshold on each pool. Available macros: C<name>, C<status>,
+C<overallocation>, C<data_reduction>.
+
+=item B<--critical-pool-status>
+
+Define the conditions to match for the status to be CRITICAL.
+
+Threshold on each pool. Available macros: C<name>, C<status>,
+C<overallocation>, C<data_reduction>.
+
+Default critical: C<%{status} !~ /^online$/i>.
+
+=item B<--warning-pool-usage-prct>
+
+Warning threshold.
+
+Thresholds per pool. Remember these are virtual figures on a FlashCore Module
+system.
+
+=item B<--critical-pool-usage-prct>
+
+Critical threshold.
+
+Thresholds per pool. Remember these are virtual figures on a FlashCore Module
+system.
+
+=item B<--warning-pool-free>
+
+Warning threshold.
+
+Thresholds per pool. Remember these are virtual figures on a FlashCore Module
+system.
+
+=item B<--critical-pool-free>
+
+Critical threshold.
 
 Thresholds per pool. Remember these are virtual figures on a FlashCore Module
 system.

--- a/src/storage/ibm/flashsystem/restapi/mode/capacity.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/capacity.pm
@@ -171,7 +171,7 @@ sub set_counters {
     $self->{maps_counters}->{pools} = [
         {
             label => 'pool-status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             critical_default => '%{status} !~ /^online$/i',
             set => {
                 key_values => [

--- a/src/storage/ibm/flashsystem/restapi/mode/capacity.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/capacity.pm
@@ -1,0 +1,414 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Remplissage de la baie.
+#
+# Piege central : sur une baie a FlashCore Modules, la capacite d'un pool est
+# une vue VIRTUELLE sur-allouee au-dessus du materiel. Un pool peut annoncer
+# 630 To libres alors qu'il reste 164 To physiques sur 311. Poser le seuil
+# d'alerte sur l'espace libre du pool revient donc a surveiller un chiffre sans
+# rapport avec le moment ou la baie sera pleine.
+#
+# Le seuil par defaut porte donc sur physical_free_capacity, remonte par
+# lssystem. Les chiffres du pool restent exposes en metrique, pour la tendance
+# et pour le taux de sur-allocation, mais ne declenchent rien d'eux-memes.
+#
+
+package storage::ibm::flashsystem::restapi::mode::capacity;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_pool_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        'status: %s, overallocation: %s%%, data reduction: %s',
+        $self->{result_values}->{status},
+        $self->{result_values}->{overallocation},
+        $self->{result_values}->{data_reduction}
+    );
+}
+
+sub prefix_physical_output {
+    my ($self, %options) = @_;
+
+    return 'Physical capacity: ';
+}
+
+sub prefix_logical_output {
+    my ($self, %options) = @_;
+
+    return 'Logical: ';
+}
+
+sub prefix_reduction_output {
+    my ($self, %options) = @_;
+
+    return 'Data reduction: ';
+}
+
+sub prefix_pool_output {
+    my ($self, %options) = @_;
+
+    return "Pool '" . $options{instance_value}->{name} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'physical', type => 0, cb_prefix_output => 'prefix_physical_output' },
+        { name => 'logical', type => 0, cb_prefix_output => 'prefix_logical_output' },
+        { name => 'reduction', type => 1, cb_prefix_output => 'prefix_reduction_output',
+          skipped_code => { -10 => 1 } },
+        { name => 'pools', type => 1, cb_prefix_output => 'prefix_pool_output',
+          message_multiple => 'All pools are online', skipped_code => { -10 => 1 } }
+    ];
+
+    # C'est ce compteur qui porte l'alerte. Les seuils par defaut restent
+    # volontairement larges : le bon reglage depend du delai d'appro d'une
+    # extension, pas d'une regle generale.
+    $self->{maps_counters}->{physical} = [
+        { label => 'physical-usage-prct', nlabel => 'system.physical.space.usage.percentage',
+          set => {
+                key_values => [ { name => 'physical_used_prct' } ],
+                output_template => 'used %.2f %%',
+                perfdatas => [ { template => '%.2f', unit => '%', min => 0, max => 100 } ]
+            }
+        },
+        # output_change_bytes convertit la valeur ET rend l'unite : le gabarit
+        # doit donc porter DEUX %s. Avec un seul, l'unite est perdue et la
+        # sortie affiche « used 146.45 » sans dire de quoi.
+        { label => 'physical-usage', nlabel => 'system.physical.space.usage.bytes', set => {
+                key_values => [ { name => 'physical_used' }, { name => 'physical_total' } ],
+                output_template => '%s %s',
+                output_change_bytes => 1,
+                perfdatas => [ { template => '%d', unit => 'B', min => 0, max => 'physical_total' } ]
+            }
+        },
+        { label => 'physical-free', nlabel => 'system.physical.space.free.bytes', set => {
+                key_values => [ { name => 'physical_free' }, { name => 'physical_total' } ],
+                output_template => 'free %s %s',
+                output_change_bytes => 1,
+                perfdatas => [ { template => '%d', unit => 'B', min => 0, max => 'physical_total' } ]
+            }
+        },
+        { label => 'overallocation', nlabel => 'system.space.overallocation.percentage', set => {
+                key_values => [ { name => 'overallocation' } ],
+                output_template => 'overallocation %s %%',
+                perfdatas => [ { template => '%s', unit => '%', min => 0 } ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{logical} = [
+        { label => 'logical-usage', nlabel => 'system.logical.space.usage.bytes', set => {
+                key_values => [ { name => 'logical_used' } ],
+                output_template => 'used %s %s',
+                output_change_bytes => 1,
+                perfdatas => [ { template => '%d', unit => 'B', min => 0 } ]
+            }
+        },
+        { label => 'logical-free', nlabel => 'system.logical.space.free.bytes', set => {
+                key_values => [ { name => 'logical_free' } ],
+                output_template => 'free %s %s',
+                output_change_bytes => 1,
+                perfdatas => [ { template => '%d', unit => 'B', min => 0 } ]
+            }
+        }
+    ];
+
+    # Ce que la reduction de donnees fait gagner. Le ratio parle mieux que les
+    # octets : « 2.40:1 » se compare d'une baie a l'autre et d'un mois a
+    # l'autre, « 12 To » non.
+    #
+    # Ces deux compteurs vivent dans un groupe A PART, et de type 1, pour une
+    # raison precise : un compteur de type 0 dont la valeur manque n'est pas
+    # tu, il s'affiche « skipped (no value(s)) ». Quand aucun pool n'active la
+    # reduction — le cas ici — cela mettait deux mentions de saut dans une
+    # sortie par ailleurs normale, qui se lisent comme une panne. Un groupe de
+    # type 1 laisse vide ne produit, lui, aucune sortie.
+    $self->{maps_counters}->{reduction} = [
+        { label => 'data-reduction-ratio', nlabel => 'system.data.reduction.ratio.count', set => {
+                key_values => [ { name => 'reduction_ratio' } ],
+                output_template => '%.2f:1',
+                perfdatas => [ { template => '%.2f', min => 0 } ]
+            }
+        },
+        { label => 'data-reduction-saved', nlabel => 'system.data.reduction.saved.bytes', set => {
+                key_values => [ { name => 'reduction_saved' } ],
+                output_template => 'saved %s %s',
+                output_change_bytes => 1,
+                perfdatas => [ { template => '%d', unit => 'B', min => 0 } ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{pools} = [
+        {
+            label => 'pool-status',
+            type => 2,
+            critical_default => '%{status} !~ /^online$/i',
+            set => {
+                key_values => [
+                    { name => 'name' }, { name => 'status' },
+                    { name => 'overallocation' }, { name => 'data_reduction' }
+                ],
+                closure_custom_output => $self->can('custom_pool_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        },
+        { label => 'pool-usage-prct', nlabel => 'pool.space.usage.percentage', set => {
+                key_values => [ { name => 'used_prct' }, { name => 'name' } ],
+                output_template => 'used %.2f %%',
+                perfdatas => [ { template => '%.2f', unit => '%', min => 0, max => 100,
+                                 label_extra_instance => 1, instance_use => 'name' } ]
+            }
+        },
+        { label => 'pool-free', nlabel => 'pool.space.free.bytes', set => {
+                key_values => [ { name => 'free' }, { name => 'name' } ],
+                output_template => 'free %s %s',
+                output_change_bytes => 1,
+                perfdatas => [ { template => '%d', unit => 'B', min => 0,
+                                 label_extra_instance => 1, instance_use => 'name' } ]
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-pool:s' => { name => 'filter_pool' }
+    });
+
+    return $self;
+}
+
+sub field {
+    my ($entry, $name) = @_;
+
+    return '-' if (!defined($entry->{$name}) || $entry->{$name} eq '');
+    return $entry->{$name};
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $system = $options{custom}->request(command => 'lssystem')->[0];
+
+    my $physical_total = $options{custom}->size_to_bytes(value => $system->{physical_capacity});
+    my $physical_free = $options{custom}->size_to_bytes(value => $system->{physical_free_capacity});
+
+    # Sans capacite physique, on est probablement sur un modele sans FlashCore
+    # Module. Plutot que d'inventer un chiffre, on le dit et on s'en tient aux
+    # pools, dont les seuils restent utilisables.
+    if (!defined($physical_total) || !defined($physical_free) || $physical_total == 0) {
+        $self->{output}->output_add(
+            long_msg => 'System reports no physical capacity: thresholds on pools only.',
+            severity => 'OK'
+        );
+        $self->{physical} = {};
+    } else {
+        my $physical_used = $physical_total - $physical_free;
+        $self->{physical} = {
+            physical_total => $physical_total,
+            physical_free => $physical_free,
+            physical_used => $physical_used,
+            physical_used_prct => $physical_used * 100 / $physical_total,
+            overallocation => field($system, 'total_overallocation')
+        };
+    }
+
+    $self->{logical} = {
+        logical_used => $options{custom}->size_to_bytes(value => $system->{total_used_capacity}),
+        logical_free => $options{custom}->size_to_bytes(value => $system->{total_free_space})
+    };
+
+    # Taux de reduction : rapport de ce qui a ete ecrit sur ce qui est
+    # reellement stocke. Les deux compteurs valent 0 quand aucun pool n'active
+    # la reduction de donnees — on ne publie alors ni ratio ni gain, plutot que
+    # d'afficher un 1:1 trompeur.
+    my $before = $options{custom}->size_to_bytes(value => $system->{used_capacity_before_reduction});
+    my $after = $options{custom}->size_to_bytes(value => $system->{used_capacity_after_reduction});
+
+    # La reduction de donnees peut se produire a DEUX etages, publies par des
+    # champs differents :
+    #
+    #   - la couche logicielle (Data Reduction Pools) : les compteurs
+    #     used_capacity_before/after_reduction de lssystem. Ils valent 0 des
+    #     que les pools sont en data_reduction=no.
+    #   - la compression MATERIELLE des FlashCore Modules, un etage plus bas,
+    #     dans les disques. Elle n'apparait QUE dans la vue detaillee des
+    #     mdisks (effective_used_capacity = ecrit avant compression, contre le
+    #     physique reellement consomme). C'est elle que la GUI appelle
+    #     « Data reduction » sur ces baies : 265.45/146.45 = 1.81:1, verifie
+    #     au dixieme pres contre l'affichage.
+    #
+    # On publie la couche active, en disant laquelle en sortie longue.
+    $self->{reduction} = {};
+    if (defined($before) && defined($after) && $after > 0) {
+        $self->{reduction}->{system} = {
+            reduction_ratio => $before / $after,
+            reduction_saved => $before - $after
+        };
+        $self->{output}->output_add(
+            long_msg => 'Data reduction measured at the pool layer (data reduction pools).'
+        );
+    } else {
+        my ($effective, $used) = (0, 0);
+        foreach my $mdisk (@{ $options{custom}->request_optional(command => 'lsmdisk') }) {
+            next unless (ref $mdisk eq 'HASH' && defined($mdisk->{id}) && $mdisk->{id} =~ /^\d+$/);
+            # La vue concise ne porte aucun de ces champs : il faut la vue
+            # detaillee, un appel par mdisk. Il y en a un ou deux par baie.
+            my $detail = $options{custom}->request_optional(command => 'lsmdisk/' . $mdisk->{id})->[0];
+            next unless (ref $detail eq 'HASH');
+
+            my $eff   = $options{custom}->size_to_bytes(value => $detail->{effective_used_capacity});
+            my $ptot  = $options{custom}->size_to_bytes(value => $detail->{physical_capacity});
+            my $pfree = $options{custom}->size_to_bytes(value => $detail->{physical_free_capacity});
+            # Un mdisk sans capacite physique n'est pas porte par des FCM
+            # (baie a disques classiques) : il ne compresse rien.
+            next if (!defined($eff) || !defined($ptot) || !defined($pfree) || $ptot == 0);
+
+            $effective += $eff;
+            $used += $ptot - $pfree;
+        }
+
+        if ($used > 0 && $effective > 0) {
+            $self->{reduction}->{system} = {
+                reduction_ratio => $effective / $used,
+                reduction_saved => $effective - $used
+            };
+            $self->{output}->output_add(
+                long_msg => 'Data reduction measured at the drive layer (FlashCore Module compression).'
+            );
+        } else {
+            # Le dire une fois, en sortie longue, plutot que de laisser deux
+            # compteurs vides encombrer la ligne de resume.
+            $self->{output}->output_add(
+                long_msg => 'No data reduction active at any layer: no ratio to report.'
+            );
+        }
+    }
+
+    $self->{pools} = {};
+    foreach my $pool (@{ $options{custom}->request(command => 'lsmdiskgrp') }) {
+        my $name = field($pool, 'name');
+        next if (defined($self->{option_results}->{filter_pool}) && $self->{option_results}->{filter_pool} ne ''
+            && $name !~ /$self->{option_results}->{filter_pool}/);
+
+        my $capacity = $options{custom}->size_to_bytes(value => $pool->{capacity});
+        my $free = $options{custom}->size_to_bytes(value => $pool->{free_capacity});
+
+        $self->{pools}->{$name} = {
+            name => $name,
+            status => field($pool, 'status'),
+            overallocation => field($pool, 'overallocation'),
+            data_reduction => field($pool, 'data_reduction'),
+            free => $free,
+            used_prct => (defined($capacity) && defined($free) && $capacity > 0)
+                ? ($capacity - $free) * 100 / $capacity
+                : undef
+        };
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check how full the system is.
+
+On a system fitted with FlashCore Modules, a pool's capacity is a B<virtual>,
+over-allocated view of the hardware: a pool can report 630 TB free while only
+164 TB of 311 remain physically. A threshold on the pool's free space therefore
+watches a number unrelated to the moment the array fills up.
+
+Thresholds are meant to be set on B<physical-usage-prct>, taken from
+C<lssystem>. Pool figures are still published as metrics — for the trend and for
+the over-allocation ratio — but only the pool B<status> alerts on its own.
+
+The data reduction ratio is read from whichever layer actually reduces:
+the software layer (data reduction pools, C<used_capacity_*_reduction>) when a
+pool enables it, otherwise the B<FlashCore Module hardware compression>, which
+only the detailed per-mdisk view exposes (C<effective_used_capacity> — written
+by hosts — against the physical capacity actually consumed). The long output
+names the layer being measured. This matches the GUI's "Data reduction" figure;
+the GUI's larger "Total savings" ratio additionally counts thin provisioning
+and is deliberately not reproduced — over-allocation is already published as
+its own metric.
+
+Example:
+
+    perl centreon_plugins.pl --plugin=storage::ibm::flashsystem::restapi::plugin \
+        --mode=capacity --hostname=10.0.0.1 \
+        --api-username=svc_monitor --api-password=xxx --insecure \
+        --warning-physical-usage-prct=75 --critical-physical-usage-prct=85
+
+=over 8
+
+=item B<--filter-pool>
+
+Only check pools whose name matches this regular expression.
+
+=item B<--warning-physical-usage-prct> B<--critical-physical-usage-prct>
+
+Thresholds on the percentage of B<physical> capacity used. This is the one to
+set. No default is shipped: the right value depends on how long it takes to get
+an extension delivered, not on a general rule.
+
+=item B<--warning-physical-free> B<--critical-physical-free>
+
+Thresholds on the physical space left, in bytes. Useful when the answer is "we
+need N TB of headroom" rather than a percentage.
+
+=item B<--warning-overallocation> B<--critical-overallocation>
+
+Threshold on the over-allocation ratio, in percent.
+
+=item B<--unknown-pool-status> B<--warning-pool-status> B<--critical-pool-status>
+
+Threshold on each pool. Available macros: C<name>, C<status>,
+C<overallocation>, C<data_reduction>.
+
+Default critical: C<%{status} !~ /^online$/i>
+
+=item B<--warning-pool-usage-prct> B<--critical-pool-usage-prct> B<--warning-pool-free> B<--critical-pool-free>
+
+Thresholds per pool. Remember these are virtual figures on a FlashCore Module
+system.
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/mode/capacity.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/capacity.pm
@@ -40,6 +40,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use centreon::plugins::constants qw/:counters :values/;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
 sub custom_pool_output {
@@ -81,12 +82,12 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'physical', type => 0, cb_prefix_output => 'prefix_physical_output' },
-        { name => 'logical', type => 0, cb_prefix_output => 'prefix_logical_output' },
-        { name => 'reduction', type => 1, cb_prefix_output => 'prefix_reduction_output',
-          skipped_code => { -10 => 1 } },
-        { name => 'pools', type => 1, cb_prefix_output => 'prefix_pool_output',
-          message_multiple => 'All pools are online', skipped_code => { -10 => 1 } }
+        { name => 'physical', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_physical_output' },
+        { name => 'logical', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_logical_output' },
+        { name => 'reduction', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_reduction_output',
+          skipped_code => { NO_VALUE() => 1 } },
+        { name => 'pools', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_pool_output',
+          message_multiple => 'All pools are online', skipped_code => { NO_VALUE() => 1 } }
     ];
 
     # This is the counter that carries the alert. No default is shipped: the

--- a/src/storage/ibm/flashsystem/restapi/mode/drives.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/drives.pm
@@ -111,7 +111,7 @@ sub set_counters {
         # status does not show.
         {
             label => 'status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             critical_default => '%{port_1_status} !~ /^online$/i and %{port_2_status} !~ /^online$/i',
             warning_default => '%{port_1_status} !~ /^online$/i or %{port_2_status} !~ /^online$/i or %{replacement_date} ne "-"',
             set => {

--- a/src/storage/ibm/flashsystem/restapi/mode/drives.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/drives.pm
@@ -21,26 +21,25 @@
 #
 
 #
-# Suivi des disques : usure, chemins et remplissage par disque.
+# Drive tracking: wear, paths and fill, per drive.
 #
-# La vue concise de lsdrive ne porte que le statut et la capacite. Tout ce qui
-# fait un SUIVI de disque vit dans la vue detaillee, un appel par disque :
+# The concise lsdrive view only carries status and capacity. Everything that
+# makes drive TRACKING lives in the detailed view, one call per drive:
 #
-#   write_endurance_used     usure du FlashCore Module, en % — la metrique de
-#                            long terme d'un disque flash
-#   port_1/2_status          les deux chemins NVMe vers le disque
-#   physical_used_capacity   remplissage physique reel du module
-#   replacement_date         renseigne quand IBM predit une fin de vie
+#   write_endurance_used     FlashCore Module wear, in % - the long-term
+#                            metric of a flash drive
+#   port_1/2_status          the two NVMe paths to the drive
+#   physical_used_capacity   real physical fill of the module
+#   replacement_date         set when IBM predicts an end of life
 #
-# Le STATUT du disque reste au mode hardware, qui couvre deja les 12 disques
-# parmi ses composants : le porter ici aussi doublerait chaque alerte. Ce mode
-# couvre ce que hardware ne voit pas — la redondance des chemins, l'usure et
-# le remplissage — et n'alerte par defaut que sur un chemin tombe ou une fin
-# de vie predite.
+# Drive STATUS stays with the hardware mode, which already covers every drive
+# among its components: carrying it here too would double each alert. This
+# mode covers what hardware does not see - path redundancy, wear and fill -
+# and by default only alerts on a fallen path or a predicted end of life.
 #
-# Les seuils d'usure ne sont pas codes ici : ils se posent dans la macro
-# EXTRAOPTIONS du modele de service (--warning-endurance=80
-# --critical-endurance=90), visibles et reglables dans Centreon.
+# Wear thresholds are not coded here: they are set on the service side
+# (--warning-endurance=80 --critical-endurance=90), visible and adjustable in
+# Centreon.
 #
 
 package storage::ibm::flashsystem::restapi::mode::drives;
@@ -62,8 +61,8 @@ sub custom_drive_output {
     );
     $msg .= sprintf(', firmware %s', $self->{result_values}->{firmware})
         if ($self->{result_values}->{firmware} ne '-');
-    # Une date de remplacement n'est renseignee que quand la baie predit une
-    # fin de vie : quand elle existe, c'est l'information la plus importante.
+    # A replacement date is only set when the array predicts an end of life:
+    # when it exists, it is the most important piece of information.
     $msg .= sprintf(', REPLACEMENT PREDICTED %s', $self->{result_values}->{replacement_date})
         if ($self->{result_values}->{replacement_date} ne '-');
 
@@ -106,9 +105,9 @@ sub set_counters {
     ];
 
     $self->{maps_counters}->{drives} = [
-        # Le statut du disque appartient au mode hardware : ici on surveille la
-        # REDONDANCE. Un chemin tombe pendant que le disque sert encore, c'est
-        # exactement le defaut qu'un statut global ne montre pas.
+        # Drive status belongs to the hardware mode: here we watch REDUNDANCY. A
+        # path down while the drive still serves is exactly the fault a global
+        # status does not show.
         {
             label => 'status',
             type => 2,
@@ -125,8 +124,8 @@ sub set_counters {
                 closure_custom_threshold_check => \&catalog_status_threshold_ng
             }
         },
-        # L'usure s'use dans un seul sens : la courbe est le vrai livrable, le
-        # seuil se pose dans la macro du modele de service.
+        # Wear only goes one way: the curve is the real deliverable, the threshold
+        # is set on the service side.
         { label => 'endurance', nlabel => 'drive.endurance.used.percentage', set => {
                 key_values => [ { name => 'endurance' }, { name => 'display' } ],
                 output_template => 'endurance used %s %%',
@@ -175,8 +174,8 @@ sub manage_selection {
         next if (defined($self->{option_results}->{filter_id}) && $self->{option_results}->{filter_id} ne ''
             && $drive->{id} !~ /$self->{option_results}->{filter_id}/);
 
-        # Tout ce qui fait le suivi est dans la vue detaillee. Une douzaine
-        # d'appels par controle : le jeton est en cache, le cout est faible.
+        # Everything that makes the tracking is in the detailed view. A dozen
+        # calls per check: the token is cached, the cost is low.
         my $detail = $options{custom}->request_optional(command => 'lsdrive/' . $drive->{id})->[0];
         $detail = $drive unless (ref $detail eq 'HASH');
 
@@ -192,7 +191,7 @@ sub manage_selection {
             replacement_date => field($detail, 'replacement_date'),
             firmware => field($detail, 'firmware_level')
         };
-        # firmware_level arrive avec des espaces de fin sur ces firmwares.
+        # firmware_level comes with trailing spaces on some firmwares.
         $entry->{firmware} =~ s/\s+$//;
 
         my $endurance = $detail->{write_endurance_used};

--- a/src/storage/ibm/flashsystem/restapi/mode/drives.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/drives.pm
@@ -48,6 +48,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use centreon::plugins::constants qw/:counters :values/;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
 sub custom_drive_output {
@@ -90,9 +91,9 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
-        { name => 'drives', type => 1, cb_prefix_output => 'prefix_drive_output',
-          message_multiple => 'All drives have both paths online', skipped_code => { -10 => 1 } }
+        { name => 'global', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_global_output' },
+        { name => 'drives', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_drive_output',
+          message_multiple => 'All drives have both paths online', skipped_code => { NO_VALUE() => 1 } }
     ];
 
     $self->{maps_counters}->{global} = [
@@ -207,8 +208,7 @@ sub manage_selection {
     }
 
     if ($self->{global}->{detected} == 0) {
-        $self->{output}->add_option_msg(short_msg => 'No drive returned by lsdrive.');
-        $self->{output}->option_exit();
+        $self->{output}->option_exit(short_msg => 'No drive returned by lsdrive.');
     }
 }
 

--- a/src/storage/ibm/flashsystem/restapi/mode/drives.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/drives.pm
@@ -1,0 +1,274 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Suivi des disques : usure, chemins et remplissage par disque.
+#
+# La vue concise de lsdrive ne porte que le statut et la capacite. Tout ce qui
+# fait un SUIVI de disque vit dans la vue detaillee, un appel par disque :
+#
+#   write_endurance_used     usure du FlashCore Module, en % — la metrique de
+#                            long terme d'un disque flash
+#   port_1/2_status          les deux chemins NVMe vers le disque
+#   physical_used_capacity   remplissage physique reel du module
+#   replacement_date         renseigne quand IBM predit une fin de vie
+#
+# Le STATUT du disque reste au mode hardware, qui couvre deja les 12 disques
+# parmi ses composants : le porter ici aussi doublerait chaque alerte. Ce mode
+# couvre ce que hardware ne voit pas — la redondance des chemins, l'usure et
+# le remplissage — et n'alerte par defaut que sur un chemin tombe ou une fin
+# de vie predite.
+#
+# Les seuils d'usure ne sont pas codes ici : ils se posent dans la macro
+# EXTRAOPTIONS du modele de service (--warning-endurance=80
+# --critical-endurance=90), visibles et reglables dans Centreon.
+#
+
+package storage::ibm::flashsystem::restapi::mode::drives;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_drive_output {
+    my ($self, %options) = @_;
+
+    my $msg = sprintf(
+        'paths %s/%s, use: %s',
+        $self->{result_values}->{port_1_status},
+        $self->{result_values}->{port_2_status},
+        $self->{result_values}->{use}
+    );
+    $msg .= sprintf(', firmware %s', $self->{result_values}->{firmware})
+        if ($self->{result_values}->{firmware} ne '-');
+    # Une date de remplacement n'est renseignee que quand la baie predit une
+    # fin de vie : quand elle existe, c'est l'information la plus importante.
+    $msg .= sprintf(', REPLACEMENT PREDICTED %s', $self->{result_values}->{replacement_date})
+        if ($self->{result_values}->{replacement_date} ne '-');
+
+    return $msg;
+}
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+
+    return 'Drives: ';
+}
+
+sub prefix_drive_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        "Drive '%s' (enclosure %s slot %s) ",
+        $options{instance_value}->{display},
+        $options{instance_value}->{enclosure},
+        $options{instance_value}->{slot}
+    );
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
+        { name => 'drives', type => 1, cb_prefix_output => 'prefix_drive_output',
+          message_multiple => 'All drives have both paths online', skipped_code => { -10 => 1 } }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'detected', nlabel => 'drives.detected.count', set => {
+                key_values => [ { name => 'detected' } ],
+                output_template => '%s detected',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{drives} = [
+        # Le statut du disque appartient au mode hardware : ici on surveille la
+        # REDONDANCE. Un chemin tombe pendant que le disque sert encore, c'est
+        # exactement le defaut qu'un statut global ne montre pas.
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '%{port_1_status} !~ /^online$/i and %{port_2_status} !~ /^online$/i',
+            warning_default => '%{port_1_status} !~ /^online$/i or %{port_2_status} !~ /^online$/i or %{replacement_date} ne "-"',
+            set => {
+                key_values => [
+                    { name => 'display' }, { name => 'use' },
+                    { name => 'port_1_status' }, { name => 'port_2_status' },
+                    { name => 'replacement_date' }, { name => 'firmware' }
+                ],
+                closure_custom_output => $self->can('custom_drive_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        },
+        # L'usure s'use dans un seul sens : la courbe est le vrai livrable, le
+        # seuil se pose dans la macro du modele de service.
+        { label => 'endurance', nlabel => 'drive.endurance.used.percentage', set => {
+                key_values => [ { name => 'endurance' }, { name => 'display' } ],
+                output_template => 'endurance used %s %%',
+                perfdatas => [ { template => '%s', unit => '%', min => 0, max => 100,
+                                 label_extra_instance => 1, instance_use => 'display' } ]
+            }
+        },
+        { label => 'physical-usage-prct', nlabel => 'drive.physical.space.usage.percentage', set => {
+                key_values => [ { name => 'physical_used_prct' }, { name => 'display' } ],
+                output_template => 'physical used %.2f %%',
+                perfdatas => [ { template => '%.2f', unit => '%', min => 0, max => 100,
+                                 label_extra_instance => 1, instance_use => 'display' } ]
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-id:s' => { name => 'filter_id' }
+    });
+
+    return $self;
+}
+
+sub field {
+    my ($entry, $name) = @_;
+
+    return '-' if (!defined($entry->{$name}) || $entry->{$name} eq '');
+    return $entry->{$name};
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    $self->{global} = { detected => 0 };
+    $self->{drives} = {};
+
+    foreach my $drive (@{ $options{custom}->request(command => 'lsdrive') }) {
+        next unless (ref $drive eq 'HASH' && defined($drive->{id}) && $drive->{id} =~ /^\d+$/);
+
+        next if (defined($self->{option_results}->{filter_id}) && $self->{option_results}->{filter_id} ne ''
+            && $drive->{id} !~ /$self->{option_results}->{filter_id}/);
+
+        # Tout ce qui fait le suivi est dans la vue detaillee. Une douzaine
+        # d'appels par controle : le jeton est en cache, le cout est faible.
+        my $detail = $options{custom}->request_optional(command => 'lsdrive/' . $drive->{id})->[0];
+        $detail = $drive unless (ref $detail eq 'HASH');
+
+        $self->{global}->{detected}++;
+
+        my $entry = {
+            display => $drive->{id},
+            enclosure => field($detail, 'enclosure_id'),
+            slot => field($detail, 'slot_id'),
+            use => field($detail, 'use'),
+            port_1_status => field($detail, 'port_1_status'),
+            port_2_status => field($detail, 'port_2_status'),
+            replacement_date => field($detail, 'replacement_date'),
+            firmware => field($detail, 'firmware_level')
+        };
+        # firmware_level arrive avec des espaces de fin sur ces firmwares.
+        $entry->{firmware} =~ s/\s+$//;
+
+        my $endurance = $detail->{write_endurance_used};
+        $entry->{endurance} = $endurance
+            if (defined($endurance) && $endurance =~ /^\d+(?:\.\d+)?$/);
+
+        my $ptot = $options{custom}->size_to_bytes(value => $detail->{physical_capacity});
+        my $pused = $options{custom}->size_to_bytes(value => $detail->{physical_used_capacity});
+        $entry->{physical_used_prct} = $pused * 100 / $ptot
+            if (defined($ptot) && defined($pused) && $ptot > 0);
+
+        $self->{drives}->{ $drive->{id} } = $entry;
+    }
+
+    if ($self->{global}->{detected} == 0) {
+        $self->{output}->add_option_msg(short_msg => 'No drive returned by lsdrive.');
+        $self->{output}->option_exit();
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Track the drives: FlashCore Module wear, NVMe paths and physical fill, per
+drive.
+
+The concise C<lsdrive> view only carries status and capacity; everything that
+makes drive B<tracking> lives in the detailed per-drive view (one call per
+drive): C<write_endurance_used>, the two path statuses, the physical fill and
+the predicted C<replacement_date>.
+
+Drive B<status> stays with the C<hardware> mode, which already covers every
+drive among its components — carrying it here too would double each alert.
+This mode alerts, by default, on a fallen path or a predicted end of life.
+
+Example:
+
+    perl centreon_plugins.pl --plugin=storage::ibm::flashsystem::restapi::plugin \
+        --mode=drives --hostname=10.0.0.1 \
+        --api-username=svc_monitor --api-password=xxx --insecure \
+        --warning-endurance=80 --critical-endurance=90
+
+=over 8
+
+=item B<--filter-id>
+
+Only check drives whose id matches this regular expression.
+
+=item B<--unknown-status> B<--warning-status> B<--critical-status>
+
+Threshold on each drive. Available macros: C<display>, C<use>,
+C<port_1_status>, C<port_2_status>, C<replacement_date>, C<firmware>.
+
+Default critical:
+C<%{port_1_status} !~ /^online$/i and %{port_2_status} !~ /^online$/i> — both
+NVMe paths down, the drive is unreachable.
+
+Default warning:
+C<%{port_1_status} !~ /^online$/i or %{port_2_status} !~ /^online$/i or %{replacement_date} ne "-">
+— one path left, or an end of life the array predicts.
+
+=item B<--warning-endurance> B<--critical-endurance>
+
+Thresholds on the FlashCore Module wear, in percent. No default in the code:
+the values are set in the service template macro (80/90 suggested). Observed
+on these arrays after their first months: 0 %.
+
+=item B<--warning-physical-usage-prct> B<--critical-physical-usage-prct>
+
+Thresholds on the physical fill of each module. The system-level threshold in
+the capacity mode is the one that matters; the per-drive figure exists to spot
+an unbalanced distribution.
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/mode/drives.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/drives.pm
@@ -243,26 +243,62 @@ Example:
 
 Only check drives whose id matches this regular expression.
 
-=item B<--unknown-status> B<--warning-status> B<--critical-status>
+=item B<--unknown-status>
+
+Define the conditions to match for the status to be UNKNOWN.
+
+Threshold on each drive. Available macros: C<display>, C<use>,
+C<port_1_status>, C<port_2_status>, C<replacement_date>, C<firmware>.
+
+=item B<--warning-status>
+
+Define the conditions to match for the status to be WARNING.
+
+Threshold on each drive. Available macros: C<display>, C<use>,
+C<port_1_status>, C<port_2_status>, C<replacement_date>, C<firmware>.
+
+Default warning:
+C<%{port_1_status} !~ /^online$/i or %{port_2_status} !~ /^online$/i or %{replacement_date} ne "-">.
+— one path left, or an end of life the array predicts.
+
+=item B<--critical-status>
+
+Define the conditions to match for the status to be CRITICAL.
 
 Threshold on each drive. Available macros: C<display>, C<use>,
 C<port_1_status>, C<port_2_status>, C<replacement_date>, C<firmware>.
 
 Default critical:
-C<%{port_1_status} !~ /^online$/i and %{port_2_status} !~ /^online$/i> — both
+C<%{port_1_status} !~ /^online$/i and %{port_2_status} !~ /^online$/i> - both.
 NVMe paths down, the drive is unreachable.
 
-Default warning:
-C<%{port_1_status} !~ /^online$/i or %{port_2_status} !~ /^online$/i or %{replacement_date} ne "-">
-— one path left, or an end of life the array predicts.
+=item B<--warning-endurance>
 
-=item B<--warning-endurance> B<--critical-endurance>
+Warning threshold.
 
 Thresholds on the FlashCore Module wear, in percent. No default in the code:
 the values are set in the service template macro (80/90 suggested). Observed
 on these arrays after their first months: 0 %.
 
-=item B<--warning-physical-usage-prct> B<--critical-physical-usage-prct>
+=item B<--critical-endurance>
+
+Critical threshold.
+
+Thresholds on the FlashCore Module wear, in percent. No default in the code:
+the values are set in the service template macro (80/90 suggested). Observed
+on these arrays after their first months: 0 %.
+
+=item B<--warning-physical-usage-prct>
+
+Warning threshold.
+
+Thresholds on the physical fill of each module. The system-level threshold in
+the capacity mode is the one that matters; the per-drive figure exists to spot
+an unbalanced distribution.
+
+=item B<--critical-physical-usage-prct>
+
+Critical threshold.
 
 Thresholds on the physical fill of each module. The system-level threshold in
 the capacity mode is the one that matters; the per-drive figure exists to spot

--- a/src/storage/ibm/flashsystem/restapi/mode/drives.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/drives.pm
@@ -112,8 +112,10 @@ sub set_counters {
         {
             label => 'status',
             type => COUNTER_KIND_TEXT,
-            critical_default => '%{port_1_status} !~ /^online$/i and %{port_2_status} !~ /^online$/i',
-            warning_default => '%{port_1_status} !~ /^online$/i or %{port_2_status} !~ /^online$/i or %{replacement_date} ne "-"',
+            # A path state of '-' means the detailed view was not available
+            # (older firmware): unknown is not down.
+            critical_default => '%{port_1_status} ne "-" and %{port_2_status} ne "-" and %{port_1_status} !~ /^online$/i and %{port_2_status} !~ /^online$/i',
+            warning_default => '(%{port_1_status} ne "-" and %{port_1_status} !~ /^online$/i) or (%{port_2_status} ne "-" and %{port_2_status} !~ /^online$/i) or %{replacement_date} ne "-"',
             set => {
                 key_values => [
                     { name => 'display' }, { name => 'use' },
@@ -258,7 +260,7 @@ Threshold on each drive. Available macros: C<display>, C<use>,
 C<port_1_status>, C<port_2_status>, C<replacement_date>, C<firmware>.
 
 Default warning:
-C<%{port_1_status} !~ /^online$/i or %{port_2_status} !~ /^online$/i or %{replacement_date} ne "-">.
+C<(%{port_1_status} ne "-" and %{port_1_status} !~ /^online$/i) or (%{port_2_status} ne "-" and %{port_2_status} !~ /^online$/i) or %{replacement_date} ne "-">.
 — one path left, or an end of life the array predicts.
 
 =item B<--critical-status>
@@ -269,7 +271,7 @@ Threshold on each drive. Available macros: C<display>, C<use>,
 C<port_1_status>, C<port_2_status>, C<replacement_date>, C<firmware>.
 
 Default critical:
-C<%{port_1_status} !~ /^online$/i and %{port_2_status} !~ /^online$/i> - both.
+C<%{port_1_status} ne "-" and %{port_2_status} ne "-" and %{port_1_status} !~ /^online$/i and %{port_2_status} !~ /^online$/i> - both.
 NVMe paths down, the drive is unreachable.
 
 =item B<--warning-endurance>

--- a/src/storage/ibm/flashsystem/restapi/mode/ethports.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/ethports.pm
@@ -1,0 +1,312 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Ports Ethernet et IP.
+#
+# Deux commandes, deux objets differents, et la confusion est facile :
+#
+#   lsportethernet  le port PHYSIQUE. link_state, vitesse negociee, et les
+#                   drapeaux qui disent a quoi il sert : management, host,
+#                   storage, replication.
+#   lsportip        la configuration IP posee dessus. Une entree par port et par
+#                   usage, d'ou plusieurs lignes pour un meme port physique.
+#
+# Sur les baies relevees, les 12 entrees IP sont 'unconfigured' — l'iSCSI n'est
+# pas utilise, tout passe en Fibre Channel — et 2 des 6 ports physiques sont
+# actifs a 1 Gb/s. Le mode ne considere donc pas un port inactif comme une
+# panne : un port non cable est un choix de cablage, pas un defaut.
+#
+# ATTENTION aux drapeaux management/host/storage/replication : ce sont les
+# usages AUTORISES sur le port, pas les usages en cours. La premiere version de
+# ce mode alertait sur « porte un role et lien inactif », ce qui a mis les
+# quatre ports non cables en CRITICAL permanent — ils portent tous les roles
+# parce que rien ne les interdit, pas parce qu'ils servent. Le seul signe qu'un
+# port est reellement en service est une adresse IP configuree dessus.
+#
+
+package storage::ibm::flashsystem::restapi::mode::ethports;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+# Drapeaux de lsportethernet qui donnent un role au port. Un port sans aucun
+# role n'est pas surveille : il n'est simplement pas utilise.
+my $ROLES = [
+    { field => 'management',  label => 'management' },
+    { field => 'host',        label => 'host' },
+    { field => 'storage',     label => 'storage' },
+    { field => 'replication', label => 'replication' }
+];
+
+sub custom_port_output {
+    my ($self, %options) = @_;
+
+    my $msg = sprintf('link %s', $self->{result_values}->{link_state});
+
+    $msg .= sprintf(', speed %s', $self->{result_values}->{speed})
+        if ($self->{result_values}->{speed} ne '-');
+    $msg .= sprintf(', roles: %s', $self->{result_values}->{roles})
+        if ($self->{result_values}->{roles} ne '-');
+    $msg .= sprintf(', %s', $self->{result_values}->{ip})
+        if ($self->{result_values}->{ip} ne '-');
+
+    return $msg;
+}
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+
+    return 'Ethernet ports: ';
+}
+
+sub prefix_port_output {
+    my ($self, %options) = @_;
+
+    return "Port '" . $options{instance_value}->{name} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
+        { name => 'ports', type => 1, cb_prefix_output => 'prefix_port_output',
+          message_multiple => 'All Ethernet ports in service are active',
+          skipped_code => { -10 => 1 } }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'detected', nlabel => 'ethports.detected.count', set => {
+                key_values => [ { name => 'detected' } ],
+                output_template => '%s detected',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'active', nlabel => 'ethports.active.count', set => {
+                key_values => [ { name => 'active' } ],
+                output_template => '%s active',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        # « role-capable » et non « carrying a role » : les drapeaux disent ce
+        # qu'un port a le droit de porter. Les six le peuvent, deux servent.
+        # Le compteur qui dit combien servent vraiment, c'est ip-configured.
+        { label => 'with-role', nlabel => 'ethports.withrole.count', set => {
+                key_values => [ { name => 'with_role' } ],
+                output_template => '%s role-capable',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'ip-configured', nlabel => 'ethports.ip.configured.count', set => {
+                key_values => [ { name => 'ip_configured' } ],
+                output_template => '%s IP configured',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        }
+    ];
+
+    # Un port inactif non configure est normal : il n'est pas cable. Le seuil
+    # ne porte que sur les ports qui portent une adresse IP, seul signe qu'ils
+    # sont reellement en service.
+    $self->{maps_counters}->{ports} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '%{configured} eq "yes" and %{link_state} !~ /^active$/i',
+            set => {
+                key_values => [
+                    { name => 'name' }, { name => 'link_state' }, { name => 'speed' },
+                    { name => 'roles' }, { name => 'ip' }, { name => 'node_name' },
+                    { name => 'port_id' }, { name => 'configured' }
+                ],
+                closure_custom_output => $self->can('custom_port_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s'  => { name => 'filter_name' },
+        'add-unused'     => { name => 'add_unused' }
+    });
+
+    return $self;
+}
+
+sub field {
+    my ($entry, $name) = @_;
+
+    return '-' if (!defined($entry->{$name}) || $entry->{$name} eq '');
+    return $entry->{$name};
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    # lsportip a plusieurs entrees par port physique, indexees par 'id' et non
+    # par 'port_id'. On garde la premiere adresse reellement configuree.
+    my %addresses;
+    my $ip_configured = 0;
+    foreach my $entry (@{ $options{custom}->request_optional(command => 'lsportip') }) {
+        next unless (ref $entry eq 'HASH');
+        my $state = field($entry, 'state');
+        next if ($state =~ /^unconfigured$/i);
+        $ip_configured++;
+
+        my $key = field($entry, 'node_name') . '-' . field($entry, 'id');
+        my $address = field($entry, 'IP_address');
+        $addresses{$key} = $address if ($address ne '-' && !exists($addresses{$key}));
+    }
+
+    $self->{global} = { detected => 0, active => 0, with_role => 0, ip_configured => $ip_configured };
+    $self->{ports} = {};
+
+    foreach my $port (@{ $options{custom}->request(command => 'lsportethernet') }) {
+        my $name = field($port, 'node_name') . '-' . field($port, 'port_id');
+
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $name !~ /$self->{option_results}->{filter_name}/);
+
+        my $link = field($port, 'link_state');
+
+        # Un port « porte un role » des qu'un des drapeaux est arme. Les valeurs
+        # observees sont 'yes'/'no', mais certains firmwares rendent le nom du
+        # role : on accepte tout ce qui n'est ni vide ni 'no'.
+        my @roles;
+        foreach my $role (@$ROLES) {
+            my $value = field($port, $role->{field});
+            push @roles, $role->{label} if ($value ne '-' && $value !~ /^no$/i);
+        }
+        my $roles = @roles ? join('/', @roles) : '-';
+
+        $self->{global}->{detected}++;
+        $self->{global}->{active}++ if ($link =~ /^active$/i);
+        $self->{global}->{with_role}++ if ($roles ne '-');
+
+        my $configured = exists($addresses{$name}) ? 'yes' : 'no';
+
+        # Ni adresse ni lien : le port n'est pas cable. L'exposer ferait du
+        # bruit permanent. --add-unused le rend visible quand on veut
+        # l'inventaire complet.
+        next if ($configured eq 'no' && $link !~ /^active$/i
+                 && !defined($self->{option_results}->{add_unused}));
+
+        $self->{ports}->{$name} = {
+            name => $name,
+            link_state => $link,
+            speed => field($port, 'speed'),
+            roles => $roles,
+            ip => exists($addresses{$name}) ? $addresses{$name} : '-',
+            node_name => field($port, 'node_name'),
+            port_id => field($port, 'port_id'),
+            configured => $configured
+        };
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check the Ethernet ports and their IP configuration.
+
+Two commands describe two different things, and mixing them up is easy:
+
+=over 4
+
+=item * C<lsportethernet> is the B<physical> port: link state, negotiated speed,
+and the flags saying what it is used for — management, host, storage,
+replication.
+
+=item * C<lsportip> is the IP configuration laid on top. There is one entry per
+port B<and per use>, so a single physical port produces several rows, keyed on
+C<id> rather than C<port_id>.
+
+=back
+
+On the arrays surveyed, all twelve IP entries are C<unconfigured> — iSCSI is not
+used, everything goes over Fibre Channel — and two of the six physical ports are
+active at 1 Gb/s.
+
+So an inactive port is B<not> treated as a fault: an uncabled port is a cabling
+choice, not a defect, and alerting on it would produce permanent noise.
+
+B<Do not threshold on the role flags.> C<management>, C<host>, C<storage> and
+C<replication> report what a port is B<allowed> to carry, not what it currently
+carries: an uncabled port has them all set simply because nothing forbids them.
+Thresholding on "carries a role and link is down" put all four uncabled ports in
+permanent CRITICAL. The one reliable sign that a port is in service is an IP
+address configured on it, which is what the default threshold uses.
+
+Example:
+
+    perl centreon_plugins.pl --plugin=storage::ibm::flashsystem::restapi::plugin \
+        --mode=eth-ports --hostname=10.0.0.1 \
+        --api-username=svc_monitor --api-password=xxx --insecure
+
+=over 8
+
+=item B<--filter-name>
+
+Only check ports whose C<node-port> name matches this regular expression.
+
+=item B<--add-unused>
+
+Also report ports that carry no role and have no link — the full inventory
+rather than just what is in service.
+
+=item B<--unknown-status> B<--warning-status> B<--critical-status>
+
+Threshold on each port. Available macros: C<name>, C<link_state>, C<speed>,
+C<roles>, C<ip>, C<node_name>, C<port_id>, C<configured>.
+
+Default critical: C<%{configured} eq "yes" and %{link_state} !~ /^active$/i>
+
+To also require a negotiated speed on the management ports:
+
+    --warning-status='%{roles} =~ /management/ && %{speed} !~ /^1Gb/'
+
+With no iSCSI in service, no port carries an address and the mode reports the
+inventory without ever alerting. That is the intended behaviour: it starts
+alerting by itself the day an address is configured.
+
+=item B<--warning-active> B<--critical-active> B<--warning-with-role> B<--critical-with-role> B<--warning-ip-configured> B<--critical-ip-configured>
+
+Thresholds on the counts. C<ip-configured> is worth watching if iSCSI is ever
+put into service: it stays at zero as long as nothing is configured.
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/mode/ethports.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/ethports.pm
@@ -50,6 +50,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use centreon::plugins::constants qw/:counters :values/;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
 # lsportethernet flags giving a role to the port. A port without any role is
@@ -92,10 +93,10 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
-        { name => 'ports', type => 1, cb_prefix_output => 'prefix_port_output',
+        { name => 'global', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_global_output' },
+        { name => 'ports', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_port_output',
           message_multiple => 'All Ethernet ports in service are active',
-          skipped_code => { -10 => 1 } }
+          skipped_code => { NO_VALUE() => 1 } }
     ];
 
     $self->{maps_counters}->{global} = [

--- a/src/storage/ibm/flashsystem/restapi/mode/ethports.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/ethports.pm
@@ -135,7 +135,7 @@ sub set_counters {
     $self->{maps_counters}->{ports} = [
         {
             label => 'status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             critical_default => '%{configured} eq "yes" and %{link_state} !~ /^active$/i',
             set => {
                 key_values => [

--- a/src/storage/ibm/flashsystem/restapi/mode/ethports.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/ethports.pm
@@ -247,11 +247,15 @@ Two commands describe two different things, and mixing them up is easy:
 
 =over 4
 
-=item * C<lsportethernet> is the B<physical> port: link state, negotiated speed,
+=item *
+
+C<lsportethernet> is the B<physical> port: link state, negotiated speed,
 and the flags saying what it is used for — management, host, storage,
 replication.
 
-=item * C<lsportip> is the IP configuration laid on top. There is one entry per
+=item *
+
+C<lsportip> is the IP configuration laid on top. There is one entry per
 port B<and per use>, so a single physical port produces several rows, keyed on
 C<id> rather than C<port_id>.
 
@@ -288,12 +292,12 @@ Only check ports whose C<node-port> name matches this regular expression.
 Also report ports that carry no role and have no link — the full inventory
 rather than just what is in service.
 
-=item B<--unknown-status> B<--warning-status> B<--critical-status>
+=item B<--unknown-status>
+
+Define the conditions to match for the status to be UNKNOWN.
 
 Threshold on each port. Available macros: C<name>, C<link_state>, C<speed>,
 C<roles>, C<ip>, C<node_name>, C<port_id>, C<configured>.
-
-Default critical: C<%{configured} eq "yes" and %{link_state} !~ /^active$/i>
 
 To also require a negotiated speed on the management ports:
 
@@ -303,7 +307,76 @@ With no iSCSI in service, no port carries an address and the mode reports the
 inventory without ever alerting. That is the intended behaviour: it starts
 alerting by itself the day an address is configured.
 
-=item B<--warning-active> B<--critical-active> B<--warning-with-role> B<--critical-with-role> B<--warning-ip-configured> B<--critical-ip-configured>
+=item B<--warning-status>
+
+Define the conditions to match for the status to be WARNING.
+
+Threshold on each port. Available macros: C<name>, C<link_state>, C<speed>,
+C<roles>, C<ip>, C<node_name>, C<port_id>, C<configured>.
+
+To also require a negotiated speed on the management ports:
+
+    --warning-status='%{roles} =~ /management/ && %{speed} !~ /^1Gb/'
+
+With no iSCSI in service, no port carries an address and the mode reports the
+inventory without ever alerting. That is the intended behaviour: it starts
+alerting by itself the day an address is configured.
+
+=item B<--critical-status>
+
+Define the conditions to match for the status to be CRITICAL.
+
+Threshold on each port. Available macros: C<name>, C<link_state>, C<speed>,
+C<roles>, C<ip>, C<node_name>, C<port_id>, C<configured>.
+
+Default critical: C<%{configured} eq "yes" and %{link_state} !~ /^active$/i>.
+
+To also require a negotiated speed on the management ports:
+
+    --warning-status='%{roles} =~ /management/ && %{speed} !~ /^1Gb/'
+
+With no iSCSI in service, no port carries an address and the mode reports the
+inventory without ever alerting. That is the intended behaviour: it starts
+alerting by itself the day an address is configured.
+
+=item B<--warning-active>
+
+Warning threshold.
+
+Thresholds on the counts. C<ip-configured> is worth watching if iSCSI is ever
+put into service: it stays at zero as long as nothing is configured.
+
+=item B<--critical-active>
+
+Critical threshold.
+
+Thresholds on the counts. C<ip-configured> is worth watching if iSCSI is ever
+put into service: it stays at zero as long as nothing is configured.
+
+=item B<--warning-with-role>
+
+Warning threshold.
+
+Thresholds on the counts. C<ip-configured> is worth watching if iSCSI is ever
+put into service: it stays at zero as long as nothing is configured.
+
+=item B<--critical-with-role>
+
+Critical threshold.
+
+Thresholds on the counts. C<ip-configured> is worth watching if iSCSI is ever
+put into service: it stays at zero as long as nothing is configured.
+
+=item B<--warning-ip-configured>
+
+Warning threshold.
+
+Thresholds on the counts. C<ip-configured> is worth watching if iSCSI is ever
+put into service: it stays at zero as long as nothing is configured.
+
+=item B<--critical-ip-configured>
+
+Critical threshold.
 
 Thresholds on the counts. C<ip-configured> is worth watching if iSCSI is ever
 put into service: it stays at zero as long as nothing is configured.

--- a/src/storage/ibm/flashsystem/restapi/mode/ethports.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/ethports.pm
@@ -21,27 +21,27 @@
 #
 
 #
-# Ports Ethernet et IP.
+# Ethernet and IP ports.
 #
-# Deux commandes, deux objets differents, et la confusion est facile :
+# Two commands, two different objects, and mixing them up is easy:
 #
-#   lsportethernet  le port PHYSIQUE. link_state, vitesse negociee, et les
-#                   drapeaux qui disent a quoi il sert : management, host,
-#                   storage, replication.
-#   lsportip        la configuration IP posee dessus. Une entree par port et par
-#                   usage, d'ou plusieurs lignes pour un meme port physique.
+#   lsportethernet  the PHYSICAL port: link_state, negotiated speed, and the
+#                   flags saying what it is for - management, host, storage,
+#                   replication.
+#   lsportip        the IP configuration laid on top. One entry per port and
+#                   per use, hence several rows for one physical port.
 #
-# Sur les baies relevees, les 12 entrees IP sont 'unconfigured' — l'iSCSI n'est
-# pas utilise, tout passe en Fibre Channel — et 2 des 6 ports physiques sont
-# actifs a 1 Gb/s. Le mode ne considere donc pas un port inactif comme une
-# panne : un port non cable est un choix de cablage, pas un defaut.
+# On the arrays surveyed, all 12 IP entries were 'unconfigured' - iSCSI not in
+# use, everything over Fibre Channel - and 2 of the 6 physical ports were
+# active at 1 Gb/s. So the mode does not treat an inactive port as a fault: an
+# uncabled port is a cabling choice, not a defect.
 #
-# ATTENTION aux drapeaux management/host/storage/replication : ce sont les
-# usages AUTORISES sur le port, pas les usages en cours. La premiere version de
-# ce mode alertait sur « porte un role et lien inactif », ce qui a mis les
-# quatre ports non cables en CRITICAL permanent — ils portent tous les roles
-# parce que rien ne les interdit, pas parce qu'ils servent. Le seul signe qu'un
-# port est reellement en service est une adresse IP configuree dessus.
+# BEWARE of the management/host/storage/replication flags: they are the uses
+# ALLOWED on the port, not the uses in progress. The first version of this
+# mode alerted on "carries a role and link inactive", which put the four
+# uncabled ports in permanent CRITICAL - they carry every role because nothing
+# forbids it, not because they serve. The one sign a port is really in service
+# is an IP address configured on it.
 #
 
 package storage::ibm::flashsystem::restapi::mode::ethports;
@@ -52,8 +52,8 @@ use strict;
 use warnings;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
-# Drapeaux de lsportethernet qui donnent un role au port. Un port sans aucun
-# role n'est pas surveille : il n'est simplement pas utilise.
+# lsportethernet flags giving a role to the port. A port without any role is
+# not watched: it is simply not used.
 my $ROLES = [
     { field => 'management',  label => 'management' },
     { field => 'host',        label => 'host' },
@@ -111,9 +111,9 @@ sub set_counters {
                 perfdatas => [ { template => '%s', min => 0 } ]
             }
         },
-        # « role-capable » et non « carrying a role » : les drapeaux disent ce
-        # qu'un port a le droit de porter. Les six le peuvent, deux servent.
-        # Le compteur qui dit combien servent vraiment, c'est ip-configured.
+        # "role-capable" and not "carrying a role": the flags say what a port is
+        # allowed to carry. All six can, two serve. The counter that says how
+        # many really serve is ip-configured.
         { label => 'with-role', nlabel => 'ethports.withrole.count', set => {
                 key_values => [ { name => 'with_role' } ],
                 output_template => '%s role-capable',
@@ -128,9 +128,9 @@ sub set_counters {
         }
     ];
 
-    # Un port inactif non configure est normal : il n'est pas cable. Le seuil
-    # ne porte que sur les ports qui portent une adresse IP, seul signe qu'ils
-    # sont reellement en service.
+    # An inactive, unconfigured port is normal: it is not cabled. The threshold
+    # only covers ports carrying an IP address, the one sign they are really
+    # in service.
     $self->{maps_counters}->{ports} = [
         {
             label => 'status',
@@ -173,8 +173,8 @@ sub field {
 sub manage_selection {
     my ($self, %options) = @_;
 
-    # lsportip a plusieurs entrees par port physique, indexees par 'id' et non
-    # par 'port_id'. On garde la premiere adresse reellement configuree.
+    # lsportip has several entries per physical port, keyed on 'id' and not on
+    # 'port_id'. The first really configured address is kept.
     my %addresses;
     my $ip_configured = 0;
     foreach my $entry (@{ $options{custom}->request_optional(command => 'lsportip') }) {
@@ -199,9 +199,9 @@ sub manage_selection {
 
         my $link = field($port, 'link_state');
 
-        # Un port « porte un role » des qu'un des drapeaux est arme. Les valeurs
-        # observees sont 'yes'/'no', mais certains firmwares rendent le nom du
-        # role : on accepte tout ce qui n'est ni vide ni 'no'.
+        # A port "carries a role" as soon as one flag is set. Observed values
+        # are 'yes'/'no', but some firmwares return the role name: anything that
+        # is neither empty nor 'no' is accepted.
         my @roles;
         foreach my $role (@$ROLES) {
             my $value = field($port, $role->{field});
@@ -215,9 +215,9 @@ sub manage_selection {
 
         my $configured = exists($addresses{$name}) ? 'yes' : 'no';
 
-        # Ni adresse ni lien : le port n'est pas cable. L'exposer ferait du
-        # bruit permanent. --add-unused le rend visible quand on veut
-        # l'inventaire complet.
+        # Neither address nor link: the port is not cabled. Exposing it would
+        # make permanent noise. --add-unused shows it when the full inventory
+        # is wanted.
         next if ($configured eq 'no' && $link !~ /^active$/i
                  && !defined($self->{option_results}->{add_unused}));
 

--- a/src/storage/ibm/flashsystem/restapi/mode/eventlog.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/eventlog.pm
@@ -40,6 +40,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use centreon::plugins::constants qw/:counters :values/;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
 sub custom_event_output {
@@ -77,9 +78,9 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
-        { name => 'events', type => 1, cb_prefix_output => 'prefix_event_output',
-          message_multiple => 'No actionable event', skipped_code => { -10 => 1 } }
+        { name => 'global', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_global_output' },
+        { name => 'events', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_event_output',
+          message_multiple => 'No actionable event', skipped_code => { NO_VALUE() => 1 } }
     ];
 
     $self->{maps_counters}->{global} = [

--- a/src/storage/ibm/flashsystem/restapi/mode/eventlog.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/eventlog.pm
@@ -228,20 +228,73 @@ Example:
 Regular expression selecting which entries become checkable instances
 (default: C<^alert$>). Set it to C<.> to also evaluate informational messages.
 
-=item B<--filter-error-code> B<--filter-event-id> B<--filter-object-type> B<--filter-object-name>
+=item B<--filter-error-code>
 
 Further restrict the selected entries. Empty by default: nothing is hidden
 unless it is explicitly excluded.
 
-=item B<--unknown-event-status> B<--warning-event-status> B<--critical-event-status>
+=item B<--filter-event-id>
+
+Further restrict the selected entries. Empty by default: nothing is hidden
+unless it is explicitly excluded.
+
+=item B<--filter-object-type>
+
+Further restrict the selected entries. Empty by default: nothing is hidden
+unless it is explicitly excluded.
+
+=item B<--filter-object-name>
+
+Further restrict the selected entries. Empty by default: nothing is hidden
+unless it is explicitly excluded.
+
+=item B<--unknown-event-status>
+
+Define the conditions to match for the status to be UNKNOWN.
 
 Threshold on each selected entry. Available macros: C<status>, C<error_code>,
 C<event_id>, C<object_type>, C<object_name>, C<description>,
 C<last_timestamp>, C<sequence_number>.
 
-Default critical: C<%{status} =~ /^alert$/i>
+=item B<--warning-event-status>
 
-=item B<--warning-alerts> B<--critical-alerts> B<--warning-messages> B<--critical-messages>
+Define the conditions to match for the status to be WARNING.
+
+Threshold on each selected entry. Available macros: C<status>, C<error_code>,
+C<event_id>, C<object_type>, C<object_name>, C<description>,
+C<last_timestamp>, C<sequence_number>.
+
+=item B<--critical-event-status>
+
+Define the conditions to match for the status to be CRITICAL.
+
+Threshold on each selected entry. Available macros: C<status>, C<error_code>,
+C<event_id>, C<object_type>, C<object_name>, C<description>,
+C<last_timestamp>, C<sequence_number>.
+
+Default critical: C<%{status} =~ /^alert$/i>.
+
+=item B<--warning-alerts>
+
+Warning threshold.
+
+Thresholds on the number of unfixed alerts and messages.
+
+=item B<--critical-alerts>
+
+Critical threshold.
+
+Thresholds on the number of unfixed alerts and messages.
+
+=item B<--warning-messages>
+
+Warning threshold.
+
+Thresholds on the number of unfixed alerts and messages.
+
+=item B<--critical-messages>
+
+Critical threshold.
 
 Thresholds on the number of unfixed alerts and messages.
 

--- a/src/storage/ibm/flashsystem/restapi/mode/eventlog.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/eventlog.pm
@@ -21,17 +21,17 @@
 #
 
 #
-# Journal d'evenements non resolus.
+# Unresolved event log.
 #
-# Piege central de cette commande : filtrer sur 'fixed=no' seul ne suffit pas.
-# Le journal melange des entrees 'alert', qui appellent une action, et des
-# entrees 'message' purement informatives, qui ne se resolvent jamais parce
-# qu'un message ne se corrige pas. Une baie peut ainsi porter des centaines
-# d'entrees non resolues sans qu'aucune ne soit un probleme.
+# Central trap of this command: filtering on 'fixed=no' alone is not enough.
+# The log mixes 'alert' entries, which call for an action, with purely
+# informational 'message' entries, which never get resolved because a message
+# cannot be fixed. An array can thus carry hundreds of unresolved entries with
+# none of them being a problem.
 #
-# Ce sont les entrees 'alert' qui reproduisent le panneau "Recommended Actions"
-# de l'interface. Les 'message' sont comptes et exposes en metrique, mais ne
-# declenchent rien par defaut.
+# The 'alert' entries are what reproduce the GUI "Recommended Actions" panel.
+# The 'message' entries are counted and exposed as a metric, but trigger
+# nothing by default.
 #
 
 package storage::ibm::flashsystem::restapi::mode::eventlog;
@@ -97,8 +97,8 @@ sub set_counters {
         }
     ];
 
-    # Toute entree retenue est signalee : le tri a deja eu lieu au moment de la
-    # selection. On ne masque rien ici.
+    # Every retained entry is reported: the sorting already happened at
+    # selection time. Nothing is hidden here.
     $self->{maps_counters}->{events} = [
         {
             label => 'event-status',
@@ -144,17 +144,17 @@ sub field {
 sub manage_selection {
     my ($self, %options) = @_;
 
-    # Le tri se fait cote plugin plutot que dans le filtervalue de l'API : on
-    # veut compter les 'message' pour les exposer en metrique, sans les
-    # transformer en instances a evaluer.
+    # The sorting is done plugin-side rather than in the API filtervalue: the
+    # 'message' entries are counted to be exposed as a metric, without turning
+    # them into instances to evaluate.
     my $entries = $options{custom}->request(
         command => 'lseventlog',
         payload => { filtervalue => 'fixed=no' }
     );
 
-    # Par defaut on ne retient que les alertes comme instances a evaluer. Le
-    # filtre est une option, pas une valeur en dur : une baie dont on voudrait
-    # aussi voir les messages se configure sans toucher au code.
+    # By default only alerts are retained as instances to evaluate. The filter
+    # is an option, not a hard-coded value: an array whose messages should
+    # also be seen is configured without touching the code.
     my $status_filter = defined($self->{option_results}->{filter_status}) && $self->{option_results}->{filter_status} ne ''
         ? $self->{option_results}->{filter_status}
         : '^alert$';

--- a/src/storage/ibm/flashsystem/restapi/mode/eventlog.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/eventlog.pm
@@ -103,7 +103,7 @@ sub set_counters {
     $self->{maps_counters}->{events} = [
         {
             label => 'event-status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             critical_default => '%{status} =~ /^alert$/i',
             set => {
                 key_values => [

--- a/src/storage/ibm/flashsystem/restapi/mode/eventlog.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/eventlog.pm
@@ -1,0 +1,249 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Journal d'evenements non resolus.
+#
+# Piege central de cette commande : filtrer sur 'fixed=no' seul ne suffit pas.
+# Le journal melange des entrees 'alert', qui appellent une action, et des
+# entrees 'message' purement informatives, qui ne se resolvent jamais parce
+# qu'un message ne se corrige pas. Une baie peut ainsi porter des centaines
+# d'entrees non resolues sans qu'aucune ne soit un probleme.
+#
+# Ce sont les entrees 'alert' qui reproduisent le panneau "Recommended Actions"
+# de l'interface. Les 'message' sont comptes et exposes en metrique, mais ne
+# declenchent rien par defaut.
+#
+
+package storage::ibm::flashsystem::restapi::mode::eventlog;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_event_output {
+    my ($self, %options) = @_;
+
+    my $msg = sprintf('status: %s', $self->{result_values}->{status});
+
+    $msg .= sprintf(', error code: %s', $self->{result_values}->{error_code})
+        if ($self->{result_values}->{error_code} ne '-');
+    $msg .= sprintf(', event id: %s', $self->{result_values}->{event_id})
+        if ($self->{result_values}->{event_id} ne '-');
+    $msg .= sprintf(', object: %s %s', $self->{result_values}->{object_type}, $self->{result_values}->{object_name})
+        if ($self->{result_values}->{object_name} ne '-');
+    $msg .= sprintf(', last seen: %s', $self->{result_values}->{last_timestamp})
+        if ($self->{result_values}->{last_timestamp} ne '-');
+    $msg .= sprintf(' [%s]', $self->{result_values}->{description})
+        if ($self->{result_values}->{description} ne '-');
+
+    return $msg;
+}
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+
+    return 'Unfixed event log entries: ';
+}
+
+sub prefix_event_output {
+    my ($self, %options) = @_;
+
+    return "Event '" . $options{instance_value}->{sequence_number} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
+        { name => 'events', type => 1, cb_prefix_output => 'prefix_event_output',
+          message_multiple => 'No actionable event', skipped_code => { -10 => 1 } }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'alerts', nlabel => 'eventlog.alerts.count', set => {
+                key_values => [ { name => 'alerts' } ],
+                output_template => '%s alert(s)',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'messages', nlabel => 'eventlog.messages.count', set => {
+                key_values => [ { name => 'messages' } ],
+                output_template => '%s message(s)',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        }
+    ];
+
+    # Toute entree retenue est signalee : le tri a deja eu lieu au moment de la
+    # selection. On ne masque rien ici.
+    $self->{maps_counters}->{events} = [
+        {
+            label => 'event-status',
+            type => 2,
+            critical_default => '%{status} =~ /^alert$/i',
+            set => {
+                key_values => [
+                    { name => 'sequence_number' }, { name => 'status' }, { name => 'error_code' },
+                    { name => 'event_id' }, { name => 'object_type' }, { name => 'object_name' },
+                    { name => 'description' }, { name => 'last_timestamp' }
+                ],
+                closure_custom_output => $self->can('custom_event_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-status:s'      => { name => 'filter_status' },
+        'filter-error-code:s'  => { name => 'filter_error_code' },
+        'filter-event-id:s'    => { name => 'filter_event_id' },
+        'filter-object-type:s' => { name => 'filter_object_type' },
+        'filter-object-name:s' => { name => 'filter_object_name' }
+    });
+
+    return $self;
+}
+
+sub field {
+    my ($entry, $name) = @_;
+
+    return '-' if (!defined($entry->{$name}) || $entry->{$name} eq '');
+    return $entry->{$name};
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    # Le tri se fait cote plugin plutot que dans le filtervalue de l'API : on
+    # veut compter les 'message' pour les exposer en metrique, sans les
+    # transformer en instances a evaluer.
+    my $entries = $options{custom}->request(
+        command => 'lseventlog',
+        payload => { filtervalue => 'fixed=no' }
+    );
+
+    # Par defaut on ne retient que les alertes comme instances a evaluer. Le
+    # filtre est une option, pas une valeur en dur : une baie dont on voudrait
+    # aussi voir les messages se configure sans toucher au code.
+    my $status_filter = defined($self->{option_results}->{filter_status}) && $self->{option_results}->{filter_status} ne ''
+        ? $self->{option_results}->{filter_status}
+        : '^alert$';
+
+    $self->{global} = { alerts => 0, messages => 0 };
+    $self->{events} = {};
+
+    foreach my $entry (@$entries) {
+        my $status = field($entry, 'status');
+
+        if ($status =~ /^alert$/i) {
+            $self->{global}->{alerts}++;
+        } elsif ($status =~ /^message$/i) {
+            $self->{global}->{messages}++;
+        }
+
+        next if ($status !~ /$status_filter/i);
+
+        my $error_code  = field($entry, 'error_code');
+        my $event_id    = field($entry, 'event_id');
+        my $object_type = field($entry, 'object_type');
+        my $object_name = field($entry, 'object_name');
+
+        next if (defined($self->{option_results}->{filter_error_code}) && $self->{option_results}->{filter_error_code} ne ''
+            && $error_code !~ /$self->{option_results}->{filter_error_code}/);
+        next if (defined($self->{option_results}->{filter_event_id}) && $self->{option_results}->{filter_event_id} ne ''
+            && $event_id !~ /$self->{option_results}->{filter_event_id}/);
+        next if (defined($self->{option_results}->{filter_object_type}) && $self->{option_results}->{filter_object_type} ne ''
+            && $object_type !~ /$self->{option_results}->{filter_object_type}/);
+        next if (defined($self->{option_results}->{filter_object_name}) && $self->{option_results}->{filter_object_name} ne ''
+            && $object_name !~ /$self->{option_results}->{filter_object_name}/);
+
+        my $sequence = field($entry, 'sequence_number');
+        $self->{events}->{$sequence} = {
+            sequence_number => $sequence,
+            status => $status,
+            error_code => $error_code,
+            event_id => $event_id,
+            object_type => $object_type,
+            object_name => $object_name,
+            description => field($entry, 'description'),
+            last_timestamp => field($entry, 'last_timestamp')
+        };
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check unfixed entries of the event log.
+
+The array reports two kinds of unfixed entries: C<alert>, which require an
+action and populate the "Recommended Actions" panel of the GUI, and C<message>,
+which are informational and never clear. Only alerts are evaluated by default;
+messages are counted and exposed as a metric.
+
+Example:
+
+    perl centreon_plugins.pl --plugin=storage::ibm::flashsystem::restapi::plugin \
+        --mode=eventlog --hostname=10.0.0.1 \
+        --api-username=svc_monitor --api-password=xxx
+
+=over 8
+
+=item B<--filter-status>
+
+Regular expression selecting which entries become checkable instances
+(default: C<^alert$>). Set it to C<.> to also evaluate informational messages.
+
+=item B<--filter-error-code> B<--filter-event-id> B<--filter-object-type> B<--filter-object-name>
+
+Further restrict the selected entries. Empty by default: nothing is hidden
+unless it is explicitly excluded.
+
+=item B<--unknown-event-status> B<--warning-event-status> B<--critical-event-status>
+
+Threshold on each selected entry. Available macros: C<status>, C<error_code>,
+C<event_id>, C<object_type>, C<object_name>, C<description>,
+C<last_timestamp>, C<sequence_number>.
+
+Default critical: C<%{status} =~ /^alert$/i>
+
+=item B<--warning-alerts> B<--critical-alerts> B<--warning-messages> B<--critical-messages>
+
+Thresholds on the number of unfixed alerts and messages.
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/mode/fcports.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/fcports.pm
@@ -21,20 +21,20 @@
 #
 
 #
-# Ports Fibre Channel — le chemin de donnees, que le mode hardware ne couvre pas.
+# Fibre Channel ports - the data path, which the hardware mode does not cover.
 #
-# Deux precisions tirees de l'API :
+# Two facts taken from the API:
 #
-#   - lsportfc n'expose NI compteur d'erreurs NI debit. Les seuls etats sont le
-#     statut, la vitesse negociee et le rattachement. Le debit FC ne s'obtient
-#     qu'au niveau du noeud, via lsnodecanisterstats.
-#   - un port equipe d'un SFP mais non raccorde remonte 'inactive_configured'
-#     en permanence, par conception IBM, et aucune option ne change ce
-#     comportement. Le seuil par defaut ne le traite donc pas comme une panne :
-#     il alerte sur ce qui a cesse d'etre actif, pas sur ce qui ne l'a jamais ete.
+#   - lsportfc exposes NEITHER error counters NOR throughput. The only states
+#     are the status, the negotiated speed and the attachment. FC throughput
+#     is only available at node level, through lsnodecanisterstats.
+#   - a port fitted with an SFP but not connected reports 'inactive_configured'
+#     permanently, by IBM design, and no option changes that behaviour. The
+#     default threshold therefore does not treat it as a fault: it alerts on
+#     what stopped being active, not on what never was.
 #
-# lstargetportfc ajoute le nombre de connexions hotes par port : un port actif
-# qui perd ses connexions est un chemin perdu, invisible autrement.
+# lstargetportfc adds the number of host logins per port: an active port that
+# loses its logins is a lost path, invisible otherwise.
 #
 
 package storage::ibm::flashsystem::restapi::mode::fcports;
@@ -109,11 +109,11 @@ sub set_counters {
         }
     ];
 
-    # 'inactive_unconfigured' = pas de SFP, 'inactive_configured' = SFP pose mais
-    # rien de branche : deux etats normaux sur une baie partiellement cablee.
-    # Alerter dessus produirait un Critical perpetuel, ce qui apprend a l'equipe
-    # a ignorer le service. On ne retient donc que les etats qui traduisent une
-    # degradation reelle.
+    # 'inactive_unconfigured' = no SFP, 'inactive_configured' = SFP fitted but
+    # nothing plugged: two normal states on a partially cabled array. Alerting
+    # on them would produce a perpetual Critical, which teaches the team to
+    # ignore the service. Only the states reflecting a real degradation are
+    # retained.
     $self->{maps_counters}->{ports} = [
         {
             label => 'status',
@@ -158,9 +158,9 @@ sub field {
 sub manage_selection {
     my ($self, %options) = @_;
 
-    # Les connexions hotes se lisent sur les ports virtualises (NPIV), indexes
-    # par fc_io_port_id. On les agrege avant de les rattacher aux ports
-    # physiques.
+    # Host logins are read on the virtualised (NPIV) ports, keyed on
+    # fc_io_port_id. They are aggregated before being attached to the physical
+    # ports.
     my %logins;
     foreach my $target (@{ $options{custom}->request_optional(command => 'lstargetportfc') }) {
         my $port = field($target, 'fc_io_port_id');
@@ -173,9 +173,9 @@ sub manage_selection {
     $self->{ports} = {};
 
     foreach my $port (@{ $options{custom}->request(command => 'lsportfc') }) {
-        # Les identifiants de port ne sont pas contigus — 0 a 3 puis 24 a 27 —
-        # donc un service « Port 24 » n'aiderait personne. On nomme par noeud et
-        # numero de port, ce que lit un exploitant.
+        # Port ids are not contiguous - 0 to 3 then 24 to 27 - so a "Port 24"
+        # service would help nobody. Ports are named by node and port number,
+        # what an operator reads.
         my $name = field($port, 'node_name') . '-' . field($port, 'port_id');
         my $type = field($port, 'type');
 

--- a/src/storage/ibm/flashsystem/restapi/mode/fcports.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/fcports.pm
@@ -1,0 +1,278 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Ports Fibre Channel — le chemin de donnees, que le mode hardware ne couvre pas.
+#
+# Deux precisions tirees de l'API :
+#
+#   - lsportfc n'expose NI compteur d'erreurs NI debit. Les seuls etats sont le
+#     statut, la vitesse negociee et le rattachement. Le debit FC ne s'obtient
+#     qu'au niveau du noeud, via lsnodecanisterstats.
+#   - un port equipe d'un SFP mais non raccorde remonte 'inactive_configured'
+#     en permanence, par conception IBM, et aucune option ne change ce
+#     comportement. Le seuil par defaut ne le traite donc pas comme une panne :
+#     il alerte sur ce qui a cesse d'etre actif, pas sur ce qui ne l'a jamais ete.
+#
+# lstargetportfc ajoute le nombre de connexions hotes par port : un port actif
+# qui perd ses connexions est un chemin perdu, invisible autrement.
+#
+
+package storage::ibm::flashsystem::restapi::mode::fcports;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_port_output {
+    my ($self, %options) = @_;
+
+    my $msg = sprintf(
+        'status: %s, speed: %s, attachment: %s',
+        $self->{result_values}->{status},
+        $self->{result_values}->{port_speed},
+        $self->{result_values}->{attachment}
+    );
+
+    $msg .= sprintf(', host logins: %s', $self->{result_values}->{active_login_count})
+        if ($self->{result_values}->{active_login_count} ne '-');
+
+    return $msg;
+}
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+
+    return 'Fibre Channel ports: ';
+}
+
+sub prefix_port_output {
+    my ($self, %options) = @_;
+
+    return "Port '" . $options{instance_value}->{name} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
+        { name => 'ports', type => 1, cb_prefix_output => 'prefix_port_output',
+          message_multiple => 'All Fibre Channel ports are active', skipped_code => { -10 => 1 } }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'detected', nlabel => 'fcports.detected.count', set => {
+                key_values => [ { name => 'detected' } ],
+                output_template => '%s detected',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'active', nlabel => 'fcports.active.count', set => {
+                key_values => [ { name => 'active' } ],
+                output_template => '%s active',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'inactive', nlabel => 'fcports.inactive.count', set => {
+                key_values => [ { name => 'inactive' } ],
+                output_template => '%s inactive',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'host-logins', nlabel => 'fcports.host.logins.count', set => {
+                key_values => [ { name => 'host_logins' } ],
+                output_template => '%s host login(s)',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        }
+    ];
+
+    # 'inactive_unconfigured' = pas de SFP, 'inactive_configured' = SFP pose mais
+    # rien de branche : deux etats normaux sur une baie partiellement cablee.
+    # Alerter dessus produirait un Critical perpetuel, ce qui apprend a l'equipe
+    # a ignorer le service. On ne retient donc que les etats qui traduisent une
+    # degradation reelle.
+    $self->{maps_counters}->{ports} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default =>
+                '%{status} !~ /^(active|inactive_configured|inactive_unconfigured)$/i',
+            warning_default => '%{status} =~ /^inactive_configured$/i and %{attachment} =~ /^switch$/i',
+            set => {
+                key_values => [
+                    { name => 'name' }, { name => 'status' }, { name => 'port_speed' },
+                    { name => 'attachment' }, { name => 'node_name' }, { name => 'port_id' },
+                    { name => 'type' }, { name => 'active_login_count' }
+                ],
+                closure_custom_output => $self->can('custom_port_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s' => { name => 'filter_name' },
+        'filter-type:s' => { name => 'filter_type' }
+    });
+
+    return $self;
+}
+
+sub field {
+    my ($entry, $name) = @_;
+
+    return '-' if (!defined($entry->{$name}) || $entry->{$name} eq '');
+    return $entry->{$name};
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    # Les connexions hotes se lisent sur les ports virtualises (NPIV), indexes
+    # par fc_io_port_id. On les agrege avant de les rattacher aux ports
+    # physiques.
+    my %logins;
+    foreach my $target (@{ $options{custom}->request_optional(command => 'lstargetportfc') }) {
+        my $port = field($target, 'fc_io_port_id');
+        my $count = $target->{active_login_count};
+        next if ($port eq '-' || !defined($count) || $count !~ /^\d+$/);
+        $logins{$port} += $count;
+    }
+
+    $self->{global} = { detected => 0, active => 0, inactive => 0, host_logins => 0 };
+    $self->{ports} = {};
+
+    foreach my $port (@{ $options{custom}->request(command => 'lsportfc') }) {
+        # Les identifiants de port ne sont pas contigus — 0 a 3 puis 24 a 27 —
+        # donc un service « Port 24 » n'aiderait personne. On nomme par noeud et
+        # numero de port, ce que lit un exploitant.
+        my $name = field($port, 'node_name') . '-' . field($port, 'port_id');
+        my $type = field($port, 'type');
+
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $name !~ /$self->{option_results}->{filter_name}/);
+        next if (defined($self->{option_results}->{filter_type}) && $self->{option_results}->{filter_type} ne ''
+            && $type !~ /$self->{option_results}->{filter_type}/);
+
+        my $status = field($port, 'status');
+        my $io_port = field($port, 'fc_io_port_id');
+        my $login_count = defined($logins{$io_port}) ? $logins{$io_port} : '-';
+
+        $self->{global}->{detected}++;
+        if ($status =~ /^active$/i) {
+            $self->{global}->{active}++;
+        } else {
+            $self->{global}->{inactive}++;
+        }
+        $self->{global}->{host_logins} += $login_count if ($login_count ne '-');
+
+        $self->{ports}->{$name} = {
+            name => $name,
+            status => $status,
+            port_speed => field($port, 'port_speed'),
+            attachment => field($port, 'attachment'),
+            node_name => field($port, 'node_name'),
+            port_id => field($port, 'port_id'),
+            type => $type,
+            active_login_count => $login_count
+        };
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check the Fibre Channel ports — the data path, which the C<hardware> mode does
+not cover.
+
+C<lsportfc> exposes neither error counters nor throughput: status, negotiated
+speed and attachment are all there is. Throughput is only available per node,
+through C<lsnodecanisterstats>.
+
+Host logins come from C<lstargetportfc>, aggregated per physical port. An active
+port that loses its logins is a lost path, and nothing else would show it.
+
+Ports are named after their node and port number — C<node1-1> — because port ids
+are not contiguous (0 to 3 then 24 to 27 on a two-canister system), so a service
+called "Port 24" would help nobody.
+
+Example:
+
+    perl centreon_plugins.pl --plugin=storage::ibm::flashsystem::restapi::plugin \
+        --mode=fc-ports --hostname=10.0.0.1 \
+        --api-username=svc_monitor --api-password=xxx --insecure
+
+=over 8
+
+=item B<--filter-name>
+
+Only check ports whose C<node-port> name matches this regular expression.
+
+=item B<--filter-type>
+
+Only check ports of this type (C<fc>, C<ethernet>…).
+
+=item B<--unknown-status> B<--warning-status> B<--critical-status>
+
+Threshold on each port. Available macros: C<name>, C<status>, C<port_speed>,
+C<attachment>, C<node_name>, C<port_id>, C<type>, C<active_login_count>.
+
+Default warning: C<%{status} =~ /^inactive_configured$/i and %{attachment} =~ /^switch$/i>
+
+Default critical: C<%{status} !~ /^(active|inactive_configured|inactive_unconfigured)$/i>
+
+A port fitted with an SFP but cabled to nothing reports C<inactive_configured>
+permanently, by IBM design, and no option changes that. Treating it as a fault
+would make the service critical forever, which teaches people to ignore it. The
+defaults therefore only warn when such a port claims to be attached to a switch,
+and only alert on states that mean something actually degraded.
+
+To require a negotiated speed, add it explicitly:
+
+    --critical-status='%{status} !~ /^active$/i || %{port_speed} !~ /^16Gb$/'
+
+=item B<--warning-active> B<--critical-active> B<--warning-inactive> B<--critical-inactive>
+
+Thresholds on the number of active and inactive ports.
+
+=item B<--warning-host-logins> B<--critical-host-logins>
+
+Threshold on the total number of host logins across all ports. Useful to catch
+a fabric-wide loss that leaves every port nominally active.
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/mode/fcports.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/fcports.pm
@@ -246,14 +246,12 @@ Only check ports whose C<node-port> name matches this regular expression.
 
 Only check ports of this type (C<fc>, C<ethernet>…).
 
-=item B<--unknown-status> B<--warning-status> B<--critical-status>
+=item B<--unknown-status>
+
+Define the conditions to match for the status to be UNKNOWN.
 
 Threshold on each port. Available macros: C<name>, C<status>, C<port_speed>,
 C<attachment>, C<node_name>, C<port_id>, C<type>, C<active_login_count>.
-
-Default warning: C<%{status} =~ /^inactive_configured$/i and %{attachment} =~ /^switch$/i>
-
-Default critical: C<%{status} !~ /^(active|inactive_configured|inactive_unconfigured)$/i>
 
 A port fitted with an SFP but cabled to nothing reports C<inactive_configured>
 permanently, by IBM design, and no option changes that. Treating it as a fault
@@ -265,11 +263,78 @@ To require a negotiated speed, add it explicitly:
 
     --critical-status='%{status} !~ /^active$/i || %{port_speed} !~ /^16Gb$/'
 
-=item B<--warning-active> B<--critical-active> B<--warning-inactive> B<--critical-inactive>
+=item B<--warning-status>
+
+Define the conditions to match for the status to be WARNING.
+
+Threshold on each port. Available macros: C<name>, C<status>, C<port_speed>,
+C<attachment>, C<node_name>, C<port_id>, C<type>, C<active_login_count>.
+
+Default warning: C<%{status} =~ /^inactive_configured$/i and %{attachment} =~ /^switch$/i>.
+
+A port fitted with an SFP but cabled to nothing reports C<inactive_configured>
+permanently, by IBM design, and no option changes that. Treating it as a fault
+would make the service critical forever, which teaches people to ignore it. The
+defaults therefore only warn when such a port claims to be attached to a switch,
+and only alert on states that mean something actually degraded.
+
+To require a negotiated speed, add it explicitly:
+
+    --critical-status='%{status} !~ /^active$/i || %{port_speed} !~ /^16Gb$/'
+
+=item B<--critical-status>
+
+Define the conditions to match for the status to be CRITICAL.
+
+Threshold on each port. Available macros: C<name>, C<status>, C<port_speed>,
+C<attachment>, C<node_name>, C<port_id>, C<type>, C<active_login_count>.
+
+Default critical: C<%{status} !~ /^(active|inactive_configured|inactive_unconfigured)$/i>.
+
+A port fitted with an SFP but cabled to nothing reports C<inactive_configured>
+permanently, by IBM design, and no option changes that. Treating it as a fault
+would make the service critical forever, which teaches people to ignore it. The
+defaults therefore only warn when such a port claims to be attached to a switch,
+and only alert on states that mean something actually degraded.
+
+To require a negotiated speed, add it explicitly:
+
+    --critical-status='%{status} !~ /^active$/i || %{port_speed} !~ /^16Gb$/'
+
+=item B<--warning-active>
+
+Warning threshold.
 
 Thresholds on the number of active and inactive ports.
 
-=item B<--warning-host-logins> B<--critical-host-logins>
+=item B<--critical-active>
+
+Critical threshold.
+
+Thresholds on the number of active and inactive ports.
+
+=item B<--warning-inactive>
+
+Warning threshold.
+
+Thresholds on the number of active and inactive ports.
+
+=item B<--critical-inactive>
+
+Critical threshold.
+
+Thresholds on the number of active and inactive ports.
+
+=item B<--warning-host-logins>
+
+Warning threshold.
+
+Threshold on the total number of host logins across all ports. Useful to catch
+a fabric-wide loss that leaves every port nominally active.
+
+=item B<--critical-host-logins>
+
+Critical threshold.
 
 Threshold on the total number of host logins across all ports. Useful to catch
 a fabric-wide loss that leaves every port nominally active.

--- a/src/storage/ibm/flashsystem/restapi/mode/fcports.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/fcports.pm
@@ -118,7 +118,7 @@ sub set_counters {
     $self->{maps_counters}->{ports} = [
         {
             label => 'status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             critical_default =>
                 '%{status} !~ /^(active|inactive_configured|inactive_unconfigured)$/i',
             warning_default => '%{status} =~ /^inactive_configured$/i and %{attachment} =~ /^switch$/i',

--- a/src/storage/ibm/flashsystem/restapi/mode/fcports.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/fcports.pm
@@ -43,6 +43,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use centreon::plugins::constants qw/:counters :values/;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
 sub custom_port_output {
@@ -77,9 +78,9 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
-        { name => 'ports', type => 1, cb_prefix_output => 'prefix_port_output',
-          message_multiple => 'All Fibre Channel ports are active', skipped_code => { -10 => 1 } }
+        { name => 'global', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_global_output' },
+        { name => 'ports', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_port_output',
+          message_multiple => 'All Fibre Channel ports are active', skipped_code => { NO_VALUE() => 1 } }
     ];
 
     $self->{maps_counters}->{global} = [

--- a/src/storage/ibm/flashsystem/restapi/mode/hardware.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/hardware.pm
@@ -21,15 +21,15 @@
 #
 
 #
-# Etat du materiel.
+# Hardware health.
 #
-# lsenclosure porte deja les compteurs online/total de chaque sous-ensemble du
-# chassis : alimentations, canisters, ventilateurs, SEM. Une seule commande
-# suffit donc la ou l'approche naive en demandait quatre.
+# lsenclosure already carries the online/total counters of every enclosure
+# subsystem: power supplies, canisters, fan modules, SEMs. One command is thus
+# enough where the naive approach needed four.
 #
-# Un sous-ensemble dont le total vaut 0 n'est pas installe sur ce modele : il
-# est ignore et non compte comme defaillant. C'est ce qui permet au meme mode
-# de couvrir un FlashSystem 5300 sans SEM et un chassis qui en possede.
+# A subsystem whose total is 0 is not fitted on that model: it is skipped and
+# not counted as failed. That is what lets the same mode cover a FlashSystem
+# 5300 without SEMs and an enclosure that has some.
 #
 
 package storage::ibm::flashsystem::restapi::mode::hardware;
@@ -40,15 +40,15 @@ use strict;
 use warnings;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
-# Les familles d'objets interrogees, avec le libelle affiche. La liste est
-# parcourue telle quelle : ajouter une famille ne demande qu'une ligne.
+# The object families queried, with the displayed label. The list is walked
+# as is: adding a family takes one line.
 #
-# id_fields : les champs ou chercher l'identite, dans l'ordre. Le premier
-# renseigne gagne. Les objets de Storage Virtualize ne portent pas tous la meme
-# clef — un ventilateur s'appelle fan_module_id, un quorum applicatif n'a ni
-# name ni id et n'est designe que par quorum_index. Essayer plusieurs champs
-# evite d'avoir a le deviner famille par famille, et evite surtout le « '-' »
-# qui rendait le message d'alerte illisible.
+# id_fields: the fields where to look for the identity, in order. The first
+# one set wins. Storage Virtualize objects do not all carry the same key - a
+# fan module is called fan_module_id, an application quorum has neither name
+# nor id and is only designated by quorum_index. Trying several fields avoids
+# guessing family by family, and above all avoids the "'-'" that made the
+# alert message unreadable.
 my $COMPONENT_COMMANDS = [
     { command => 'lsenclosure',         label => 'enclosure' },
     { command => 'lsnodecanister',      label => 'node canister' },
@@ -62,7 +62,7 @@ my $COMPONENT_COMMANDS = [
     { command => 'lsquorum',            label => 'quorum', id_fields => [ 'quorum_index' ] }
 ];
 
-# Sous-ensembles decrits par un couple online_X / total_X dans lsenclosure.
+# Subsystems described by an online_X / total_X pair in lsenclosure.
 my $ENCLOSURE_SUBSYSTEMS = [
     { field => 'PSUs',        label => 'power supplies' },
     { field => 'canisters',   label => 'canisters' },
@@ -87,8 +87,8 @@ sub custom_subsystem_output {
     );
 }
 
-# Compteurs environnementaux exposes par lssystemstats. Ce sont des grandeurs
-# physiques du chassis, pas de la performance : leur place est ici.
+# Environmental counters exposed by lssystemstats. They are physical measures
+# of the enclosure, not performance: their place is here.
 my $ENVIRONMENT_STATS = [
     { stat => 'temp_c',  key => 'temperature', label => 'temperature', unit => 'C' },
     { stat => 'power_w', key => 'power',       label => 'power draw',  unit => 'W' }
@@ -130,9 +130,9 @@ sub set_counters {
           message_multiple => 'All enclosure subsystems are fully populated', skipped_code => { -10 => 1 } }
     ];
 
-    # Grandeurs physiques du chassis. Aucun seuil par defaut : le bon reglage
-    # depend de la salle et du modele, pas d'une regle generale. La metrique est
-    # tracee dans tous les cas, ce qui permet de la regler sur l'observe.
+    # Physical measures of the enclosure. No default threshold: the right
+    # setting depends on the room and the model, not on a general rule. The
+    # metric is graphed in every case, which allows tuning it on what is seen.
     $self->{maps_counters}->{environment} = [
         { label => 'temperature', nlabel => 'hardware.temperature.celsius', set => {
                 key_values => [ { name => 'temperature' } ],
@@ -163,11 +163,11 @@ sub set_counters {
         }
     ];
 
-    # CRITICAL = perte de SERVICE, WARNING = perte de REDONDANCE. Tout ce
-    # materiel est redonde (2 alimentations, 2 canisters, 6 ventilateurs, DRAID
-    # sur 12 disques) : un composant 'degraded' entame la marge, il n'arrete
-    # rien. Le confondre avec 'offline' reveille l'astreinte pour un defaut qui
-    # attend l'heure ouvree — et, a l'inverse, noie le vrai arret dans le lot.
+    # CRITICAL = SERVICE lost, WARNING = REDUNDANCY lost. All this hardware is
+    # redundant (2 power supplies, 2 canisters, 6 fan modules, a DRAID across
+    # the drives): a 'degraded' component eats the margin, it stops nothing.
+    # Confusing it with 'offline' wakes someone up for a fault that can wait
+    # for business hours - and, conversely, buries the real outage among them.
     $self->{maps_counters}->{components} = [
         {
             label => 'component-status',
@@ -183,9 +183,9 @@ sub set_counters {
         }
     ];
 
-    # Meme principe sur les sous-ensembles du chassis : une alimentation sur
-    # deux est une redondance perdue (WARNING), zero alimentation en ligne est
-    # un arret (CRITICAL).
+    # Same principle on the enclosure subsystems: one power supply out of two
+    # is a lost redundancy (WARNING), zero power supply online is an outage
+    # (CRITICAL).
     $self->{maps_counters}->{subsystems} = [
         {
             label => 'subsystem-status',
@@ -230,9 +230,9 @@ sub manage_selection {
     $self->{components} = {};
     $self->{subsystems} = {};
 
-    # Temperature et consommation viennent de lssystemstats, avec les compteurs
-    # de performance — mais ce sont des grandeurs physiques du chassis, donc
-    # elles se lisent ici plutot que dans le mode performance.
+    # Temperature and power draw come from lssystemstats, with the performance
+    # counters - but they are physical measures of the enclosure, so they are
+    # read here rather than in the performance mode.
     my %stats;
     foreach my $entry (@{ $options{custom}->request_optional(command => 'lssystemstats') }) {
         next unless (ref $entry eq 'HASH' && defined($entry->{stat_name}));
@@ -248,14 +248,14 @@ sub manage_selection {
         next if (defined($self->{option_results}->{filter_type}) && $self->{option_results}->{filter_type} ne ''
             && $family->{label} !~ /$self->{option_results}->{filter_type}/);
 
-        # Une famille absente du modele ou du firmware ne doit pas faire
-        # echouer le controle des autres.
+        # A family missing from the model or the firmware must not fail the
+        # check of the others.
         my $entries = $options{custom}->request_optional(command => $family->{command});
 
         foreach my $entry (@$entries) {
-            # Tous les objets n'ont pas de champ 'name' : un disque ou une
-            # alimentation ne portent qu'un identifiant. On prend le premier
-            # champ renseigne, en commencant par ceux propres a la famille.
+            # Not every object has a 'name' field: a drive or a power supply only
+            # carries an identifier. The first field set is taken, starting with
+            # those specific to the family.
             my @candidates = ('name');
             push @candidates, @{ $family->{id_fields} } if (defined($family->{id_fields}));
             push @candidates, 'id';
@@ -284,14 +284,14 @@ sub manage_selection {
 
             next if ($family->{command} ne 'lsenclosure');
 
-            # Compteurs online/total portes par le chassis lui-meme.
+            # online/total counters carried by the enclosure itself.
             foreach my $subsystem (@$ENCLOSURE_SUBSYSTEMS) {
                 my $online = $entry->{'online_' . $subsystem->{field}};
                 my $total  = $entry->{'total_' . $subsystem->{field}};
 
                 next if (!defined($online) || !defined($total));
                 next if ($online !~ /^\d+$/ || $total !~ /^\d+$/);
-                # total = 0 : le sous-ensemble n'existe pas sur ce materiel.
+                # total = 0: the subsystem does not exist on this hardware.
                 next if ($total == 0);
 
                 $self->{subsystems}->{ $name . '.' . $subsystem->{field} } = {

--- a/src/storage/ibm/flashsystem/restapi/mode/hardware.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/hardware.pm
@@ -172,7 +172,7 @@ sub set_counters {
     $self->{maps_counters}->{components} = [
         {
             label => 'component-status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             critical_default => '%{status} =~ /^(offline|excluded)$/i',
             warning_default => '%{status} =~ /^(degraded|degraded_paths|degraded_ports)$/i',
             set => {
@@ -190,7 +190,7 @@ sub set_counters {
     $self->{maps_counters}->{subsystems} = [
         {
             label => 'subsystem-status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             critical_default => '%{online} == 0',
             warning_default => '%{online} < %{total}',
             set => {

--- a/src/storage/ibm/flashsystem/restapi/mode/hardware.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/hardware.pm
@@ -340,13 +340,11 @@ array, mdisk, quorum).
 
 Only check components whose name or id matches this regular expression.
 
-=item B<--unknown-component-status> B<--warning-component-status> B<--critical-component-status>
+=item B<--unknown-component-status>
+
+Define the conditions to match for the status to be UNKNOWN.
 
 Threshold on each component. Available macros: C<name>, C<type>, C<status>.
-
-Default critical: C<%{status} =~ /^(offline|excluded)$/i>
-
-Default warning: C<%{status} =~ /^(degraded|degraded_paths|degraded_ports)$/i>
 
 Critical means B<service lost>, warning means B<redundancy lost>. Every part
 here is redundant — two power supplies, two canisters, six fan modules, a DRAID
@@ -354,17 +352,70 @@ across twelve drives — so a degraded component eats the margin without stoppin
 anything. Merging the two wakes someone up for a fault that can wait for
 business hours, and buries the real outage among them.
 
-=item B<--unknown-subsystem-status> B<--warning-subsystem-status> B<--critical-subsystem-status>
+=item B<--warning-component-status>
+
+Define the conditions to match for the status to be WARNING.
+
+Threshold on each component. Available macros: C<name>, C<type>, C<status>.
+
+Default warning: C<%{status} =~ /^(degraded|degraded_paths|degraded_ports)$/i>.
+
+Critical means B<service lost>, warning means B<redundancy lost>. Every part
+here is redundant — two power supplies, two canisters, six fan modules, a DRAID
+across twelve drives — so a degraded component eats the margin without stopping
+anything. Merging the two wakes someone up for a fault that can wait for
+business hours, and buries the real outage among them.
+
+=item B<--critical-component-status>
+
+Define the conditions to match for the status to be CRITICAL.
+
+Threshold on each component. Available macros: C<name>, C<type>, C<status>.
+
+Default critical: C<%{status} =~ /^(offline|excluded)$/i>.
+
+Critical means B<service lost>, warning means B<redundancy lost>. Every part
+here is redundant — two power supplies, two canisters, six fan modules, a DRAID
+across twelve drives — so a degraded component eats the margin without stopping
+anything. Merging the two wakes someone up for a fault that can wait for
+business hours, and buries the real outage among them.
+
+=item B<--unknown-subsystem-status>
+
+Define the conditions to match for the status to be UNKNOWN.
 
 Threshold on each enclosure subsystem. Available macros: C<enclosure>,
 C<label>, C<online>, C<total>.
 
-Default critical: C<%{online} == 0> — nothing left in that subsystem.
+=item B<--warning-subsystem-status>
 
-Default warning: C<%{online} E<lt> %{total}> — one power supply out of two is a
+Define the conditions to match for the status to be WARNING.
+
+Threshold on each enclosure subsystem. Available macros: C<enclosure>,
+C<label>, C<online>, C<total>.
+
+Default warning: C<%{online} E<lt> %{total}> - one power supply out of two is a.
 lost redundancy, not an outage.
 
-=item B<--warning-components-degraded> B<--critical-components-degraded>
+=item B<--critical-subsystem-status>
+
+Define the conditions to match for the status to be CRITICAL.
+
+Threshold on each enclosure subsystem. Available macros: C<enclosure>,
+C<label>, C<online>, C<total>.
+
+Default critical: C<%{online} == 0> - nothing left in that subsystem.
+.
+
+=item B<--warning-components-degraded>
+
+Warning threshold.
+
+Thresholds on the number of components that are not online.
+
+=item B<--critical-components-degraded>
+
+Critical threshold.
 
 Thresholds on the number of components that are not online.
 

--- a/src/storage/ibm/flashsystem/restapi/mode/hardware.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/hardware.pm
@@ -38,6 +38,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use centreon::plugins::constants qw/:counters :values/;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
 # The object families queried, with the displayed label. The list is walked
@@ -122,12 +123,12 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
-        { name => 'components', type => 1, cb_prefix_output => 'prefix_component_output',
-          message_multiple => 'All hardware components are online', skipped_code => { -10 => 1 } },
-        { name => 'environment', type => 0, cb_prefix_output => 'prefix_environment_output' },
-        { name => 'subsystems', type => 1, cb_prefix_output => 'prefix_subsystem_output',
-          message_multiple => 'All enclosure subsystems are fully populated', skipped_code => { -10 => 1 } }
+        { name => 'global', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_global_output' },
+        { name => 'components', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_component_output',
+          message_multiple => 'All hardware components are online', skipped_code => { NO_VALUE() => 1 } },
+        { name => 'environment', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_environment_output' },
+        { name => 'subsystems', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_subsystem_output',
+          message_multiple => 'All enclosure subsystems are fully populated', skipped_code => { NO_VALUE() => 1 } }
     ];
 
     # Physical measures of the enclosure. No default threshold: the right

--- a/src/storage/ibm/flashsystem/restapi/mode/hardware.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/hardware.pm
@@ -1,0 +1,372 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Etat du materiel.
+#
+# lsenclosure porte deja les compteurs online/total de chaque sous-ensemble du
+# chassis : alimentations, canisters, ventilateurs, SEM. Une seule commande
+# suffit donc la ou l'approche naive en demandait quatre.
+#
+# Un sous-ensemble dont le total vaut 0 n'est pas installe sur ce modele : il
+# est ignore et non compte comme defaillant. C'est ce qui permet au meme mode
+# de couvrir un FlashSystem 5300 sans SEM et un chassis qui en possede.
+#
+
+package storage::ibm::flashsystem::restapi::mode::hardware;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+# Les familles d'objets interrogees, avec le libelle affiche. La liste est
+# parcourue telle quelle : ajouter une famille ne demande qu'une ligne.
+#
+# id_fields : les champs ou chercher l'identite, dans l'ordre. Le premier
+# renseigne gagne. Les objets de Storage Virtualize ne portent pas tous la meme
+# clef — un ventilateur s'appelle fan_module_id, un quorum applicatif n'a ni
+# name ni id et n'est designe que par quorum_index. Essayer plusieurs champs
+# evite d'avoir a le deviner famille par famille, et evite surtout le « '-' »
+# qui rendait le message d'alerte illisible.
+my $COMPONENT_COMMANDS = [
+    { command => 'lsenclosure',         label => 'enclosure' },
+    { command => 'lsnodecanister',      label => 'node canister' },
+    { command => 'lsenclosurecanister', label => 'expansion canister' },
+    { command => 'lsenclosurepsu',      label => 'power supply' },
+    { command => 'lsenclosurebattery',  label => 'battery' },
+    { command => 'lsenclosurefanmodule', label => 'fan module', id_fields => [ 'fan_module_id' ] },
+    { command => 'lsdrive',             label => 'drive' },
+    { command => 'lsarray',             label => 'array' },
+    { command => 'lsmdisk',             label => 'mdisk' },
+    { command => 'lsquorum',            label => 'quorum', id_fields => [ 'quorum_index' ] }
+];
+
+# Sous-ensembles decrits par un couple online_X / total_X dans lsenclosure.
+my $ENCLOSURE_SUBSYSTEMS = [
+    { field => 'PSUs',        label => 'power supplies' },
+    { field => 'canisters',   label => 'canisters' },
+    { field => 'fan_modules', label => 'fan modules' },
+    { field => 'sems',        label => 'secondary expander modules' }
+];
+
+sub custom_component_output {
+    my ($self, %options) = @_;
+
+    return sprintf('status: %s', $self->{result_values}->{status});
+}
+
+sub custom_subsystem_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        '%s online: %s/%s',
+        $self->{result_values}->{label},
+        $self->{result_values}->{online},
+        $self->{result_values}->{total}
+    );
+}
+
+# Compteurs environnementaux exposes par lssystemstats. Ce sont des grandeurs
+# physiques du chassis, pas de la performance : leur place est ici.
+my $ENVIRONMENT_STATS = [
+    { stat => 'temp_c',  key => 'temperature', label => 'temperature', unit => 'C' },
+    { stat => 'power_w', key => 'power',       label => 'power draw',  unit => 'W' }
+];
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+
+    return 'Hardware: ';
+}
+
+sub prefix_environment_output {
+    my ($self, %options) = @_;
+
+    return 'Enclosure: ';
+}
+
+sub prefix_component_output {
+    my ($self, %options) = @_;
+
+    return ucfirst($options{instance_value}->{type}) . " '" . $options{instance_value}->{name} . "' ";
+}
+
+sub prefix_subsystem_output {
+    my ($self, %options) = @_;
+
+    return "Enclosure '" . $options{instance_value}->{enclosure} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
+        { name => 'components', type => 1, cb_prefix_output => 'prefix_component_output',
+          message_multiple => 'All hardware components are online', skipped_code => { -10 => 1 } },
+        { name => 'environment', type => 0, cb_prefix_output => 'prefix_environment_output' },
+        { name => 'subsystems', type => 1, cb_prefix_output => 'prefix_subsystem_output',
+          message_multiple => 'All enclosure subsystems are fully populated', skipped_code => { -10 => 1 } }
+    ];
+
+    # Grandeurs physiques du chassis. Aucun seuil par defaut : le bon reglage
+    # depend de la salle et du modele, pas d'une regle generale. La metrique est
+    # tracee dans tous les cas, ce qui permet de la regler sur l'observe.
+    $self->{maps_counters}->{environment} = [
+        { label => 'temperature', nlabel => 'hardware.temperature.celsius', set => {
+                key_values => [ { name => 'temperature' } ],
+                output_template => 'temperature %s C',
+                perfdatas => [ { template => '%s', unit => 'C' } ]
+            }
+        },
+        { label => 'power', nlabel => 'hardware.power.watt', set => {
+                key_values => [ { name => 'power' } ],
+                output_template => 'power draw %s W',
+                perfdatas => [ { template => '%s', unit => 'W', min => 0 } ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'components-detected', nlabel => 'hardware.components.detected.count', set => {
+                key_values => [ { name => 'detected' } ],
+                output_template => '%s component(s)',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'components-degraded', nlabel => 'hardware.components.degraded.count', set => {
+                key_values => [ { name => 'degraded' } ],
+                output_template => '%s not online',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        }
+    ];
+
+    # CRITICAL = perte de SERVICE, WARNING = perte de REDONDANCE. Tout ce
+    # materiel est redonde (2 alimentations, 2 canisters, 6 ventilateurs, DRAID
+    # sur 12 disques) : un composant 'degraded' entame la marge, il n'arrete
+    # rien. Le confondre avec 'offline' reveille l'astreinte pour un defaut qui
+    # attend l'heure ouvree — et, a l'inverse, noie le vrai arret dans le lot.
+    $self->{maps_counters}->{components} = [
+        {
+            label => 'component-status',
+            type => 2,
+            critical_default => '%{status} =~ /^(offline|excluded)$/i',
+            warning_default => '%{status} =~ /^(degraded|degraded_paths|degraded_ports)$/i',
+            set => {
+                key_values => [ { name => 'name' }, { name => 'type' }, { name => 'status' } ],
+                closure_custom_output => $self->can('custom_component_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+
+    # Meme principe sur les sous-ensembles du chassis : une alimentation sur
+    # deux est une redondance perdue (WARNING), zero alimentation en ligne est
+    # un arret (CRITICAL).
+    $self->{maps_counters}->{subsystems} = [
+        {
+            label => 'subsystem-status',
+            type => 2,
+            critical_default => '%{online} == 0',
+            warning_default => '%{online} < %{total}',
+            set => {
+                key_values => [ { name => 'enclosure' }, { name => 'label' }, { name => 'online' }, { name => 'total' } ],
+                closure_custom_output => $self->can('custom_subsystem_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-type:s' => { name => 'filter_type' },
+        'filter-name:s' => { name => 'filter_name' }
+    });
+
+    return $self;
+}
+
+sub field {
+    my ($entry, $name) = @_;
+
+    return '-' if (!defined($entry->{$name}) || $entry->{$name} eq '');
+    return $entry->{$name};
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    $self->{global} = { detected => 0, degraded => 0 };
+    $self->{environment} = {};
+    $self->{components} = {};
+    $self->{subsystems} = {};
+
+    # Temperature et consommation viennent de lssystemstats, avec les compteurs
+    # de performance — mais ce sont des grandeurs physiques du chassis, donc
+    # elles se lisent ici plutot que dans le mode performance.
+    my %stats;
+    foreach my $entry (@{ $options{custom}->request_optional(command => 'lssystemstats') }) {
+        next unless (ref $entry eq 'HASH' && defined($entry->{stat_name}));
+        $stats{ $entry->{stat_name} } = $entry->{stat_current};
+    }
+    foreach my $measure (@$ENVIRONMENT_STATS) {
+        my $value = $stats{ $measure->{stat} };
+        next if (!defined($value) || $value !~ /^-?\d+(?:\.\d+)?$/);
+        $self->{environment}->{ $measure->{key} } = $value;
+    }
+
+    foreach my $family (@$COMPONENT_COMMANDS) {
+        next if (defined($self->{option_results}->{filter_type}) && $self->{option_results}->{filter_type} ne ''
+            && $family->{label} !~ /$self->{option_results}->{filter_type}/);
+
+        # Une famille absente du modele ou du firmware ne doit pas faire
+        # echouer le controle des autres.
+        my $entries = $options{custom}->request_optional(command => $family->{command});
+
+        foreach my $entry (@$entries) {
+            # Tous les objets n'ont pas de champ 'name' : un disque ou une
+            # alimentation ne portent qu'un identifiant. On prend le premier
+            # champ renseigne, en commencant par ceux propres a la famille.
+            my @candidates = ('name');
+            push @candidates, @{ $family->{id_fields} } if (defined($family->{id_fields}));
+            push @candidates, 'id';
+
+            my $name = '-';
+            foreach my $candidate (@candidates) {
+                next if (!defined($entry->{$candidate}) || $entry->{$candidate} eq '');
+                $name = $entry->{$candidate};
+                last;
+            }
+            my $instance = $family->{label} . '.' . $name;
+
+            next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+                && $name !~ /$self->{option_results}->{filter_name}/);
+
+            my $status = field($entry, 'status');
+
+            $self->{global}->{detected}++;
+            $self->{global}->{degraded}++ if ($status !~ /^online$/i);
+
+            $self->{components}->{$instance} = {
+                name => $name,
+                type => $family->{label},
+                status => $status
+            };
+
+            next if ($family->{command} ne 'lsenclosure');
+
+            # Compteurs online/total portes par le chassis lui-meme.
+            foreach my $subsystem (@$ENCLOSURE_SUBSYSTEMS) {
+                my $online = $entry->{'online_' . $subsystem->{field}};
+                my $total  = $entry->{'total_' . $subsystem->{field}};
+
+                next if (!defined($online) || !defined($total));
+                next if ($online !~ /^\d+$/ || $total !~ /^\d+$/);
+                # total = 0 : le sous-ensemble n'existe pas sur ce materiel.
+                next if ($total == 0);
+
+                $self->{subsystems}->{ $name . '.' . $subsystem->{field} } = {
+                    enclosure => $name,
+                    label => $subsystem->{label},
+                    online => $online,
+                    total => $total
+                };
+            }
+        }
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check hardware health: enclosures, node and expansion canisters, power
+supplies, batteries, drives, arrays, mdisks and quorum devices.
+
+Enclosure subsystems are additionally checked through the C<online_*>/C<total_*>
+counters the enclosure itself reports. A subsystem whose total is zero is not
+fitted on that model and is skipped rather than counted as missing.
+
+Families that do not exist on a given model or firmware are skipped silently,
+so the same mode covers every Storage Virtualize system.
+
+Example:
+
+    perl centreon_plugins.pl --plugin=storage::ibm::flashsystem::restapi::plugin \
+        --mode=hardware --hostname=10.0.0.1 \
+        --api-username=svc_monitor --api-password=xxx
+
+=over 8
+
+=item B<--filter-type>
+
+Only check component families whose label matches this regular expression
+(enclosure, node canister, expansion canister, power supply, battery, drive,
+array, mdisk, quorum).
+
+=item B<--filter-name>
+
+Only check components whose name or id matches this regular expression.
+
+=item B<--unknown-component-status> B<--warning-component-status> B<--critical-component-status>
+
+Threshold on each component. Available macros: C<name>, C<type>, C<status>.
+
+Default critical: C<%{status} =~ /^(offline|excluded)$/i>
+
+Default warning: C<%{status} =~ /^(degraded|degraded_paths|degraded_ports)$/i>
+
+Critical means B<service lost>, warning means B<redundancy lost>. Every part
+here is redundant — two power supplies, two canisters, six fan modules, a DRAID
+across twelve drives — so a degraded component eats the margin without stopping
+anything. Merging the two wakes someone up for a fault that can wait for
+business hours, and buries the real outage among them.
+
+=item B<--unknown-subsystem-status> B<--warning-subsystem-status> B<--critical-subsystem-status>
+
+Threshold on each enclosure subsystem. Available macros: C<enclosure>,
+C<label>, C<online>, C<total>.
+
+Default critical: C<%{online} == 0> — nothing left in that subsystem.
+
+Default warning: C<%{online} E<lt> %{total}> — one power supply out of two is a
+lost redundancy, not an outage.
+
+=item B<--warning-components-degraded> B<--critical-components-degraded>
+
+Thresholds on the number of components that are not online.
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/mode/hardware.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/hardware.pm
@@ -53,12 +53,12 @@ use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_
 my $COMPONENT_COMMANDS = [
     { command => 'lsenclosure',         label => 'enclosure' },
     { command => 'lsnodecanister',      label => 'node canister' },
-    { command => 'lsenclosurecanister', label => 'expansion canister' },
-    { command => 'lsenclosurepsu',      label => 'power supply' },
-    { command => 'lsenclosurebattery',  label => 'battery' },
+    { command => 'lsenclosurecanister', label => 'expansion canister', id_fields => [ 'canister_id' ] },
+    { command => 'lsenclosurepsu',      label => 'power supply', id_fields => [ 'PSU_id' ] },
+    { command => 'lsenclosurebattery',  label => 'battery', id_fields => [ 'battery_id' ] },
     { command => 'lsenclosurefanmodule', label => 'fan module', id_fields => [ 'fan_module_id' ] },
     { command => 'lsdrive',             label => 'drive' },
-    { command => 'lsarray',             label => 'array' },
+    { command => 'lsarray',             label => 'array', id_fields => [ 'mdisk_name', 'mdisk_id' ] },
     { command => 'lsmdisk',             label => 'mdisk' },
     { command => 'lsquorum',            label => 'quorum', id_fields => [ 'quorum_index' ] }
 ];

--- a/src/storage/ibm/flashsystem/restapi/mode/hosts.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/hosts.pm
@@ -121,7 +121,7 @@ sub set_counters {
     $self->{maps_counters}->{hosts} = [
         {
             label => 'status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             critical_default => '%{status} =~ /^degraded$/i',
             warning_default => '%{status} =~ /^offline$/i',
             set => {

--- a/src/storage/ibm/flashsystem/restapi/mode/hosts.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/hosts.pm
@@ -1,0 +1,248 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Etat des hotes declares sur la baie.
+#
+# Aucune exclusion n'est ecrite dans le plugin. Un hote hors ligne remonte,
+# qu'il le soit par panne ou par construction : c'est le role de la supervision
+# de refleter l'etat reel. Un hote hors ligne en toute connaissance de cause
+# s'acquitte ou se met en maintenance dans Centreon — ce qui laisse une trace
+# et une date de revue, la ou un filtre code en dur le ferait disparaitre
+# silencieusement.
+#
+# --filter-name reste disponible pour restreindre le perimetre d'un service,
+# mais il est vide par defaut.
+#
+
+package storage::ibm::flashsystem::restapi::mode::hosts;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_host_output {
+    my ($self, %options) = @_;
+
+    my $msg = sprintf('status: %s', $self->{result_values}->{status});
+
+    $msg .= sprintf(', ports: %s', $self->{result_values}->{port_count})
+        if ($self->{result_values}->{port_count} ne '-');
+    $msg .= sprintf(', host cluster: %s', $self->{result_values}->{host_cluster_name})
+        if ($self->{result_values}->{host_cluster_name} ne '-');
+    $msg .= sprintf(', partition: %s', $self->{result_values}->{partition_name})
+        if ($self->{result_values}->{partition_name} ne '-');
+
+    return $msg;
+}
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+
+    return 'Hosts: ';
+}
+
+sub prefix_host_output {
+    my ($self, %options) = @_;
+
+    return "Host '" . $options{instance_value}->{name} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
+        { name => 'hosts', type => 1, cb_prefix_output => 'prefix_host_output',
+          message_multiple => 'All hosts are online', skipped_code => { -10 => 1 } }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'detected', nlabel => 'hosts.detected.count', set => {
+                key_values => [ { name => 'detected' } ],
+                output_template => '%s declared',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'online', nlabel => 'hosts.online.count', set => {
+                key_values => [ { name => 'online' } ],
+                output_template => '%s online',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'offline', nlabel => 'hosts.offline.count', set => {
+                key_values => [ { name => 'offline' } ],
+                output_template => '%s offline',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'degraded', nlabel => 'hosts.degraded.count', set => {
+                key_values => [ { name => 'degraded' } ],
+                output_template => '%s degraded',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        }
+    ];
+
+    # Les deux etats ne disent pas ce qu'on croit, et l'ordre de gravite
+    # naturel est INVERSE :
+    #
+    #   offline  = plus aucun WWPN de l'hote ne se connecte. La baie ne sait
+    #              pas distinguer un serveur eteint a dessein d'un serveur en
+    #              panne — et le cas courant est le premier (reserves,
+    #              sauvegardes). Ce n'est pas un defaut de la baie : WARNING,
+    #              visible sans reveiller l'astreinte.
+    #   degraded = une PARTIE seulement des chemins repond. L'hote tourne, en
+    #              production, sur une redondance entamee : le prochain chemin
+    #              perdu lui coupe son stockage. C'est actionnable tout de
+    #              suite (zoning, SFP, switch) et souvent le seul endroit ou ce
+    #              defaut de fabrique se voit : CRITICAL.
+    $self->{maps_counters}->{hosts} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '%{status} =~ /^degraded$/i',
+            warning_default => '%{status} =~ /^offline$/i',
+            set => {
+                key_values => [
+                    { name => 'name' }, { name => 'status' }, { name => 'port_count' },
+                    { name => 'host_cluster_name' }, { name => 'partition_name' }
+                ],
+                closure_custom_output => $self->can('custom_host_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s'      => { name => 'filter_name' },
+        'filter-partition:s' => { name => 'filter_partition' }
+    });
+
+    return $self;
+}
+
+sub field {
+    my ($entry, $name) = @_;
+
+    return '-' if (!defined($entry->{$name}) || $entry->{$name} eq '');
+    return $entry->{$name};
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    my $entries = $options{custom}->request(command => 'lshost');
+
+    $self->{global} = { detected => 0, online => 0, offline => 0, degraded => 0 };
+    $self->{hosts} = {};
+
+    foreach my $entry (@$entries) {
+        my $name = field($entry, 'name');
+        my $partition = field($entry, 'partition_name');
+
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $name !~ /$self->{option_results}->{filter_name}/);
+        next if (defined($self->{option_results}->{filter_partition}) && $self->{option_results}->{filter_partition} ne ''
+            && $partition !~ /$self->{option_results}->{filter_partition}/);
+
+        my $status = field($entry, 'status');
+
+        $self->{global}->{detected}++;
+        $self->{global}->{online}++   if ($status =~ /^online$/i);
+        $self->{global}->{offline}++  if ($status =~ /^offline$/i);
+        $self->{global}->{degraded}++ if ($status =~ /^degraded$/i);
+
+        $self->{hosts}->{$name} = {
+            name => $name,
+            status => $status,
+            port_count => field($entry, 'port_count'),
+            host_cluster_name => field($entry, 'host_cluster_name'),
+            partition_name => $partition
+        };
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check the status of the hosts declared on the system.
+
+Every declared host is evaluated. A host that is offline on purpose — a spare
+LPAR profile, an idle backup host — still reports offline: acknowledging it in
+Centreon records who decided it is expected and when that should be revisited,
+which a hard-coded exclusion would not.
+
+Example:
+
+    perl centreon_plugins.pl --plugin=storage::ibm::flashsystem::restapi::plugin \
+        --mode=hosts --hostname=10.0.0.1 \
+        --api-username=svc_monitor --api-password=xxx
+
+=over 8
+
+=item B<--filter-name>
+
+Only check hosts whose name matches this regular expression. Empty by default.
+
+=item B<--filter-partition>
+
+Only check hosts belonging to a storage partition matching this regular
+expression. Empty by default.
+
+=item B<--unknown-status> B<--warning-status> B<--critical-status>
+
+Threshold on each host. Available macros: C<name>, C<status>, C<port_count>,
+C<host_cluster_name>, C<partition_name>.
+
+Default warning: C<%{status} =~ /^offline$/i>
+
+Default critical: C<%{status} =~ /^degraded$/i>
+
+The natural order of severity is B<inverted> here, on purpose. C<offline> means
+no WWPN of that host connects any more: the array cannot tell a deliberately
+powered-off server from a failed one, and the common case is the former
+(spares, backup hosts) — a warning keeps it visible without waking anyone.
+C<degraded> means only B<part> of the paths answer: the host is running, in
+production, on eaten-into redundancy, and the next lost path cuts its storage.
+That is actionable right now (zoning, SFP, switch) and is often the only place
+such a fabric fault shows up.
+
+=item B<--warning-offline> B<--critical-offline> B<--warning-degraded> B<--critical-degraded>
+
+Thresholds on the number of offline and degraded hosts.
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/mode/hosts.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/hosts.pm
@@ -39,6 +39,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use centreon::plugins::constants qw/:counters :values/;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
 sub custom_host_output {
@@ -72,9 +73,9 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
-        { name => 'hosts', type => 1, cb_prefix_output => 'prefix_host_output',
-          message_multiple => 'All hosts are online', skipped_code => { -10 => 1 } }
+        { name => 'global', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_global_output' },
+        { name => 'hosts', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_host_output',
+          message_multiple => 'All hosts are online', skipped_code => { NO_VALUE() => 1 } }
     ];
 
     $self->{maps_counters}->{global} = [

--- a/src/storage/ibm/flashsystem/restapi/mode/hosts.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/hosts.pm
@@ -221,14 +221,12 @@ Only check hosts whose name matches this regular expression. Empty by default.
 Only check hosts belonging to a storage partition matching this regular
 expression. Empty by default.
 
-=item B<--unknown-status> B<--warning-status> B<--critical-status>
+=item B<--unknown-status>
+
+Define the conditions to match for the status to be UNKNOWN.
 
 Threshold on each host. Available macros: C<name>, C<status>, C<port_count>,
 C<host_cluster_name>, C<partition_name>.
-
-Default warning: C<%{status} =~ /^offline$/i>
-
-Default critical: C<%{status} =~ /^degraded$/i>
 
 The natural order of severity is B<inverted> here, on purpose. C<offline> means
 no WWPN of that host connects any more: the array cannot tell a deliberately
@@ -239,7 +237,63 @@ production, on eaten-into redundancy, and the next lost path cuts its storage.
 That is actionable right now (zoning, SFP, switch) and is often the only place
 such a fabric fault shows up.
 
-=item B<--warning-offline> B<--critical-offline> B<--warning-degraded> B<--critical-degraded>
+=item B<--warning-status>
+
+Define the conditions to match for the status to be WARNING.
+
+Threshold on each host. Available macros: C<name>, C<status>, C<port_count>,
+C<host_cluster_name>, C<partition_name>.
+
+Default warning: C<%{status} =~ /^offline$/i>.
+
+The natural order of severity is B<inverted> here, on purpose. C<offline> means
+no WWPN of that host connects any more: the array cannot tell a deliberately
+powered-off server from a failed one, and the common case is the former
+(spares, backup hosts) — a warning keeps it visible without waking anyone.
+C<degraded> means only B<part> of the paths answer: the host is running, in
+production, on eaten-into redundancy, and the next lost path cuts its storage.
+That is actionable right now (zoning, SFP, switch) and is often the only place
+such a fabric fault shows up.
+
+=item B<--critical-status>
+
+Define the conditions to match for the status to be CRITICAL.
+
+Threshold on each host. Available macros: C<name>, C<status>, C<port_count>,
+C<host_cluster_name>, C<partition_name>.
+
+Default critical: C<%{status} =~ /^degraded$/i>.
+
+The natural order of severity is B<inverted> here, on purpose. C<offline> means
+no WWPN of that host connects any more: the array cannot tell a deliberately
+powered-off server from a failed one, and the common case is the former
+(spares, backup hosts) — a warning keeps it visible without waking anyone.
+C<degraded> means only B<part> of the paths answer: the host is running, in
+production, on eaten-into redundancy, and the next lost path cuts its storage.
+That is actionable right now (zoning, SFP, switch) and is often the only place
+such a fabric fault shows up.
+
+=item B<--warning-offline>
+
+Warning threshold.
+
+Thresholds on the number of offline and degraded hosts.
+
+=item B<--critical-offline>
+
+Critical threshold.
+
+Thresholds on the number of offline and degraded hosts.
+
+=item B<--warning-degraded>
+
+Warning threshold.
+
+Thresholds on the number of offline and degraded hosts.
+
+=item B<--critical-degraded>
+
+Critical threshold.
 
 Thresholds on the number of offline and degraded hosts.
 

--- a/src/storage/ibm/flashsystem/restapi/mode/hosts.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/hosts.pm
@@ -21,17 +21,16 @@
 #
 
 #
-# Etat des hotes declares sur la baie.
+# Status of the hosts declared on the system.
 #
-# Aucune exclusion n'est ecrite dans le plugin. Un hote hors ligne remonte,
-# qu'il le soit par panne ou par construction : c'est le role de la supervision
-# de refleter l'etat reel. Un hote hors ligne en toute connaissance de cause
-# s'acquitte ou se met en maintenance dans Centreon — ce qui laisse une trace
-# et une date de revue, la ou un filtre code en dur le ferait disparaitre
-# silencieusement.
+# No exclusion is written in the plugin. An offline host is reported, whether
+# it is offline by failure or by design: reflecting the real state is what
+# monitoring is for. A host knowingly offline is acknowledged or put in
+# downtime in Centreon - which leaves a trace and a review date, where a
+# hard-coded filter would make it disappear silently.
 #
-# --filter-name reste disponible pour restreindre le perimetre d'un service,
-# mais il est vide par defaut.
+# --filter-name remains available to restrict the scope of a service, but it
+# is empty by default.
 #
 
 package storage::ibm::flashsystem::restapi::mode::hosts;
@@ -105,19 +104,19 @@ sub set_counters {
         }
     ];
 
-    # Les deux etats ne disent pas ce qu'on croit, et l'ordre de gravite
-    # naturel est INVERSE :
+    # The two states do not mean what one expects, and the natural order of
+    # severity is INVERTED:
     #
-    #   offline  = plus aucun WWPN de l'hote ne se connecte. La baie ne sait
-    #              pas distinguer un serveur eteint a dessein d'un serveur en
-    #              panne — et le cas courant est le premier (reserves,
-    #              sauvegardes). Ce n'est pas un defaut de la baie : WARNING,
-    #              visible sans reveiller l'astreinte.
-    #   degraded = une PARTIE seulement des chemins repond. L'hote tourne, en
-    #              production, sur une redondance entamee : le prochain chemin
-    #              perdu lui coupe son stockage. C'est actionnable tout de
-    #              suite (zoning, SFP, switch) et souvent le seul endroit ou ce
-    #              defaut de fabrique se voit : CRITICAL.
+    #   offline  = no WWPN of the host connects any more. The array cannot
+    #              tell a deliberately powered-off server from a failed one -
+    #              and the common case is the former (spares, backup hosts).
+    #              It is not a fault of the array: WARNING, visible without
+    #              waking anyone up.
+    #   degraded = only PART of the paths answer. The host is running, in
+    #              production, on eaten-into redundancy: the next lost path
+    #              cuts its storage. Actionable right away (zoning, SFP,
+    #              switch) and often the only place such a fabric fault
+    #              shows: CRITICAL.
     $self->{maps_counters}->{hosts} = [
         {
             label => 'status',

--- a/src/storage/ibm/flashsystem/restapi/mode/performance.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/performance.pm
@@ -45,6 +45,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use centreon::plugins::constants qw/:counters :values/;
 
 # Mapping between the array counters and the published metrics. 'scale'
 # converts to the unit Centreon expects; the array's MB/s become bytes per
@@ -83,9 +84,9 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'system', type => 0, cb_prefix_output => 'prefix_system_output' },
-        { name => 'nodes', type => 1, cb_prefix_output => 'prefix_node_output',
-          message_multiple => 'All node CPUs are ok', skipped_code => { -10 => 1 } }
+        { name => 'system', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_system_output' },
+        { name => 'nodes', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_node_output',
+          message_multiple => 'All node CPUs are ok', skipped_code => { NO_VALUE() => 1 } }
     ];
 
     # There is no "load average" on Storage Virtualize: the closest equivalent

--- a/src/storage/ibm/flashsystem/restapi/mode/performance.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/performance.pm
@@ -319,34 +319,141 @@ Example:
 
 Add each counter's peak value and peak time to the long output.
 
-=item B<--warning-latency> B<--critical-latency>
+=item B<--warning-latency>
+
+Warning threshold.
 
 Thresholds on the overall volume latency, in milliseconds. Suggested starting
 point on these all-flash systems: 10 and 20. Measured idle values sit around
 0.3 ms, so anything in that range is already an order of magnitude off.
 
-=item B<--warning-read-latency> B<--critical-read-latency> B<--warning-write-latency> B<--critical-write-latency>
+=item B<--critical-latency>
+
+Critical threshold.
+
+Thresholds on the overall volume latency, in milliseconds. Suggested starting
+point on these all-flash systems: 10 and 20. Measured idle values sit around
+0.3 ms, so anything in that range is already an order of magnitude off.
+
+=item B<--warning-read-latency>
+
+Warning threshold.
 
 Same, split by direction. Writes are normally slower than reads — around 0.5 ms
 against 0.2 on these arrays — so a single threshold on both hides a write
 problem.
 
-=item B<--warning-backend-latency> B<--critical-backend-latency> B<--warning-drive-latency> B<--critical-drive-latency>
+=item B<--critical-read-latency>
+
+Critical threshold.
+
+Same, split by direction. Writes are normally slower than reads — around 0.5 ms
+against 0.2 on these arrays — so a single threshold on both hides a write
+problem.
+
+=item B<--warning-write-latency>
+
+Warning threshold.
+
+Same, split by direction. Writes are normally slower than reads — around 0.5 ms
+against 0.2 on these arrays — so a single threshold on both hides a write
+problem.
+
+=item B<--critical-write-latency>
+
+Critical threshold.
+
+Same, split by direction. Writes are normally slower than reads — around 0.5 ms
+against 0.2 on these arrays — so a single threshold on both hides a write
+problem.
+
+=item B<--warning-backend-latency>
+
+Warning threshold.
 
 Latency of the mdisks and of the drives. Compare with the volume latency: a
 system slow at the front but fast at the back points at the cache or the
 fabric, not at the disks.
 
-=item B<--warning-iops> B<--critical-iops> B<--warning-bandwidth> B<--critical-bandwidth>
+=item B<--critical-backend-latency>
+
+Critical threshold.
+
+Latency of the mdisks and of the drives. Compare with the volume latency: a
+system slow at the front but fast at the back points at the cache or the
+fabric, not at the disks.
+
+=item B<--warning-drive-latency>
+
+Warning threshold.
+
+Latency of the mdisks and of the drives. Compare with the volume latency: a
+system slow at the front but fast at the back points at the cache or the
+fabric, not at the disks.
+
+=item B<--critical-drive-latency>
+
+Critical threshold.
+
+Latency of the mdisks and of the drives. Compare with the volume latency: a
+system slow at the front but fast at the back points at the cache or the
+fabric, not at the disks.
+
+=item B<--warning-iops>
+
+Warning threshold.
 
 Thresholds on volume IOPS and throughput. Throughput is in bytes per second —
 the array reports MB/s and the mode converts.
 
-=item B<--warning-cpu> B<--critical-cpu> B<--warning-compression-cpu> B<--critical-compression-cpu>
+=item B<--critical-iops>
+
+Critical threshold.
+
+Thresholds on volume IOPS and throughput. Throughput is in bytes per second —
+the array reports MB/s and the mode converts.
+
+=item B<--warning-bandwidth>
+
+Warning threshold.
+
+Thresholds on volume IOPS and throughput. Throughput is in bytes per second —
+the array reports MB/s and the mode converts.
+
+=item B<--critical-bandwidth>
+
+Critical threshold.
+
+Thresholds on volume IOPS and throughput. Throughput is in bytes per second —
+the array reports MB/s and the mode converts.
+
+=item B<--warning-cpu>
+
+Warning threshold.
 
 Thresholds on the processor load, overall and for compression.
 
-=item B<--warning-node-cpu> B<--critical-node-cpu>
+=item B<--critical-cpu>
+
+Critical threshold.
+
+Thresholds on the processor load, overall and for compression.
+
+=item B<--warning-compression-cpu>
+
+Warning threshold.
+
+Thresholds on the processor load, overall and for compression.
+
+=item B<--critical-compression-cpu>
+
+Critical threshold.
+
+Thresholds on the processor load, overall and for compression.
+
+=item B<--warning-node-cpu>
+
+Warning threshold.
 
 Thresholds on the B<per-canister> CPU load. Storage Virtualize has no load
 average; on an active/active pair the telling figure is the imbalance — one
@@ -355,12 +462,66 @@ hides. The C<node-cpu> label is chosen so the Cpu service's
 C<--filter-counters=cpu> picks these counters up without touching any Centreon
 template.
 
-=item B<--warning-write-cache> B<--critical-write-cache> B<--warning-total-cache> B<--critical-total-cache>
+=item B<--critical-node-cpu>
+
+Critical threshold.
+
+Thresholds on the B<per-canister> CPU load. Storage Virtualize has no load
+average; on an active/active pair the telling figure is the imbalance — one
+canister carrying everything while the other idles — which the global average
+hides. The C<node-cpu> label is chosen so the Cpu service's
+C<--filter-counters=cpu> picks these counters up without touching any Centreon
+template.
+
+=item B<--warning-write-cache>
+
+Warning threshold.
 
 Thresholds on cache occupancy. A write cache that stays full is a sign the
 backend cannot absorb what the hosts send.
 
-=item B<--warning-fc-iops> B<--critical-fc-iops> B<--warning-fc-bandwidth> B<--critical-fc-bandwidth>
+=item B<--critical-write-cache>
+
+Critical threshold.
+
+Thresholds on cache occupancy. A write cache that stays full is a sign the
+backend cannot absorb what the hosts send.
+
+=item B<--warning-total-cache>
+
+Warning threshold.
+
+Thresholds on cache occupancy. A write cache that stays full is a sign the
+backend cannot absorb what the hosts send.
+
+=item B<--critical-total-cache>
+
+Critical threshold.
+
+Thresholds on cache occupancy. A write cache that stays full is a sign the
+backend cannot absorb what the hosts send.
+
+=item B<--warning-fc-iops>
+
+Warning threshold.
+
+Thresholds on the Fibre Channel load, all ports together.
+
+=item B<--critical-fc-iops>
+
+Critical threshold.
+
+Thresholds on the Fibre Channel load, all ports together.
+
+=item B<--warning-fc-bandwidth>
+
+Warning threshold.
+
+Thresholds on the Fibre Channel load, all ports together.
+
+=item B<--critical-fc-bandwidth>
+
+Critical threshold.
 
 Thresholds on the Fibre Channel load, all ports together.
 

--- a/src/storage/ibm/flashsystem/restapi/mode/performance.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/performance.pm
@@ -21,23 +21,22 @@
 #
 
 #
-# Performance de la baie : latence, debit, IOPS et charge processeur.
+# Array performance: latency, throughput, IOPS and processor load.
 #
-# lssystemstats rend une liste de compteurs { stat_name, stat_current,
-# stat_peak, stat_peak_time }. On expose la valeur courante en metrique et le
-# pic en donnee complementaire : sur un echantillonnage a cinq minutes, le pic
-# dit ce que la moyenne efface.
+# lssystemstats returns a list of counters { stat_name, stat_current,
+# stat_peak, stat_peak_time }. The current value is exposed as the metric and
+# the peak as extra information: on a five-minute sampling, the peak says what
+# the average erases.
 #
-# Aucun compteur ne porte de seuil par defaut : les IOPS, le debit et le
-# processeur n'ont pas de bonne valeur dans l'absolu — ils se reglent sur
-# l'observe. La latence est le seul indicateur a norme physique (sur du
-# tout-flash, quelques ms sont normales, quelques dizaines non) : la doc
-# suggere 10/20 ms comme point de depart, a poser via --warning-latency /
-# --critical-latency dans la macro EXTRAOPTIONS du modele Latency, en UAT.
+# No counter ships with a default threshold: IOPS, throughput and processor
+# have no good absolute value - they are set against what is observed. Latency
+# is the one indicator with a physical norm (on all-flash, a few ms are normal,
+# a few tens are not): the help suggests 5/15 ms as a starting point, to be set
+# with --warning-latency / --critical-latency on the service side.
 #
-# IBM Storage Insights Pro garde un an d'historique et des dizaines de
-# metriques : la metrologie fine vit la-bas. Ce mode existe pour l'ALERTE, qui
-# doit naitre dans Centreon parce que c'est lui qui parle a ServiceNow.
+# Fine metrology usually lives in the vendor tool (IBM Storage Insights keeps
+# a year of history and dozens of metrics). This mode exists for the ALERT,
+# which has to be raised by the monitoring platform.
 #
 
 package storage::ibm::flashsystem::restapi::mode::performance;
@@ -47,9 +46,9 @@ use base qw(centreon::plugins::templates::counter);
 use strict;
 use warnings;
 
-# Correspondance entre les compteurs de la baie et les metriques publiees.
-# 'scale' convertit vers l'unite attendue par Centreon ; les Mo/s de la baie
-# deviennent des octets par seconde.
+# Mapping between the array counters and the published metrics. 'scale'
+# converts to the unit Centreon expects; the array's MB/s become bytes per
+# second.
 my $MEASURES = [
     { stat => 'vdisk_ms',           key => 'latency',            unit => 'ms' },
     { stat => 'vdisk_r_ms',         key => 'read_latency',       unit => 'ms' },
@@ -60,8 +59,8 @@ my $MEASURES = [
     { stat => 'compression_cpu_pc', key => 'compression_cpu',    unit => '%' },
     { stat => 'write_cache_pc',     key => 'write_cache',        unit => '%' },
     { stat => 'total_cache_pc',     key => 'total_cache',        unit => '%' },
-    # Cote arriere : utile pour distinguer une latence vue par les hotes d'une
-    # latence reellement produite par les disques.
+    # Back end: useful to tell a latency seen by the hosts from a latency really
+    # produced by the drives.
     { stat => 'mdisk_ms',           key => 'backend_latency',    unit => 'ms' },
     { stat => 'drive_ms',           key => 'drive_latency',      unit => 'ms' },
     { stat => 'fc_io',              key => 'fc_iops',            unit => 'iops' },
@@ -89,15 +88,14 @@ sub set_counters {
           message_multiple => 'All node CPUs are ok', skipped_code => { -10 => 1 } }
     ];
 
-    # Il n'y a pas de « load average » sur Storage Virtualize : l'equivalent
-    # le plus proche est la charge CPU PAR CANISTER (lsnodecanisterstats).
-    # Sur un actif/actif a deux noeuds, c'est le desequilibre qui parle : un
-    # noeud qui porte tout pendant que l'autre dort signale une bascule ou
-    # des chemins malades — invisible dans le CPU global, qui moyenne.
+    # There is no "load average" on Storage Virtualize: the closest equivalent
+    # is the CPU load PER CANISTER (lsnodecanisterstats). On an active/active
+    # pair it is the imbalance that speaks: one node carrying everything while
+    # the other idles signals a failover or sick paths - invisible in the global
+    # CPU, which averages.
     #
-    # Le label 'node-cpu' est choisi pour que le filtre --filter-counters=cpu
-    # du service Cpu l'attrape tel quel : la declinaison arrive dans le bon
-    # service sans toucher aux modeles Centreon.
+    # The 'node-cpu' label is chosen so that --filter-counters=cpu picks it up
+    # as is: a service split on the CPU counters gets it without any change.
     $self->{maps_counters}->{nodes} = [
         { label => 'node-cpu', nlabel => 'node.cpu.utilization.percentage', set => {
                 key_values => [ { name => 'cpu' }, { name => 'display' } ],
@@ -109,9 +107,9 @@ sub set_counters {
     ];
 
     $self->{maps_counters}->{system} = [
-        # La latence est le seul compteur livre avec des seuils : sur du
-        # tout-flash, au-dela de quelques dizaines de millisecondes le probleme
-        # est reel quelle que soit la charge.
+        # Latency is the one counter with a physical norm: on all-flash, beyond a
+        # few tens of milliseconds the problem is real whatever the load. No
+        # default is shipped; the help gives a suggested starting point.
         { label => 'latency', nlabel => 'system.io.latency.milliseconds',
           set => {
                 key_values => [ { name => 'latency' } ],
@@ -137,13 +135,13 @@ sub set_counters {
                 perfdatas => [ { template => '%s', unit => 'iops', min => 0 } ]
             }
         },
-        # output_change_bytes rend un couple (valeur, unite) : sans le second
-        # %s, la sortie affiche « bandwidth 1.34 » et l'unite disparait.
+        # output_change_bytes returns a (value, unit) pair: without the second
+        # %s, the output reads "bandwidth 1.34" and the unit disappears.
         #
-        # Et il faut le mode 1, pas 2 : le mode 2 est prevu pour le reseau, ou
-        # l'on compte des BITS, et rend une unite en « b » — « 1.74 Gb/s » pour
-        # une valeur qui est en octets par seconde. Un facteur huit dans la
-        # tete du lecteur. Le mode 1 rend « GB », ce que la mesure est vraiment.
+        # And it must be mode 1, not 2: mode 2 is meant for networking, where
+        # BITS are counted, and returns a unit in "b" - "1.74 Gb/s" for a value
+        # that is in bytes per second. A factor of eight in the reader's head.
+        # Mode 1 returns "GB", what the measure really is.
         { label => 'bandwidth', nlabel => 'system.io.usage.bytespersecond', set => {
                 key_values => [ { name => 'bandwidth' } ],
                 output_template => 'bandwidth %s %s/s',
@@ -218,9 +216,9 @@ sub new {
 sub manage_selection {
     my ($self, %options) = @_;
 
-    # statistics_status a 'off' fige lssystemstats sans le signaler : les
-    # valeurs restent lisibles mais ne bougent plus. Mieux vaut le dire que
-    # publier une courbe morte.
+    # statistics_status at 'off' freezes lssystemstats without saying so: the
+    # values stay readable but no longer move. Better to say it than to
+    # publish a dead curve.
     my $system = $options{custom}->request(command => 'lssystem')->[0];
     if (defined($system->{statistics_status}) && $system->{statistics_status} !~ /^on$/i) {
         $self->{output}->output_add(
@@ -238,8 +236,8 @@ sub manage_selection {
         $stats{ $entry->{stat_name} } = $entry;
     }
 
-    # Charge CPU par canister. request_optional : un firmware qui ne rendrait
-    # pas la commande prive du detail par noeud, pas du controle entier.
+    # CPU load per canister. request_optional: a firmware that would not
+    # return the command loses the per-node detail, not the whole check.
     $self->{nodes} = {};
     foreach my $entry (@{ $options{custom}->request_optional(command => 'lsnodecanisterstats') }) {
         next unless (ref $entry eq 'HASH'
@@ -281,8 +279,8 @@ sub manage_selection {
         $self->{output}->option_exit();
     }
 
-    # Le pic est ce que la moyenne sur cinq minutes efface : on le montre en
-    # sortie longue plutot que d'en faire une metrique de plus.
+    # The peak is what the five-minute average erases: it is shown in the long
+    # output rather than turned into one more metric.
     $self->{output}->output_add(long_msg => join("\n", @peaks)) if (@peaks);
 }
 

--- a/src/storage/ibm/flashsystem/restapi/mode/performance.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/performance.pm
@@ -1,0 +1,370 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Performance de la baie : latence, debit, IOPS et charge processeur.
+#
+# lssystemstats rend une liste de compteurs { stat_name, stat_current,
+# stat_peak, stat_peak_time }. On expose la valeur courante en metrique et le
+# pic en donnee complementaire : sur un echantillonnage a cinq minutes, le pic
+# dit ce que la moyenne efface.
+#
+# Aucun compteur ne porte de seuil par defaut : les IOPS, le debit et le
+# processeur n'ont pas de bonne valeur dans l'absolu — ils se reglent sur
+# l'observe. La latence est le seul indicateur a norme physique (sur du
+# tout-flash, quelques ms sont normales, quelques dizaines non) : la doc
+# suggere 10/20 ms comme point de depart, a poser via --warning-latency /
+# --critical-latency dans la macro EXTRAOPTIONS du modele Latency, en UAT.
+#
+# IBM Storage Insights Pro garde un an d'historique et des dizaines de
+# metriques : la metrologie fine vit la-bas. Ce mode existe pour l'ALERTE, qui
+# doit naitre dans Centreon parce que c'est lui qui parle a ServiceNow.
+#
+
+package storage::ibm::flashsystem::restapi::mode::performance;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+
+# Correspondance entre les compteurs de la baie et les metriques publiees.
+# 'scale' convertit vers l'unite attendue par Centreon ; les Mo/s de la baie
+# deviennent des octets par seconde.
+my $MEASURES = [
+    { stat => 'vdisk_ms',           key => 'latency',            unit => 'ms' },
+    { stat => 'vdisk_r_ms',         key => 'read_latency',       unit => 'ms' },
+    { stat => 'vdisk_w_ms',         key => 'write_latency',      unit => 'ms' },
+    { stat => 'vdisk_io',           key => 'iops',               unit => 'iops' },
+    { stat => 'vdisk_mb',           key => 'bandwidth',          unit => 'B/s', scale => 1024 * 1024 },
+    { stat => 'cpu_pc',             key => 'cpu',                unit => '%' },
+    { stat => 'compression_cpu_pc', key => 'compression_cpu',    unit => '%' },
+    { stat => 'write_cache_pc',     key => 'write_cache',        unit => '%' },
+    { stat => 'total_cache_pc',     key => 'total_cache',        unit => '%' },
+    # Cote arriere : utile pour distinguer une latence vue par les hotes d'une
+    # latence reellement produite par les disques.
+    { stat => 'mdisk_ms',           key => 'backend_latency',    unit => 'ms' },
+    { stat => 'drive_ms',           key => 'drive_latency',      unit => 'ms' },
+    { stat => 'fc_io',              key => 'fc_iops',            unit => 'iops' },
+    { stat => 'fc_mb',              key => 'fc_bandwidth',       unit => 'B/s', scale => 1024 * 1024 }
+];
+
+sub prefix_system_output {
+    my ($self, %options) = @_;
+
+    return 'Performance: ';
+}
+
+sub prefix_node_output {
+    my ($self, %options) = @_;
+
+    return "Node '" . $options{instance_value}->{display} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'system', type => 0, cb_prefix_output => 'prefix_system_output' },
+        { name => 'nodes', type => 1, cb_prefix_output => 'prefix_node_output',
+          message_multiple => 'All node CPUs are ok', skipped_code => { -10 => 1 } }
+    ];
+
+    # Il n'y a pas de « load average » sur Storage Virtualize : l'equivalent
+    # le plus proche est la charge CPU PAR CANISTER (lsnodecanisterstats).
+    # Sur un actif/actif a deux noeuds, c'est le desequilibre qui parle : un
+    # noeud qui porte tout pendant que l'autre dort signale une bascule ou
+    # des chemins malades — invisible dans le CPU global, qui moyenne.
+    #
+    # Le label 'node-cpu' est choisi pour que le filtre --filter-counters=cpu
+    # du service Cpu l'attrape tel quel : la declinaison arrive dans le bon
+    # service sans toucher aux modeles Centreon.
+    $self->{maps_counters}->{nodes} = [
+        { label => 'node-cpu', nlabel => 'node.cpu.utilization.percentage', set => {
+                key_values => [ { name => 'cpu' }, { name => 'display' } ],
+                output_template => 'cpu %s %%',
+                perfdatas => [ { template => '%s', unit => '%', min => 0, max => 100,
+                                 label_extra_instance => 1, instance_use => 'display' } ]
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{system} = [
+        # La latence est le seul compteur livre avec des seuils : sur du
+        # tout-flash, au-dela de quelques dizaines de millisecondes le probleme
+        # est reel quelle que soit la charge.
+        { label => 'latency', nlabel => 'system.io.latency.milliseconds',
+          set => {
+                key_values => [ { name => 'latency' } ],
+                output_template => 'latency %.3f ms',
+                perfdatas => [ { template => '%.3f', unit => 'ms', min => 0 } ]
+            }
+        },
+        { label => 'read-latency', nlabel => 'system.io.read.latency.milliseconds', set => {
+                key_values => [ { name => 'read_latency' } ],
+                output_template => 'read %.3f ms',
+                perfdatas => [ { template => '%.3f', unit => 'ms', min => 0 } ]
+            }
+        },
+        { label => 'write-latency', nlabel => 'system.io.write.latency.milliseconds', set => {
+                key_values => [ { name => 'write_latency' } ],
+                output_template => 'write %.3f ms',
+                perfdatas => [ { template => '%.3f', unit => 'ms', min => 0 } ]
+            }
+        },
+        { label => 'iops', nlabel => 'system.io.usage.iops', set => {
+                key_values => [ { name => 'iops' } ],
+                output_template => '%s IOPS',
+                perfdatas => [ { template => '%s', unit => 'iops', min => 0 } ]
+            }
+        },
+        # output_change_bytes rend un couple (valeur, unite) : sans le second
+        # %s, la sortie affiche « bandwidth 1.34 » et l'unite disparait.
+        #
+        # Et il faut le mode 1, pas 2 : le mode 2 est prevu pour le reseau, ou
+        # l'on compte des BITS, et rend une unite en « b » — « 1.74 Gb/s » pour
+        # une valeur qui est en octets par seconde. Un facteur huit dans la
+        # tete du lecteur. Le mode 1 rend « GB », ce que la mesure est vraiment.
+        { label => 'bandwidth', nlabel => 'system.io.usage.bytespersecond', set => {
+                key_values => [ { name => 'bandwidth' } ],
+                output_template => 'bandwidth %s %s/s',
+                output_change_bytes => 1,
+                perfdatas => [ { template => '%s', unit => 'B/s', min => 0 } ]
+            }
+        },
+        { label => 'cpu', nlabel => 'system.cpu.utilization.percentage', set => {
+                key_values => [ { name => 'cpu' } ],
+                output_template => 'cpu %s %%',
+                perfdatas => [ { template => '%s', unit => '%', min => 0, max => 100 } ]
+            }
+        },
+        { label => 'compression-cpu', nlabel => 'system.cpu.compression.utilization.percentage', set => {
+                key_values => [ { name => 'compression_cpu' } ],
+                output_template => 'compression cpu %s %%',
+                perfdatas => [ { template => '%s', unit => '%', min => 0, max => 100 } ]
+            }
+        },
+        { label => 'write-cache', nlabel => 'system.cache.write.usage.percentage', set => {
+                key_values => [ { name => 'write_cache' } ],
+                output_template => 'write cache %s %%',
+                perfdatas => [ { template => '%s', unit => '%', min => 0, max => 100 } ]
+            }
+        },
+        { label => 'total-cache', nlabel => 'system.cache.total.usage.percentage', set => {
+                key_values => [ { name => 'total_cache' } ],
+                output_template => 'total cache %s %%',
+                perfdatas => [ { template => '%s', unit => '%', min => 0, max => 100 } ]
+            }
+        },
+        { label => 'backend-latency', nlabel => 'system.backend.latency.milliseconds', set => {
+                key_values => [ { name => 'backend_latency' } ],
+                output_template => 'backend %.3f ms',
+                perfdatas => [ { template => '%.3f', unit => 'ms', min => 0 } ]
+            }
+        },
+        { label => 'drive-latency', nlabel => 'system.drive.latency.milliseconds', set => {
+                key_values => [ { name => 'drive_latency' } ],
+                output_template => 'drives %.3f ms',
+                perfdatas => [ { template => '%.3f', unit => 'ms', min => 0 } ]
+            }
+        },
+        { label => 'fc-iops', nlabel => 'system.fc.usage.iops', set => {
+                key_values => [ { name => 'fc_iops' } ],
+                output_template => 'fc %s IOPS',
+                perfdatas => [ { template => '%s', unit => 'iops', min => 0 } ]
+            }
+        },
+        { label => 'fc-bandwidth', nlabel => 'system.fc.usage.bytespersecond', set => {
+                key_values => [ { name => 'fc_bandwidth' } ],
+                output_template => 'fc %s %s/s',
+                output_change_bytes => 1,
+                perfdatas => [ { template => '%s', unit => 'B/s', min => 0 } ]
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'add-peaks' => { name => 'add_peaks' }
+    });
+
+    return $self;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    # statistics_status a 'off' fige lssystemstats sans le signaler : les
+    # valeurs restent lisibles mais ne bougent plus. Mieux vaut le dire que
+    # publier une courbe morte.
+    my $system = $options{custom}->request(command => 'lssystem')->[0];
+    if (defined($system->{statistics_status}) && $system->{statistics_status} !~ /^on$/i) {
+        $self->{output}->output_add(
+            severity => 'UNKNOWN',
+            short_msg => 'Statistics collection is ' . $system->{statistics_status}
+                . ' on this system: the counters below would be stale.'
+        );
+        $self->{output}->display();
+        $self->{output}->exit();
+    }
+
+    my %stats;
+    foreach my $entry (@{ $options{custom}->request(command => 'lssystemstats') }) {
+        next unless (ref $entry eq 'HASH' && defined($entry->{stat_name}));
+        $stats{ $entry->{stat_name} } = $entry;
+    }
+
+    # Charge CPU par canister. request_optional : un firmware qui ne rendrait
+    # pas la commande prive du detail par noeud, pas du controle entier.
+    $self->{nodes} = {};
+    foreach my $entry (@{ $options{custom}->request_optional(command => 'lsnodecanisterstats') }) {
+        next unless (ref $entry eq 'HASH'
+            && defined($entry->{stat_name}) && $entry->{stat_name} eq 'cpu_pc');
+        my $node = $entry->{node_name};
+        next if (!defined($node) || $node eq '');
+        my $value = $entry->{stat_current};
+        next if (!defined($value) || $value !~ /^-?\d+(?:\.\d+)?$/);
+        $self->{nodes}->{$node} = { display => $node, cpu => $value };
+    }
+
+    $self->{system} = {};
+    my @peaks;
+
+    foreach my $measure (@$MEASURES) {
+        my $entry = $stats{ $measure->{stat} };
+        next if (!defined($entry));
+
+        my $current = $entry->{stat_current};
+        next if (!defined($current) || $current !~ /^-?\d+(?:\.\d+)?$/);
+
+        my $scale = defined($measure->{scale}) ? $measure->{scale} : 1;
+        $self->{system}->{ $measure->{key} } = $current * $scale;
+
+        next if (!defined($self->{option_results}->{add_peaks}));
+        my $peak = $entry->{stat_peak};
+        next if (!defined($peak) || $peak !~ /^-?\d+(?:\.\d+)?$/);
+        push @peaks, sprintf(
+            '%s peak %s%s at %s',
+            $measure->{stat}, $peak, $measure->{unit},
+            defined($entry->{stat_peak_time}) ? $entry->{stat_peak_time} : 'unknown'
+        );
+    }
+
+    if (!keys %{ $self->{system} }) {
+        $self->{output}->add_option_msg(
+            short_msg => 'No usable counter returned by lssystemstats.'
+        );
+        $self->{output}->option_exit();
+    }
+
+    # Le pic est ce que la moyenne sur cinq minutes efface : on le montre en
+    # sortie longue plutot que d'en faire une metrique de plus.
+    $self->{output}->output_add(long_msg => join("\n", @peaks)) if (@peaks);
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check the array performance: latency, bandwidth, IOPS and processor load.
+
+C<lssystemstats> returns counters sampled every five minutes. The current value
+becomes the metric; C<--add-peaks> adds the peak and its timestamp to the long
+output, because on a five-minute average the peak is what the mean erases.
+
+Only latency ships with thresholds. It is the one indicator with a physical
+norm: on all-flash, a few milliseconds is normal and a few tens is not,
+whichever array you look at. IOPS, bandwidth and CPU have no good absolute
+value — they are set against what you observe, so no default is shipped.
+
+IBM Storage Insights Pro keeps a year of history and dozens of metrics: fine
+metrology lives there. This mode exists for the B<alert>, which has to be raised
+in Centreon because Centreon is what talks to ServiceNow.
+
+Example:
+
+    perl centreon_plugins.pl --plugin=storage::ibm::flashsystem::restapi::plugin \
+        --mode=performance --hostname=10.0.0.1 \
+        --api-username=svc_monitor --api-password=xxx --insecure \
+        --warning-latency=10 --critical-latency=20
+
+=over 8
+
+=item B<--add-peaks>
+
+Add each counter's peak value and peak time to the long output.
+
+=item B<--warning-latency> B<--critical-latency>
+
+Thresholds on the overall volume latency, in milliseconds. Suggested starting
+point on these all-flash systems: 10 and 20. Measured idle values sit around
+0.3 ms, so anything in that range is already an order of magnitude off.
+
+=item B<--warning-read-latency> B<--critical-read-latency> B<--warning-write-latency> B<--critical-write-latency>
+
+Same, split by direction. Writes are normally slower than reads — around 0.5 ms
+against 0.2 on these arrays — so a single threshold on both hides a write
+problem.
+
+=item B<--warning-backend-latency> B<--critical-backend-latency> B<--warning-drive-latency> B<--critical-drive-latency>
+
+Latency of the mdisks and of the drives. Compare with the volume latency: a
+system slow at the front but fast at the back points at the cache or the
+fabric, not at the disks.
+
+=item B<--warning-iops> B<--critical-iops> B<--warning-bandwidth> B<--critical-bandwidth>
+
+Thresholds on volume IOPS and throughput. Throughput is in bytes per second —
+the array reports MB/s and the mode converts.
+
+=item B<--warning-cpu> B<--critical-cpu> B<--warning-compression-cpu> B<--critical-compression-cpu>
+
+Thresholds on the processor load, overall and for compression.
+
+=item B<--warning-node-cpu> B<--critical-node-cpu>
+
+Thresholds on the B<per-canister> CPU load. Storage Virtualize has no load
+average; on an active/active pair the telling figure is the imbalance — one
+canister carrying everything while the other idles — which the global average
+hides. The C<node-cpu> label is chosen so the Cpu service's
+C<--filter-counters=cpu> picks these counters up without touching any Centreon
+template.
+
+=item B<--warning-write-cache> B<--critical-write-cache> B<--warning-total-cache> B<--critical-total-cache>
+
+Thresholds on cache occupancy. A write cache that stays full is a sign the
+backend cannot absorb what the hosts send.
+
+=item B<--warning-fc-iops> B<--critical-fc-iops> B<--warning-fc-bandwidth> B<--critical-fc-bandwidth>
+
+Thresholds on the Fibre Channel load, all ports together.
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/mode/replication.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/replication.pm
@@ -21,19 +21,18 @@
 #
 
 #
-# Etat de la replication, sous les trois formes que Storage Virtualize connait :
+# Replication health, in the three forms Storage Virtualize knows:
 #
-#   - partitions de stockage (8.7+) : c'est la partition qui porte l'etat de
-#     sante de la haute disponibilite. Un ha_status a 'problem' coexiste sans
-#     contradiction avec des groupes de volumes tous 'synchronized' : regarder
-#     les seuls groupes ferait conclure a tort que tout va bien.
-#   - replication par politique (8.5.2+) : lsvolumegroupreplication.
-#   - Metro / Global Mirror (historique) : lsrcrelationship.
+#   - storage partitions (8.7+): the partition is what carries the high
+#     availability health. An ha_status at 'problem' coexists without
+#     contradiction with volume groups all 'synchronized': looking at the
+#     groups alone would wrongly conclude that all is well.
+#   - policy-based replication (8.5.2+): lsvolumegroupreplication.
+#   - Metro / Global Mirror (legacy): lsrcrelationship.
 #
-# Les trois sont interrogees systematiquement. Une baie qui n'en utilise
-# aucune rend OK avec la mention explicite qu'aucune replication n'est
-# configuree ; une baie qui en utilise deux voit les deux. Aucun mode n'est a
-# activer par option.
+# All three are queried systematically. A system using none of them reports
+# OK with an explicit mention that no replication is configured; a system
+# using two sees both. No mode has to be enabled by option.
 #
 
 package storage::ibm::flashsystem::restapi::mode::replication;
@@ -53,7 +52,7 @@ sub custom_partition_output {
         $self->{result_values}->{link_status}
     );
 
-    # Les deux cotes ne sont renseignes que sur une partition repliquee.
+    # Both sides are only set on a replicated partition.
     foreach my $side (1, 2) {
         my $system = $self->{result_values}->{'location' . $side . '_system_name'};
         my $status = $self->{result_values}->{'location' . $side . '_status'};
@@ -75,9 +74,9 @@ sub custom_group_output {
     $msg .= sprintf(', partition: %s', $self->{result_values}->{partition_name})
         if ($self->{result_values}->{partition_name} ne '-');
 
-    # En 2-site-ha ces champs restent vides : ils ne decrivent que la
-    # replication asynchrone. On ne les affiche donc que s'ils portent une
-    # valeur, ce qui rend le meme mode lisible dans les deux topologies.
+    # In 2-site-ha these fields stay empty: they only describe asynchronous
+    # replication. They are therefore only shown when they carry a value,
+    # which keeps the same mode readable in both topologies.
     foreach my $side (1, 2) {
         my $rpo = $self->{result_values}->{'location' . $side . '_within_rpo'};
         next if ($rpo eq '-');
@@ -176,10 +175,10 @@ sub set_counters {
         }
     ];
 
-    # Les seuils par defaut signalent tout ce qui n'est pas explicitement sain.
-    # Une valeur inconnue — firmware plus recent, topologie non rencontree —
-    # remonte donc plutot que de passer inapercue ; --critical-status permet de
-    # l'accepter ensuite, par service, sans toucher au code.
+    # Default thresholds report everything that is not explicitly healthy. An
+    # unknown value - newer firmware, topology not met yet - is therefore
+    # raised rather than going unnoticed; --critical-status then allows
+    # accepting it, per service, without touching the code.
     $self->{maps_counters}->{partitions} = [
         {
             label => 'partition-status',
@@ -203,9 +202,9 @@ sub set_counters {
         {
             label => 'volume-group-status',
             type => 2,
-            # L'expression sur within_rpo est volontairement inerte quand le
-            # champ est vide : elle ne se declenche qu'en replication
-            # asynchrone, ou la baie le renseigne.
+            # The expression on within_rpo is deliberately inert when the field
+            # is empty: it only triggers on asynchronous replication, where the
+            # array sets it.
             critical_default => '%{link1_status} !~ /^(synchronized|running|connected)$/i'
                 . ' || %{location1_within_rpo} =~ /^no$/i'
                 . ' || %{location2_within_rpo} =~ /^no$/i',
@@ -223,8 +222,8 @@ sub set_counters {
         }
     ];
 
-    # Le partenariat local n'a pas d'etat : il se decrit lui-meme. Seuls les
-    # partenariats distants sont evalues, d'ou le filtre pose en selection.
+    # The local partnership has no state: it describes itself. Only remote
+    # partnerships are evaluated, hence the filter applied at selection.
     $self->{maps_counters}->{partnerships} = [
         {
             label => 'partnership-status',
@@ -269,8 +268,8 @@ sub new {
     return $self;
 }
 
-# Renvoie la valeur du champ, ou '-' : les seuils et les sorties travaillent
-# alors sur une chaine toujours definie, quelle que soit la version de l'API.
+# Returns the field value, or '-': thresholds and outputs then work on an
+# always-defined string, whatever the API version.
 sub field {
     my ($entry, $name) = @_;
 
@@ -300,10 +299,10 @@ sub manage_selection {
     $self->{partnerships} = {};
     $self->{relationships} = {};
 
-    # request_optional : lspartition n'existe qu'a partir de la 8.7, et les
-    # autres commandes peuvent manquer selon le modele. Une commande absente ne
-    # doit pas faire echouer le controle sur une baie ou les autres formes de
-    # replication fonctionnent.
+    # request_optional: lspartition only exists from 8.7, and the other
+    # commands may be missing depending on the model. A missing command must
+    # not fail the check on a system where the other forms of replication
+    # work.
     my $partitions    = $options{custom}->request_optional(command => 'lspartition');
     my $groups        = $options{custom}->request_optional(command => 'lsvolumegroupreplication');
     my $partnerships  = $options{custom}->request_optional(command => 'lspartnership');
@@ -329,11 +328,11 @@ sub manage_selection {
     foreach my $entry (@$groups) {
         my $name = field($entry, 'name');
         next if ($self->filtered(filter => 'filter_volume_group', value => $name));
-        # Le filtre de partition restreint aussi les groupes, par leur
-        # partition d'appartenance : c'est ce qui permet un service PAR
-        # partition — meme commande, meme modele, seule la macro de service
-        # change. Les partenariats restent hors filtre : un partenariat casse
-        # concerne toutes les partitions.
+        # The partition filter also restricts the groups, by the partition
+        # they belong to: that is what allows one service PER partition -
+        # same command, same template, only the service macro changes.
+        # Partnerships stay unfiltered: a broken partnership concerns every
+        # partition.
         next if ($self->filtered(filter => 'filter_partition', value => field($entry, 'partition_name')));
 
         $self->{global}->{groups_detected}++;
@@ -353,8 +352,8 @@ sub manage_selection {
         my $name = field($entry, 'name');
         my $location = field($entry, 'location');
 
-        # L'entree 'local' decrit la baie interrogee, pas un lien : elle n'a ni
-        # partnership ni type, et n'a donc pas d'etat a evaluer.
+        # The 'local' entry describes the queried system, not a link: it has
+        # neither partnership nor type, hence no state to evaluate.
         next if ($location =~ /^local$/i);
         next if ($self->filtered(filter => 'filter_partnership', value => $name));
 
@@ -379,8 +378,8 @@ sub manage_selection {
         };
     }
 
-    # Aucune replication n'est une configuration valide, pas une anomalie ni
-    # une erreur de collecte : on le dit, et le service reste OK.
+    # No replication is a valid configuration, neither an anomaly nor a
+    # collection error: say so, and the service stays OK.
     if (scalar(keys %{$self->{partitions}}) == 0
         && scalar(keys %{$self->{groups}}) == 0
         && scalar(keys %{$self->{partnerships}}) == 0

--- a/src/storage/ibm/flashsystem/restapi/mode/replication.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/replication.pm
@@ -183,7 +183,7 @@ sub set_counters {
     $self->{maps_counters}->{partitions} = [
         {
             label => 'partition-status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             critical_default => '%{ha_status} !~ /^(established|healthy|synchronized)$/i',
             set => {
                 key_values => [
@@ -202,7 +202,7 @@ sub set_counters {
     $self->{maps_counters}->{groups} = [
         {
             label => 'volume-group-status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             # The expression on within_rpo is deliberately inert when the field
             # is empty: it only triggers on asynchronous replication, where the
             # array sets it.
@@ -228,7 +228,7 @@ sub set_counters {
     $self->{maps_counters}->{partnerships} = [
         {
             label => 'partnership-status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             critical_default => '%{partnership} !~ /^fully_configured$/i',
             set => {
                 key_values => [ { name => 'name' }, { name => 'partnership' }, { name => 'type' }, { name => 'location' } ],
@@ -242,7 +242,7 @@ sub set_counters {
     $self->{maps_counters}->{relationships} = [
         {
             label => 'relationship-status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             critical_default => '%{state} !~ /^(consistent_synchronized|consistent_copying)$/i',
             set => {
                 key_values => [ { name => 'name' }, { name => 'state' }, { name => 'progress' }, { name => 'freeze_time' } ],

--- a/src/storage/ibm/flashsystem/restapi/mode/replication.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/replication.pm
@@ -41,6 +41,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use centreon::plugins::constants qw/:counters :values/;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
 sub custom_partition_output {
@@ -143,15 +144,15 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
-        { name => 'partitions', type => 1, cb_prefix_output => 'prefix_partition_output',
-          message_multiple => 'All storage partitions are healthy', skipped_code => { -10 => 1 } },
-        { name => 'groups', type => 1, cb_prefix_output => 'prefix_group_output',
-          message_multiple => 'All replicated volume groups are healthy', skipped_code => { -10 => 1 } },
-        { name => 'partnerships', type => 1, cb_prefix_output => 'prefix_partnership_output',
-          message_multiple => 'All partnerships are healthy', skipped_code => { -10 => 1 } },
-        { name => 'relationships', type => 1, cb_prefix_output => 'prefix_relationship_output',
-          message_multiple => 'All remote copy relationships are healthy', skipped_code => { -10 => 1 } }
+        { name => 'global', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_global_output' },
+        { name => 'partitions', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_partition_output',
+          message_multiple => 'All storage partitions are healthy', skipped_code => { NO_VALUE() => 1 } },
+        { name => 'groups', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_group_output',
+          message_multiple => 'All replicated volume groups are healthy', skipped_code => { NO_VALUE() => 1 } },
+        { name => 'partnerships', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_partnership_output',
+          message_multiple => 'All partnerships are healthy', skipped_code => { NO_VALUE() => 1 } },
+        { name => 'relationships', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_relationship_output',
+          message_multiple => 'All remote copy relationships are healthy', skipped_code => { NO_VALUE() => 1 } }
     ];
 
     $self->{maps_counters}->{global} = [

--- a/src/storage/ibm/flashsystem/restapi/mode/replication.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/replication.pm
@@ -431,15 +431,35 @@ Only check partnerships whose name matches this regular expression.
 
 Only check remote copy relationships whose name matches this regular expression.
 
-=item B<--unknown-partition-status> B<--warning-partition-status> B<--critical-partition-status>
+=item B<--unknown-partition-status>
+
+Define the conditions to match for the status to be UNKNOWN.
 
 Threshold on the partition state. Available macros: C<ha_status>,
 C<link_status>, C<location1_system_name>, C<location1_status>,
 C<location2_system_name>, C<location2_status>, C<migration_status>, C<name>.
 
-Default critical: C<%{ha_status} !~ /^(established|healthy|synchronized)$/i>
+=item B<--warning-partition-status>
 
-=item B<--unknown-volume-group-status> B<--warning-volume-group-status> B<--critical-volume-group-status>
+Define the conditions to match for the status to be WARNING.
+
+Threshold on the partition state. Available macros: C<ha_status>,
+C<link_status>, C<location1_system_name>, C<location1_status>,
+C<location2_system_name>, C<location2_status>, C<migration_status>, C<name>.
+
+=item B<--critical-partition-status>
+
+Define the conditions to match for the status to be CRITICAL.
+
+Threshold on the partition state. Available macros: C<ha_status>,
+C<link_status>, C<location1_system_name>, C<location1_status>,
+C<location2_system_name>, C<location2_status>, C<migration_status>, C<name>.
+
+Default critical: C<%{ha_status} !~ /^(established|healthy|synchronized)$/i>.
+
+=item B<--unknown-volume-group-status>
+
+Define the conditions to match for the status to be UNKNOWN.
 
 Threshold on the volume group replication state. Available macros:
 C<link1_status>, C<partition_name>, C<location1_within_rpo>,
@@ -450,20 +470,97 @@ The C<within_rpo> macros stay empty in C<2-site-ha> topologies, where they do
 not apply; the default expression is inert in that case and only triggers on
 asynchronous replication.
 
-=item B<--unknown-partnership-status> B<--warning-partnership-status> B<--critical-partnership-status>
+=item B<--warning-volume-group-status>
+
+Define the conditions to match for the status to be WARNING.
+
+Threshold on the volume group replication state. Available macros:
+C<link1_status>, C<partition_name>, C<location1_within_rpo>,
+C<location2_within_rpo>, C<location1_replication_mode>,
+C<location2_replication_mode>, C<recovery_test_active>, C<name>.
+
+The C<within_rpo> macros stay empty in C<2-site-ha> topologies, where they do
+not apply; the default expression is inert in that case and only triggers on
+asynchronous replication.
+
+=item B<--critical-volume-group-status>
+
+Define the conditions to match for the status to be CRITICAL.
+
+Threshold on the volume group replication state. Available macros:
+C<link1_status>, C<partition_name>, C<location1_within_rpo>,
+C<location2_within_rpo>, C<location1_replication_mode>,
+C<location2_replication_mode>, C<recovery_test_active>, C<name>.
+
+The C<within_rpo> macros stay empty in C<2-site-ha> topologies, where they do
+not apply; the default expression is inert in that case and only triggers on
+asynchronous replication.
+
+=item B<--unknown-partnership-status>
+
+Define the conditions to match for the status to be UNKNOWN.
 
 Threshold on the partnership state. Available macros: C<partnership>, C<type>,
 C<location>, C<name>.
 
-=item B<--unknown-relationship-status> B<--warning-relationship-status> B<--critical-relationship-status>
+=item B<--warning-partnership-status>
+
+Define the conditions to match for the status to be WARNING.
+
+Threshold on the partnership state. Available macros: C<partnership>, C<type>,
+C<location>, C<name>.
+
+=item B<--critical-partnership-status>
+
+Define the conditions to match for the status to be CRITICAL.
+
+Threshold on the partnership state. Available macros: C<partnership>, C<type>,
+C<location>, C<name>.
+
+=item B<--unknown-relationship-status>
+
+Define the conditions to match for the status to be UNKNOWN.
 
 Threshold on the remote copy relationship state. Available macros: C<state>,
 C<progress>, C<freeze_time>, C<name>.
 
-=item B<--warning-*> B<--critical-*>
+=item B<--warning-relationship-status>
 
-Thresholds on the detected counts: C<partitions-detected>,
-C<volume-groups-detected>, C<relationships-detected>.
+Define the conditions to match for the status to be WARNING.
+
+Threshold on the remote copy relationship state. Available macros: C<state>,
+C<progress>, C<freeze_time>, C<name>.
+
+=item B<--critical-relationship-status>
+
+Define the conditions to match for the status to be CRITICAL.
+
+Threshold on the remote copy relationship state. Available macros: C<state>,
+C<progress>, C<freeze_time>, C<name>.
+
+=item B<--warning-partitions-detected>
+
+Warning threshold on the number of storage partitions detected.
+
+=item B<--critical-partitions-detected>
+
+Critical threshold on the number of storage partitions detected.
+
+=item B<--warning-volume-groups-detected>
+
+Warning threshold on the number of replicated volume groups detected.
+
+=item B<--critical-volume-groups-detected>
+
+Critical threshold on the number of replicated volume groups detected.
+
+=item B<--warning-relationships-detected>
+
+Warning threshold on the number of remote copy relationships detected.
+
+=item B<--critical-relationships-detected>
+
+Critical threshold on the number of remote copy relationships detected.
 
 =back
 

--- a/src/storage/ibm/flashsystem/restapi/mode/replication.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/replication.pm
@@ -1,0 +1,470 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Etat de la replication, sous les trois formes que Storage Virtualize connait :
+#
+#   - partitions de stockage (8.7+) : c'est la partition qui porte l'etat de
+#     sante de la haute disponibilite. Un ha_status a 'problem' coexiste sans
+#     contradiction avec des groupes de volumes tous 'synchronized' : regarder
+#     les seuls groupes ferait conclure a tort que tout va bien.
+#   - replication par politique (8.5.2+) : lsvolumegroupreplication.
+#   - Metro / Global Mirror (historique) : lsrcrelationship.
+#
+# Les trois sont interrogees systematiquement. Une baie qui n'en utilise
+# aucune rend OK avec la mention explicite qu'aucune replication n'est
+# configuree ; une baie qui en utilise deux voit les deux. Aucun mode n'est a
+# activer par option.
+#
+
+package storage::ibm::flashsystem::restapi::mode::replication;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_partition_output {
+    my ($self, %options) = @_;
+
+    my $msg = sprintf(
+        'high availability status: %s, link: %s',
+        $self->{result_values}->{ha_status},
+        $self->{result_values}->{link_status}
+    );
+
+    # Les deux cotes ne sont renseignes que sur une partition repliquee.
+    foreach my $side (1, 2) {
+        my $system = $self->{result_values}->{'location' . $side . '_system_name'};
+        my $status = $self->{result_values}->{'location' . $side . '_status'};
+        next if ($system eq '-' && $status eq '-');
+        $msg .= sprintf(', %s: %s', $system, $status);
+    }
+
+    $msg .= sprintf(', migration: %s', $self->{result_values}->{migration_status})
+        if ($self->{result_values}->{migration_status} ne '-');
+
+    return $msg;
+}
+
+sub custom_group_output {
+    my ($self, %options) = @_;
+
+    my $msg = sprintf('link status: %s', $self->{result_values}->{link1_status});
+
+    $msg .= sprintf(', partition: %s', $self->{result_values}->{partition_name})
+        if ($self->{result_values}->{partition_name} ne '-');
+
+    # En 2-site-ha ces champs restent vides : ils ne decrivent que la
+    # replication asynchrone. On ne les affiche donc que s'ils portent une
+    # valeur, ce qui rend le meme mode lisible dans les deux topologies.
+    foreach my $side (1, 2) {
+        my $rpo = $self->{result_values}->{'location' . $side . '_within_rpo'};
+        next if ($rpo eq '-');
+        $msg .= sprintf(', site %s within RPO: %s', $side, $rpo);
+    }
+
+    $msg .= ', recovery test in progress'
+        if ($self->{result_values}->{recovery_test_active} =~ /^yes$/i);
+
+    return $msg;
+}
+
+sub custom_partnership_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        'partnership: %s, type: %s',
+        $self->{result_values}->{partnership},
+        $self->{result_values}->{type}
+    );
+}
+
+sub custom_relationship_output {
+    my ($self, %options) = @_;
+
+    return sprintf(
+        'state: %s, progress: %s%%',
+        $self->{result_values}->{state},
+        $self->{result_values}->{progress}
+    );
+}
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+
+    return 'Replication: ';
+}
+
+sub prefix_partition_output {
+    my ($self, %options) = @_;
+
+    return "Storage partition '" . $options{instance_value}->{name} . "' ";
+}
+
+sub prefix_group_output {
+    my ($self, %options) = @_;
+
+    return "Volume group replication '" . $options{instance_value}->{name} . "' ";
+}
+
+sub prefix_partnership_output {
+    my ($self, %options) = @_;
+
+    return "Partnership '" . $options{instance_value}->{name} . "' ";
+}
+
+sub prefix_relationship_output {
+    my ($self, %options) = @_;
+
+    return "Remote copy relationship '" . $options{instance_value}->{name} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
+        { name => 'partitions', type => 1, cb_prefix_output => 'prefix_partition_output',
+          message_multiple => 'All storage partitions are healthy', skipped_code => { -10 => 1 } },
+        { name => 'groups', type => 1, cb_prefix_output => 'prefix_group_output',
+          message_multiple => 'All replicated volume groups are healthy', skipped_code => { -10 => 1 } },
+        { name => 'partnerships', type => 1, cb_prefix_output => 'prefix_partnership_output',
+          message_multiple => 'All partnerships are healthy', skipped_code => { -10 => 1 } },
+        { name => 'relationships', type => 1, cb_prefix_output => 'prefix_relationship_output',
+          message_multiple => 'All remote copy relationships are healthy', skipped_code => { -10 => 1 } }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'partitions-detected', nlabel => 'replication.partitions.detected.count', set => {
+                key_values => [ { name => 'partitions_detected' } ],
+                output_template => '%s partition(s)',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'volume-groups-detected', nlabel => 'replication.volumegroups.detected.count', set => {
+                key_values => [ { name => 'groups_detected' } ],
+                output_template => '%s replicated volume group(s)',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'relationships-detected', nlabel => 'replication.relationships.detected.count', set => {
+                key_values => [ { name => 'relationships_detected' } ],
+                output_template => '%s remote copy relationship(s)',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        }
+    ];
+
+    # Les seuils par defaut signalent tout ce qui n'est pas explicitement sain.
+    # Une valeur inconnue — firmware plus recent, topologie non rencontree —
+    # remonte donc plutot que de passer inapercue ; --critical-status permet de
+    # l'accepter ensuite, par service, sans toucher au code.
+    $self->{maps_counters}->{partitions} = [
+        {
+            label => 'partition-status',
+            type => 2,
+            critical_default => '%{ha_status} !~ /^(established|healthy|synchronized)$/i',
+            set => {
+                key_values => [
+                    { name => 'name' }, { name => 'ha_status' }, { name => 'link_status' },
+                    { name => 'location1_system_name' }, { name => 'location1_status' },
+                    { name => 'location2_system_name' }, { name => 'location2_status' },
+                    { name => 'migration_status' }
+                ],
+                closure_custom_output => $self->can('custom_partition_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{groups} = [
+        {
+            label => 'volume-group-status',
+            type => 2,
+            # L'expression sur within_rpo est volontairement inerte quand le
+            # champ est vide : elle ne se declenche qu'en replication
+            # asynchrone, ou la baie le renseigne.
+            critical_default => '%{link1_status} !~ /^(synchronized|running|connected)$/i'
+                . ' || %{location1_within_rpo} =~ /^no$/i'
+                . ' || %{location2_within_rpo} =~ /^no$/i',
+            set => {
+                key_values => [
+                    { name => 'name' }, { name => 'partition_name' }, { name => 'link1_status' },
+                    { name => 'location1_within_rpo' }, { name => 'location2_within_rpo' },
+                    { name => 'location1_replication_mode' }, { name => 'location2_replication_mode' },
+                    { name => 'recovery_test_active' }
+                ],
+                closure_custom_output => $self->can('custom_group_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+
+    # Le partenariat local n'a pas d'etat : il se decrit lui-meme. Seuls les
+    # partenariats distants sont evalues, d'ou le filtre pose en selection.
+    $self->{maps_counters}->{partnerships} = [
+        {
+            label => 'partnership-status',
+            type => 2,
+            critical_default => '%{partnership} !~ /^fully_configured$/i',
+            set => {
+                key_values => [ { name => 'name' }, { name => 'partnership' }, { name => 'type' }, { name => 'location' } ],
+                closure_custom_output => $self->can('custom_partnership_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+
+    $self->{maps_counters}->{relationships} = [
+        {
+            label => 'relationship-status',
+            type => 2,
+            critical_default => '%{state} !~ /^(consistent_synchronized|consistent_copying)$/i',
+            set => {
+                key_values => [ { name => 'name' }, { name => 'state' }, { name => 'progress' }, { name => 'freeze_time' } ],
+                closure_custom_output => $self->can('custom_relationship_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-partition:s'    => { name => 'filter_partition' },
+        'filter-volume-group:s' => { name => 'filter_volume_group' },
+        'filter-partnership:s'  => { name => 'filter_partnership' },
+        'filter-relationship:s' => { name => 'filter_relationship' }
+    });
+
+    return $self;
+}
+
+# Renvoie la valeur du champ, ou '-' : les seuils et les sorties travaillent
+# alors sur une chaine toujours definie, quelle que soit la version de l'API.
+sub field {
+    my ($entry, $name) = @_;
+
+    return '-' if (!defined($entry->{$name}) || $entry->{$name} eq '');
+    return $entry->{$name};
+}
+
+sub filtered {
+    my ($self, %options) = @_;
+
+    my $filter = $self->{option_results}->{ $options{filter} };
+    return 0 if (!defined($filter) || $filter eq '');
+    return 1 if ($options{value} !~ /$filter/);
+    return 0;
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    $self->{global} = {
+        partitions_detected => 0,
+        groups_detected => 0,
+        relationships_detected => 0
+    };
+    $self->{partitions} = {};
+    $self->{groups} = {};
+    $self->{partnerships} = {};
+    $self->{relationships} = {};
+
+    # request_optional : lspartition n'existe qu'a partir de la 8.7, et les
+    # autres commandes peuvent manquer selon le modele. Une commande absente ne
+    # doit pas faire echouer le controle sur une baie ou les autres formes de
+    # replication fonctionnent.
+    my $partitions    = $options{custom}->request_optional(command => 'lspartition');
+    my $groups        = $options{custom}->request_optional(command => 'lsvolumegroupreplication');
+    my $partnerships  = $options{custom}->request_optional(command => 'lspartnership');
+    my $relationships = $options{custom}->request_optional(command => 'lsrcrelationship');
+
+    foreach my $entry (@$partitions) {
+        my $name = field($entry, 'name');
+        next if ($self->filtered(filter => 'filter_partition', value => $name));
+
+        $self->{global}->{partitions_detected}++;
+        $self->{partitions}->{$name} = {
+            name => $name,
+            ha_status => field($entry, 'ha_status'),
+            link_status => field($entry, 'link_status'),
+            location1_system_name => field($entry, 'location1_system_name'),
+            location1_status => field($entry, 'location1_status'),
+            location2_system_name => field($entry, 'location2_system_name'),
+            location2_status => field($entry, 'location2_status'),
+            migration_status => field($entry, 'migration_status')
+        };
+    }
+
+    foreach my $entry (@$groups) {
+        my $name = field($entry, 'name');
+        next if ($self->filtered(filter => 'filter_volume_group', value => $name));
+        # Le filtre de partition restreint aussi les groupes, par leur
+        # partition d'appartenance : c'est ce qui permet un service PAR
+        # partition — meme commande, meme modele, seule la macro de service
+        # change. Les partenariats restent hors filtre : un partenariat casse
+        # concerne toutes les partitions.
+        next if ($self->filtered(filter => 'filter_partition', value => field($entry, 'partition_name')));
+
+        $self->{global}->{groups_detected}++;
+        $self->{groups}->{$name} = {
+            name => $name,
+            partition_name => field($entry, 'partition_name'),
+            link1_status => field($entry, 'link1_status'),
+            location1_within_rpo => field($entry, 'location1_within_rpo'),
+            location2_within_rpo => field($entry, 'location2_within_rpo'),
+            location1_replication_mode => field($entry, 'location1_replication_mode'),
+            location2_replication_mode => field($entry, 'location2_replication_mode'),
+            recovery_test_active => field($entry, 'recovery_test_active')
+        };
+    }
+
+    foreach my $entry (@$partnerships) {
+        my $name = field($entry, 'name');
+        my $location = field($entry, 'location');
+
+        # L'entree 'local' decrit la baie interrogee, pas un lien : elle n'a ni
+        # partnership ni type, et n'a donc pas d'etat a evaluer.
+        next if ($location =~ /^local$/i);
+        next if ($self->filtered(filter => 'filter_partnership', value => $name));
+
+        $self->{partnerships}->{$name} = {
+            name => $name,
+            location => $location,
+            partnership => field($entry, 'partnership'),
+            type => field($entry, 'type')
+        };
+    }
+
+    foreach my $entry (@$relationships) {
+        my $name = field($entry, 'name');
+        next if ($self->filtered(filter => 'filter_relationship', value => $name));
+
+        $self->{global}->{relationships_detected}++;
+        $self->{relationships}->{$name} = {
+            name => $name,
+            state => field($entry, 'state'),
+            progress => field($entry, 'progress'),
+            freeze_time => field($entry, 'freeze_time')
+        };
+    }
+
+    # Aucune replication n'est une configuration valide, pas une anomalie ni
+    # une erreur de collecte : on le dit, et le service reste OK.
+    if (scalar(keys %{$self->{partitions}}) == 0
+        && scalar(keys %{$self->{groups}}) == 0
+        && scalar(keys %{$self->{partnerships}}) == 0
+        && scalar(keys %{$self->{relationships}}) == 0) {
+        $self->{output}->output_add(short_msg => 'No replication configured on this system');
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check replication health: storage partitions, policy-based volume group
+replication, partnerships and remote copy relationships.
+
+All four are queried on every run. A system using none of them reports OK with
+an explicit message; a system using several reports on each. Nothing has to be
+enabled per array.
+
+Example:
+
+    perl centreon_plugins.pl --plugin=storage::ibm::flashsystem::restapi::plugin \
+        --mode=replication --hostname=10.0.0.1 \
+        --api-username=svc_monitor --api-password=xxx
+
+=over 8
+
+=item B<--filter-partition>
+
+Only check storage partitions whose name matches this regular expression.
+Volume group replications are restricted to the matching partitions too, so
+one service per partition is a matter of Centreon configuration: create a
+service from the same template and set the service-level C<EXTRAOPTIONS>
+macro, e.g. C<--filter-partition=Partition_AIX_HA>. Partnerships stay
+unfiltered — a broken partnership concerns every partition.
+
+=item B<--filter-volume-group>
+
+Only check volume group replications whose name matches this regular expression.
+
+=item B<--filter-partnership>
+
+Only check partnerships whose name matches this regular expression.
+
+=item B<--filter-relationship>
+
+Only check remote copy relationships whose name matches this regular expression.
+
+=item B<--unknown-partition-status> B<--warning-partition-status> B<--critical-partition-status>
+
+Threshold on the partition state. Available macros: C<ha_status>,
+C<link_status>, C<location1_system_name>, C<location1_status>,
+C<location2_system_name>, C<location2_status>, C<migration_status>, C<name>.
+
+Default critical: C<%{ha_status} !~ /^(established|healthy|synchronized)$/i>
+
+=item B<--unknown-volume-group-status> B<--warning-volume-group-status> B<--critical-volume-group-status>
+
+Threshold on the volume group replication state. Available macros:
+C<link1_status>, C<partition_name>, C<location1_within_rpo>,
+C<location2_within_rpo>, C<location1_replication_mode>,
+C<location2_replication_mode>, C<recovery_test_active>, C<name>.
+
+The C<within_rpo> macros stay empty in C<2-site-ha> topologies, where they do
+not apply; the default expression is inert in that case and only triggers on
+asynchronous replication.
+
+=item B<--unknown-partnership-status> B<--warning-partnership-status> B<--critical-partnership-status>
+
+Threshold on the partnership state. Available macros: C<partnership>, C<type>,
+C<location>, C<name>.
+
+=item B<--unknown-relationship-status> B<--warning-relationship-status> B<--critical-relationship-status>
+
+Threshold on the remote copy relationship state. Available macros: C<state>,
+C<progress>, C<freeze_time>, C<name>.
+
+=item B<--warning-*> B<--critical-*>
+
+Thresholds on the detected counts: C<partitions-detected>,
+C<volume-groups-detected>, C<relationships-detected>.
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/mode/systemstatus.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/systemstatus.pm
@@ -153,7 +153,7 @@ __END__
 
 =head1 MODE
 
-Host check: is the array still working?
+Host check: whether the array is still working.
 
 This mode is meant for the B<host check command>, not for a service. It returns
 only OK (host UP) or CRITICAL (host DOWN) — never WARNING or UNKNOWN, whose
@@ -170,11 +170,17 @@ Three facts, and only three, count as a stopped array:
 
 =over 4
 
-=item * the array does not answer at all;
+=item *
 
-=item * no canister is online, so nothing processes I/O any more;
+the array does not answer at all;
 
-=item * no pool is online, so no volume is served any more.
+=item *
+
+no canister is online, so nothing processes I/O any more;
+
+=item *
+
+no pool is online, so no volume is served any more.
 
 =back
 

--- a/src/storage/ibm/flashsystem/restapi/mode/systemstatus.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/systemstatus.pm
@@ -21,28 +21,28 @@
 #
 
 #
-# Controle d'HOTE : la baie fonctionne-t-elle encore ?
+# HOST check: is the array still working?
 #
-# Ce mode est concu pour la commande de verification d'hote, pas pour un
-# service. Il ne rend donc que deux verdicts — OK (hote UP) ou CRITICAL (hote
-# DOWN) — et jamais WARNING ni UNKNOWN, dont l'interpretation par le moteur est
-# ambigue.
+# This mode is designed for the host check command, not for a service. It
+# therefore only returns two verdicts - OK (host UP) or CRITICAL (host DOWN) -
+# and never WARNING nor UNKNOWN, whose interpretation by the engine is
+# ambiguous.
 #
-# Le critere est etroit a dessein : DOWN veut dire « la baie a cesse de
-# fonctionner », pas « quelque chose ne va pas ». Passer un hote DOWN rend TOUS
-# ses services UNREACHABLE et les fait taire ; une alimentation en panne, un
-# disque mort ou une partition degradee ne doivent donc surtout pas y conduire —
-# ce sont les services Hardware, Replication et Event-Log qui les portent, et on
-# a besoin de les entendre precisement dans ces moments-la.
+# The criterion is narrow on purpose: DOWN means "the array stopped working",
+# not "something is wrong". Taking a host DOWN makes ALL its services
+# UNREACHABLE and silences them; a failed power supply, a dead drive or a
+# degraded partition must therefore never lead there - the hardware,
+# replication and eventlog services carry those, and they need to be heard
+# precisely at such moments.
 #
-# Trois faits, et trois seulement, valent arret de service :
-#   - la baie ne repond plus du tout ;
-#   - aucun canister n'est en ligne, donc plus rien ne traite d'E/S ;
-#   - aucun pool n'est en ligne, donc plus aucun volume n'est servi.
+# Three facts, and three only, mean the service is down:
+#   - the array does not answer at all;
+#   - no canister is online, so nothing processes I/O any more;
+#   - no pool is online, so no volume is served any more.
 #
-# Une API qui repond mais refuse de nous servir — jeton expire, 429, certificat
-# — n'est PAS une baie morte : c'est notre supervision qui a un souci. L'hote
-# reste UP, avec le motif dans la sortie.
+# An API that answers but refuses to serve us - expired token, 429,
+# certificate - is NOT a dead array: it is our monitoring that has an issue.
+# The host stays UP, with the reason in the output.
 #
 
 package storage::ibm::flashsystem::restapi::mode::systemstatus;
@@ -58,8 +58,8 @@ sub new {
     bless $self, $class;
 
     $options{options}->add_options(arguments => {
-        # Sur une baie mono-controleur ou en cours de maintenance planifiee, on
-        # peut vouloir desactiver l'un des deux criteres fonctionnels.
+        # On a single-controller system or during planned maintenance, one may
+        # want to disable one of the two functional criteria.
         'skip-canisters' => { name => 'skip_canisters' },
         'skip-pools'     => { name => 'skip_pools' }
     });
@@ -100,8 +100,8 @@ sub run {
     }
 
     if ($state eq 'degraded') {
-        # L'equipement repond : ce n'est pas lui qui est mort. On le dit sans
-        # faire tomber l'hote, sinon toute sa supervision se tairait.
+        # The device answers: it is not the one that is dead. Say so without
+        # taking the host down, or all its monitoring would go silent.
         $self->{output}->output_add(
             severity => 'OK',
             short_msg => 'Array is answering but the API refused the call, '

--- a/src/storage/ibm/flashsystem/restapi/mode/systemstatus.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/systemstatus.pm
@@ -1,0 +1,207 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Controle d'HOTE : la baie fonctionne-t-elle encore ?
+#
+# Ce mode est concu pour la commande de verification d'hote, pas pour un
+# service. Il ne rend donc que deux verdicts — OK (hote UP) ou CRITICAL (hote
+# DOWN) — et jamais WARNING ni UNKNOWN, dont l'interpretation par le moteur est
+# ambigue.
+#
+# Le critere est etroit a dessein : DOWN veut dire « la baie a cesse de
+# fonctionner », pas « quelque chose ne va pas ». Passer un hote DOWN rend TOUS
+# ses services UNREACHABLE et les fait taire ; une alimentation en panne, un
+# disque mort ou une partition degradee ne doivent donc surtout pas y conduire —
+# ce sont les services Hardware, Replication et Event-Log qui les portent, et on
+# a besoin de les entendre precisement dans ces moments-la.
+#
+# Trois faits, et trois seulement, valent arret de service :
+#   - la baie ne repond plus du tout ;
+#   - aucun canister n'est en ligne, donc plus rien ne traite d'E/S ;
+#   - aucun pool n'est en ligne, donc plus aucun volume n'est servi.
+#
+# Une API qui repond mais refuse de nous servir — jeton expire, 429, certificat
+# — n'est PAS une baie morte : c'est notre supervision qui a un souci. L'hote
+# reste UP, avec le motif dans la sortie.
+#
+
+package storage::ibm::flashsystem::restapi::mode::systemstatus;
+
+use base qw(centreon::plugins::mode);
+
+use strict;
+use warnings;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        # Sur une baie mono-controleur ou en cours de maintenance planifiee, on
+        # peut vouloir desactiver l'un des deux criteres fonctionnels.
+        'skip-canisters' => { name => 'skip_canisters' },
+        'skip-pools'     => { name => 'skip_pools' }
+    });
+
+    return $self;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+    $self->SUPER::init(%options);
+}
+
+sub count_online {
+    my (%options) = @_;
+
+    my ($total, $online) = (0, 0);
+    foreach my $entry (@{ $options{entries} }) {
+        next unless (ref $entry eq 'HASH');
+        $total++;
+        $online++ if (defined($entry->{status}) && $entry->{status} =~ /^online$/i);
+    }
+
+    return ($total, $online);
+}
+
+sub run {
+    my ($self, %options) = @_;
+
+    my ($state, $detail) = $options{custom}->reachability();
+
+    if ($state eq 'unreachable') {
+        $self->{output}->output_add(
+            severity => 'CRITICAL',
+            short_msg => 'Array is not answering: ' . $detail
+        );
+        $self->{output}->display();
+        $self->{output}->exit();
+    }
+
+    if ($state eq 'degraded') {
+        # L'equipement repond : ce n'est pas lui qui est mort. On le dit sans
+        # faire tomber l'hote, sinon toute sa supervision se tairait.
+        $self->{output}->output_add(
+            severity => 'OK',
+            short_msg => 'Array is answering but the API refused the call, '
+                . 'host left UP: ' . $detail
+        );
+        $self->{output}->display();
+        $self->{output}->exit();
+    }
+
+    my @reasons;
+    my @facts;
+
+    if (!defined($self->{option_results}->{skip_canisters})) {
+        my ($total, $online) = count_online(
+            entries => $options{custom}->request_optional(command => 'lsnodecanister')
+        );
+        push @facts, sprintf('canisters %s/%s online', $online, $total);
+        push @reasons, 'no canister online' if ($total > 0 && $online == 0);
+    }
+
+    if (!defined($self->{option_results}->{skip_pools})) {
+        my ($total, $online) = count_online(
+            entries => $options{custom}->request_optional(command => 'lsmdiskgrp')
+        );
+        push @facts, sprintf('pools %s/%s online', $online, $total);
+        push @reasons, 'no pool online' if ($total > 0 && $online == 0);
+    }
+
+    if (@reasons) {
+        $self->{output}->output_add(
+            severity => 'CRITICAL',
+            short_msg => 'Array has stopped serving: ' . join(', ', @reasons)
+                . ' [' . join(', ', @facts) . ']'
+        );
+    } else {
+        $self->{output}->output_add(
+            severity => 'OK',
+            short_msg => 'Array is serving: ' . join(', ', @facts)
+        );
+    }
+
+    $self->{output}->display();
+    $self->{output}->exit();
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Host check: is the array still working?
+
+This mode is meant for the B<host check command>, not for a service. It returns
+only OK (host UP) or CRITICAL (host DOWN) — never WARNING or UNKNOWN, whose
+meaning for a host check is ambiguous.
+
+The criterion is deliberately narrow. DOWN means "the array has stopped
+working", not "something is wrong". Marking a host DOWN turns B<all> its
+services UNREACHABLE and silences them, so a failed power supply, a dead drive
+or a degraded partition must never lead there — the C<hardware>, C<replication>
+and C<eventlog> services carry those, and they are exactly what you need to hear
+at that moment.
+
+Three facts, and only three, count as a stopped array:
+
+=over 4
+
+=item * the array does not answer at all;
+
+=item * no canister is online, so nothing processes I/O any more;
+
+=item * no pool is online, so no volume is served any more.
+
+=back
+
+An API that answers but refuses the call — expired token, 429, certificate —
+is B<not> a dead array: it is our own monitoring having trouble. The host stays
+UP and the reason is printed.
+
+Used as a host check command:
+
+    $CENTREONPLUGINS$/centreon_ibm_flashsystem_restapi.pl \
+      --plugin=storage::ibm::flashsystem::restapi::plugin --mode=system-status \
+      --hostname='$HOSTADDRESS$' --api-username='$_HOSTIBMAPIUSERNAME$' \
+      --api-password='$_HOSTIBMAPIPASSWORD$' --port='$_HOSTIBMAPIPORT$' \
+      $_HOSTEXTRAOPTIONS$
+
+=over 8
+
+=item B<--skip-canisters>
+
+Do not treat "no canister online" as a stopped array. Useful on a
+single-controller model.
+
+=item B<--skip-pools>
+
+Do not treat "no pool online" as a stopped array, for instance during a planned
+migration where pools are deliberately taken offline.
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/mode/volumegroups.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/volumegroups.pm
@@ -39,6 +39,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use centreon::plugins::constants qw/:counters :values/;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
 sub custom_group_output {
@@ -80,9 +81,9 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
-        { name => 'groups', type => 1, cb_prefix_output => 'prefix_group_output',
-          message_multiple => 'All volume groups are healthy', skipped_code => { -10 => 1 } }
+        { name => 'global', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_global_output' },
+        { name => 'groups', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_group_output',
+          message_multiple => 'All volume groups are healthy', skipped_code => { NO_VALUE() => 1 } }
     ];
 
     $self->{maps_counters}->{global} = [

--- a/src/storage/ibm/flashsystem/restapi/mode/volumegroups.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/volumegroups.pm
@@ -224,19 +224,24 @@ Example, one service per group through service discovery:
 
 =over 8
 
-=item B<--filter-name> B<--filter-partition>
+=item B<--filter-name>
 
 Only check groups whose name or storage partition matches this regular
 expression. Empty by default.
 
-=item B<--unknown-status> B<--warning-status> B<--critical-status>
+=item B<--filter-partition>
+
+Only check groups whose name or storage partition matches this regular
+expression. Empty by default.
+
+=item B<--unknown-status>
+
+Define the conditions to match for the status to be UNKNOWN.
 
 Threshold on each group. Available macros: C<name>, C<volume_count>,
 C<backup_status>, C<last_backup_time>, C<partition_name>,
 C<replication_policy>, C<snapshot_policy>, C<safeguarded_policy>,
 C<restore_in_progress>.
-
-Default critical: C<%{backup_status} =~ /^failed$/i>
 
 Nothing else alerts by default. On these arrays C<backup_status> is C<off>
 everywhere and no group references a snapshot policy — an operational choice,
@@ -245,12 +250,75 @@ code:
 
     --warning-status='%{snapshot_policy} eq "-"'
 
-=item B<--warning-without-snapshot-policy> B<--critical-without-snapshot-policy>
+=item B<--warning-status>
+
+Define the conditions to match for the status to be WARNING.
+
+Threshold on each group. Available macros: C<name>, C<volume_count>,
+C<backup_status>, C<last_backup_time>, C<partition_name>,
+C<replication_policy>, C<snapshot_policy>, C<safeguarded_policy>,
+C<restore_in_progress>.
+
+Nothing else alerts by default. On these arrays C<backup_status> is C<off>
+everywhere and no group references a snapshot policy — an operational choice,
+not a fault. Once that choice is settled, express it here rather than in the
+code:
+
+    --warning-status='%{snapshot_policy} eq "-"'
+
+=item B<--critical-status>
+
+Define the conditions to match for the status to be CRITICAL.
+
+Threshold on each group. Available macros: C<name>, C<volume_count>,
+C<backup_status>, C<last_backup_time>, C<partition_name>,
+C<replication_policy>, C<snapshot_policy>, C<safeguarded_policy>,
+C<restore_in_progress>.
+
+Default critical: C<%{backup_status} =~ /^failed$/i>.
+
+Nothing else alerts by default. On these arrays C<backup_status> is C<off>
+everywhere and no group references a snapshot policy — an operational choice,
+not a fault. Once that choice is settled, express it here rather than in the
+code:
+
+    --warning-status='%{snapshot_policy} eq "-"'
+
+=item B<--warning-without-snapshot-policy>
+
+Warning threshold.
 
 Threshold on the number of groups with no snapshot policy attached. The blunt
 version of the same question, when the answer is "all of them should have one".
 
-=item B<--warning-replicated> B<--critical-replicated> B<--warning-restoring> B<--critical-restoring>
+=item B<--critical-without-snapshot-policy>
+
+Critical threshold.
+
+Threshold on the number of groups with no snapshot policy attached. The blunt
+version of the same question, when the answer is "all of them should have one".
+
+=item B<--warning-replicated>
+
+Warning threshold.
+
+Thresholds on the counts.
+
+=item B<--critical-replicated>
+
+Critical threshold.
+
+Thresholds on the counts.
+
+=item B<--warning-restoring>
+
+Warning threshold.
+
+Thresholds on the counts.
+
+=item B<--critical-restoring>
+
+Critical threshold.
 
 Thresholds on the counts.
 

--- a/src/storage/ibm/flashsystem/restapi/mode/volumegroups.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/volumegroups.pm
@@ -21,16 +21,16 @@
 #
 
 #
-# Groupes de volumes — la granularite par objet qui a du sens sur ces baies.
+# Volume groups - the per-object granularity that makes sense on these systems.
 #
-# Le volume ne porte qu'un statut, identique sur les 349. Le groupe, lui, porte
-# un etat de sauvegarde, une date de derniere sauvegarde, une restauration en
-# cours et les politiques qui lui sont attachees. Et ses noms sont metier :
-# Volume_Group_ESXi, Volume_Group_DBWMSPRTRI01 — lisibles en astreinte.
+# A volume only carries a status, identical across hundreds of them. A group
+# carries a backup state, a last backup time, a restore in progress and the
+# policies attached to it. And its names are business names: Volume_Group_ESXi,
+# Volume_Group_DB01 - readable on call.
 #
-# Un groupe sans politique n'est pas une anomalie en soi : c'est une decision
-# d'exploitation. Le mode l'expose donc en metrique et laisse --warning-status
-# trancher, plutot que d'imposer un jugement.
+# A group without a policy is not an anomaly in itself: it is an operational
+# decision. The mode therefore exposes it as a metric and lets --warning-status
+# decide, rather than imposing a judgement.
 #
 
 package storage::ibm::flashsystem::restapi::mode::volumegroups;
@@ -112,9 +112,9 @@ sub set_counters {
         }
     ];
 
-    # Rien n'est critique par defaut : sur ces baies backup_status vaut 'off'
-    # partout, ce qui est un choix d'exploitation et non une panne. Le seuil se
-    # pose une fois la politique de sauvegarde arretee, pas avant.
+    # Nothing is critical by default: on the arrays surveyed backup_status was
+    # 'off' everywhere, which is an operational choice and not a failure. The
+    # threshold is set once the backup policy is decided, not before.
     $self->{maps_counters}->{groups} = [
         {
             label => 'status',
@@ -172,9 +172,9 @@ sub manage_selection {
         next if (defined($self->{option_results}->{filter_partition}) && $self->{option_results}->{filter_partition} ne ''
             && $partition !~ /$self->{option_results}->{filter_partition}/);
 
-        # La politique de replication se lit soit directement, soit via la
-        # politique HA quand la baie est en 2-site-ha : les deux champs
-        # coexistent et un seul est renseigne selon la topologie.
+        # The replication policy is read either directly, or through the HA
+        # policy when the system is in 2-site-ha: both fields coexist and only
+        # one is set depending on the topology.
         my $replication = field($group, 'replication_policy_name');
         $replication = field($group, 'ha_replication_policy_name') if ($replication eq '-');
 

--- a/src/storage/ibm/flashsystem/restapi/mode/volumegroups.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/volumegroups.pm
@@ -119,7 +119,7 @@ sub set_counters {
     $self->{maps_counters}->{groups} = [
         {
             label => 'status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             critical_default => '%{backup_status} =~ /^failed$/i',
             set => {
                 key_values => [

--- a/src/storage/ibm/flashsystem/restapi/mode/volumegroups.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/volumegroups.pm
@@ -1,0 +1,258 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Groupes de volumes — la granularite par objet qui a du sens sur ces baies.
+#
+# Le volume ne porte qu'un statut, identique sur les 349. Le groupe, lui, porte
+# un etat de sauvegarde, une date de derniere sauvegarde, une restauration en
+# cours et les politiques qui lui sont attachees. Et ses noms sont metier :
+# Volume_Group_ESXi, Volume_Group_DBWMSPRTRI01 — lisibles en astreinte.
+#
+# Un groupe sans politique n'est pas une anomalie en soi : c'est une decision
+# d'exploitation. Le mode l'expose donc en metrique et laisse --warning-status
+# trancher, plutot que d'imposer un jugement.
+#
+
+package storage::ibm::flashsystem::restapi::mode::volumegroups;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_group_output {
+    my ($self, %options) = @_;
+
+    my $msg = sprintf(
+        '%s volume(s), backup: %s',
+        $self->{result_values}->{volume_count},
+        $self->{result_values}->{backup_status}
+    );
+
+    $msg .= sprintf(', last backup: %s', $self->{result_values}->{last_backup_time})
+        if ($self->{result_values}->{last_backup_time} ne '-');
+    $msg .= sprintf(', partition: %s', $self->{result_values}->{partition_name})
+        if ($self->{result_values}->{partition_name} ne '-');
+    $msg .= sprintf(', replication: %s', $self->{result_values}->{replication_policy})
+        if ($self->{result_values}->{replication_policy} ne '-');
+    $msg .= sprintf(', snapshot policy: %s', $self->{result_values}->{snapshot_policy})
+        if ($self->{result_values}->{snapshot_policy} ne '-');
+    $msg .= ', restore in progress'
+        if ($self->{result_values}->{restore_in_progress} =~ /^yes$/i);
+
+    return $msg;
+}
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+
+    return 'Volume groups: ';
+}
+
+sub prefix_group_output {
+    my ($self, %options) = @_;
+
+    return "Volume group '" . $options{instance_value}->{name} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
+        { name => 'groups', type => 1, cb_prefix_output => 'prefix_group_output',
+          message_multiple => 'All volume groups are healthy', skipped_code => { -10 => 1 } }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'detected', nlabel => 'volumegroups.detected.count', set => {
+                key_values => [ { name => 'detected' } ],
+                output_template => '%s detected',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'replicated', nlabel => 'volumegroups.replicated.count', set => {
+                key_values => [ { name => 'replicated' } ],
+                output_template => '%s replicated',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'without-snapshot-policy', nlabel => 'volumegroups.without.snapshot.policy.count', set => {
+                key_values => [ { name => 'without_snapshot_policy' } ],
+                output_template => '%s without a snapshot policy',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'restoring', nlabel => 'volumegroups.restoring.count', set => {
+                key_values => [ { name => 'restoring' } ],
+                output_template => '%s restoring',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        }
+    ];
+
+    # Rien n'est critique par defaut : sur ces baies backup_status vaut 'off'
+    # partout, ce qui est un choix d'exploitation et non une panne. Le seuil se
+    # pose une fois la politique de sauvegarde arretee, pas avant.
+    $self->{maps_counters}->{groups} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '%{backup_status} =~ /^failed$/i',
+            set => {
+                key_values => [
+                    { name => 'name' }, { name => 'volume_count' }, { name => 'backup_status' },
+                    { name => 'last_backup_time' }, { name => 'partition_name' },
+                    { name => 'replication_policy' }, { name => 'snapshot_policy' },
+                    { name => 'safeguarded_policy' }, { name => 'restore_in_progress' }
+                ],
+                closure_custom_output => $self->can('custom_group_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s'      => { name => 'filter_name' },
+        'filter-partition:s' => { name => 'filter_partition' }
+    });
+
+    return $self;
+}
+
+sub field {
+    my ($entry, $name) = @_;
+
+    return '-' if (!defined($entry->{$name}) || $entry->{$name} eq '');
+    return $entry->{$name};
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    $self->{global} = {
+        detected => 0, replicated => 0, without_snapshot_policy => 0, restoring => 0
+    };
+    $self->{groups} = {};
+
+    foreach my $group (@{ $options{custom}->request(command => 'lsvolumegroup') }) {
+        my $name = field($group, 'name');
+        my $partition = field($group, 'partition_name');
+
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $name !~ /$self->{option_results}->{filter_name}/);
+        next if (defined($self->{option_results}->{filter_partition}) && $self->{option_results}->{filter_partition} ne ''
+            && $partition !~ /$self->{option_results}->{filter_partition}/);
+
+        # La politique de replication se lit soit directement, soit via la
+        # politique HA quand la baie est en 2-site-ha : les deux champs
+        # coexistent et un seul est renseigne selon la topologie.
+        my $replication = field($group, 'replication_policy_name');
+        $replication = field($group, 'ha_replication_policy_name') if ($replication eq '-');
+
+        my $snapshot = field($group, 'snapshot_policy_name');
+        my $restore = field($group, 'restore_in_progress');
+
+        $self->{global}->{detected}++;
+        $self->{global}->{replicated}++ if ($replication ne '-');
+        $self->{global}->{without_snapshot_policy}++ if ($snapshot eq '-');
+        $self->{global}->{restoring}++ if ($restore =~ /^yes$/i);
+
+        $self->{groups}->{$name} = {
+            name => $name,
+            volume_count => field($group, 'volume_count'),
+            backup_status => field($group, 'backup_status'),
+            last_backup_time => field($group, 'last_backup_time'),
+            partition_name => $partition,
+            replication_policy => $replication,
+            snapshot_policy => $snapshot,
+            safeguarded_policy => field($group, 'safeguarded_policy_name'),
+            restore_in_progress => $restore
+        };
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check the volume groups — the per-object granularity that means something on
+these arrays.
+
+A volume carries only a status, identical across all 349 of them. A group
+carries a backup state, a last backup time, a restore in progress and the
+policies attached to it. And its name is a business one — C<Volume_Group_ESXi>,
+C<Volume_Group_DBWMSPRTRI01> — which reads well on call.
+
+Example, one service per group through service discovery:
+
+    perl centreon_plugins.pl --plugin=storage::ibm::flashsystem::restapi::plugin \
+        --mode=volume-groups --hostname=10.0.0.1 \
+        --api-username=svc_monitor --api-password=xxx --insecure \
+        --filter-name='^Volume_Group_ESXi$'
+
+=over 8
+
+=item B<--filter-name> B<--filter-partition>
+
+Only check groups whose name or storage partition matches this regular
+expression. Empty by default.
+
+=item B<--unknown-status> B<--warning-status> B<--critical-status>
+
+Threshold on each group. Available macros: C<name>, C<volume_count>,
+C<backup_status>, C<last_backup_time>, C<partition_name>,
+C<replication_policy>, C<snapshot_policy>, C<safeguarded_policy>,
+C<restore_in_progress>.
+
+Default critical: C<%{backup_status} =~ /^failed$/i>
+
+Nothing else alerts by default. On these arrays C<backup_status> is C<off>
+everywhere and no group references a snapshot policy — an operational choice,
+not a fault. Once that choice is settled, express it here rather than in the
+code:
+
+    --warning-status='%{snapshot_policy} eq "-"'
+
+=item B<--warning-without-snapshot-policy> B<--critical-without-snapshot-policy>
+
+Threshold on the number of groups with no snapshot policy attached. The blunt
+version of the same question, when the answer is "all of them should have one".
+
+=item B<--warning-replicated> B<--critical-replicated> B<--warning-restoring> B<--critical-restoring>
+
+Thresholds on the counts.
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/mode/volumes.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/volumes.pm
@@ -1,0 +1,298 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Etat d'ensemble des volumes.
+#
+# Ce mode est volontairement agrege. Ni lsvdisk ni lsvdiskcopy n'exposent
+# used_capacity en vue concise : la consommation d'un volume exigerait la vue
+# detaillee, soit un appel par volume — 349 par cycle sur ces baies. Le seul
+# etat reellement disponible par volume est son statut, et ils sont tous
+# 'online'. Un service par volume afficherait donc « online » et une taille
+# figee, sept cents fois.
+#
+# Le service compte les etats et NOMME les volumes anormaux dans sa sortie :
+# la granularite de diagnostic est conservee, les sept cents services non.
+# Pour une supervision par objet, voir le mode volume-groups, dont les objets
+# portent un vrai etat.
+#
+# Deux pieges de lecture :
+#   - fast_write_state = 'not_empty' est l'etat NORMAL d'un volume qui travaille
+#     (des donnees en cache d'ecriture). Seul 'corrupt' est anormal.
+#   - un volume 'plein' au sens de sa taille provisionnee ne veut rien dire en
+#     thin provisioning : la capacite se gere au niveau du pool.
+#
+
+package storage::ibm::flashsystem::restapi::mode::volumes;
+
+use base qw(centreon::plugins::templates::counter);
+
+use strict;
+use warnings;
+use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
+
+sub custom_volume_output {
+    my ($self, %options) = @_;
+
+    my $msg = sprintf('status: %s', $self->{result_values}->{status});
+
+    $msg .= sprintf(', pool: %s', $self->{result_values}->{mdisk_grp_name})
+        if ($self->{result_values}->{mdisk_grp_name} ne '-');
+    $msg .= sprintf(', volume group: %s', $self->{result_values}->{volume_group_name})
+        if ($self->{result_values}->{volume_group_name} ne '-');
+    $msg .= sprintf(', write cache: %s', $self->{result_values}->{fast_write_state})
+        if ($self->{result_values}->{fast_write_state} !~ /^(empty|not_empty)$/i);
+    $msg .= ', formatting'
+        if ($self->{result_values}->{formatting} =~ /^yes$/i);
+    $msg .= ', copies not synchronised'
+        if ($self->{result_values}->{sync} =~ /^no$/i);
+
+    return $msg;
+}
+
+sub prefix_global_output {
+    my ($self, %options) = @_;
+
+    return 'Volumes: ';
+}
+
+sub prefix_volume_output {
+    my ($self, %options) = @_;
+
+    return "Volume '" . $options{instance_value}->{name} . "' ";
+}
+
+sub set_counters {
+    my ($self, %options) = @_;
+
+    $self->{maps_counters_type} = [
+        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
+        { name => 'volumes', type => 1, cb_prefix_output => 'prefix_volume_output',
+          message_multiple => 'All volumes are online and synchronised', skipped_code => { -10 => 1 } }
+    ];
+
+    $self->{maps_counters}->{global} = [
+        { label => 'detected', nlabel => 'volumes.detected.count', set => {
+                key_values => [ { name => 'detected' } ],
+                output_template => '%s detected',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'online', nlabel => 'volumes.online.count', set => {
+                key_values => [ { name => 'online' } ],
+                output_template => '%s online',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'degraded', nlabel => 'volumes.degraded.count', set => {
+                key_values => [ { name => 'degraded' } ],
+                output_template => '%s degraded',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'offline', nlabel => 'volumes.offline.count', set => {
+                key_values => [ { name => 'offline' } ],
+                output_template => '%s offline',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        },
+        { label => 'unsynchronised', nlabel => 'volumes.unsynchronised.count', set => {
+                key_values => [ { name => 'unsynchronised' } ],
+                output_template => '%s with copies out of sync',
+                perfdatas => [ { template => '%s', min => 0 } ]
+            }
+        }
+    ];
+
+    # Seuls les volumes anormaux deviennent des instances : on ne cree pas
+    # trois cent quarante-neuf lignes pour dire que tout va bien.
+    $self->{maps_counters}->{volumes} = [
+        {
+            label => 'status',
+            type => 2,
+            critical_default => '%{status} =~ /^offline$/i || %{fast_write_state} =~ /^corrupt$/i',
+            warning_default => '%{status} =~ /^degraded$/i || %{sync} =~ /^no$/i',
+            set => {
+                key_values => [
+                    { name => 'name' }, { name => 'status' }, { name => 'fast_write_state' },
+                    { name => 'formatting' }, { name => 'sync' },
+                    { name => 'mdisk_grp_name' }, { name => 'volume_group_name' }
+                ],
+                closure_custom_output => $self->can('custom_volume_output'),
+                closure_custom_perfdata => sub { return 0; },
+                closure_custom_threshold_check => \&catalog_status_threshold_ng
+            }
+        }
+    ];
+}
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options, force_new_perfdata => 1);
+    bless $self, $class;
+
+    $options{options}->add_options(arguments => {
+        'filter-name:s'         => { name => 'filter_name' },
+        'filter-pool:s'         => { name => 'filter_pool' },
+        'filter-volume-group:s' => { name => 'filter_volume_group' },
+        'add-all-volumes'       => { name => 'add_all_volumes' }
+    });
+
+    return $self;
+}
+
+sub field {
+    my ($entry, $name) = @_;
+
+    return '-' if (!defined($entry->{$name}) || $entry->{$name} eq '');
+    return $entry->{$name};
+}
+
+sub manage_selection {
+    my ($self, %options) = @_;
+
+    # La synchronisation des copies vit sur lsvdiskcopy, pas sur lsvdisk : un
+    # volume peut etre 'online' avec une copie desynchronisee.
+    my %unsynced;
+    foreach my $copy (@{ $options{custom}->request_optional(command => 'lsvdiskcopy') }) {
+        my $name = field($copy, 'vdisk_name');
+        $unsynced{$name} = 1 if (field($copy, 'sync') =~ /^no$/i);
+    }
+
+    $self->{global} = {
+        detected => 0, online => 0, degraded => 0, offline => 0, unsynchronised => 0
+    };
+    $self->{volumes} = {};
+
+    foreach my $volume (@{ $options{custom}->request(command => 'lsvdisk') }) {
+        my $name = field($volume, 'name');
+        my $pool = field($volume, 'mdisk_grp_name');
+        my $group = field($volume, 'volume_group_name');
+
+        next if (defined($self->{option_results}->{filter_name}) && $self->{option_results}->{filter_name} ne ''
+            && $name !~ /$self->{option_results}->{filter_name}/);
+        next if (defined($self->{option_results}->{filter_pool}) && $self->{option_results}->{filter_pool} ne ''
+            && $pool !~ /$self->{option_results}->{filter_pool}/);
+        next if (defined($self->{option_results}->{filter_volume_group}) && $self->{option_results}->{filter_volume_group} ne ''
+            && $group !~ /$self->{option_results}->{filter_volume_group}/);
+
+        my $status = field($volume, 'status');
+        my $fast_write = field($volume, 'fast_write_state');
+        my $sync = $unsynced{$name} ? 'no' : 'yes';
+
+        $self->{global}->{detected}++;
+        $self->{global}->{online}++   if ($status =~ /^online$/i);
+        $self->{global}->{degraded}++ if ($status =~ /^degraded$/i);
+        $self->{global}->{offline}++  if ($status =~ /^offline$/i);
+        $self->{global}->{unsynchronised}++ if ($sync eq 'no');
+
+        my $healthy = ($status =~ /^online$/i)
+            && ($fast_write !~ /^corrupt$/i)
+            && ($sync eq 'yes')
+            && (field($volume, 'formatting') !~ /^yes$/i);
+
+        # Par defaut, seuls les volumes anormaux deviennent des instances.
+        next if ($healthy && !defined($self->{option_results}->{add_all_volumes}));
+
+        $self->{volumes}->{$name} = {
+            name => $name,
+            status => $status,
+            fast_write_state => $fast_write,
+            formatting => field($volume, 'formatting'),
+            sync => $sync,
+            mdisk_grp_name => $pool,
+            volume_group_name => $group
+        };
+    }
+}
+
+1;
+
+__END__
+
+=head1 MODE
+
+Check the volumes as a whole.
+
+This mode is aggregated on purpose. Neither C<lsvdisk> nor C<lsvdiskcopy>
+exposes C<used_capacity> in their concise output: a volume's consumption would
+need the detailed view, one call per volume — 349 per cycle on these arrays. The
+only per-volume state actually available is the status, and they are all
+C<online>. One service per volume would display "online" and a frozen size,
+seven hundred times over.
+
+So the service counts the states and B<names> the abnormal volumes in its
+output: the diagnostic detail is kept, the seven hundred services are not. For
+per-object monitoring, use the C<volume-groups> mode, whose objects carry a real
+state — replication, backup, attached policies.
+
+Two reading traps:
+
+=over 4
+
+=item * C<fast_write_state = not_empty> is the B<normal> state of a working
+volume — data sitting in the write cache. Only C<corrupt> is abnormal.
+
+=item * A volume "full" with respect to its provisioned size means nothing under
+thin provisioning. Capacity is managed at the pool level, see the C<capacity>
+mode.
+
+=back
+
+Example:
+
+    perl centreon_plugins.pl --plugin=storage::ibm::flashsystem::restapi::plugin \
+        --mode=volumes --hostname=10.0.0.1 \
+        --api-username=svc_monitor --api-password=xxx --insecure
+
+=over 8
+
+=item B<--filter-name> B<--filter-pool> B<--filter-volume-group>
+
+Only check volumes whose name, pool or volume group matches this regular
+expression. Empty by default.
+
+=item B<--add-all-volumes>
+
+Turn every volume into a checkable instance, not just the abnormal ones. Use
+with a filter — this is what makes a per-volume service possible if you really
+want one:
+
+    --mode=volumes --add-all-volumes --filter-name='^VOL_PRD_01$'
+
+=item B<--unknown-status> B<--warning-status> B<--critical-status>
+
+Threshold on each selected volume. Available macros: C<name>, C<status>,
+C<fast_write_state>, C<formatting>, C<sync>, C<mdisk_grp_name>,
+C<volume_group_name>.
+
+Default warning: C<%{status} =~ /^degraded$/i || %{sync} =~ /^no$/i>
+
+Default critical: C<%{status} =~ /^offline$/i || %{fast_write_state} =~ /^corrupt$/i>
+
+=item B<--warning-offline> B<--critical-offline> B<--warning-degraded> B<--critical-degraded> B<--warning-unsynchronised> B<--critical-unsynchronised>
+
+Thresholds on the counts.
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/mode/volumes.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/volumes.pm
@@ -48,6 +48,7 @@ use base qw(centreon::plugins::templates::counter);
 
 use strict;
 use warnings;
+use centreon::plugins::constants qw/:counters :values/;
 use centreon::plugins::templates::catalog_functions qw(catalog_status_threshold_ng);
 
 sub custom_volume_output {
@@ -85,9 +86,9 @@ sub set_counters {
     my ($self, %options) = @_;
 
     $self->{maps_counters_type} = [
-        { name => 'global', type => 0, cb_prefix_output => 'prefix_global_output' },
-        { name => 'volumes', type => 1, cb_prefix_output => 'prefix_volume_output',
-          message_multiple => 'All volumes are online and synchronised', skipped_code => { -10 => 1 } }
+        { name => 'global', type => COUNTER_TYPE_GLOBAL, cb_prefix_output => 'prefix_global_output' },
+        { name => 'volumes', type => COUNTER_TYPE_INSTANCE, cb_prefix_output => 'prefix_volume_output',
+          message_multiple => 'All volumes are online and synchronised', skipped_code => { NO_VALUE() => 1 } }
     ];
 
     $self->{maps_counters}->{global} = [

--- a/src/storage/ibm/flashsystem/restapi/mode/volumes.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/volumes.pm
@@ -21,25 +21,25 @@
 #
 
 #
-# Etat d'ensemble des volumes.
+# Overall volume state.
 #
-# Ce mode est volontairement agrege. Ni lsvdisk ni lsvdiskcopy n'exposent
-# used_capacity en vue concise : la consommation d'un volume exigerait la vue
-# detaillee, soit un appel par volume — 349 par cycle sur ces baies. Le seul
-# etat reellement disponible par volume est son statut, et ils sont tous
-# 'online'. Un service par volume afficherait donc « online » et une taille
-# figee, sept cents fois.
+# This mode is aggregated on purpose. Neither lsvdisk nor lsvdiskcopy exposes
+# used_capacity in the concise view: a volume's consumption would need the
+# detailed view, one call per volume - several hundred per cycle on a typical
+# array. The only state really available per volume is its status, and they
+# are all 'online'. One service per volume would therefore show "online" and a
+# fixed size, hundreds of times.
 #
-# Le service compte les etats et NOMME les volumes anormaux dans sa sortie :
-# la granularite de diagnostic est conservee, les sept cents services non.
-# Pour une supervision par objet, voir le mode volume-groups, dont les objets
-# portent un vrai etat.
+# The service counts the states and NAMES the abnormal volumes in its output:
+# the diagnostic granularity is kept, the hundreds of services are not. For a
+# per-object monitoring, see the volume-groups mode, whose objects carry a real
+# state.
 #
-# Deux pieges de lecture :
-#   - fast_write_state = 'not_empty' est l'etat NORMAL d'un volume qui travaille
-#     (des donnees en cache d'ecriture). Seul 'corrupt' est anormal.
-#   - un volume 'plein' au sens de sa taille provisionnee ne veut rien dire en
-#     thin provisioning : la capacite se gere au niveau du pool.
+# Two reading traps:
+#   - fast_write_state = 'not_empty' is the NORMAL state of a working volume
+#     (data in the write cache). Only 'corrupt' is abnormal.
+#   - a volume 'full' with regard to its provisioned size means nothing with
+#     thin provisioning: capacity is managed at pool level.
 #
 
 package storage::ibm::flashsystem::restapi::mode::volumes;
@@ -123,8 +123,8 @@ sub set_counters {
         }
     ];
 
-    # Seuls les volumes anormaux deviennent des instances : on ne cree pas
-    # trois cent quarante-neuf lignes pour dire que tout va bien.
+    # Only abnormal volumes become instances: hundreds of lines are not
+    # created to say that all is well.
     $self->{maps_counters}->{volumes} = [
         {
             label => 'status',
@@ -170,8 +170,8 @@ sub field {
 sub manage_selection {
     my ($self, %options) = @_;
 
-    # La synchronisation des copies vit sur lsvdiskcopy, pas sur lsvdisk : un
-    # volume peut etre 'online' avec une copie desynchronisee.
+    # Copy synchronisation lives on lsvdiskcopy, not on lsvdisk: a volume can
+    # be 'online' with an out-of-sync copy.
     my %unsynced;
     foreach my $copy (@{ $options{custom}->request_optional(command => 'lsvdiskcopy') }) {
         my $name = field($copy, 'vdisk_name');
@@ -210,7 +210,7 @@ sub manage_selection {
             && ($sync eq 'yes')
             && (field($volume, 'formatting') !~ /^yes$/i);
 
-        # Par defaut, seuls les volumes anormaux deviennent des instances.
+        # By default, only abnormal volumes become instances.
         next if ($healthy && !defined($self->{option_results}->{add_all_volumes}));
 
         $self->{volumes}->{$name} = {

--- a/src/storage/ibm/flashsystem/restapi/mode/volumes.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/volumes.pm
@@ -250,10 +250,14 @@ Two reading traps:
 
 =over 4
 
-=item * C<fast_write_state = not_empty> is the B<normal> state of a working
+=item *
+
+C<fast_write_state = not_empty> is the B<normal> state of a working
 volume — data sitting in the write cache. Only C<corrupt> is abnormal.
 
-=item * A volume "full" with respect to its provisioned size means nothing under
+=item *
+
+A volume "full" with respect to its provisioned size means nothing under
 thin provisioning. Capacity is managed at the pool level, see the C<capacity>
 mode.
 
@@ -267,7 +271,17 @@ Example:
 
 =over 8
 
-=item B<--filter-name> B<--filter-pool> B<--filter-volume-group>
+=item B<--filter-name>
+
+Only check volumes whose name, pool or volume group matches this regular
+expression. Empty by default.
+
+=item B<--filter-pool>
+
+Only check volumes whose name, pool or volume group matches this regular
+expression. Empty by default.
+
+=item B<--filter-volume-group>
 
 Only check volumes whose name, pool or volume group matches this regular
 expression. Empty by default.
@@ -280,17 +294,67 @@ want one:
 
     --mode=volumes --add-all-volumes --filter-name='^VOL_PRD_01$'
 
-=item B<--unknown-status> B<--warning-status> B<--critical-status>
+=item B<--unknown-status>
+
+Define the conditions to match for the status to be UNKNOWN.
 
 Threshold on each selected volume. Available macros: C<name>, C<status>,
 C<fast_write_state>, C<formatting>, C<sync>, C<mdisk_grp_name>,
 C<volume_group_name>.
 
-Default warning: C<%{status} =~ /^degraded$/i || %{sync} =~ /^no$/i>
+=item B<--warning-status>
 
-Default critical: C<%{status} =~ /^offline$/i || %{fast_write_state} =~ /^corrupt$/i>
+Define the conditions to match for the status to be WARNING.
 
-=item B<--warning-offline> B<--critical-offline> B<--warning-degraded> B<--critical-degraded> B<--warning-unsynchronised> B<--critical-unsynchronised>
+Threshold on each selected volume. Available macros: C<name>, C<status>,
+C<fast_write_state>, C<formatting>, C<sync>, C<mdisk_grp_name>,
+C<volume_group_name>.
+
+Default warning: C<%{status} =~ /^degraded$/i || %{sync} =~ /^no$/i>.
+
+=item B<--critical-status>
+
+Define the conditions to match for the status to be CRITICAL.
+
+Threshold on each selected volume. Available macros: C<name>, C<status>,
+C<fast_write_state>, C<formatting>, C<sync>, C<mdisk_grp_name>,
+C<volume_group_name>.
+
+Default critical: C<%{status} =~ /^offline$/i || %{fast_write_state} =~ /^corrupt$/i>.
+
+=item B<--warning-offline>
+
+Warning threshold.
+
+Thresholds on the counts.
+
+=item B<--critical-offline>
+
+Critical threshold.
+
+Thresholds on the counts.
+
+=item B<--warning-degraded>
+
+Warning threshold.
+
+Thresholds on the counts.
+
+=item B<--critical-degraded>
+
+Critical threshold.
+
+Thresholds on the counts.
+
+=item B<--warning-unsynchronised>
+
+Warning threshold.
+
+Thresholds on the counts.
+
+=item B<--critical-unsynchronised>
+
+Critical threshold.
 
 Thresholds on the counts.
 

--- a/src/storage/ibm/flashsystem/restapi/mode/volumes.pm
+++ b/src/storage/ibm/flashsystem/restapi/mode/volumes.pm
@@ -129,7 +129,7 @@ sub set_counters {
     $self->{maps_counters}->{volumes} = [
         {
             label => 'status',
-            type => 2,
+            type => COUNTER_KIND_TEXT,
             critical_default => '%{status} =~ /^offline$/i || %{fast_write_state} =~ /^corrupt$/i',
             warning_default => '%{status} =~ /^degraded$/i || %{sync} =~ /^no$/i',
             set => {

--- a/src/storage/ibm/flashsystem/restapi/plugin.pm
+++ b/src/storage/ibm/flashsystem/restapi/plugin.pm
@@ -1,0 +1,119 @@
+#
+# Copyright 2026 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Authors : Valentin MAROT <contact@valentin-marot.fr>
+#
+
+#
+# Supervision des baies IBM Storage Virtualize (FlashSystem, Storwize, SVC)
+# via l'API REST exposee sur le port 7443.
+#
+# Principe de conception : le plugin ne connait aucune specificite d'une baie
+# donnee. Tout est decouvert par l'API. Ajouter une baie se limite a creer un
+# hote portant le calque et deux macros ; aucune modification de code.
+#
+
+package storage::ibm::flashsystem::restapi::plugin;
+
+use strict;
+use warnings;
+use base qw(centreon::plugins::script_custom);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = $class->SUPER::new(package => __PACKAGE__, %options);
+    bless $self, $class;
+
+    $self->{version} = '1.0';
+
+    # Seuls les modes reellement implementes sont declares : un mode declare
+    # sans son module apparait dans --list-mode puis echoue a l'execution sur
+    # "Cannot load module".
+    $self->{modes} = {
+        'capacity'      => 'storage::ibm::flashsystem::restapi::mode::capacity',
+        'drives'        => 'storage::ibm::flashsystem::restapi::mode::drives',
+        'eth-ports'     => 'storage::ibm::flashsystem::restapi::mode::ethports',
+        'eventlog'      => 'storage::ibm::flashsystem::restapi::mode::eventlog',
+        'fc-ports'      => 'storage::ibm::flashsystem::restapi::mode::fcports',
+        'hardware'      => 'storage::ibm::flashsystem::restapi::mode::hardware',
+        'hosts'         => 'storage::ibm::flashsystem::restapi::mode::hosts',
+        'performance'   => 'storage::ibm::flashsystem::restapi::mode::performance',
+        'replication'   => 'storage::ibm::flashsystem::restapi::mode::replication',
+        # Destine a la commande de verification d'HOTE, pas a un service.
+        'system-status' => 'storage::ibm::flashsystem::restapi::mode::systemstatus',
+        'volume-groups' => 'storage::ibm::flashsystem::restapi::mode::volumegroups',
+        'volumes'       => 'storage::ibm::flashsystem::restapi::mode::volumes'
+        # Restent a ecrire, le jour ou la decouverte automatique de services
+        # sera mise en place (elle demande aussi des regles cote Centreon, que
+        # ni CLAPI ni l'API v2 n'exposent) :
+        # 'list-fc-ports'      => '...::mode::listfcports',
+        # 'list-volume-groups' => '...::mode::listvolumegroups'
+    };
+
+    $self->{custom_modes}->{api} = 'storage::ibm::flashsystem::restapi::custom::api';
+
+    return $self;
+}
+
+1;
+
+__END__
+
+=head1 PLUGIN DESCRIPTION
+
+Monitor IBM Storage Virtualize systems (FlashSystem, Storwize, SAN Volume
+Controller) through the REST API served on port 7443.
+
+The plugin discovers everything from the API: no array-specific value is
+hard-coded, so a newly added system is monitored by the same commands and the
+same service templates as the existing ones.
+
+Requires Storage Virtualize 8.1.3 or later, and an array account with the
+B<Monitor> role.
+
+=over 8
+
+=item B<Available modes>
+
+capacity, drives, eth-ports, eventlog, fc-ports, hardware, hosts, performance,
+replication, system-status, volume-groups, volumes.
+
+Run C<--list-mode> to get the authoritative list: only implemented modes are
+declared, so anything listed can actually be run.
+
+C<system-status> is meant to be the B<host check command>, not a service: it
+reports DOWN only when the array stopped serving — no canister online, no pool
+online, or no answer at all. A dead power supply or a degraded partition must
+not take the host down, because that would make every service UNREACHABLE and
+silence them.
+
+=item B<Splitting a mode across several services>
+
+A mode that returns several concerns at once is split with
+C<--filter-counters>, a regular expression on the counter labels — no plugin
+code and no extra command. C<performance> is split that way into three
+services: C<--filter-counters=latency>,
+C<--filter-counters=iops|bandwidth|cache> and C<--filter-counters=cpu>.
+
+The same idea restricts a scope rather than a counter set:
+C<--filter-partition> gives one replication service per storage partition.
+
+=back
+
+=cut

--- a/src/storage/ibm/flashsystem/restapi/plugin.pm
+++ b/src/storage/ibm/flashsystem/restapi/plugin.pm
@@ -21,12 +21,12 @@
 #
 
 #
-# Supervision des baies IBM Storage Virtualize (FlashSystem, Storwize, SVC)
-# via l'API REST exposee sur le port 7443.
+# Monitoring of IBM Storage Virtualize systems (FlashSystem, Storwize, SVC)
+# through the REST API served on port 7443.
 #
-# Principe de conception : le plugin ne connait aucune specificite d'une baie
-# donnee. Tout est decouvert par l'API. Ajouter une baie se limite a creer un
-# hote portant le calque et deux macros ; aucune modification de code.
+# Design principle: the plugin knows nothing specific to a given array.
+# Everything is discovered through the API. Adding an array comes down to
+# creating a host with the template and two macros; no code change.
 #
 
 package storage::ibm::flashsystem::restapi::plugin;
@@ -42,8 +42,8 @@ sub new {
 
     $self->{version} = '1.0';
 
-    # Seuls les modes reellement implementes sont declares : un mode declare
-    # sans son module apparait dans --list-mode puis echoue a l'execution sur
+    # Only the modes that really exist are declared: a mode declared without
+    # its module shows up in --list-mode and then fails at run time with
     # "Cannot load module".
     $self->{modes} = {
         'capacity'      => 'storage::ibm::flashsystem::restapi::mode::capacity',
@@ -55,13 +55,13 @@ sub new {
         'hosts'         => 'storage::ibm::flashsystem::restapi::mode::hosts',
         'performance'   => 'storage::ibm::flashsystem::restapi::mode::performance',
         'replication'   => 'storage::ibm::flashsystem::restapi::mode::replication',
-        # Destine a la commande de verification d'HOTE, pas a un service.
+        # Meant for the HOST check command, not for a service.
         'system-status' => 'storage::ibm::flashsystem::restapi::mode::systemstatus',
         'volume-groups' => 'storage::ibm::flashsystem::restapi::mode::volumegroups',
         'volumes'       => 'storage::ibm::flashsystem::restapi::mode::volumes'
-        # Restent a ecrire, le jour ou la decouverte automatique de services
-        # sera mise en place (elle demande aussi des regles cote Centreon, que
-        # ni CLAPI ni l'API v2 n'exposent) :
+        # Still to be written, for the day automatic service discovery is set
+        # up (it also needs discovery rules on the Centreon side, which
+        # neither CLAPI nor the v2 API expose):
         # 'list-fc-ports'      => '...::mode::listfcports',
         # 'list-volume-groups' => '...::mode::listvolumegroups'
     };

--- a/tests/resources/spellcheck/stopwords.txt
+++ b/tests/resources/spellcheck/stopwords.txt
@@ -48,6 +48,8 @@ blocked-by-uf
 bootable
 BPL
 --cacert-file
+canister
+canisters
 cardtemperature
 CDN
 centreon
@@ -88,6 +90,7 @@ dfsrevent
 --display-transform-dst
 --display-transform-src
 dns-resolve-time
+DRAID
 DSM
 --dyn-mode
 Ekara
@@ -102,6 +105,8 @@ F5OS
 failover
 fanspeed
 FCCapacity
+FCM
+FCMs
 fibre
 FibreAlliance
 --filter-fs
@@ -109,6 +114,8 @@ FibreAlliance
 --filter-ppid
 --filter-vdom
 --filter-vm
+FlashCore
+FlashSystem
 --force-64bits-counters
 --force-counters32
 --force-counters64
@@ -161,6 +168,7 @@ iPushPro
 ipv4
 ipv6
 ISAM
+iSCSI
 iSendPro
 IVE
 Iwsva
@@ -189,7 +197,14 @@ libSSH
 Libvirt
 license-instances-usage-prct
 Loggly
+lsdrive
+lseventlog
+lsmdisk
 LSP
+lspartition
+lssystem
+lssystemstats
+lsvdisk
 LTE
 LUN
 LUNs
@@ -200,6 +215,8 @@ MAPI
 MBean
 Mbps
 McAfee
+mdisk
+mdisks
 Mellanox
 memAvailReal
 memBuffer
@@ -250,12 +267,14 @@ NLCapacity
 -NoLogo
 --nomachineaccount
 notapplicable
+NPIV
 NRPE
 NSClient
 --ntlmv2
 NTLMv2
 NTP
 Nutanix
+NVMe
 NVOS
 OAuth
 OAuth2
@@ -308,6 +327,7 @@ PVX
 QoS
 Qtree
 queue-messages-inflighted
+quorum
 quts
 raidvolume
 redis-cli
@@ -322,6 +342,10 @@ RSS
 rssi
 RTT
 Rubrik
+Storwize
+vdisk
+Virtualize
+WWPN
 µs
 Sansymphony
 SAS

--- a/tests/storage/ibm/flashsystem/restapi/capacity.robot
+++ b/tests/storage/ibm/flashsystem/restapi/capacity.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}mockoon.json
+
+${CMD}              ${CENTREON_PLUGINS}
+...                 --plugin=storage::ibm::flashsystem::restapi::plugin
+...                 --mode=capacity
+...                 --hostname=${HOSTNAME}
+...                 --proto='http'
+...                 --port=${APIPORT}
+...                 --api-path='/rest/v1'
+...                 --api-username='user'
+...                 --api-password='pass'
+...                 --statefile-dir=/tmp
+
+
+*** Test Cases ***
+capacity ${tc}
+    [Tags]    storage    ibm    flashsystem    restapi
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:         tc      extra_options                                                         expected_result    --
+            ...       1       ${EMPTY}                                                              OK: Physical capacity: used 47.10 %, 146.48 TB, free 164.51 TB, overallocation 137 % - Logical: used 292.98 TB, free 629.20 TB - Data reduction: 1.81:1, saved 118.97 TB - Pool 'pool-a' status: online, overallocation: 137%, data reduction: no, used 32.78 %, free 629.06 TB | 'system.physical.space.usage.percentage'=47.10%;;;0;100 'system.physical.space.usage.bytes'=161056463236628B;;;0;341937121122058 'system.physical.space.free.bytes'=180880657885429B;;;0;341937121122058 'system.space.overallocation.percentage'=137%;;;0; 'system.logical.space.usage.bytes'=322134916705812B;;;0; 'system.logical.space.free.bytes'=691812716196659B;;;0; 'system.data.reduction.ratio.count'=1.81;;;0; 'system.data.reduction.saved.bytes'=130808898356510B;;;0; 'pool-a#pool.space.usage.percentage'=32.78%;;;0;100 'pool-a#pool.space.free.bytes'=691658784568770B;;;0;
+            ...       2       --warning-physical-usage-prct=40 --critical-physical-usage-prct=90    WARNING: Physical capacity: used 47.10 % | 'system.physical.space.usage.percentage'=47.10%;0:40;0:90;0;100 'system.physical.space.usage.bytes'=161056463236628B;;;0;341937121122058 'system.physical.space.free.bytes'=180880657885429B;;;0;341937121122058 'system.space.overallocation.percentage'=137%;;;0; 'system.logical.space.usage.bytes'=322134916705812B;;;0; 'system.logical.space.free.bytes'=691812716196659B;;;0; 'system.data.reduction.ratio.count'=1.81;;;0; 'system.data.reduction.saved.bytes'=130808898356510B;;;0; 'pool-a#pool.space.usage.percentage'=32.78%;;;0;100 'pool-a#pool.space.free.bytes'=691658784568770B;;;0;
+            ...       3       --filter-pool='nomatch'                                               OK: Physical capacity: used 47.10 %, 146.48 TB, free 164.51 TB, overallocation 137 % - Logical: used 292.98 TB, free 629.20 TB - Data reduction: 1.81:1, saved 118.97 TB | 'system.physical.space.usage.percentage'=47.10%;;;0;100 'system.physical.space.usage.bytes'=161056463236628B;;;0;341937121122058 'system.physical.space.free.bytes'=180880657885429B;;;0;341937121122058 'system.space.overallocation.percentage'=137%;;;0; 'system.logical.space.usage.bytes'=322134916705812B;;;0; 'system.logical.space.free.bytes'=691812716196659B;;;0; 'system.data.reduction.ratio.count'=1.81;;;0; 'system.data.reduction.saved.bytes'=130808898356510B;;;0;
+            ...       4       --critical-pool-status='\\\%{status} =~ /online/'                        CRITICAL: Pool 'pool-a' status: online, overallocation: 137%, data reduction: no | 'system.physical.space.usage.percentage'=47.10%;;;0;100 'system.physical.space.usage.bytes'=161056463236628B;;;0;341937121122058 'system.physical.space.free.bytes'=180880657885429B;;;0;341937121122058 'system.space.overallocation.percentage'=137%;;;0; 'system.logical.space.usage.bytes'=322134916705812B;;;0; 'system.logical.space.free.bytes'=691812716196659B;;;0; 'system.data.reduction.ratio.count'=1.81;;;0; 'system.data.reduction.saved.bytes'=130808898356510B;;;0; 'pool-a#pool.space.usage.percentage'=32.78%;;;0;100 'pool-a#pool.space.free.bytes'=691658784568770B;;;0;
+            ...       5       --filter-counters='data-reduction'                                    OK: Data reduction: 1.81:1, saved 118.97 TB - Pool 'pool-a' | 'system.data.reduction.ratio.count'=1.81;;;0; 'system.data.reduction.saved.bytes'=130808898356510B;;;0;

--- a/tests/storage/ibm/flashsystem/restapi/drives.robot
+++ b/tests/storage/ibm/flashsystem/restapi/drives.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}mockoon.json
+
+${CMD}              ${CENTREON_PLUGINS}
+...                 --plugin=storage::ibm::flashsystem::restapi::plugin
+...                 --mode=drives
+...                 --hostname=${HOSTNAME}
+...                 --proto='http'
+...                 --port=${APIPORT}
+...                 --api-path='/rest/v1'
+...                 --api-username='user'
+...                 --api-password='pass'
+...                 --statefile-dir=/tmp
+
+
+*** Test Cases ***
+drives ${tc}
+    [Tags]    storage    ibm    flashsystem    restapi
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:         tc      extra_options                            expected_result    --
+            ...       1       ${EMPTY}                                 OK: Drives: 12 detected - All drives have both paths online | 'drives.detected.count'=12;;;0; '0#drive.endurance.used.percentage'=0%;;;0;100 '0#drive.physical.space.usage.percentage'=42.94%;;;0;100 '1#drive.endurance.used.percentage'=0%;;;0;100 '1#drive.physical.space.usage.percentage'=42.94%;;;0;100 '10#drive.endurance.used.percentage'=0%;;;0;100 '10#drive.physical.space.usage.percentage'=42.94%;;;0;100 '11#drive.endurance.used.percentage'=0%;;;0;100 '11#drive.physical.space.usage.percentage'=42.94%;;;0;100 '2#drive.endurance.used.percentage'=0%;;;0;100 '2#drive.physical.space.usage.percentage'=42.94%;;;0;100 '3#drive.endurance.used.percentage'=0%;;;0;100 '3#drive.physical.space.usage.percentage'=42.94%;;;0;100 '4#drive.endurance.used.percentage'=0%;;;0;100 '4#drive.physical.space.usage.percentage'=42.94%;;;0;100 '5#drive.endurance.used.percentage'=0%;;;0;100 '5#drive.physical.space.usage.percentage'=42.94%;;;0;100 '6#drive.endurance.used.percentage'=0%;;;0;100 '6#drive.physical.space.usage.percentage'=42.94%;;;0;100 '7#drive.endurance.used.percentage'=0%;;;0;100 '7#drive.physical.space.usage.percentage'=42.94%;;;0;100 '8#drive.endurance.used.percentage'=0%;;;0;100 '8#drive.physical.space.usage.percentage'=42.94%;;;0;100 '9#drive.endurance.used.percentage'=0%;;;0;100 '9#drive.physical.space.usage.percentage'=42.94%;;;0;100
+            ...       2       --filter-id='^0$'                        OK: Drives: 1 detected - Drive '0' (enclosure 1 slot 8) paths online/online, use: member, firmware 4_1_8, endurance used 0 %, physical used 42.94 % | 'drives.detected.count'=1;;;0; '0#drive.endurance.used.percentage'=0%;;;0;100 '0#drive.physical.space.usage.percentage'=42.94%;;;0;100
+            ...       3       --critical-physical-usage-prct=10        CRITICAL: Drive '0' (enclosure 1 slot 8) physical used 42.94 % - Drive '1' (enclosure 1 slot 7) physical used 42.94 % - Drive '10' (enclosure 1 slot 12) physical used 42.94 % - Drive '11' (enclosure 1 slot 9) physical used 42.94 % - Drive '2' (enclosure 1 slot 6) physical used 42.94 % - Drive '3' (enclosure 1 slot 11) physical used 42.94 % - Drive '4' (enclosure 1 slot 5) physical used 42.94 % - Drive '5' (enclosure 1 slot 2) physical used 42.94 % - Drive '6' (enclosure 1 slot 4) physical used 42.94 % - Drive '7' (enclosure 1 slot 1) physical used 42.94 % - Drive '8' (enclosure 1 slot 3) physical used 42.94 % - Drive '9' (enclosure 1 slot 10) physical used 42.94 % | 'drives.detected.count'=12;;;0; '0#drive.endurance.used.percentage'=0%;;;0;100 '0#drive.physical.space.usage.percentage'=42.94%;;0:10;0;100 '1#drive.endurance.used.percentage'=0%;;;0;100 '1#drive.physical.space.usage.percentage'=42.94%;;0:10;0;100 '10#drive.endurance.used.percentage'=0%;;;0;100 '10#drive.physical.space.usage.percentage'=42.94%;;0:10;0;100 '11#drive.endurance.used.percentage'=0%;;;0;100 '11#drive.physical.space.usage.percentage'=42.94%;;0:10;0;100 '2#drive.endurance.used.percentage'=0%;;;0;100 '2#drive.physical.space.usage.percentage'=42.94%;;0:10;0;100 '3#drive.endurance.used.percentage'=0%;;;0;100 '3#drive.physical.space.usage.percentage'=42.94%;;0:10;0;100 '4#drive.endurance.used.percentage'=0%;;;0;100 '4#drive.physical.space.usage.percentage'=42.94%;;0:10;0;100 '5#drive.endurance.used.percentage'=0%;;;0;100 '5#drive.physical.space.usage.percentage'=42.94%;;0:10;0;100 '6#drive.endurance.used.percentage'=0%;;;0;100 '6#drive.physical.space.usage.percentage'=42.94%;;0:10;0;100 '7#drive.endurance.used.percentage'=0%;;;0;100 '7#drive.physical.space.usage.percentage'=42.94%;;0:10;0;100 '8#drive.endurance.used.percentage'=0%;;;0;100 '8#drive.physical.space.usage.percentage'=42.94%;;0:10;0;100 '9#drive.endurance.used.percentage'=0%;;;0;100 '9#drive.physical.space.usage.percentage'=42.94%;;0:10;0;100
+            ...       4       --warning-status='\\\%{use} eq "member"'    WARNING: Drive '0' (enclosure 1 slot 8) paths online/online, use: member, firmware 4_1_8 - Drive '1' (enclosure 1 slot 7) paths online/online, use: member, firmware 4_1_8 - Drive '10' (enclosure 1 slot 12) paths online/online, use: member, firmware 4_1_8 - Drive '11' (enclosure 1 slot 9) paths online/online, use: member, firmware 4_1_8 - Drive '2' (enclosure 1 slot 6) paths online/online, use: member, firmware 4_1_8 - Drive '3' (enclosure 1 slot 11) paths online/online, use: member, firmware 4_1_8 - Drive '4' (enclosure 1 slot 5) paths online/online, use: member, firmware 4_1_8 - Drive '5' (enclosure 1 slot 2) paths online/online, use: member, firmware 4_1_8 - Drive '6' (enclosure 1 slot 4) paths online/online, use: member, firmware 4_1_8 - Drive '7' (enclosure 1 slot 1) paths online/online, use: member, firmware 4_1_8 - Drive '8' (enclosure 1 slot 3) paths online/online, use: member, firmware 4_1_8 - Drive '9' (enclosure 1 slot 10) paths online/online, use: member, firmware 4_1_8 | 'drives.detected.count'=12;;;0; '0#drive.endurance.used.percentage'=0%;;;0;100 '0#drive.physical.space.usage.percentage'=42.94%;;;0;100 '1#drive.endurance.used.percentage'=0%;;;0;100 '1#drive.physical.space.usage.percentage'=42.94%;;;0;100 '10#drive.endurance.used.percentage'=0%;;;0;100 '10#drive.physical.space.usage.percentage'=42.94%;;;0;100 '11#drive.endurance.used.percentage'=0%;;;0;100 '11#drive.physical.space.usage.percentage'=42.94%;;;0;100 '2#drive.endurance.used.percentage'=0%;;;0;100 '2#drive.physical.space.usage.percentage'=42.94%;;;0;100 '3#drive.endurance.used.percentage'=0%;;;0;100 '3#drive.physical.space.usage.percentage'=42.94%;;;0;100 '4#drive.endurance.used.percentage'=0%;;;0;100 '4#drive.physical.space.usage.percentage'=42.94%;;;0;100 '5#drive.endurance.used.percentage'=0%;;;0;100 '5#drive.physical.space.usage.percentage'=42.94%;;;0;100 '6#drive.endurance.used.percentage'=0%;;;0;100 '6#drive.physical.space.usage.percentage'=42.94%;;;0;100 '7#drive.endurance.used.percentage'=0%;;;0;100 '7#drive.physical.space.usage.percentage'=42.94%;;;0;100 '8#drive.endurance.used.percentage'=0%;;;0;100 '8#drive.physical.space.usage.percentage'=42.94%;;;0;100 '9#drive.endurance.used.percentage'=0%;;;0;100 '9#drive.physical.space.usage.percentage'=42.94%;;;0;100

--- a/tests/storage/ibm/flashsystem/restapi/eth-ports.robot
+++ b/tests/storage/ibm/flashsystem/restapi/eth-ports.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}mockoon.json
+
+${CMD}              ${CENTREON_PLUGINS}
+...                 --plugin=storage::ibm::flashsystem::restapi::plugin
+...                 --mode=eth-ports
+...                 --hostname=${HOSTNAME}
+...                 --proto='http'
+...                 --port=${APIPORT}
+...                 --api-path='/rest/v1'
+...                 --api-username='user'
+...                 --api-password='pass'
+...                 --statefile-dir=/tmp
+
+
+*** Test Cases ***
+eth-ports ${tc}
+    [Tags]    storage    ibm    flashsystem    restapi
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:         tc      extra_options             expected_result    --
+            ...       1       ${EMPTY}                  OK: Ethernet ports: 6 detected, 2 active, 6 role-capable, 0 IP configured - All Ethernet ports in service are active | 'ethports.detected.count'=6;;;0; 'ethports.active.count'=2;;;0; 'ethports.withrole.count'=6;;;0; 'ethports.ip.configured.count'=0;;;0;
+            ...       2       --add-unused              OK: Ethernet ports: 6 detected, 2 active, 6 role-capable, 0 IP configured - All Ethernet ports in service are active | 'ethports.detected.count'=6;;;0; 'ethports.active.count'=2;;;0; 'ethports.withrole.count'=6;;;0; 'ethports.ip.configured.count'=0;;;0;
+            ...       3       --critical-active=1       CRITICAL: Ethernet ports: 2 active | 'ethports.detected.count'=6;;;0; 'ethports.active.count'=2;;0:1;0; 'ethports.withrole.count'=6;;;0; 'ethports.ip.configured.count'=0;;;0;
+            ...       4       --filter-name='^node1'    OK: Ethernet ports: 3 detected, 1 active, 3 role-capable, 0 IP configured - Port 'node1-1' link active, speed 1Gb/s, roles: management | 'ethports.detected.count'=3;;;0; 'ethports.active.count'=1;;;0; 'ethports.withrole.count'=3;;;0; 'ethports.ip.configured.count'=0;;;0;

--- a/tests/storage/ibm/flashsystem/restapi/eventlog.robot
+++ b/tests/storage/ibm/flashsystem/restapi/eventlog.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}mockoon.json
+
+${CMD}              ${CENTREON_PLUGINS}
+...                 --plugin=storage::ibm::flashsystem::restapi::plugin
+...                 --mode=eventlog
+...                 --hostname=${HOSTNAME}
+...                 --proto='http'
+...                 --port=${APIPORT}
+...                 --api-path='/rest/v1'
+...                 --api-username='user'
+...                 --api-password='pass'
+...                 --statefile-dir=/tmp
+
+
+*** Test Cases ***
+eventlog ${tc}
+    [Tags]    storage    ibm    flashsystem    restapi
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:         tc      extra_options                                                          expected_result    --
+            ...       1       ${EMPTY}                                                               CRITICAL: Event '3101' status: alert, error code: 2017, event id: 064003, object: host host-29, last seen: 260902154807 [One or more configured hosts are offline] | 'eventlog.alerts.count'=1;;;0; 'eventlog.messages.count'=11;;;0;
+            ...       2       --filter-error-code='^9999$'                                           OK: Unfixed event log entries: 1 alert(s), 11 message(s) | 'eventlog.alerts.count'=1;;;0; 'eventlog.messages.count'=11;;;0;
+            ...       3       --critical-event-status='\\\%{status} =~ /never/' --warning-messages=0    WARNING: Unfixed event log entries: 11 message(s) | 'eventlog.alerts.count'=1;;;0; 'eventlog.messages.count'=11;0:0;;0;
+            ...       4       --filter-object-type='host'                                            CRITICAL: Event '3101' status: alert, error code: 2017, event id: 064003, object: host host-29, last seen: 260902154807 [One or more configured hosts are offline] | 'eventlog.alerts.count'=1;;;0; 'eventlog.messages.count'=11;;;0;

--- a/tests/storage/ibm/flashsystem/restapi/fc-ports.robot
+++ b/tests/storage/ibm/flashsystem/restapi/fc-ports.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}mockoon.json
+
+${CMD}              ${CENTREON_PLUGINS}
+...                 --plugin=storage::ibm::flashsystem::restapi::plugin
+...                 --mode=fc-ports
+...                 --hostname=${HOSTNAME}
+...                 --proto='http'
+...                 --port=${APIPORT}
+...                 --api-path='/rest/v1'
+...                 --api-username='user'
+...                 --api-password='pass'
+...                 --statefile-dir=/tmp
+
+
+*** Test Cases ***
+fc-ports ${tc}
+    [Tags]    storage    ibm    flashsystem    restapi
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:         tc      extra_options                                 expected_result    --
+            ...       1       ${EMPTY}                                      OK: Fibre Channel ports: 8 detected, 8 active, 0 inactive, 648 host login(s) - All Fibre Channel ports are active | 'fcports.detected.count'=8;;;0; 'fcports.active.count'=8;;;0; 'fcports.inactive.count'=0;;;0; 'fcports.host.logins.count'=648;;;0;
+            ...       2       --filter-name='^node1'                        OK: Fibre Channel ports: 4 detected, 4 active, 0 inactive, 324 host login(s) - All Fibre Channel ports are active | 'fcports.detected.count'=4;;;0; 'fcports.active.count'=4;;;0; 'fcports.inactive.count'=0;;;0; 'fcports.host.logins.count'=324;;;0;
+            ...       3       --critical-host-logins=10                     CRITICAL: Fibre Channel ports: 648 host login(s) | 'fcports.detected.count'=8;;;0; 'fcports.active.count'=8;;;0; 'fcports.inactive.count'=0;;;0; 'fcports.host.logins.count'=648;;0:10;0;
+            ...       4       --warning-status='\\\%{port_speed} =~ /16Gb/'    WARNING: Port 'node1-1' status: active, speed: 16Gb, attachment: switch, host logins: 6 - Port 'node1-2' status: active, speed: 16Gb, attachment: switch, host logins: 6 - Port 'node1-3' status: active, speed: 16Gb, attachment: switch, host logins: 156 - Port 'node1-4' status: active, speed: 16Gb, attachment: switch, host logins: 156 - Port 'node2-1' status: active, speed: 16Gb, attachment: switch, host logins: 6 - Port 'node2-2' status: active, speed: 16Gb, attachment: switch, host logins: 6 - Port 'node2-3' status: active, speed: 16Gb, attachment: switch, host logins: 156 - Port 'node2-4' status: active, speed: 16Gb, attachment: switch, host logins: 156 | 'fcports.detected.count'=8;;;0; 'fcports.active.count'=8;;;0; 'fcports.inactive.count'=0;;;0; 'fcports.host.logins.count'=648;;;0;

--- a/tests/storage/ibm/flashsystem/restapi/hardware.robot
+++ b/tests/storage/ibm/flashsystem/restapi/hardware.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}mockoon.json
+
+${CMD}              ${CENTREON_PLUGINS}
+...                 --plugin=storage::ibm::flashsystem::restapi::plugin
+...                 --mode=hardware
+...                 --hostname=${HOSTNAME}
+...                 --proto='http'
+...                 --port=${APIPORT}
+...                 --api-path='/rest/v1'
+...                 --api-username='user'
+...                 --api-password='pass'
+...                 --statefile-dir=/tmp
+
+
+*** Test Cases ***
+hardware ${tc}
+    [Tags]    storage    ibm    flashsystem    restapi
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:         tc      extra_options                                         expected_result    --
+            ...       1       ${EMPTY}                                              OK: Hardware: 35 component(s), 0 not online - All hardware components are online - Enclosure: temperature 26 C, power draw 543 W - All enclosure subsystems are fully populated | 'hardware.components.detected.count'=35;;;0; 'hardware.components.degraded.count'=0;;;0; 'hardware.temperature.celsius'=26C;;;; 'hardware.power.watt'=543W;;;0;
+            ...       2       --filter-type='quorum'                                OK: Hardware: 6 component(s), 0 not online - All hardware components are online - Enclosure: temperature 26 C, power draw 543 W | 'hardware.components.detected.count'=6;;;0; 'hardware.components.degraded.count'=0;;;0; 'hardware.temperature.celsius'=26C;;;; 'hardware.power.watt'=543W;;;0;
+            ...       3       --warning-component-status='\\\%{status} =~ /online/'    WARNING: Array 'MDisk1' status: online - Battery '1' status: online - Battery '2' status: online - Drive '0' status: online - Drive '1' status: online - Drive '10' status: online - Drive '11' status: online - Drive '2' status: online - Drive '3' status: online - Drive '4' status: online - Drive '5' status: online - Drive '6' status: online - Drive '7' status: online - Drive '8' status: online - Drive '9' status: online - Enclosure '1' status: online - Expansion canister '1' status: online - Expansion canister '2' status: online - Fan module '1' status: online - Fan module '2' status: online - Fan module '3' status: online - Fan module '4' status: online - Fan module '5' status: online - Fan module '6' status: online - Mdisk 'MDisk1' status: online - Node canister 'node1' status: online - Node canister 'node2' status: online - Power supply '1' status: online - Power supply '2' status: online - Quorum '0' status: online - Quorum '1' status: online - Quorum '10' status: online - Quorum '2' status: online - Quorum '8' status: online - Quorum '9' status: online | 'hardware.components.detected.count'=35;;;0; 'hardware.components.degraded.count'=0;;;0; 'hardware.temperature.celsius'=26C;;;; 'hardware.power.watt'=543W;;;0;
+            ...       4       --warning-temperature=10 --critical-temperature=20    CRITICAL: Enclosure: temperature 26 C | 'hardware.components.detected.count'=35;;;0; 'hardware.components.degraded.count'=0;;;0; 'hardware.temperature.celsius'=26C;0:10;0:20;; 'hardware.power.watt'=543W;;;0;
+            ...       5       --warning-components-detected=10                      WARNING: Hardware: 35 component(s) | 'hardware.components.detected.count'=35;0:10;;0; 'hardware.components.degraded.count'=0;;;0; 'hardware.temperature.celsius'=26C;;;; 'hardware.power.watt'=543W;;;0;

--- a/tests/storage/ibm/flashsystem/restapi/hosts.robot
+++ b/tests/storage/ibm/flashsystem/restapi/hosts.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}mockoon.json
+
+${CMD}              ${CENTREON_PLUGINS}
+...                 --plugin=storage::ibm::flashsystem::restapi::plugin
+...                 --mode=hosts
+...                 --hostname=${HOSTNAME}
+...                 --proto='http'
+...                 --port=${APIPORT}
+...                 --api-path='/rest/v1'
+...                 --api-username='user'
+...                 --api-password='pass'
+...                 --statefile-dir=/tmp
+
+
+*** Test Cases ***
+hosts ${tc}
+    [Tags]    storage    ibm    flashsystem    restapi
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:         tc      extra_options                                 expected_result    --
+            ...       1       ${EMPTY}                                      WARNING: Host 'host-29' status: offline, ports: 4, partition: partition-b - Host 'host-43' status: offline, ports: 4, partition: partition-b - Host 'host-51' status: offline, ports: 4, partition: partition-b - Host 'host-54' status: offline, ports: 4, partition: partition-b | 'hosts.detected.count'=12;;;0; 'hosts.online.count'=8;;;0; 'hosts.offline.count'=4;;;0; 'hosts.degraded.count'=0;;;0;
+            ...       2       --filter-partition='partition-a'              OK: Hosts: 8 declared, 8 online, 0 offline, 0 degraded - All hosts are online | 'hosts.detected.count'=8;;;0; 'hosts.online.count'=8;;;0; 'hosts.offline.count'=0;;;0; 'hosts.degraded.count'=0;;;0;
+            ...       3       --critical-status='\\\%{status} =~ /offline/'    CRITICAL: Host 'host-29' status: offline, ports: 4, partition: partition-b - Host 'host-43' status: offline, ports: 4, partition: partition-b - Host 'host-51' status: offline, ports: 4, partition: partition-b - Host 'host-54' status: offline, ports: 4, partition: partition-b | 'hosts.detected.count'=12;;;0; 'hosts.online.count'=8;;;0; 'hosts.offline.count'=4;;;0; 'hosts.degraded.count'=0;;;0;
+            ...       4       --filter-name='^host-2'                       WARNING: Host 'host-29' status: offline, ports: 4, partition: partition-b | 'hosts.detected.count'=1;;;0; 'hosts.online.count'=0;;;0; 'hosts.offline.count'=1;;;0; 'hosts.degraded.count'=0;;;0;

--- a/tests/storage/ibm/flashsystem/restapi/mockoon.json
+++ b/tests/storage/ibm/flashsystem/restapi/mockoon.json
@@ -1,0 +1,1883 @@
+{
+  "uuid": "c9b3b02f-191c-4d8a-b857-a8348adb19ce",
+  "lastMigration": 32,
+  "name": "ibm-flashsystem-restapi",
+  "endpointPrefix": "",
+  "latency": 0,
+  "port": 3000,
+  "hostname": "",
+  "folders": [],
+  "routes": [
+    {
+      "uuid": "b4f61efd-1ba0-5771-97f0-059191ecdce1",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/auth",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "af78cdb5-73b8-5b82-81c5-b5f2a3617b8d",
+          "body": "{\n  \"token\": \"test-token\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "cea66f97-6715-5ae2-b1f7-f22d75abdef4",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsarray",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "20fba665-b7df-5e63-bd23-2fc7190a4015",
+          "body": "[\n  {\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"937.6TB\",\n    \"raid_status\": \"online\",\n    \"raid_level\": \"raid6\",\n    \"redundancy\": \"2\",\n    \"strip_size\": \"256\",\n    \"tier\": \"tier0_flash\",\n    \"encrypt\": \"no\",\n    \"distributed\": \"yes\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "aa50e61c-2aa8-53ec-9997-8ec9ad242c58",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsarray/0",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "b04a2b98-99be-5745-b2e1-1bfc407c35a4",
+          "body": "{\n  \"mdisk_id\": \"0\",\n  \"mdisk_name\": \"MDisk1\",\n  \"status\": \"online\",\n  \"mode\": \"array\",\n  \"mdisk_grp_id\": \"0\",\n  \"mdisk_grp_name\": \"pool-a\",\n  \"capacity\": \"937.6TB\",\n  \"quorum_index\": \"\",\n  \"block_size\": \"\",\n  \"controller_name\": \"\",\n  \"ctrl_type\": \"\",\n  \"ctrl_WWNN\": \"\",\n  \"controller_id\": \"\",\n  \"path_count\": \"\",\n  \"max_path_count\": \"\",\n  \"ctrl_LUN_#\": \"\",\n  \"UID\": \"\",\n  \"preferred_WWPN\": \"\",\n  \"active_WWPN\": \"\",\n  \"fast_write_state\": \"not_empty\",\n  \"raid_status\": \"online\",\n  \"raid_level\": \"raid6\",\n  \"redundancy\": \"2\",\n  \"strip_size\": \"256\",\n  \"spare_goal\": \"\",\n  \"spare_protection_min\": \"\",\n  \"balanced\": \"exact\",\n  \"tier\": \"tier0_flash\",\n  \"slow_write_priority\": \"latency\",\n  \"fabric_type\": \"\",\n  \"site_id\": \"\",\n  \"site_name\": \"\",\n  \"easy_tier_load\": \"\",\n  \"encrypt\": \"no\",\n  \"distributed\": \"yes\",\n  \"drive_class_id\": \"0\",\n  \"drive_count\": \"12\",\n  \"stripe_width\": \"11\",\n  \"rebuild_areas_total\": \"1\",\n  \"rebuild_areas_available\": \"1\",\n  \"rebuild_areas_goal\": \"1\",\n  \"dedupe\": \"no\",\n  \"preferred_iscsi_port_id\": \"\",\n  \"active_iscsi_port_id\": \"\",\n  \"replacement_date\": \"\",\n  \"over_provisioned\": \"yes\",\n  \"supports_unmap\": \"yes\",\n  \"provisioning_group_id\": \"0\",\n  \"physical_capacity\": \"310.99TB\",\n  \"physical_free_capacity\": \"164.51TB\",\n  \"write_protected\": \"no\",\n  \"allocated_capacity\": \"306.74TB\",\n  \"effective_used_capacity\": \"265.45TB\",\n  \"fips_enabled\": \"no\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "b503e9e3-021c-516f-90a7-5d61b257e761",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsdrive",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "3de62513-35e1-5ca8-a9e8-8a0e9fc0334a",
+          "body": "[\n  {\n    \"id\": \"0\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"0\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"8\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\"\n  },\n  {\n    \"id\": \"1\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"1\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"7\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\"\n  },\n  {\n    \"id\": \"2\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"2\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"6\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\"\n  },\n  {\n    \"id\": \"3\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"3\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"11\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\"\n  },\n  {\n    \"id\": \"4\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"4\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"5\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\"\n  },\n  {\n    \"id\": \"5\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"5\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"2\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\"\n  },\n  {\n    \"id\": \"6\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"6\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"4\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\"\n  },\n  {\n    \"id\": \"7\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"7\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"1\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\"\n  },\n  {\n    \"id\": \"8\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"8\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"3\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\"\n  },\n  {\n    \"id\": \"9\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"9\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"10\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\"\n  },\n  {\n    \"id\": \"10\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"10\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"12\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\"\n  },\n  {\n    \"id\": \"11\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"11\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"9\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "7613504c-de71-5d6e-ae90-8aa37337aee9",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsdrive/0",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "9e965d4f-c2b7-5dfd-9e7f-9dbca29b36a0",
+          "body": "{\n  \"id\": \"0\",\n  \"status\": \"online\",\n  \"error_sequence_number\": \"\",\n  \"use\": \"member\",\n  \"UID\": \"9249ac2e2910802be6da3de65fe2ede0cd998c7889f64781cadd5e8c9d59b2f4\",\n  \"tech_type\": \"tier0_flash\",\n  \"capacity\": \"104.8TB\",\n  \"block_size\": \"512\",\n  \"vendor_id\": \"IBM-A072\",\n  \"product_id\": \"6863800b\",\n  \"FRU_part_number\": \"32ab30f\",\n  \"FRU_identity\": \"667e16e10ea76180310e04\",\n  \"RPM\": \"\",\n  \"firmware_level\": \"4_1_8   \",\n  \"FPGA_level\": \"\",\n  \"date_of_manufacture\": \"\",\n  \"mdisk_id\": \"0\",\n  \"mdisk_name\": \"MDisk1\",\n  \"member_id\": \"0\",\n  \"enclosure_id\": \"1\",\n  \"slot_id\": \"8\",\n  \"node_id\": \"\",\n  \"node_name\": \"\",\n  \"quorum_id\": \"\",\n  \"port_1_status\": \"online\",\n  \"port_2_status\": \"online\",\n  \"interface_speed\": \"\",\n  \"protection_enabled\": \"yes\",\n  \"auto_manage\": \"inactive\",\n  \"drive_class_id\": \"0\",\n  \"write_endurance_used\": \"0\",\n  \"write_endurance_usage_rate\": \"\",\n  \"replacement_date\": \"\",\n  \"transport_protocol\": \"nvme\",\n  \"compressed\": \"yes\",\n  \"physical_capacity\": \"34.93TB\",\n  \"physical_used_capacity\": \"15.00TB\",\n  \"effective_used_capacity\": \"27.19TB\",\n  \"fips_enabled\": \"no\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "e1896e37-70a6-5899-aefd-98001788d585",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsdrive/1",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "6f0f7a5a-c978-50cd-81e1-94d187eb4a3c",
+          "body": "[\n  {\n    \"id\": \"1\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"UID\": \"9249ac2e2910802be6da3de65fe2ede0cd998c7889f64781cadd5e8c9d59b2f4\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"block_size\": \"512\",\n    \"vendor_id\": \"IBM-A072\",\n    \"product_id\": \"6863800b\",\n    \"FRU_part_number\": \"32ab30f\",\n    \"FRU_identity\": \"667e16e10ea76180310e04\",\n    \"RPM\": \"\",\n    \"firmware_level\": \"4_1_8   \",\n    \"FPGA_level\": \"\",\n    \"date_of_manufacture\": \"\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"1\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"7\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"quorum_id\": \"\",\n    \"port_1_status\": \"online\",\n    \"port_2_status\": \"online\",\n    \"interface_speed\": \"\",\n    \"protection_enabled\": \"yes\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\",\n    \"write_endurance_used\": \"0\",\n    \"write_endurance_usage_rate\": \"\",\n    \"replacement_date\": \"\",\n    \"transport_protocol\": \"nvme\",\n    \"compressed\": \"yes\",\n    \"physical_capacity\": \"34.93TB\",\n    \"physical_used_capacity\": \"15.00TB\",\n    \"effective_used_capacity\": \"27.19TB\",\n    \"fips_enabled\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "f8a3cbd5-f84b-521d-adab-266b5fb968c2",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsdrive/10",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "8aa788c8-d2d1-5df3-8d40-e3b50f59ffef",
+          "body": "[\n  {\n    \"id\": \"10\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"UID\": \"9249ac2e2910802be6da3de65fe2ede0cd998c7889f64781cadd5e8c9d59b2f4\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"block_size\": \"512\",\n    \"vendor_id\": \"IBM-A072\",\n    \"product_id\": \"6863800b\",\n    \"FRU_part_number\": \"32ab30f\",\n    \"FRU_identity\": \"667e16e10ea76180310e04\",\n    \"RPM\": \"\",\n    \"firmware_level\": \"4_1_8   \",\n    \"FPGA_level\": \"\",\n    \"date_of_manufacture\": \"\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"10\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"12\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"quorum_id\": \"\",\n    \"port_1_status\": \"online\",\n    \"port_2_status\": \"online\",\n    \"interface_speed\": \"\",\n    \"protection_enabled\": \"yes\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\",\n    \"write_endurance_used\": \"0\",\n    \"write_endurance_usage_rate\": \"\",\n    \"replacement_date\": \"\",\n    \"transport_protocol\": \"nvme\",\n    \"compressed\": \"yes\",\n    \"physical_capacity\": \"34.93TB\",\n    \"physical_used_capacity\": \"15.00TB\",\n    \"effective_used_capacity\": \"27.19TB\",\n    \"fips_enabled\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "a2c2c4cc-8228-52a7-973a-148e08a62fcb",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsdrive/11",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "05e71797-b98c-5f31-90db-be4a4bdaf3a8",
+          "body": "[\n  {\n    \"id\": \"11\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"UID\": \"9249ac2e2910802be6da3de65fe2ede0cd998c7889f64781cadd5e8c9d59b2f4\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"block_size\": \"512\",\n    \"vendor_id\": \"IBM-A072\",\n    \"product_id\": \"6863800b\",\n    \"FRU_part_number\": \"32ab30f\",\n    \"FRU_identity\": \"667e16e10ea76180310e04\",\n    \"RPM\": \"\",\n    \"firmware_level\": \"4_1_8   \",\n    \"FPGA_level\": \"\",\n    \"date_of_manufacture\": \"\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"11\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"9\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"quorum_id\": \"\",\n    \"port_1_status\": \"online\",\n    \"port_2_status\": \"online\",\n    \"interface_speed\": \"\",\n    \"protection_enabled\": \"yes\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\",\n    \"write_endurance_used\": \"0\",\n    \"write_endurance_usage_rate\": \"\",\n    \"replacement_date\": \"\",\n    \"transport_protocol\": \"nvme\",\n    \"compressed\": \"yes\",\n    \"physical_capacity\": \"34.93TB\",\n    \"physical_used_capacity\": \"15.00TB\",\n    \"effective_used_capacity\": \"27.19TB\",\n    \"fips_enabled\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "5cb7f41a-75fa-5ee9-9b43-6917b57811e3",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsdrive/2",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "5df1edd8-9767-5596-9359-896b3da979aa",
+          "body": "[\n  {\n    \"id\": \"2\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"UID\": \"9249ac2e2910802be6da3de65fe2ede0cd998c7889f64781cadd5e8c9d59b2f4\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"block_size\": \"512\",\n    \"vendor_id\": \"IBM-A072\",\n    \"product_id\": \"6863800b\",\n    \"FRU_part_number\": \"32ab30f\",\n    \"FRU_identity\": \"667e16e10ea76180310e04\",\n    \"RPM\": \"\",\n    \"firmware_level\": \"4_1_8   \",\n    \"FPGA_level\": \"\",\n    \"date_of_manufacture\": \"\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"2\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"6\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"quorum_id\": \"\",\n    \"port_1_status\": \"online\",\n    \"port_2_status\": \"online\",\n    \"interface_speed\": \"\",\n    \"protection_enabled\": \"yes\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\",\n    \"write_endurance_used\": \"0\",\n    \"write_endurance_usage_rate\": \"\",\n    \"replacement_date\": \"\",\n    \"transport_protocol\": \"nvme\",\n    \"compressed\": \"yes\",\n    \"physical_capacity\": \"34.93TB\",\n    \"physical_used_capacity\": \"15.00TB\",\n    \"effective_used_capacity\": \"27.19TB\",\n    \"fips_enabled\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "91eca571-df43-5432-bd5c-e4d73f5b1ba2",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsdrive/3",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "a6a436d3-68b7-50f6-a32d-a40e58df4321",
+          "body": "[\n  {\n    \"id\": \"3\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"UID\": \"9249ac2e2910802be6da3de65fe2ede0cd998c7889f64781cadd5e8c9d59b2f4\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"block_size\": \"512\",\n    \"vendor_id\": \"IBM-A072\",\n    \"product_id\": \"6863800b\",\n    \"FRU_part_number\": \"32ab30f\",\n    \"FRU_identity\": \"667e16e10ea76180310e04\",\n    \"RPM\": \"\",\n    \"firmware_level\": \"4_1_8   \",\n    \"FPGA_level\": \"\",\n    \"date_of_manufacture\": \"\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"3\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"11\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"quorum_id\": \"\",\n    \"port_1_status\": \"online\",\n    \"port_2_status\": \"online\",\n    \"interface_speed\": \"\",\n    \"protection_enabled\": \"yes\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\",\n    \"write_endurance_used\": \"0\",\n    \"write_endurance_usage_rate\": \"\",\n    \"replacement_date\": \"\",\n    \"transport_protocol\": \"nvme\",\n    \"compressed\": \"yes\",\n    \"physical_capacity\": \"34.93TB\",\n    \"physical_used_capacity\": \"15.00TB\",\n    \"effective_used_capacity\": \"27.19TB\",\n    \"fips_enabled\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "85e96d1a-65ab-5647-ae3c-31d209bfae00",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsdrive/4",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "280d8cbd-380d-543a-a2fe-977d9b1aa940",
+          "body": "[\n  {\n    \"id\": \"4\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"UID\": \"9249ac2e2910802be6da3de65fe2ede0cd998c7889f64781cadd5e8c9d59b2f4\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"block_size\": \"512\",\n    \"vendor_id\": \"IBM-A072\",\n    \"product_id\": \"6863800b\",\n    \"FRU_part_number\": \"32ab30f\",\n    \"FRU_identity\": \"667e16e10ea76180310e04\",\n    \"RPM\": \"\",\n    \"firmware_level\": \"4_1_8   \",\n    \"FPGA_level\": \"\",\n    \"date_of_manufacture\": \"\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"4\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"5\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"quorum_id\": \"\",\n    \"port_1_status\": \"online\",\n    \"port_2_status\": \"online\",\n    \"interface_speed\": \"\",\n    \"protection_enabled\": \"yes\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\",\n    \"write_endurance_used\": \"0\",\n    \"write_endurance_usage_rate\": \"\",\n    \"replacement_date\": \"\",\n    \"transport_protocol\": \"nvme\",\n    \"compressed\": \"yes\",\n    \"physical_capacity\": \"34.93TB\",\n    \"physical_used_capacity\": \"15.00TB\",\n    \"effective_used_capacity\": \"27.19TB\",\n    \"fips_enabled\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "c859791f-2238-56ed-b944-72000a3c0229",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsdrive/5",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "64926061-d289-5a49-aa7f-b108025141f9",
+          "body": "[\n  {\n    \"id\": \"5\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"UID\": \"9249ac2e2910802be6da3de65fe2ede0cd998c7889f64781cadd5e8c9d59b2f4\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"block_size\": \"512\",\n    \"vendor_id\": \"IBM-A072\",\n    \"product_id\": \"6863800b\",\n    \"FRU_part_number\": \"32ab30f\",\n    \"FRU_identity\": \"667e16e10ea76180310e04\",\n    \"RPM\": \"\",\n    \"firmware_level\": \"4_1_8   \",\n    \"FPGA_level\": \"\",\n    \"date_of_manufacture\": \"\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"5\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"2\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"quorum_id\": \"\",\n    \"port_1_status\": \"online\",\n    \"port_2_status\": \"online\",\n    \"interface_speed\": \"\",\n    \"protection_enabled\": \"yes\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\",\n    \"write_endurance_used\": \"0\",\n    \"write_endurance_usage_rate\": \"\",\n    \"replacement_date\": \"\",\n    \"transport_protocol\": \"nvme\",\n    \"compressed\": \"yes\",\n    \"physical_capacity\": \"34.93TB\",\n    \"physical_used_capacity\": \"15.00TB\",\n    \"effective_used_capacity\": \"27.19TB\",\n    \"fips_enabled\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "908433d6-5090-52f3-aaf3-e629c127c259",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsdrive/6",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "fe129c13-3e33-5a5f-afd8-d75bc75324a8",
+          "body": "[\n  {\n    \"id\": \"6\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"UID\": \"9249ac2e2910802be6da3de65fe2ede0cd998c7889f64781cadd5e8c9d59b2f4\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"block_size\": \"512\",\n    \"vendor_id\": \"IBM-A072\",\n    \"product_id\": \"6863800b\",\n    \"FRU_part_number\": \"32ab30f\",\n    \"FRU_identity\": \"667e16e10ea76180310e04\",\n    \"RPM\": \"\",\n    \"firmware_level\": \"4_1_8   \",\n    \"FPGA_level\": \"\",\n    \"date_of_manufacture\": \"\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"6\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"4\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"quorum_id\": \"\",\n    \"port_1_status\": \"online\",\n    \"port_2_status\": \"online\",\n    \"interface_speed\": \"\",\n    \"protection_enabled\": \"yes\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\",\n    \"write_endurance_used\": \"0\",\n    \"write_endurance_usage_rate\": \"\",\n    \"replacement_date\": \"\",\n    \"transport_protocol\": \"nvme\",\n    \"compressed\": \"yes\",\n    \"physical_capacity\": \"34.93TB\",\n    \"physical_used_capacity\": \"15.00TB\",\n    \"effective_used_capacity\": \"27.19TB\",\n    \"fips_enabled\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "cf562a14-70b1-5c78-9c8e-20a16f8ddaab",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsdrive/7",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "72b62473-5d84-5ede-b251-ae3dcd76a1a0",
+          "body": "[\n  {\n    \"id\": \"7\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"UID\": \"9249ac2e2910802be6da3de65fe2ede0cd998c7889f64781cadd5e8c9d59b2f4\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"block_size\": \"512\",\n    \"vendor_id\": \"IBM-A072\",\n    \"product_id\": \"6863800b\",\n    \"FRU_part_number\": \"32ab30f\",\n    \"FRU_identity\": \"667e16e10ea76180310e04\",\n    \"RPM\": \"\",\n    \"firmware_level\": \"4_1_8   \",\n    \"FPGA_level\": \"\",\n    \"date_of_manufacture\": \"\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"7\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"1\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"quorum_id\": \"\",\n    \"port_1_status\": \"online\",\n    \"port_2_status\": \"online\",\n    \"interface_speed\": \"\",\n    \"protection_enabled\": \"yes\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\",\n    \"write_endurance_used\": \"0\",\n    \"write_endurance_usage_rate\": \"\",\n    \"replacement_date\": \"\",\n    \"transport_protocol\": \"nvme\",\n    \"compressed\": \"yes\",\n    \"physical_capacity\": \"34.93TB\",\n    \"physical_used_capacity\": \"15.00TB\",\n    \"effective_used_capacity\": \"27.19TB\",\n    \"fips_enabled\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "69b0e2e5-9edd-5d0b-a6ce-8841b579d136",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsdrive/8",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "3365d0db-106d-5bbb-aa7e-c5d453fa97de",
+          "body": "[\n  {\n    \"id\": \"8\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"UID\": \"9249ac2e2910802be6da3de65fe2ede0cd998c7889f64781cadd5e8c9d59b2f4\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"block_size\": \"512\",\n    \"vendor_id\": \"IBM-A072\",\n    \"product_id\": \"6863800b\",\n    \"FRU_part_number\": \"32ab30f\",\n    \"FRU_identity\": \"667e16e10ea76180310e04\",\n    \"RPM\": \"\",\n    \"firmware_level\": \"4_1_8   \",\n    \"FPGA_level\": \"\",\n    \"date_of_manufacture\": \"\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"8\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"3\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"quorum_id\": \"\",\n    \"port_1_status\": \"online\",\n    \"port_2_status\": \"online\",\n    \"interface_speed\": \"\",\n    \"protection_enabled\": \"yes\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\",\n    \"write_endurance_used\": \"0\",\n    \"write_endurance_usage_rate\": \"\",\n    \"replacement_date\": \"\",\n    \"transport_protocol\": \"nvme\",\n    \"compressed\": \"yes\",\n    \"physical_capacity\": \"34.93TB\",\n    \"physical_used_capacity\": \"15.00TB\",\n    \"effective_used_capacity\": \"27.19TB\",\n    \"fips_enabled\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "1e1f8175-5402-52d1-a628-f1c5b3005066",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsdrive/9",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "f7f5bdba-81c1-5185-8124-79776429a24b",
+          "body": "[\n  {\n    \"id\": \"9\",\n    \"status\": \"online\",\n    \"error_sequence_number\": \"\",\n    \"use\": \"member\",\n    \"UID\": \"9249ac2e2910802be6da3de65fe2ede0cd998c7889f64781cadd5e8c9d59b2f4\",\n    \"tech_type\": \"tier0_flash\",\n    \"capacity\": \"104.8TB\",\n    \"block_size\": \"512\",\n    \"vendor_id\": \"IBM-A072\",\n    \"product_id\": \"6863800b\",\n    \"FRU_part_number\": \"32ab30f\",\n    \"FRU_identity\": \"667e16e10ea76180310e04\",\n    \"RPM\": \"\",\n    \"firmware_level\": \"4_1_8   \",\n    \"FPGA_level\": \"\",\n    \"date_of_manufacture\": \"\",\n    \"mdisk_id\": \"0\",\n    \"mdisk_name\": \"MDisk1\",\n    \"member_id\": \"9\",\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"10\",\n    \"node_id\": \"\",\n    \"node_name\": \"\",\n    \"quorum_id\": \"\",\n    \"port_1_status\": \"online\",\n    \"port_2_status\": \"online\",\n    \"interface_speed\": \"\",\n    \"protection_enabled\": \"yes\",\n    \"auto_manage\": \"inactive\",\n    \"drive_class_id\": \"0\",\n    \"write_endurance_used\": \"0\",\n    \"write_endurance_usage_rate\": \"\",\n    \"replacement_date\": \"\",\n    \"transport_protocol\": \"nvme\",\n    \"compressed\": \"yes\",\n    \"physical_capacity\": \"34.93TB\",\n    \"physical_used_capacity\": \"15.00TB\",\n    \"effective_used_capacity\": \"27.19TB\",\n    \"fips_enabled\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "4e7f6364-b9f5-5e91-b2c1-7c5d4d3b89f1",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsenclosure",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "2401de0b-f9e7-587d-a051-f3c5dd800c17",
+          "body": "[\n  {\n    \"id\": \"1\",\n    \"status\": \"online\",\n    \"type\": \"control\",\n    \"managed\": \"yes\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"product_MTM\": \"4662-7H2\",\n    \"serial_number\": \"6e148e5\",\n    \"total_canisters\": \"2\",\n    \"online_canisters\": \"2\",\n    \"total_PSUs\": \"2\",\n    \"online_PSUs\": \"2\",\n    \"drive_slots\": \"12\",\n    \"total_fan_modules\": \"6\",\n    \"online_fan_modules\": \"6\",\n    \"total_sems\": \"0\",\n    \"online_sems\": \"0\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "aceda8b8-e54f-5018-a2f8-6252d07050f1",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsenclosurebattery",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "a3df9201-7a0e-5772-8121-08412afb9040",
+          "body": "[\n  {\n    \"enclosure_id\": \"1\",\n    \"battery_id\": \"1\",\n    \"status\": \"online\",\n    \"charging_status\": \"charged\",\n    \"recondition_needed\": \"no\",\n    \"percent_charged\": \"100\",\n    \"end_of_life_warning\": \"no\",\n    \"canister_id\": \"1\",\n    \"battery_slot\": \"1\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"battery_id\": \"2\",\n    \"status\": \"online\",\n    \"charging_status\": \"charged\",\n    \"recondition_needed\": \"no\",\n    \"percent_charged\": \"100\",\n    \"end_of_life_warning\": \"no\",\n    \"canister_id\": \"2\",\n    \"battery_slot\": \"1\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "7e85b908-06ca-5596-8d8b-5601d60f4431",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsenclosurecanister",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "5abd4130-5338-5c38-966e-8b5612a33866",
+          "body": "[\n  {\n    \"enclosure_id\": \"1\",\n    \"canister_id\": \"1\",\n    \"status\": \"online\",\n    \"type\": \"node\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"canister_id\": \"2\",\n    \"status\": \"online\",\n    \"type\": \"node\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "28ec9134-23ed-506b-ad92-7c431b09d243",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsenclosurefanmodule",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "dd6b84a0-1998-5584-9b3d-76d1ffc89598",
+          "body": "[\n  {\n    \"enclosure_id\": \"1\",\n    \"fan_module_id\": \"1\",\n    \"status\": \"online\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"fan_module_id\": \"2\",\n    \"status\": \"online\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"fan_module_id\": \"3\",\n    \"status\": \"online\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"fan_module_id\": \"4\",\n    \"status\": \"online\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"fan_module_id\": \"5\",\n    \"status\": \"online\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"fan_module_id\": \"6\",\n    \"status\": \"online\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "3cc1762c-56cc-5e01-962c-cb2843fe0712",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsenclosurepsu",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "6c194996-724e-5c36-9917-a8ff85f19b4e",
+          "body": "[\n  {\n    \"enclosure_id\": \"1\",\n    \"PSU_id\": \"1\",\n    \"status\": \"online\",\n    \"input_power\": \"ac\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"PSU_id\": \"2\",\n    \"status\": \"online\",\n    \"input_power\": \"ac\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "2fbcb166-2abc-572d-896a-10bcbbf6baa0",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsenclosureslot",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "70f682ea-9c26-50d6-b3d2-1764d6869fee",
+          "body": "[\n  {\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"1\",\n    \"port_1_status\": \"\",\n    \"port_2_status\": \"\",\n    \"drive_present\": \"yes\",\n    \"drive_id\": \"7\",\n    \"row\": \"\",\n    \"column\": \"\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"2\",\n    \"port_1_status\": \"\",\n    \"port_2_status\": \"\",\n    \"drive_present\": \"yes\",\n    \"drive_id\": \"5\",\n    \"row\": \"\",\n    \"column\": \"\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"3\",\n    \"port_1_status\": \"\",\n    \"port_2_status\": \"\",\n    \"drive_present\": \"yes\",\n    \"drive_id\": \"8\",\n    \"row\": \"\",\n    \"column\": \"\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"4\",\n    \"port_1_status\": \"\",\n    \"port_2_status\": \"\",\n    \"drive_present\": \"yes\",\n    \"drive_id\": \"6\",\n    \"row\": \"\",\n    \"column\": \"\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"5\",\n    \"port_1_status\": \"\",\n    \"port_2_status\": \"\",\n    \"drive_present\": \"yes\",\n    \"drive_id\": \"4\",\n    \"row\": \"\",\n    \"column\": \"\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"6\",\n    \"port_1_status\": \"\",\n    \"port_2_status\": \"\",\n    \"drive_present\": \"yes\",\n    \"drive_id\": \"2\",\n    \"row\": \"\",\n    \"column\": \"\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"7\",\n    \"port_1_status\": \"\",\n    \"port_2_status\": \"\",\n    \"drive_present\": \"yes\",\n    \"drive_id\": \"1\",\n    \"row\": \"\",\n    \"column\": \"\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"8\",\n    \"port_1_status\": \"\",\n    \"port_2_status\": \"\",\n    \"drive_present\": \"yes\",\n    \"drive_id\": \"0\",\n    \"row\": \"\",\n    \"column\": \"\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"9\",\n    \"port_1_status\": \"\",\n    \"port_2_status\": \"\",\n    \"drive_present\": \"yes\",\n    \"drive_id\": \"11\",\n    \"row\": \"\",\n    \"column\": \"\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"10\",\n    \"port_1_status\": \"\",\n    \"port_2_status\": \"\",\n    \"drive_present\": \"yes\",\n    \"drive_id\": \"9\",\n    \"row\": \"\",\n    \"column\": \"\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"11\",\n    \"port_1_status\": \"\",\n    \"port_2_status\": \"\",\n    \"drive_present\": \"yes\",\n    \"drive_id\": \"3\",\n    \"row\": \"\",\n    \"column\": \"\"\n  },\n  {\n    \"enclosure_id\": \"1\",\n    \"slot_id\": \"12\",\n    \"port_1_status\": \"\",\n    \"port_2_status\": \"\",\n    \"drive_present\": \"yes\",\n    \"drive_id\": \"10\",\n    \"row\": \"\",\n    \"column\": \"\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "9b9be1af-6642-5f71-9c84-db0632e8f5b7",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lseventlog",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "ff8aa24a-c75e-5983-8c0d-506f6073dde1",
+          "body": "[\n  {\n    \"sequence_number\": \"3101\",\n    \"last_timestamp\": \"260902154807\",\n    \"object_type\": \"host\",\n    \"object_id\": \"28\",\n    \"object_name\": \"host-29\",\n    \"copy_id\": \"\",\n    \"status\": \"alert\",\n    \"fixed\": \"no\",\n    \"event_id\": \"064003\",\n    \"error_code\": \"2017\",\n    \"description\": \"One or more configured hosts are offline\"\n  },\n  {\n    \"sequence_number\": \"3097\",\n    \"last_timestamp\": \"260817125247\",\n    \"object_type\": \"node\",\n    \"object_id\": \"1\",\n    \"object_name\": \"node1\",\n    \"copy_id\": \"\",\n    \"status\": \"message\",\n    \"fixed\": \"no\",\n    \"event_id\": \"980221\",\n    \"error_code\": \"\",\n    \"description\": \"Error log cleared\"\n  },\n  {\n    \"sequence_number\": \"3114\",\n    \"last_timestamp\": \"260822120349\",\n    \"object_type\": \"io_grp\",\n    \"object_id\": \"0\",\n    \"object_name\": \"io_grp0\",\n    \"copy_id\": \"\",\n    \"status\": \"message\",\n    \"fixed\": \"no\",\n    \"event_id\": \"984505\",\n    \"error_code\": \"\",\n    \"description\": \"Enclosure statesave collected\"\n  },\n  {\n    \"sequence_number\": \"3115\",\n    \"last_timestamp\": \"260822120359\",\n    \"object_type\": \"io_grp\",\n    \"object_id\": \"0\",\n    \"object_name\": \"io_grp0\",\n    \"copy_id\": \"\",\n    \"status\": \"message\",\n    \"fixed\": \"no\",\n    \"event_id\": \"984505\",\n    \"error_code\": \"\",\n    \"description\": \"Enclosure statesave collected\"\n  },\n  {\n    \"sequence_number\": \"3117\",\n    \"last_timestamp\": \"260823112816\",\n    \"object_type\": \"io_grp\",\n    \"object_id\": \"0\",\n    \"object_name\": \"io_grp0\",\n    \"copy_id\": \"\",\n    \"status\": \"message\",\n    \"fixed\": \"no\",\n    \"event_id\": \"984505\",\n    \"error_code\": \"\",\n    \"description\": \"Enclosure statesave collected\"\n  },\n  {\n    \"sequence_number\": \"3118\",\n    \"last_timestamp\": \"260823112821\",\n    \"object_type\": \"io_grp\",\n    \"object_id\": \"0\",\n    \"object_name\": \"io_grp0\",\n    \"copy_id\": \"\",\n    \"status\": \"message\",\n    \"fixed\": \"no\",\n    \"event_id\": \"984505\",\n    \"error_code\": \"\",\n    \"description\": \"Enclosure statesave collected\"\n  },\n  {\n    \"sequence_number\": \"3121\",\n    \"last_timestamp\": \"260824134741\",\n    \"object_type\": \"drive\",\n    \"object_id\": \"1\",\n    \"object_name\": \"\",\n    \"copy_id\": \"\",\n    \"status\": \"message\",\n    \"fixed\": \"no\",\n    \"event_id\": \"989003\",\n    \"error_code\": \"\",\n    \"description\": \"NVMe drive diagnostics\"\n  },\n  {\n    \"sequence_number\": \"3122\",\n    \"last_timestamp\": \"260824164306\",\n    \"object_type\": \"drive\",\n    \"object_id\": \"6\",\n    \"object_name\": \"\",\n    \"copy_id\": \"\",\n    \"status\": \"message\",\n    \"fixed\": \"no\",\n    \"event_id\": \"989003\",\n    \"error_code\": \"\",\n    \"description\": \"NVMe drive diagnostics\"\n  },\n  {\n    \"sequence_number\": \"3123\",\n    \"last_timestamp\": \"260824171636\",\n    \"object_type\": \"drive\",\n    \"object_id\": \"1\",\n    \"object_name\": \"\",\n    \"copy_id\": \"\",\n    \"status\": \"message\",\n    \"fixed\": \"no\",\n    \"event_id\": \"988322\",\n    \"error_code\": \"\",\n    \"description\": \"Block correction requests count\"\n  },\n  {\n    \"sequence_number\": \"3124\",\n    \"last_timestamp\": \"260824171636\",\n    \"object_type\": \"drive\",\n    \"object_id\": \"6\",\n    \"object_name\": \"\",\n    \"copy_id\": \"\",\n    \"status\": \"message\",\n    \"fixed\": \"no\",\n    \"event_id\": \"988322\",\n    \"error_code\": \"\",\n    \"description\": \"Block correction requests count\"\n  },\n  {\n    \"sequence_number\": \"3127\",\n    \"last_timestamp\": \"260825134750\",\n    \"object_type\": \"drive\",\n    \"object_id\": \"1\",\n    \"object_name\": \"\",\n    \"copy_id\": \"\",\n    \"status\": \"message\",\n    \"fixed\": \"no\",\n    \"event_id\": \"989003\",\n    \"error_code\": \"\",\n    \"description\": \"NVMe drive diagnostics\"\n  },\n  {\n    \"sequence_number\": \"3128\",\n    \"last_timestamp\": \"260825164315\",\n    \"object_type\": \"drive\",\n    \"object_id\": \"6\",\n    \"object_name\": \"\",\n    \"copy_id\": \"\",\n    \"status\": \"message\",\n    \"fixed\": \"no\",\n    \"event_id\": \"989003\",\n    \"error_code\": \"\",\n    \"description\": \"NVMe drive diagnostics\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "fe6f586c-73a0-5233-b603-0649aaa13309",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsfabric",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "e12d6b64-fd2c-5271-9c8a-a05dc6b620e7",
+          "body": "[\n  {\n    \"remote_wwpn\": \"5005076812128B5D\",\n    \"remote_nportid\": \"280020\",\n    \"id\": \"2\",\n    \"node_name\": \"node2\",\n    \"local_wwpn\": \"5005076812128ACD\",\n    \"local_port\": \"2\",\n    \"local_nportid\": \"280000\",\n    \"state\": \"active\",\n    \"name\": \"node1\",\n    \"cluster_name\": \"system-a\",\n    \"type\": \"node\"\n  },\n  {\n    \"remote_wwpn\": \"5005076812118B8B\",\n    \"remote_nportid\": \"3C0040\",\n    \"id\": \"1\",\n    \"node_name\": \"node1\",\n    \"local_wwpn\": \"5005076812118B5D\",\n    \"local_port\": \"1\",\n    \"local_nportid\": \"140060\",\n    \"state\": \"active\",\n    \"name\": \"node1\",\n    \"cluster_name\": \"system-b\",\n    \"type\": \"node\"\n  },\n  {\n    \"remote_wwpn\": \"5005076812118B8B\",\n    \"remote_nportid\": \"3C0040\",\n    \"id\": \"2\",\n    \"node_name\": \"node2\",\n    \"local_wwpn\": \"5005076812118ACD\",\n    \"local_port\": \"1\",\n    \"local_nportid\": \"140040\",\n    \"state\": \"active\",\n    \"name\": \"node1\",\n    \"cluster_name\": \"system-b\",\n    \"type\": \"node\"\n  },\n  {\n    \"remote_wwpn\": \"5005076812118B42\",\n    \"remote_nportid\": \"3C0060\",\n    \"id\": \"1\",\n    \"node_name\": \"node1\",\n    \"local_wwpn\": \"5005076812118B5D\",\n    \"local_port\": \"1\",\n    \"local_nportid\": \"140060\",\n    \"state\": \"active\",\n    \"name\": \"node2\",\n    \"cluster_name\": \"system-b\",\n    \"type\": \"node\"\n  },\n  {\n    \"remote_wwpn\": \"5005076812118B42\",\n    \"remote_nportid\": \"3C0060\",\n    \"id\": \"2\",\n    \"node_name\": \"node2\",\n    \"local_wwpn\": \"5005076812118ACD\",\n    \"local_port\": \"1\",\n    \"local_nportid\": \"140040\",\n    \"state\": \"active\",\n    \"name\": \"node2\",\n    \"cluster_name\": \"system-b\",\n    \"type\": \"node\"\n  },\n  {\n    \"remote_wwpn\": \"5005076812118ACD\",\n    \"remote_nportid\": \"140040\",\n    \"id\": \"1\",\n    \"node_name\": \"node1\",\n    \"local_wwpn\": \"5005076812118B5D\",\n    \"local_port\": \"1\",\n    \"local_nportid\": \"140060\",\n    \"state\": \"active\",\n    \"name\": \"node2\",\n    \"cluster_name\": \"system-a\",\n    \"type\": \"node\"\n  },\n  {\n    \"remote_wwpn\": \"5005076812128B8B\",\n    \"remote_nportid\": \"500060\",\n    \"id\": \"1\",\n    \"node_name\": \"node1\",\n    \"local_wwpn\": \"5005076812128B5D\",\n    \"local_port\": \"2\",\n    \"local_nportid\": \"280020\",\n    \"state\": \"active\",\n    \"name\": \"node1\",\n    \"cluster_name\": \"system-b\",\n    \"type\": \"node\"\n  },\n  {\n    \"remote_wwpn\": \"5005076812128B8B\",\n    \"remote_nportid\": \"500060\",\n    \"id\": \"2\",\n    \"node_name\": \"node2\",\n    \"local_wwpn\": \"5005076812128ACD\",\n    \"local_port\": \"2\",\n    \"local_nportid\": \"280000\",\n    \"state\": \"active\",\n    \"name\": \"node1\",\n    \"cluster_name\": \"system-b\",\n    \"type\": \"node\"\n  },\n  {\n    \"remote_wwpn\": \"5005076812128B42\",\n    \"remote_nportid\": \"500000\",\n    \"id\": \"1\",\n    \"node_name\": \"node1\",\n    \"local_wwpn\": \"5005076812128B5D\",\n    \"local_port\": \"2\",\n    \"local_nportid\": \"280020\",\n    \"state\": \"active\",\n    \"name\": \"node2\",\n    \"cluster_name\": \"system-b\",\n    \"type\": \"node\"\n  },\n  {\n    \"remote_wwpn\": \"5005076812128B42\",\n    \"remote_nportid\": \"500000\",\n    \"id\": \"2\",\n    \"node_name\": \"node2\",\n    \"local_wwpn\": \"5005076812128ACD\",\n    \"local_port\": \"2\",\n    \"local_nportid\": \"280000\",\n    \"state\": \"active\",\n    \"name\": \"node2\",\n    \"cluster_name\": \"system-b\",\n    \"type\": \"node\"\n  },\n  {\n    \"remote_wwpn\": \"5005076812118B5D\",\n    \"remote_nportid\": \"140060\",\n    \"id\": \"2\",\n    \"node_name\": \"node2\",\n    \"local_wwpn\": \"5005076812118ACD\",\n    \"local_port\": \"1\",\n    \"local_nportid\": \"140040\",\n    \"state\": \"active\",\n    \"name\": \"node1\",\n    \"cluster_name\": \"system-a\",\n    \"type\": \"node\"\n  },\n  {\n    \"remote_wwpn\": \"5005076812128ACD\",\n    \"remote_nportid\": \"280000\",\n    \"id\": \"1\",\n    \"node_name\": \"node1\",\n    \"local_wwpn\": \"5005076812128B5D\",\n    \"local_port\": \"2\",\n    \"local_nportid\": \"280020\",\n    \"state\": \"active\",\n    \"name\": \"node2\",\n    \"cluster_name\": \"system-a\",\n    \"type\": \"node\"\n  },\n  {\n    \"remote_wwpn\": \"C050760B5A2801B0\",\n    \"remote_nportid\": \"46018C\",\n    \"id\": \"1\",\n    \"node_name\": \"node1\",\n    \"local_wwpn\": \"5005076812188B5D\",\n    \"local_port\": \"4\",\n    \"local_nportid\": \"1E0041\",\n    \"state\": \"active\",\n    \"name\": \"host-35\",\n    \"cluster_name\": \"\",\n    \"type\": \"host\"\n  },\n  {\n    \"remote_wwpn\": \"C050760B5A2801B0\",\n    \"remote_nportid\": \"46018C\",\n    \"id\": \"2\",\n    \"node_name\": \"node2\",\n    \"local_wwpn\": \"5005076812188ACD\",\n    \"local_port\": \"4\",\n    \"local_nportid\": \"1E0061\",\n    \"state\": \"active\",\n    \"name\": \"host-35\",\n    \"cluster_name\": \"\",\n    \"type\": \"host\"\n  },\n  {\n    \"remote_wwpn\": \"C050760B5A280146\",\n    \"remote_nportid\": \"460181\",\n    \"id\": \"1\",\n    \"node_name\": \"node1\",\n    \"local_wwpn\": \"5005076812188B5D\",\n    \"local_port\": \"4\",\n    \"local_nportid\": \"1E0041\",\n    \"state\": \"active\",\n    \"name\": \"host-19\",\n    \"cluster_name\": \"\",\n    \"type\": \"host\"\n  },\n  {\n    \"remote_wwpn\": \"C050760B5A280146\",\n    \"remote_nportid\": \"460181\",\n    \"id\": \"2\",\n    \"node_name\": \"node2\",\n    \"local_wwpn\": \"5005076812188ACD\",\n    \"local_port\": \"4\",\n    \"local_nportid\": \"1E0061\",\n    \"state\": \"active\",\n    \"name\": \"host-19\",\n    \"cluster_name\": \"\",\n    \"type\": \"host\"\n  },\n  {\n    \"remote_wwpn\": \"C050760B5A2801E0\",\n    \"remote_nportid\": \"4601E9\",\n    \"id\": \"1\",\n    \"node_name\": \"node1\",\n    \"local_wwpn\": \"5005076812188B5D\",\n    \"local_port\": \"4\",\n    \"local_nportid\": \"1E0041\",\n    \"state\": \"active\",\n    \"name\": \"host-40\",\n    \"cluster_name\": \"\",\n    \"type\": \"host\"\n  },\n  {\n    \"remote_wwpn\": \"C050760B5A2801E0\",\n    \"remote_nportid\": \"4601E9\",\n    \"id\": \"2\",\n    \"node_name\": \"node2\",\n    \"local_wwpn\": \"5005076812188ACD\",\n    \"local_port\": \"4\",\n    \"local_nportid\": \"1E0061\",\n    \"state\": \"active\",\n    \"name\": \"host-40\",\n    \"cluster_name\": \"\",\n    \"type\": \"host\"\n  },\n  {\n    \"remote_wwpn\": \"100070B7E420003C\",\n    \"remote_nportid\": \"0A0120\",\n    \"id\": \"1\",\n    \"node_name\": \"node1\",\n    \"local_wwpn\": \"5005076812178B5D\",\n    \"local_port\": \"3\",\n    \"local_nportid\": \"0A0041\",\n    \"state\": \"active\",\n    \"name\": \"host-05\",\n    \"cluster_name\": \"\",\n    \"type\": \"host\"\n  },\n  {\n    \"remote_wwpn\": \"100070B7E420003C\",\n    \"remote_nportid\": \"0A0120\",\n    \"id\": \"2\",\n    \"node_name\": \"node2\",\n    \"local_wwpn\": \"5005076812178ACD\",\n    \"local_port\": \"3\",\n    \"local_nportid\": \"0A0061\",\n    \"state\": \"active\",\n    \"name\": \"host-05\",\n    \"cluster_name\": \"\",\n    \"type\": \"host\"\n  },\n  {\n    \"remote_wwpn\": \"100070B7E42000AB\",\n    \"remote_nportid\": \"0A0100\",\n    \"id\": \"1\",\n    \"node_name\": \"node1\",\n    \"local_wwpn\": \"5005076812178B5D\",\n    \"local_port\": \"3\",\n    \"local_nportid\": \"0A0041\",\n    \"state\": \"active\",\n    \"name\": \"host-08\",\n    \"cluster_name\": \"\",\n    \"type\": \"host\"\n  },\n  {\n    \"remote_wwpn\": \"100070B7E42000AB\",\n    \"remote_nportid\": \"0A0100\",\n    \"id\": \"2\",\n    \"node_name\": \"node2\",\n    \"local_wwpn\": \"5005076812178ACD\",\n    \"local_port\": \"3\",\n    \"local_nportid\": \"0A0061\",\n    \"state\": \"active\",\n    \"name\": \"host-08\",\n    \"cluster_name\": \"\",\n    \"type\": \"host\"\n  },\n  {\n    \"remote_wwpn\": \"100070B7E4200066\",\n    \"remote_nportid\": \"0A0020\",\n    \"id\": \"1\",\n    \"node_name\": \"node1\",\n    \"local_wwpn\": \"5005076812178B5D\",\n    \"local_port\": \"3\",\n    \"local_nportid\": \"0A0041\",\n    \"state\": \"active\",\n    \"name\": \"host-04\",\n    \"cluster_name\": \"\",\n    \"type\": \"host\"\n  },\n  {\n    \"remote_wwpn\": \"100070B7E4200066\",\n    \"remote_nportid\": \"0A0020\",\n    \"id\": \"2\",\n    \"node_name\": \"node2\",\n    \"local_wwpn\": \"5005076812178ACD\",\n    \"local_port\": \"3\",\n    \"local_nportid\": \"0A0061\",\n    \"state\": \"active\",\n    \"name\": \"host-04\",\n    \"cluster_name\": \"\",\n    \"type\": \"host\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "09df032d-3dc4-57e1-8e65-a8187d61fa28",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lshost",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "afc9c6e1-47b2-5467-b539-8a88ee524eb5",
+          "body": "[\n  {\n    \"id\": \"28\",\n    \"name\": \"host-29\",\n    \"port_count\": \"4\",\n    \"iogrp_count\": \"2\",\n    \"status\": \"offline\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"host_cluster_id\": \"\",\n    \"host_cluster_name\": \"\",\n    \"protocol\": \"scsi\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"portset_id\": \"64\",\n    \"portset_name\": \"portset64\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"ungrouped_volume_mapping\": \"no\",\n    \"location_system_name\": \"system-b\"\n  },\n  {\n    \"id\": \"42\",\n    \"name\": \"host-43\",\n    \"port_count\": \"4\",\n    \"iogrp_count\": \"2\",\n    \"status\": \"offline\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"host_cluster_id\": \"\",\n    \"host_cluster_name\": \"\",\n    \"protocol\": \"scsi\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"portset_id\": \"64\",\n    \"portset_name\": \"portset64\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"ungrouped_volume_mapping\": \"no\",\n    \"location_system_name\": \"system-b\"\n  },\n  {\n    \"id\": \"50\",\n    \"name\": \"host-51\",\n    \"port_count\": \"4\",\n    \"iogrp_count\": \"2\",\n    \"status\": \"offline\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"host_cluster_id\": \"\",\n    \"host_cluster_name\": \"\",\n    \"protocol\": \"scsi\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"portset_id\": \"64\",\n    \"portset_name\": \"portset64\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"ungrouped_volume_mapping\": \"no\",\n    \"location_system_name\": \"system-b\"\n  },\n  {\n    \"id\": \"53\",\n    \"name\": \"host-54\",\n    \"port_count\": \"4\",\n    \"iogrp_count\": \"2\",\n    \"status\": \"offline\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"host_cluster_id\": \"\",\n    \"host_cluster_name\": \"\",\n    \"protocol\": \"scsi\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"portset_id\": \"64\",\n    \"portset_name\": \"portset64\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"ungrouped_volume_mapping\": \"no\",\n    \"location_system_name\": \"system-b\"\n  },\n  {\n    \"id\": \"0\",\n    \"name\": \"host-01\",\n    \"port_count\": \"2\",\n    \"iogrp_count\": \"2\",\n    \"status\": \"online\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"host_cluster_id\": \"\",\n    \"host_cluster_name\": \"\",\n    \"protocol\": \"scsi\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"portset_id\": \"64\",\n    \"portset_name\": \"portset64\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"ungrouped_volume_mapping\": \"no\",\n    \"location_system_name\": \"system-b\"\n  },\n  {\n    \"id\": \"1\",\n    \"name\": \"host-02\",\n    \"port_count\": \"2\",\n    \"iogrp_count\": \"2\",\n    \"status\": \"online\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"host_cluster_id\": \"\",\n    \"host_cluster_name\": \"\",\n    \"protocol\": \"scsi\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"portset_id\": \"64\",\n    \"portset_name\": \"portset64\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"ungrouped_volume_mapping\": \"no\",\n    \"location_system_name\": \"system-b\"\n  },\n  {\n    \"id\": \"2\",\n    \"name\": \"host-03\",\n    \"port_count\": \"2\",\n    \"iogrp_count\": \"2\",\n    \"status\": \"online\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"host_cluster_id\": \"\",\n    \"host_cluster_name\": \"\",\n    \"protocol\": \"scsi\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"portset_id\": \"64\",\n    \"portset_name\": \"portset64\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"ungrouped_volume_mapping\": \"no\",\n    \"location_system_name\": \"system-a\"\n  },\n  {\n    \"id\": \"3\",\n    \"name\": \"host-04\",\n    \"port_count\": \"2\",\n    \"iogrp_count\": \"2\",\n    \"status\": \"online\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"host_cluster_id\": \"\",\n    \"host_cluster_name\": \"\",\n    \"protocol\": \"scsi\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"portset_id\": \"64\",\n    \"portset_name\": \"portset64\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"ungrouped_volume_mapping\": \"no\",\n    \"location_system_name\": \"system-a\"\n  },\n  {\n    \"id\": \"4\",\n    \"name\": \"host-05\",\n    \"port_count\": \"2\",\n    \"iogrp_count\": \"2\",\n    \"status\": \"online\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"host_cluster_id\": \"\",\n    \"host_cluster_name\": \"\",\n    \"protocol\": \"scsi\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"portset_id\": \"64\",\n    \"portset_name\": \"portset64\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"ungrouped_volume_mapping\": \"no\",\n    \"location_system_name\": \"system-a\"\n  },\n  {\n    \"id\": \"5\",\n    \"name\": \"host-06\",\n    \"port_count\": \"2\",\n    \"iogrp_count\": \"2\",\n    \"status\": \"online\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"host_cluster_id\": \"\",\n    \"host_cluster_name\": \"\",\n    \"protocol\": \"scsi\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"portset_id\": \"64\",\n    \"portset_name\": \"portset64\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"ungrouped_volume_mapping\": \"no\",\n    \"location_system_name\": \"system-a\"\n  },\n  {\n    \"id\": \"6\",\n    \"name\": \"host-07\",\n    \"port_count\": \"2\",\n    \"iogrp_count\": \"2\",\n    \"status\": \"online\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"host_cluster_id\": \"\",\n    \"host_cluster_name\": \"\",\n    \"protocol\": \"scsi\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"portset_id\": \"64\",\n    \"portset_name\": \"portset64\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"ungrouped_volume_mapping\": \"no\",\n    \"location_system_name\": \"system-a\"\n  },\n  {\n    \"id\": \"7\",\n    \"name\": \"host-08\",\n    \"port_count\": \"2\",\n    \"iogrp_count\": \"2\",\n    \"status\": \"online\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"host_cluster_id\": \"\",\n    \"host_cluster_name\": \"\",\n    \"protocol\": \"scsi\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"portset_id\": \"64\",\n    \"portset_name\": \"portset64\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"ungrouped_volume_mapping\": \"no\",\n    \"location_system_name\": \"system-a\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "721cf1e2-cdf7-5994-9be4-d2d41fa5a4c6",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsmdisk",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "bd7579ae-4b83-5b42-9784-26270979d013",
+          "body": "[\n  {\n    \"id\": \"0\",\n    \"name\": \"MDisk1\",\n    \"status\": \"online\",\n    \"mode\": \"array\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"937.6TB\",\n    \"ctrl_LUN_#\": \"\",\n    \"controller_name\": \"\",\n    \"UID\": \"\",\n    \"tier\": \"tier0_flash\",\n    \"encrypt\": \"no\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"distributed\": \"yes\",\n    \"dedupe\": \"no\",\n    \"over_provisioned\": \"yes\",\n    \"supports_unmap\": \"yes\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "5aa8cfac-9df6-522c-b6b2-8861f6f02a8d",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsmdisk/0",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "f161c3b2-58cd-5ee4-8a8b-5f3b78e02e7c",
+          "body": "{\n  \"id\": \"0\",\n  \"name\": \"MDisk1\",\n  \"status\": \"online\",\n  \"mode\": \"array\",\n  \"mdisk_grp_id\": \"0\",\n  \"mdisk_grp_name\": \"pool-a\",\n  \"capacity\": \"937.6TB\",\n  \"quorum_index\": \"\",\n  \"block_size\": \"\",\n  \"controller_name\": \"\",\n  \"ctrl_type\": \"\",\n  \"ctrl_WWNN\": \"\",\n  \"controller_id\": \"\",\n  \"path_count\": \"\",\n  \"max_path_count\": \"\",\n  \"ctrl_LUN_#\": \"\",\n  \"UID\": \"\",\n  \"preferred_WWPN\": \"\",\n  \"active_WWPN\": \"\",\n  \"fast_write_state\": \"not_empty\",\n  \"raid_status\": \"online\",\n  \"raid_level\": \"raid6\",\n  \"redundancy\": \"2\",\n  \"strip_size\": \"256\",\n  \"spare_goal\": \"\",\n  \"spare_protection_min\": \"\",\n  \"balanced\": \"exact\",\n  \"tier\": \"tier0_flash\",\n  \"slow_write_priority\": \"latency\",\n  \"fabric_type\": \"\",\n  \"site_id\": \"\",\n  \"site_name\": \"\",\n  \"easy_tier_load\": \"\",\n  \"encrypt\": \"no\",\n  \"distributed\": \"yes\",\n  \"drive_class_id\": \"0\",\n  \"drive_count\": \"12\",\n  \"stripe_width\": \"11\",\n  \"rebuild_areas_total\": \"1\",\n  \"rebuild_areas_available\": \"1\",\n  \"rebuild_areas_goal\": \"1\",\n  \"dedupe\": \"no\",\n  \"preferred_iscsi_port_id\": \"\",\n  \"active_iscsi_port_id\": \"\",\n  \"replacement_date\": \"\",\n  \"over_provisioned\": \"yes\",\n  \"supports_unmap\": \"yes\",\n  \"provisioning_group_id\": \"0\",\n  \"physical_capacity\": \"310.99TB\",\n  \"physical_free_capacity\": \"164.51TB\",\n  \"write_protected\": \"no\",\n  \"allocated_capacity\": \"306.74TB\",\n  \"effective_used_capacity\": \"265.45TB\",\n  \"fips_enabled\": \"no\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "37fe1820-d09f-5593-b8a1-62963da81edd",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsmdiskgrp",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "a555ea07-80c8-5aa5-ad7c-f716087d30f2",
+          "body": "[\n  {\n    \"id\": \"0\",\n    \"name\": \"pool-a\",\n    \"status\": \"online\",\n    \"mdisk_count\": \"1\",\n    \"vdisk_count\": \"698\",\n    \"capacity\": \"935.79TB\",\n    \"extent_size\": \"1024\",\n    \"free_capacity\": \"629.06TB\",\n    \"virtual_capacity\": \"1.25PB\",\n    \"used_capacity\": \"292.98TB\",\n    \"real_capacity\": \"306.57TB\",\n    \"overallocation\": \"137\",\n    \"warning\": \"80\",\n    \"easy_tier\": \"auto\",\n    \"easy_tier_status\": \"balanced\",\n    \"compression_active\": \"no\",\n    \"compression_virtual_capacity\": \"0.00MB\",\n    \"compression_compressed_capacity\": \"0.00MB\",\n    \"compression_uncompressed_capacity\": \"0.00MB\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"child_mdisk_grp_count\": \"0\",\n    \"child_mdisk_grp_capacity\": \"0.00MB\",\n    \"type\": \"parent\",\n    \"encrypt\": \"no\",\n    \"owner_type\": \"none\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"data_reduction\": \"no\",\n    \"used_capacity_before_reduction\": \"0.00MB\",\n    \"used_capacity_after_reduction\": \"0.00MB\",\n    \"overhead_capacity\": \"0.00MB\",\n    \"deduplication_capacity_saving\": \"0.00MB\",\n    \"reclaimable_capacity\": \"0.00MB\",\n    \"easy_tier_fcm_over_allocation_max\": \"100%\",\n    \"provisioning_policy_id\": \"\",\n    \"provisioning_policy_name\": \"\",\n    \"replication_pool_link_uid\": \"3AF506D7D7D9ED8758D4982146C75DBC\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "1c0dc23b-65ea-5e69-b9fd-bbaaa6bee6ed",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsmdiskgrp/0",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "418fd8b5-7c3e-5440-a6af-7a113afb6324",
+          "body": "{\n  \"id\": \"0\",\n  \"name\": \"pool-a\",\n  \"status\": \"online\",\n  \"mdisk_count\": \"1\",\n  \"vdisk_count\": \"698\",\n  \"capacity\": \"935.79TB\",\n  \"extent_size\": \"1024\",\n  \"free_capacity\": \"629.06TB\",\n  \"virtual_capacity\": \"1.25PB\",\n  \"used_capacity\": \"292.98TB\",\n  \"real_capacity\": \"306.57TB\",\n  \"overallocation\": \"137\",\n  \"warning\": \"80\",\n  \"easy_tier\": \"auto\",\n  \"easy_tier_status\": \"balanced\",\n  \"tiers\": [\n    {\n      \"tier\": \"tier_scm\",\n      \"tier_mdisk_count\": \"0\",\n      \"tier_capacity\": \"0.00MB\",\n      \"tier_free_capacity\": \"0.00MB\"\n    },\n    {\n      \"tier\": \"tier0_flash\",\n      \"tier_mdisk_count\": \"1\",\n      \"tier_capacity\": \"935.79TB\",\n      \"tier_free_capacity\": \"629.06TB\"\n    },\n    {\n      \"tier\": \"tier1_flash\",\n      \"tier_mdisk_count\": \"0\",\n      \"tier_capacity\": \"0.00MB\",\n      \"tier_free_capacity\": \"0.00MB\"\n    },\n    {\n      \"tier\": \"tier_enterprise\",\n      \"tier_mdisk_count\": \"0\",\n      \"tier_capacity\": \"0.00MB\",\n      \"tier_free_capacity\": \"0.00MB\"\n    },\n    {\n      \"tier\": \"tier_nearline\",\n      \"tier_mdisk_count\": \"0\",\n      \"tier_capacity\": \"0.00MB\",\n      \"tier_free_capacity\": \"0.00MB\"\n    }\n  ],\n  \"compression_active\": \"no\",\n  \"compression_virtual_capacity\": \"0.00MB\",\n  \"compression_compressed_capacity\": \"0.00MB\",\n  \"compression_uncompressed_capacity\": \"0.00MB\",\n  \"site_id\": \"\",\n  \"site_name\": \"\",\n  \"parent_mdisk_grp_id\": \"0\",\n  \"parent_mdisk_grp_name\": \"pool-a\",\n  \"child_mdisk_grp_count\": \"0\",\n  \"child_mdisk_grp_capacity\": \"0.00MB\",\n  \"type\": \"parent\",\n  \"encrypt\": \"no\",\n  \"owner_type\": \"none\",\n  \"owner_id\": \"\",\n  \"owner_name\": \"\",\n  \"data_reduction\": \"no\",\n  \"used_capacity_before_reduction\": \"0.00MB\",\n  \"used_capacity_after_reduction\": \"0.00MB\",\n  \"overhead_capacity\": \"0.00MB\",\n  \"deduplication_capacity_saving\": \"0.00MB\",\n  \"reclaimable_capacity\": \"0.00MB\",\n  \"physical_capacity\": \"310.99TB\",\n  \"physical_free_capacity\": \"164.51TB\",\n  \"shared_resources\": \"no\",\n  \"vdisk_protection_enabled\": \"yes\",\n  \"vdisk_protection_status\": \"inactive\",\n  \"easy_tier_fcm_over_allocation_max\": \"100%\",\n  \"auto_expand\": \"no\",\n  \"auto_expand_max_capacity\": \"0.00MB\",\n  \"safeguarded\": \"no\",\n  \"provisioning_policy_id\": \"\",\n  \"provisioning_policy_name\": \"\",\n  \"replication_pool_link_uid\": \"3AF506D7D7D9ED8758D4982146C75DBC\",\n  \"protection_vdisk_count\": \"350\",\n  \"protection_provisioned_capacity\": \"642.49TB\",\n  \"protection_written_capacity\": \"590.75MB\",\n  \"format_required\": \"yes\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "c5b3890b-a857-5902-901c-075565d35b8b",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsnodecanister",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "f7ee6fae-f1ba-53b2-a339-ea21f9510c76",
+          "body": "[\n  {\n    \"id\": \"1\",\n    \"name\": \"node1\",\n    \"UPS_serial_number\": \"\",\n    \"WWNN\": \"5005076810F8CAD2\",\n    \"status\": \"online\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"config_node\": \"yes\",\n    \"UPS_unique_id\": \"\",\n    \"hardware\": \"7H2\",\n    \"iscsi_name\": \"6ec.eaf2-bf.011.681:8e4b.6810fbf48601e.c181e\",\n    \"iscsi_alias\": \"\",\n    \"panel_name\": \"61-1\",\n    \"enclosure_id\": \"1\",\n    \"canister_id\": \"1\",\n    \"enclosure_serial_number\": \"8aeb856\",\n    \"site_id\": \"\",\n    \"site_name\": \"\"\n  },\n  {\n    \"id\": \"2\",\n    \"name\": \"node2\",\n    \"UPS_serial_number\": \"\",\n    \"WWNN\": \"5005076810D81735\",\n    \"status\": \"online\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"config_node\": \"no\",\n    \"UPS_unique_id\": \"\",\n    \"hardware\": \"7H2\",\n    \"iscsi_name\": \"452.5f1b-21.b75.445:b5aa.44561afab4b75.275cb\",\n    \"iscsi_alias\": \"\",\n    \"panel_name\": \"20-1\",\n    \"enclosure_id\": \"1\",\n    \"canister_id\": \"2\",\n    \"enclosure_serial_number\": \"8aeb856\",\n    \"site_id\": \"\",\n    \"site_name\": \"\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "f58f9340-9852-58fb-9141-30f0f0c49f46",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsnodecanisterstats",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "14695717-24ce-5c08-b229-aa11760277a9",
+          "body": "[\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"compression_cpu_pc\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"cpu_pc\",\n    \"stat_current\": \"15\",\n    \"stat_peak\": \"28\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"fc_mb\",\n    \"stat_current\": \"296\",\n    \"stat_peak\": \"1076\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"fc_io\",\n    \"stat_current\": \"17656\",\n    \"stat_peak\": \"34413\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"sas_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"sas_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"iscsi_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"iscsi_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"write_cache_pc\",\n    \"stat_current\": \"34\",\n    \"stat_peak\": \"35\",\n    \"stat_peak_time\": \"260902225039\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"total_cache_pc\",\n    \"stat_current\": \"80\",\n    \"stat_peak\": \"80\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"vdisk_mb\",\n    \"stat_current\": \"216\",\n    \"stat_peak\": \"546\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"vdisk_io\",\n    \"stat_current\": \"3103\",\n    \"stat_peak\": \"11694\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"vdisk_ms\",\n    \"stat_current\": \"0.439\",\n    \"stat_peak\": \"0.586\",\n    \"stat_peak_time\": \"260902225059\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"mdisk_mb\",\n    \"stat_current\": \"325\",\n    \"stat_peak\": \"851\",\n    \"stat_peak_time\": \"260902225149\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"mdisk_io\",\n    \"stat_current\": \"3394\",\n    \"stat_peak\": \"10477\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"mdisk_ms\",\n    \"stat_current\": \"0.325\",\n    \"stat_peak\": \"0.390\",\n    \"stat_peak_time\": \"260902225039\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"drive_mb\",\n    \"stat_current\": \"468\",\n    \"stat_peak\": \"1738\",\n    \"stat_peak_time\": \"260902225039\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"drive_io\",\n    \"stat_current\": \"6194\",\n    \"stat_peak\": \"35145\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"drive_ms\",\n    \"stat_current\": \"0.238\",\n    \"stat_peak\": \"0.239\",\n    \"stat_peak_time\": \"260902225149\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"vdisk_r_mb\",\n    \"stat_current\": \"185\",\n    \"stat_peak\": \"503\",\n    \"stat_peak_time\": \"260902225154\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"vdisk_r_io\",\n    \"stat_current\": \"1811\",\n    \"stat_peak\": \"8379\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"vdisk_r_ms\",\n    \"stat_current\": \"0.413\",\n    \"stat_peak\": \"0.483\",\n    \"stat_peak_time\": \"260902225149\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"vdisk_w_mb\",\n    \"stat_current\": \"30\",\n    \"stat_peak\": \"309\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"vdisk_w_io\",\n    \"stat_current\": \"1292\",\n    \"stat_peak\": \"3315\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"vdisk_w_ms\",\n    \"stat_current\": \"0.476\",\n    \"stat_peak\": \"0.953\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"mdisk_r_mb\",\n    \"stat_current\": \"284\",\n    \"stat_peak\": \"757\",\n    \"stat_peak_time\": \"260902225149\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"mdisk_r_io\",\n    \"stat_current\": \"2837\",\n    \"stat_peak\": \"5834\",\n    \"stat_peak_time\": \"260902225304\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"mdisk_r_ms\",\n    \"stat_current\": \"0.305\",\n    \"stat_peak\": \"0.348\",\n    \"stat_peak_time\": \"260902225149\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"mdisk_w_mb\",\n    \"stat_current\": \"41\",\n    \"stat_peak\": \"499\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"mdisk_w_io\",\n    \"stat_current\": \"557\",\n    \"stat_peak\": \"5488\",\n    \"stat_peak_time\": \"260902225254\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"mdisk_w_ms\",\n    \"stat_current\": \"0.425\",\n    \"stat_peak\": \"0.450\",\n    \"stat_peak_time\": \"260902225059\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"drive_r_mb\",\n    \"stat_current\": \"375\",\n    \"stat_peak\": \"912\",\n    \"stat_peak_time\": \"260902225154\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"drive_r_io\",\n    \"stat_current\": \"4447\",\n    \"stat_peak\": \"18767\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"drive_r_ms\",\n    \"stat_current\": \"0.284\",\n    \"stat_peak\": \"0.299\",\n    \"stat_peak_time\": \"260902225149\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"drive_w_mb\",\n    \"stat_current\": \"92\",\n    \"stat_peak\": \"931\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"drive_w_io\",\n    \"stat_current\": \"1747\",\n    \"stat_peak\": \"16833\",\n    \"stat_peak_time\": \"260902225254\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"drive_w_ms\",\n    \"stat_current\": \"0.122\",\n    \"stat_peak\": \"0.146\",\n    \"stat_peak_time\": \"260902225059\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"iplink_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"iplink_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"iplink_comp_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"cloud_up_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"cloud_up_ms\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"cloud_down_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"cloud_down_ms\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"iser_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"iser_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"nvme_rdma_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"nvme_rdma_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"nvme_tcp_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"stat_name\": \"nvme_tcp_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"compression_cpu_pc\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"cpu_pc\",\n    \"stat_current\": \"15\",\n    \"stat_peak\": \"29\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"fc_mb\",\n    \"stat_current\": \"250\",\n    \"stat_peak\": \"1125\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"fc_io\",\n    \"stat_current\": \"11847\",\n    \"stat_peak\": \"68434\",\n    \"stat_peak_time\": \"260902225115\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"sas_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"sas_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"iscsi_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"iscsi_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"write_cache_pc\",\n    \"stat_current\": \"34\",\n    \"stat_peak\": \"35\",\n    \"stat_peak_time\": \"260902224955\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"total_cache_pc\",\n    \"stat_current\": \"80\",\n    \"stat_peak\": \"80\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"vdisk_mb\",\n    \"stat_current\": \"192\",\n    \"stat_peak\": \"998\",\n    \"stat_peak_time\": \"260902225155\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"vdisk_io\",\n    \"stat_current\": \"4821\",\n    \"stat_peak\": \"57994\",\n    \"stat_peak_time\": \"260902225115\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"vdisk_ms\",\n    \"stat_current\": \"0.371\",\n    \"stat_peak\": \"0.451\",\n    \"stat_peak_time\": \"260902225210\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"mdisk_mb\",\n    \"stat_current\": \"303\",\n    \"stat_peak\": \"944\",\n    \"stat_peak_time\": \"260902225150\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"mdisk_io\",\n    \"stat_current\": \"4886\",\n    \"stat_peak\": \"8033\",\n    \"stat_peak_time\": \"260902225040\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"mdisk_ms\",\n    \"stat_current\": \"0.307\",\n    \"stat_peak\": \"0.358\",\n    \"stat_peak_time\": \"260902225150\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"drive_mb\",\n    \"stat_current\": \"508\",\n    \"stat_peak\": \"1269\",\n    \"stat_peak_time\": \"260902225040\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"drive_io\",\n    \"stat_current\": \"13332\",\n    \"stat_peak\": \"22534\",\n    \"stat_peak_time\": \"260902225055\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"drive_ms\",\n    \"stat_current\": \"0.174\",\n    \"stat_peak\": \"0.222\",\n    \"stat_peak_time\": \"260902225150\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"vdisk_r_mb\",\n    \"stat_current\": \"150\",\n    \"stat_peak\": \"948\",\n    \"stat_peak_time\": \"260902225155\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"vdisk_r_io\",\n    \"stat_current\": \"2667\",\n    \"stat_peak\": \"54303\",\n    \"stat_peak_time\": \"260902225115\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"vdisk_r_ms\",\n    \"stat_current\": \"0.292\",\n    \"stat_peak\": \"0.292\",\n    \"stat_peak_time\": \"260902225330\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"vdisk_w_mb\",\n    \"stat_current\": \"41\",\n    \"stat_peak\": \"209\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"vdisk_w_io\",\n    \"stat_current\": \"2154\",\n    \"stat_peak\": \"4524\",\n    \"stat_peak_time\": \"260902225110\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"vdisk_w_ms\",\n    \"stat_current\": \"0.469\",\n    \"stat_peak\": \"0.920\",\n    \"stat_peak_time\": \"260902225030\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"mdisk_r_mb\",\n    \"stat_current\": \"241\",\n    \"stat_peak\": \"872\",\n    \"stat_peak_time\": \"260902225150\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"mdisk_r_io\",\n    \"stat_current\": \"2794\",\n    \"stat_peak\": \"5959\",\n    \"stat_peak_time\": \"260902225130\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"mdisk_r_ms\",\n    \"stat_current\": \"0.292\",\n    \"stat_peak\": \"0.348\",\n    \"stat_peak_time\": \"260902225150\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"mdisk_w_mb\",\n    \"stat_current\": \"61\",\n    \"stat_peak\": \"216\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"mdisk_w_io\",\n    \"stat_current\": \"2092\",\n    \"stat_peak\": \"3748\",\n    \"stat_peak_time\": \"260902225055\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"mdisk_w_ms\",\n    \"stat_current\": \"0.326\",\n    \"stat_peak\": \"0.442\",\n    \"stat_peak_time\": \"260902225115\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"drive_r_mb\",\n    \"stat_current\": \"345\",\n    \"stat_peak\": \"993\",\n    \"stat_peak_time\": \"260902225150\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"drive_r_io\",\n    \"stat_current\": \"7084\",\n    \"stat_peak\": \"11744\",\n    \"stat_peak_time\": \"260902225040\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"drive_r_ms\",\n    \"stat_current\": \"0.243\",\n    \"stat_peak\": \"0.286\",\n    \"stat_peak_time\": \"260902225150\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"drive_w_mb\",\n    \"stat_current\": \"163\",\n    \"stat_peak\": \"578\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"drive_w_io\",\n    \"stat_current\": \"6248\",\n    \"stat_peak\": \"11232\",\n    \"stat_peak_time\": \"260902225055\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"drive_w_ms\",\n    \"stat_current\": \"0.095\",\n    \"stat_peak\": \"0.148\",\n    \"stat_peak_time\": \"260902225105\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"iplink_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"iplink_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"iplink_comp_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"cloud_up_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"cloud_up_ms\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"cloud_down_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"cloud_down_ms\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"iser_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"iser_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"nvme_rdma_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"nvme_rdma_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"nvme_tcp_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  },\n  {\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"stat_name\": \"nvme_tcp_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225100\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "418259f9-c8d5-516f-b153-6bd4db667f05",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lspartition",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "a3ac8b1f-90dc-5c87-ac1b-9fb58367c09f",
+          "body": "[\n  {\n    \"id\": \"0\",\n    \"name\": \"partition-a\",\n    \"preferred_management_system_name\": \"system-a\",\n    \"active_management_system_name\": \"system-a\",\n    \"replication_policy_id\": \"0\",\n    \"replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"system-a\",\n    \"location1_status\": \"healthy\",\n    \"location2_system_name\": \"system-b\",\n    \"location2_status\": \"healthy\",\n    \"host_count\": \"22\",\n    \"volume_group_count\": \"4\",\n    \"ha_status\": \"established\",\n    \"link_status\": \"synchronized\",\n    \"desired_location_system_name\": \"\",\n    \"migration_status\": \"\",\n    \"draft\": \"no\",\n    \"draft_volume_group_count\": \"0\",\n    \"draft_host_count\": \"0\",\n    \"uuid\": \"05b8ff65-e566-5ea7-0e6d-65579bfe4597\"\n  },\n  {\n    \"id\": \"1\",\n    \"name\": \"partition-b\",\n    \"preferred_management_system_name\": \"system-a\",\n    \"active_management_system_name\": \"system-a\",\n    \"replication_policy_id\": \"0\",\n    \"replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"system-a\",\n    \"location1_status\": \"healthy\",\n    \"location2_system_name\": \"system-b\",\n    \"location2_status\": \"healthy\",\n    \"host_count\": \"32\",\n    \"volume_group_count\": \"29\",\n    \"ha_status\": \"problem\",\n    \"link_status\": \"synchronized\",\n    \"desired_location_system_name\": \"\",\n    \"migration_status\": \"\",\n    \"draft\": \"no\",\n    \"draft_volume_group_count\": \"0\",\n    \"draft_host_count\": \"0\",\n    \"uuid\": \"70375f60-0176-7502-6492-ac66413869ac\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "df42e467-14eb-571f-bf0f-e580c1b9bff2",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lspartnership",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "23e01e01-cd38-52f1-b541-3ef3e864ee1c",
+          "body": "[\n  {\n    \"id\": \"50050768100F894A\",\n    \"name\": \"system-a\",\n    \"location\": \"local\",\n    \"partnership\": \"\",\n    \"type\": \"\",\n    \"cluster_ip\": \"\",\n    \"event_log_sequence\": \"\",\n    \"link1\": \"\",\n    \"link2\": \"\",\n    \"link1_ip_id\": \"\",\n    \"link2_ip_id\": \"\"\n  },\n  {\n    \"id\": \"5005076810A7D92B\",\n    \"name\": \"system-b\",\n    \"location\": \"remote\",\n    \"partnership\": \"fully_configured\",\n    \"type\": \"fc\",\n    \"cluster_ip\": \"\",\n    \"event_log_sequence\": \"\",\n    \"link1\": \"\",\n    \"link2\": \"\",\n    \"link1_ip_id\": \"\",\n    \"link2_ip_id\": \"\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "f63ae8a0-70de-59ee-96a9-67cfea6b7c87",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsportethernet",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "d6d5ca88-6028-5b0d-92d8-9c59b3be8b96",
+          "body": "[\n  {\n    \"port_id\": \"1\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"MAC\": \"F9:70:03:64:9A:7D\",\n    \"duplex\": \"Full\",\n    \"speed\": \"1Gb/s\",\n    \"link_state\": \"active\",\n    \"dcbx_state\": \"unsupported\",\n    \"rdma_type\": \"TCP\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"3\",\n    \"host\": \"no\",\n    \"storage\": \"no\",\n    \"replication\": \"no\",\n    \"eth_clustering\": \"no\",\n    \"management\": \"yes\"\n  },\n  {\n    \"port_id\": \"2\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"MAC\": \"49:55:AE:2F:73:7B\",\n    \"duplex\": \"\",\n    \"speed\": \"\",\n    \"link_state\": \"inactive\",\n    \"dcbx_state\": \"\",\n    \"rdma_type\": \"TCP\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"host\": \"yes\",\n    \"storage\": \"yes\",\n    \"replication\": \"yes\",\n    \"eth_clustering\": \"no\",\n    \"management\": \"yes\"\n  },\n  {\n    \"port_id\": \"3\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"MAC\": \"85:24:DF:8E:10:3C\",\n    \"duplex\": \"\",\n    \"speed\": \"\",\n    \"link_state\": \"inactive\",\n    \"dcbx_state\": \"\",\n    \"rdma_type\": \"TCP\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"2\",\n    \"host\": \"yes\",\n    \"storage\": \"yes\",\n    \"replication\": \"yes\",\n    \"eth_clustering\": \"no\",\n    \"management\": \"no\"\n  },\n  {\n    \"port_id\": \"1\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"MAC\": \"F9:E8:C7:93:3A:C3\",\n    \"duplex\": \"Full\",\n    \"speed\": \"1Gb/s\",\n    \"link_state\": \"active\",\n    \"dcbx_state\": \"unsupported\",\n    \"rdma_type\": \"TCP\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"3\",\n    \"host\": \"no\",\n    \"storage\": \"no\",\n    \"replication\": \"no\",\n    \"eth_clustering\": \"no\",\n    \"management\": \"yes\"\n  },\n  {\n    \"port_id\": \"2\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"MAC\": \"ED:54:FD:77:95:DB\",\n    \"duplex\": \"\",\n    \"speed\": \"\",\n    \"link_state\": \"inactive\",\n    \"dcbx_state\": \"\",\n    \"rdma_type\": \"TCP\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"host\": \"yes\",\n    \"storage\": \"yes\",\n    \"replication\": \"yes\",\n    \"eth_clustering\": \"no\",\n    \"management\": \"yes\"\n  },\n  {\n    \"port_id\": \"3\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"MAC\": \"71:D3:2C:D7:E1:21\",\n    \"duplex\": \"\",\n    \"speed\": \"\",\n    \"link_state\": \"inactive\",\n    \"dcbx_state\": \"\",\n    \"rdma_type\": \"TCP\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"2\",\n    \"host\": \"yes\",\n    \"storage\": \"yes\",\n    \"replication\": \"yes\",\n    \"eth_clustering\": \"no\",\n    \"management\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "8c2d1088-254c-5104-bcbc-230b342b82fb",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsportfc",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "0d37e758-c491-59db-8144-c1b1e27b97c2",
+          "body": "[\n  {\n    \"id\": \"0\",\n    \"fc_io_port_id\": \"1\",\n    \"port_id\": \"1\",\n    \"type\": \"fc\",\n    \"port_speed\": \"16Gb\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"WWPN\": \"50050768108B45C0\",\n    \"nportid\": \"140060\",\n    \"status\": \"active\",\n    \"attachment\": \"switch\",\n    \"cluster_use\": \"local_partner\",\n    \"adapter_location\": \"1\",\n    \"adapter_port_id\": \"1\"\n  },\n  {\n    \"id\": \"1\",\n    \"fc_io_port_id\": \"2\",\n    \"port_id\": \"2\",\n    \"type\": \"fc\",\n    \"port_speed\": \"16Gb\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"WWPN\": \"5005076810079942\",\n    \"nportid\": \"280020\",\n    \"status\": \"active\",\n    \"attachment\": \"switch\",\n    \"cluster_use\": \"local_partner\",\n    \"adapter_location\": \"1\",\n    \"adapter_port_id\": \"2\"\n  },\n  {\n    \"id\": \"2\",\n    \"fc_io_port_id\": \"3\",\n    \"port_id\": \"3\",\n    \"type\": \"fc\",\n    \"port_speed\": \"16Gb\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"WWPN\": \"5005076810A01169\",\n    \"nportid\": \"0A0040\",\n    \"status\": \"active\",\n    \"attachment\": \"switch\",\n    \"cluster_use\": \"local_partner\",\n    \"adapter_location\": \"1\",\n    \"adapter_port_id\": \"3\"\n  },\n  {\n    \"id\": \"3\",\n    \"fc_io_port_id\": \"4\",\n    \"port_id\": \"4\",\n    \"type\": \"fc\",\n    \"port_speed\": \"16Gb\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"WWPN\": \"5005076810E03A8A\",\n    \"nportid\": \"1E0040\",\n    \"status\": \"active\",\n    \"attachment\": \"switch\",\n    \"cluster_use\": \"local_partner\",\n    \"adapter_location\": \"1\",\n    \"adapter_port_id\": \"4\"\n  },\n  {\n    \"id\": \"24\",\n    \"fc_io_port_id\": \"1\",\n    \"port_id\": \"1\",\n    \"type\": \"fc\",\n    \"port_speed\": \"16Gb\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"WWPN\": \"5005076810079D5D\",\n    \"nportid\": \"140040\",\n    \"status\": \"active\",\n    \"attachment\": \"switch\",\n    \"cluster_use\": \"local_partner\",\n    \"adapter_location\": \"1\",\n    \"adapter_port_id\": \"1\"\n  },\n  {\n    \"id\": \"25\",\n    \"fc_io_port_id\": \"2\",\n    \"port_id\": \"2\",\n    \"type\": \"fc\",\n    \"port_speed\": \"16Gb\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"WWPN\": \"50050768103ECA97\",\n    \"nportid\": \"280000\",\n    \"status\": \"active\",\n    \"attachment\": \"switch\",\n    \"cluster_use\": \"local_partner\",\n    \"adapter_location\": \"1\",\n    \"adapter_port_id\": \"2\"\n  },\n  {\n    \"id\": \"26\",\n    \"fc_io_port_id\": \"3\",\n    \"port_id\": \"3\",\n    \"type\": \"fc\",\n    \"port_speed\": \"16Gb\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"WWPN\": \"5005076810A1D2AC\",\n    \"nportid\": \"0A0060\",\n    \"status\": \"active\",\n    \"attachment\": \"switch\",\n    \"cluster_use\": \"local_partner\",\n    \"adapter_location\": \"1\",\n    \"adapter_port_id\": \"3\"\n  },\n  {\n    \"id\": \"27\",\n    \"fc_io_port_id\": \"4\",\n    \"port_id\": \"4\",\n    \"type\": \"fc\",\n    \"port_speed\": \"16Gb\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"WWPN\": \"50050768106DF95B\",\n    \"nportid\": \"1E0060\",\n    \"status\": \"active\",\n    \"attachment\": \"switch\",\n    \"cluster_use\": \"local_partner\",\n    \"adapter_location\": \"1\",\n    \"adapter_port_id\": \"4\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "23e70d54-df07-5b5b-a2da-5bdb93499f59",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsportip",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "e7413a71-9e9d-597a-b862-2a7d276bfd2b",
+          "body": "[\n  {\n    \"id\": \"1\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"IP_address\": \"\",\n    \"mask\": \"\",\n    \"gateway\": \"\",\n    \"IP_address_6\": \"\",\n    \"prefix_6\": \"\",\n    \"gateway_6\": \"\",\n    \"MAC\": \"BC:BD:45:4D:2B:55\",\n    \"duplex\": \"Full\",\n    \"state\": \"unconfigured\",\n    \"speed\": \"1Gb/s\",\n    \"failover\": \"no\",\n    \"link_state\": \"inactive\",\n    \"host\": \"\",\n    \"remote_copy\": \"0\",\n    \"host_6\": \"\",\n    \"remote_copy_6\": \"0\",\n    \"remote_copy_status\": \"\",\n    \"remote_copy_status_6\": \"\",\n    \"vlan\": \"\",\n    \"vlan_6\": \"\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"storage\": \"\",\n    \"storage_6\": \"\",\n    \"host_port_grp_id\": \"0\",\n    \"rdma_type\": \"\",\n    \"is_rdma_clustering\": \"no\"\n  },\n  {\n    \"id\": \"1\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"IP_address\": \"\",\n    \"mask\": \"\",\n    \"gateway\": \"\",\n    \"IP_address_6\": \"\",\n    \"prefix_6\": \"\",\n    \"gateway_6\": \"\",\n    \"MAC\": \"BC:BD:45:4D:2B:55\",\n    \"duplex\": \"Full\",\n    \"state\": \"unconfigured\",\n    \"speed\": \"1Gb/s\",\n    \"failover\": \"yes\",\n    \"link_state\": \"inactive\",\n    \"host\": \"\",\n    \"remote_copy\": \"0\",\n    \"host_6\": \"\",\n    \"remote_copy_6\": \"0\",\n    \"remote_copy_status\": \"\",\n    \"remote_copy_status_6\": \"\",\n    \"vlan\": \"\",\n    \"vlan_6\": \"\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"storage\": \"\",\n    \"storage_6\": \"\",\n    \"host_port_grp_id\": \"0\",\n    \"rdma_type\": \"\",\n    \"is_rdma_clustering\": \"no\"\n  },\n  {\n    \"id\": \"2\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"IP_address\": \"\",\n    \"mask\": \"\",\n    \"gateway\": \"\",\n    \"IP_address_6\": \"\",\n    \"prefix_6\": \"\",\n    \"gateway_6\": \"\",\n    \"MAC\": \"BC:BD:45:4D:2B:55\",\n    \"duplex\": \"Full\",\n    \"state\": \"unconfigured\",\n    \"speed\": \"1Gb/s\",\n    \"failover\": \"no\",\n    \"link_state\": \"inactive\",\n    \"host\": \"\",\n    \"remote_copy\": \"0\",\n    \"host_6\": \"\",\n    \"remote_copy_6\": \"0\",\n    \"remote_copy_status\": \"\",\n    \"remote_copy_status_6\": \"\",\n    \"vlan\": \"\",\n    \"vlan_6\": \"\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"storage\": \"\",\n    \"storage_6\": \"\",\n    \"host_port_grp_id\": \"0\",\n    \"rdma_type\": \"\",\n    \"is_rdma_clustering\": \"no\"\n  },\n  {\n    \"id\": \"2\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"IP_address\": \"\",\n    \"mask\": \"\",\n    \"gateway\": \"\",\n    \"IP_address_6\": \"\",\n    \"prefix_6\": \"\",\n    \"gateway_6\": \"\",\n    \"MAC\": \"BC:BD:45:4D:2B:55\",\n    \"duplex\": \"Full\",\n    \"state\": \"unconfigured\",\n    \"speed\": \"1Gb/s\",\n    \"failover\": \"yes\",\n    \"link_state\": \"inactive\",\n    \"host\": \"\",\n    \"remote_copy\": \"0\",\n    \"host_6\": \"\",\n    \"remote_copy_6\": \"0\",\n    \"remote_copy_status\": \"\",\n    \"remote_copy_status_6\": \"\",\n    \"vlan\": \"\",\n    \"vlan_6\": \"\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"storage\": \"\",\n    \"storage_6\": \"\",\n    \"host_port_grp_id\": \"0\",\n    \"rdma_type\": \"\",\n    \"is_rdma_clustering\": \"no\"\n  },\n  {\n    \"id\": \"3\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"IP_address\": \"\",\n    \"mask\": \"\",\n    \"gateway\": \"\",\n    \"IP_address_6\": \"\",\n    \"prefix_6\": \"\",\n    \"gateway_6\": \"\",\n    \"MAC\": \"BC:BD:45:4D:2B:55\",\n    \"duplex\": \"Full\",\n    \"state\": \"unconfigured\",\n    \"speed\": \"1Gb/s\",\n    \"failover\": \"no\",\n    \"link_state\": \"inactive\",\n    \"host\": \"\",\n    \"remote_copy\": \"0\",\n    \"host_6\": \"\",\n    \"remote_copy_6\": \"0\",\n    \"remote_copy_status\": \"\",\n    \"remote_copy_status_6\": \"\",\n    \"vlan\": \"\",\n    \"vlan_6\": \"\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"storage\": \"\",\n    \"storage_6\": \"\",\n    \"host_port_grp_id\": \"0\",\n    \"rdma_type\": \"\",\n    \"is_rdma_clustering\": \"no\"\n  },\n  {\n    \"id\": \"3\",\n    \"node_id\": \"1\",\n    \"node_name\": \"node1\",\n    \"IP_address\": \"\",\n    \"mask\": \"\",\n    \"gateway\": \"\",\n    \"IP_address_6\": \"\",\n    \"prefix_6\": \"\",\n    \"gateway_6\": \"\",\n    \"MAC\": \"BC:BD:45:4D:2B:55\",\n    \"duplex\": \"Full\",\n    \"state\": \"unconfigured\",\n    \"speed\": \"1Gb/s\",\n    \"failover\": \"yes\",\n    \"link_state\": \"inactive\",\n    \"host\": \"\",\n    \"remote_copy\": \"0\",\n    \"host_6\": \"\",\n    \"remote_copy_6\": \"0\",\n    \"remote_copy_status\": \"\",\n    \"remote_copy_status_6\": \"\",\n    \"vlan\": \"\",\n    \"vlan_6\": \"\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"storage\": \"\",\n    \"storage_6\": \"\",\n    \"host_port_grp_id\": \"0\",\n    \"rdma_type\": \"\",\n    \"is_rdma_clustering\": \"no\"\n  },\n  {\n    \"id\": \"1\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"IP_address\": \"\",\n    \"mask\": \"\",\n    \"gateway\": \"\",\n    \"IP_address_6\": \"\",\n    \"prefix_6\": \"\",\n    \"gateway_6\": \"\",\n    \"MAC\": \"BC:BD:45:4D:2B:55\",\n    \"duplex\": \"Full\",\n    \"state\": \"unconfigured\",\n    \"speed\": \"1Gb/s\",\n    \"failover\": \"no\",\n    \"link_state\": \"inactive\",\n    \"host\": \"\",\n    \"remote_copy\": \"0\",\n    \"host_6\": \"\",\n    \"remote_copy_6\": \"0\",\n    \"remote_copy_status\": \"\",\n    \"remote_copy_status_6\": \"\",\n    \"vlan\": \"\",\n    \"vlan_6\": \"\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"storage\": \"\",\n    \"storage_6\": \"\",\n    \"host_port_grp_id\": \"0\",\n    \"rdma_type\": \"\",\n    \"is_rdma_clustering\": \"no\"\n  },\n  {\n    \"id\": \"1\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"IP_address\": \"\",\n    \"mask\": \"\",\n    \"gateway\": \"\",\n    \"IP_address_6\": \"\",\n    \"prefix_6\": \"\",\n    \"gateway_6\": \"\",\n    \"MAC\": \"BC:BD:45:4D:2B:55\",\n    \"duplex\": \"Full\",\n    \"state\": \"unconfigured\",\n    \"speed\": \"1Gb/s\",\n    \"failover\": \"yes\",\n    \"link_state\": \"inactive\",\n    \"host\": \"\",\n    \"remote_copy\": \"0\",\n    \"host_6\": \"\",\n    \"remote_copy_6\": \"0\",\n    \"remote_copy_status\": \"\",\n    \"remote_copy_status_6\": \"\",\n    \"vlan\": \"\",\n    \"vlan_6\": \"\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"storage\": \"\",\n    \"storage_6\": \"\",\n    \"host_port_grp_id\": \"0\",\n    \"rdma_type\": \"\",\n    \"is_rdma_clustering\": \"no\"\n  },\n  {\n    \"id\": \"2\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"IP_address\": \"\",\n    \"mask\": \"\",\n    \"gateway\": \"\",\n    \"IP_address_6\": \"\",\n    \"prefix_6\": \"\",\n    \"gateway_6\": \"\",\n    \"MAC\": \"BC:BD:45:4D:2B:55\",\n    \"duplex\": \"Full\",\n    \"state\": \"unconfigured\",\n    \"speed\": \"1Gb/s\",\n    \"failover\": \"no\",\n    \"link_state\": \"inactive\",\n    \"host\": \"\",\n    \"remote_copy\": \"0\",\n    \"host_6\": \"\",\n    \"remote_copy_6\": \"0\",\n    \"remote_copy_status\": \"\",\n    \"remote_copy_status_6\": \"\",\n    \"vlan\": \"\",\n    \"vlan_6\": \"\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"storage\": \"\",\n    \"storage_6\": \"\",\n    \"host_port_grp_id\": \"0\",\n    \"rdma_type\": \"\",\n    \"is_rdma_clustering\": \"no\"\n  },\n  {\n    \"id\": \"2\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"IP_address\": \"\",\n    \"mask\": \"\",\n    \"gateway\": \"\",\n    \"IP_address_6\": \"\",\n    \"prefix_6\": \"\",\n    \"gateway_6\": \"\",\n    \"MAC\": \"BC:BD:45:4D:2B:55\",\n    \"duplex\": \"Full\",\n    \"state\": \"unconfigured\",\n    \"speed\": \"1Gb/s\",\n    \"failover\": \"yes\",\n    \"link_state\": \"inactive\",\n    \"host\": \"\",\n    \"remote_copy\": \"0\",\n    \"host_6\": \"\",\n    \"remote_copy_6\": \"0\",\n    \"remote_copy_status\": \"\",\n    \"remote_copy_status_6\": \"\",\n    \"vlan\": \"\",\n    \"vlan_6\": \"\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"storage\": \"\",\n    \"storage_6\": \"\",\n    \"host_port_grp_id\": \"0\",\n    \"rdma_type\": \"\",\n    \"is_rdma_clustering\": \"no\"\n  },\n  {\n    \"id\": \"3\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"IP_address\": \"\",\n    \"mask\": \"\",\n    \"gateway\": \"\",\n    \"IP_address_6\": \"\",\n    \"prefix_6\": \"\",\n    \"gateway_6\": \"\",\n    \"MAC\": \"BC:BD:45:4D:2B:55\",\n    \"duplex\": \"Full\",\n    \"state\": \"unconfigured\",\n    \"speed\": \"1Gb/s\",\n    \"failover\": \"no\",\n    \"link_state\": \"inactive\",\n    \"host\": \"\",\n    \"remote_copy\": \"0\",\n    \"host_6\": \"\",\n    \"remote_copy_6\": \"0\",\n    \"remote_copy_status\": \"\",\n    \"remote_copy_status_6\": \"\",\n    \"vlan\": \"\",\n    \"vlan_6\": \"\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"storage\": \"\",\n    \"storage_6\": \"\",\n    \"host_port_grp_id\": \"0\",\n    \"rdma_type\": \"\",\n    \"is_rdma_clustering\": \"no\"\n  },\n  {\n    \"id\": \"3\",\n    \"node_id\": \"2\",\n    \"node_name\": \"node2\",\n    \"IP_address\": \"\",\n    \"mask\": \"\",\n    \"gateway\": \"\",\n    \"IP_address_6\": \"\",\n    \"prefix_6\": \"\",\n    \"gateway_6\": \"\",\n    \"MAC\": \"BC:BD:45:4D:2B:55\",\n    \"duplex\": \"Full\",\n    \"state\": \"unconfigured\",\n    \"speed\": \"1Gb/s\",\n    \"failover\": \"yes\",\n    \"link_state\": \"inactive\",\n    \"host\": \"\",\n    \"remote_copy\": \"0\",\n    \"host_6\": \"\",\n    \"remote_copy_6\": \"0\",\n    \"remote_copy_status\": \"\",\n    \"remote_copy_status_6\": \"\",\n    \"vlan\": \"\",\n    \"vlan_6\": \"\",\n    \"adapter_location\": \"0\",\n    \"adapter_port_id\": \"1\",\n    \"storage\": \"\",\n    \"storage_6\": \"\",\n    \"host_port_grp_id\": \"0\",\n    \"rdma_type\": \"\",\n    \"is_rdma_clustering\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "d7a91b9c-7770-532e-80ac-2753425d3a7f",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsquorum",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "818baef2-7413-59fc-b9a9-f7a9c3eee65c",
+          "body": "[\n  {\n    \"quorum_index\": \"0\",\n    \"status\": \"online\",\n    \"id\": \"7\",\n    \"name\": \"\",\n    \"controller_id\": \"\",\n    \"controller_name\": \"\",\n    \"active\": \"yes\",\n    \"object_type\": \"drive\",\n    \"override\": \"no\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"application_type\": \"\",\n    \"metadata_backup\": \"yes\",\n    \"partner_system_id\": \"\",\n    \"partner_system_name\": \"\"\n  },\n  {\n    \"quorum_index\": \"1\",\n    \"status\": \"online\",\n    \"id\": \"5\",\n    \"name\": \"\",\n    \"controller_id\": \"\",\n    \"controller_name\": \"\",\n    \"active\": \"no\",\n    \"object_type\": \"drive\",\n    \"override\": \"no\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"application_type\": \"\",\n    \"metadata_backup\": \"yes\",\n    \"partner_system_id\": \"\",\n    \"partner_system_name\": \"\"\n  },\n  {\n    \"quorum_index\": \"2\",\n    \"status\": \"online\",\n    \"id\": \"10\",\n    \"name\": \"\",\n    \"controller_id\": \"\",\n    \"controller_name\": \"\",\n    \"active\": \"no\",\n    \"object_type\": \"drive\",\n    \"override\": \"no\",\n    \"site_id\": \"\",\n    \"site_name\": \"\",\n    \"application_type\": \"\",\n    \"metadata_backup\": \"yes\",\n    \"partner_system_id\": \"\",\n    \"partner_system_name\": \"\"\n  },\n  {\n    \"quorum_index\": \"8\",\n    \"status\": \"online\",\n    \"id\": \"\",\n    \"name\": \"\",\n    \"controller_id\": \"\",\n    \"controller_name\": \"\",\n    \"active\": \"yes\",\n    \"object_type\": \"device\",\n    \"override\": \"no\",\n    \"site_id\": \"\",\n    \"site_name\": \"quorum-app-1/10.0.0.1\",\n    \"application_type\": \"partnership\",\n    \"metadata_backup\": \"\",\n    \"partner_system_id\": \"500507681053976A\",\n    \"partner_system_name\": \"system-b\"\n  },\n  {\n    \"quorum_index\": \"9\",\n    \"status\": \"online\",\n    \"id\": \"\",\n    \"name\": \"\",\n    \"controller_id\": \"\",\n    \"controller_name\": \"\",\n    \"active\": \"no\",\n    \"object_type\": \"device\",\n    \"override\": \"no\",\n    \"site_id\": \"\",\n    \"site_name\": \"quorum-app-2/10.0.0.2\",\n    \"application_type\": \"partnership\",\n    \"metadata_backup\": \"\",\n    \"partner_system_id\": \"500507681053976A\",\n    \"partner_system_name\": \"system-b\"\n  },\n  {\n    \"quorum_index\": \"10\",\n    \"status\": \"online\",\n    \"id\": \"\",\n    \"name\": \"\",\n    \"controller_id\": \"\",\n    \"controller_name\": \"\",\n    \"active\": \"no\",\n    \"object_type\": \"device\",\n    \"override\": \"no\",\n    \"site_id\": \"\",\n    \"site_name\": \"quorum-app-3/10.0.0.3\",\n    \"application_type\": \"partnership\",\n    \"metadata_backup\": \"\",\n    \"partner_system_id\": \"500507681053976A\",\n    \"partner_system_name\": \"system-b\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "3c68601a-dcac-5dfa-a5ca-db00b5ed6be2",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsrcrelationship",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "39cf2491-31f1-5875-8969-54fc7cfcd1c9",
+          "body": "[]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "834d7d81-6440-54a4-8422-ba9db86b37d0",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsreplicationpolicy",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "6b410654-ce9b-5873-a3ad-c1e25913ece1",
+          "body": "[\n  {\n    \"id\": \"0\",\n    \"name\": \"policy-a\",\n    \"rpo_alert\": \"0\",\n    \"topology\": \"2-site-ha\",\n    \"volume_group_count\": \"0\",\n    \"location1_system_name\": \"system-a\",\n    \"location1_iogrp_id\": \"0\",\n    \"location2_system_name\": \"system-b\",\n    \"location2_iogrp_id\": \"0\",\n    \"partition_count\": \"2\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "1740866b-e275-57d4-980a-db07701c53af",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lssnapshotpolicy",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "ad0b1842-9134-5f18-a1ac-c9a8a504204f",
+          "body": "[\n  {\n    \"id\": \"0\",\n    \"name\": \"snapshot-policy-a\",\n    \"volume_group_count\": \"0\"\n  },\n  {\n    \"id\": \"1\",\n    \"name\": \"snapshot-policy-b\",\n    \"volume_group_count\": \"0\"\n  },\n  {\n    \"id\": \"2\",\n    \"name\": \"snapshot-policy-c\",\n    \"volume_group_count\": \"0\"\n  },\n  {\n    \"id\": \"38\",\n    \"name\": \"snapshot-policy-d\",\n    \"volume_group_count\": \"0\"\n  },\n  {\n    \"id\": \"39\",\n    \"name\": \"snapshot-policy-e\",\n    \"volume_group_count\": \"0\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "749f43e5-4969-563a-97ae-11f926028b67",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lssystem",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "e694077f-41f7-5186-b0a2-dafab536dcd2",
+          "body": "{\n  \"id\": \"50050768100F894A\",\n  \"name\": \"system-a\",\n  \"location\": \"local\",\n  \"partnership\": \"\",\n  \"total_mdisk_capacity\": \"935.8TB\",\n  \"space_in_mdisk_grps\": \"935.8TB\",\n  \"space_allocated_to_vdisks\": \"306.57TB\",\n  \"total_free_space\": \"629.2TB\",\n  \"total_vdiskcopy_capacity\": \"1.25PB\",\n  \"total_used_capacity\": \"292.98TB\",\n  \"total_overallocation\": \"137\",\n  \"total_vdisk_capacity\": \"1.25PB\",\n  \"total_allocated_extent_capacity\": \"306.74TB\",\n  \"statistics_status\": \"on\",\n  \"statistics_frequency\": \"5\",\n  \"cluster_locale\": \"en_US\",\n  \"time_zone\": \"362 Europe/Brussels\",\n  \"code_level\": \"8.7.0.8 (build 177.34.2511111501000)\",\n  \"console_IP\": \"\",\n  \"id_alias\": \"500507681003A06B\",\n  \"gm_link_tolerance\": \"300\",\n  \"gm_inter_cluster_delay_simulation\": \"0\",\n  \"gm_intra_cluster_delay_simulation\": \"0\",\n  \"gm_max_host_delay\": \"5\",\n  \"email_reply\": \"\",\n  \"email_contact\": \"\",\n  \"email_contact_primary\": \"\",\n  \"email_contact_alternate\": \"\",\n  \"email_contact_location\": \"\",\n  \"email_contact2\": \"\",\n  \"email_contact2_primary\": \"\",\n  \"email_contact2_alternate\": \"\",\n  \"email_state\": \"stopped\",\n  \"inventory_mail_interval\": \"0\",\n  \"cluster_ntp_IP_address\": \"\",\n  \"cluster_isns_IP_address\": \"\",\n  \"iscsi_auth_method\": \"none\",\n  \"iscsi_chap_secret\": \"\",\n  \"auth_service_configured\": \"yes\",\n  \"auth_service_enabled\": \"yes\",\n  \"auth_service_url\": \"\",\n  \"auth_service_user_name\": \"\",\n  \"auth_service_pwd_set\": \"no\",\n  \"auth_service_cert_set\": \"no\",\n  \"auth_service_type\": \"ldap\",\n  \"relationship_bandwidth_limit\": \"25\",\n  \"tiers\": [\n    {\n      \"tier\": \"tier_scm\",\n      \"tier_capacity\": \"0.00MB\",\n      \"tier_free_capacity\": \"0.00MB\"\n    },\n    {\n      \"tier\": \"tier0_flash\",\n      \"tier_capacity\": \"0.00MB\",\n      \"tier_free_capacity\": \"0.00MB\"\n    },\n    {\n      \"tier\": \"tier1_flash\",\n      \"tier_capacity\": \"0.00MB\",\n      \"tier_free_capacity\": \"0.00MB\"\n    },\n    {\n      \"tier\": \"tier_enterprise\",\n      \"tier_capacity\": \"0.00MB\",\n      \"tier_free_capacity\": \"0.00MB\"\n    },\n    {\n      \"tier\": \"tier_nearline\",\n      \"tier_capacity\": \"0.00MB\",\n      \"tier_free_capacity\": \"0.00MB\"\n    }\n  ],\n  \"easy_tier_acceleration\": \"off\",\n  \"has_nas_key\": \"no\",\n  \"layer\": \"replication\",\n  \"rc_buffer_size\": \"256\",\n  \"compression_active\": \"no\",\n  \"compression_virtual_capacity\": \"0.00MB\",\n  \"compression_compressed_capacity\": \"0.00MB\",\n  \"compression_uncompressed_capacity\": \"0.00MB\",\n  \"cache_prefetch\": \"on\",\n  \"email_organization\": \"\",\n  \"email_machine_address\": \"\",\n  \"email_machine_city\": \"\",\n  \"email_machine_state\": \"\",\n  \"email_machine_zip\": \"\",\n  \"email_machine_country\": \"\",\n  \"email_from\": \"\",\n  \"total_drive_raw_capacity\": \"0\",\n  \"compression_destage_mode\": \"off\",\n  \"local_fc_port_mask\": \"1111111111111111111111111111111111111111111111111111111111111111\",\n  \"partner_fc_port_mask\": \"1111111111111111111111111111111111111111111111111111111111111111\",\n  \"high_temp_mode\": \"off\",\n  \"topology\": \"standard\",\n  \"topology_status\": \"\",\n  \"rc_auth_method\": \"none\",\n  \"vdisk_protection_time\": \"15\",\n  \"vdisk_protection_enabled\": \"no\",\n  \"product_name\": \"IBM Storage FlashSystem 5300\",\n  \"odx\": \"off\",\n  \"max_replication_delay\": \"0\",\n  \"partnership_exclusion_threshold\": \"315\",\n  \"gen1_compatibility_mode_enabled\": \"\",\n  \"ibm_customer\": \"\",\n  \"ibm_component\": \"\",\n  \"ibm_country\": \"\",\n  \"tier_scm_compressed_data_used\": \"0.00MB\",\n  \"tier0_flash_compressed_data_used\": \"0.00MB\",\n  \"tier1_flash_compressed_data_used\": \"0.00MB\",\n  \"tier_enterprise_compressed_data_used\": \"0.00MB\",\n  \"tier_nearline_compressed_data_used\": \"0.00MB\",\n  \"total_reclaimable_capacity\": \"0.00MB\",\n  \"physical_capacity\": \"310.99TB\",\n  \"physical_free_capacity\": \"164.51TB\",\n  \"used_capacity_before_reduction\": \"0.00MB\",\n  \"used_capacity_after_reduction\": \"0.00MB\",\n  \"overhead_capacity\": \"0.00MB\",\n  \"deduplication_capacity_saving\": \"0.00MB\",\n  \"enhanced_callhome\": \"on\",\n  \"censor_callhome\": \"off\",\n  \"host_unmap\": \"off\",\n  \"backend_unmap\": \"on\",\n  \"quorum_mode\": \"standard\",\n  \"quorum_site_id\": \"\",\n  \"quorum_site_name\": \"\",\n  \"quorum_lease\": \"short\",\n  \"automatic_vdisk_analysis_enabled\": \"on\",\n  \"callhome_accepted_usage\": \"no\",\n  \"safeguarded_copy_suspended\": \"no\",\n  \"protection_provisioned_capacity\": \"642.49TB\",\n  \"protection_written_capacity\": \"590.75MB\",\n  \"flashcopy_gui_enabled\": \"no\",\n  \"snapshot_policy_suspended\": \"no\",\n  \"snapshot_preserve_parent\": \"no\",\n  \"anomaly_detection\": \"on\",\n  \"anomaly_detection_event\": \"off\",\n  \"flashcopy_default_grainsize\": \"256\",\n  \"storage_insights_control_access\": \"no\",\n  \"flash_grid_system_uuid\": \"F4CEFA13-1469-55D1-81CF-13A325517A9A\",\n  \"flash_grid_uuid\": \"\",\n  \"flash_grid_name\": \"\",\n  \"flash_grid_owner_uuid\": \"\",\n  \"auto_drive_download\": \"on\"\n}",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "b6d1c3de-a71c-56f7-abc3-db29af52f214",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lssystemstats",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "eef63be5-783c-5930-9d40-204d344e9611",
+          "body": "[\n  {\n    \"stat_name\": \"compression_cpu_pc\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"cpu_pc\",\n    \"stat_current\": \"15\",\n    \"stat_peak\": \"27\",\n    \"stat_peak_time\": \"260902225039\"\n  },\n  {\n    \"stat_name\": \"fc_mb\",\n    \"stat_current\": \"546\",\n    \"stat_peak\": \"1821\",\n    \"stat_peak_time\": \"260902225039\"\n  },\n  {\n    \"stat_name\": \"fc_io\",\n    \"stat_current\": \"29503\",\n    \"stat_peak\": \"94314\",\n    \"stat_peak_time\": \"260902225114\"\n  },\n  {\n    \"stat_name\": \"sas_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"sas_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"iscsi_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"iscsi_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"write_cache_pc\",\n    \"stat_current\": \"34\",\n    \"stat_peak\": \"35\",\n    \"stat_peak_time\": \"260902225204\"\n  },\n  {\n    \"stat_name\": \"total_cache_pc\",\n    \"stat_current\": \"80\",\n    \"stat_peak\": \"80\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"vdisk_mb\",\n    \"stat_current\": \"408\",\n    \"stat_peak\": \"1523\",\n    \"stat_peak_time\": \"260902225154\"\n  },\n  {\n    \"stat_name\": \"vdisk_io\",\n    \"stat_current\": \"7923\",\n    \"stat_peak\": \"62772\",\n    \"stat_peak_time\": \"260902225114\"\n  },\n  {\n    \"stat_name\": \"vdisk_ms\",\n    \"stat_current\": \"0.398\",\n    \"stat_peak\": \"0.453\",\n    \"stat_peak_time\": \"260902225209\"\n  },\n  {\n    \"stat_name\": \"mdisk_mb\",\n    \"stat_current\": \"628\",\n    \"stat_peak\": \"1795\",\n    \"stat_peak_time\": \"260902225149\"\n  },\n  {\n    \"stat_name\": \"mdisk_io\",\n    \"stat_current\": \"8280\",\n    \"stat_peak\": \"15508\",\n    \"stat_peak_time\": \"260902225039\"\n  },\n  {\n    \"stat_name\": \"mdisk_ms\",\n    \"stat_current\": \"0.314\",\n    \"stat_peak\": \"0.364\",\n    \"stat_peak_time\": \"260902225039\"\n  },\n  {\n    \"stat_name\": \"drive_mb\",\n    \"stat_current\": \"976\",\n    \"stat_peak\": \"3007\",\n    \"stat_peak_time\": \"260902225039\"\n  },\n  {\n    \"stat_name\": \"drive_io\",\n    \"stat_current\": \"19526\",\n    \"stat_peak\": \"49740\",\n    \"stat_peak_time\": \"260902225254\"\n  },\n  {\n    \"stat_name\": \"drive_ms\",\n    \"stat_current\": \"0.194\",\n    \"stat_peak\": \"0.230\",\n    \"stat_peak_time\": \"260902225149\"\n  },\n  {\n    \"stat_name\": \"vdisk_r_mb\",\n    \"stat_current\": \"335\",\n    \"stat_peak\": \"1451\",\n    \"stat_peak_time\": \"260902225154\"\n  },\n  {\n    \"stat_name\": \"vdisk_r_io\",\n    \"stat_current\": \"4477\",\n    \"stat_peak\": \"57204\",\n    \"stat_peak_time\": \"260902225114\"\n  },\n  {\n    \"stat_name\": \"vdisk_r_ms\",\n    \"stat_current\": \"0.341\",\n    \"stat_peak\": \"0.341\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"vdisk_w_mb\",\n    \"stat_current\": \"71\",\n    \"stat_peak\": \"387\",\n    \"stat_peak_time\": \"260902225054\"\n  },\n  {\n    \"stat_name\": \"vdisk_w_io\",\n    \"stat_current\": \"3446\",\n    \"stat_peak\": \"6966\",\n    \"stat_peak_time\": \"260902225054\"\n  },\n  {\n    \"stat_name\": \"vdisk_w_ms\",\n    \"stat_current\": \"0.472\",\n    \"stat_peak\": \"0.811\",\n    \"stat_peak_time\": \"260902225029\"\n  },\n  {\n    \"stat_name\": \"mdisk_r_mb\",\n    \"stat_current\": \"525\",\n    \"stat_peak\": \"1629\",\n    \"stat_peak_time\": \"260902225149\"\n  },\n  {\n    \"stat_name\": \"mdisk_r_io\",\n    \"stat_current\": \"5631\",\n    \"stat_peak\": \"11065\",\n    \"stat_peak_time\": \"260902225154\"\n  },\n  {\n    \"stat_name\": \"mdisk_r_ms\",\n    \"stat_current\": \"0.299\",\n    \"stat_peak\": \"0.348\",\n    \"stat_peak_time\": \"260902225149\"\n  },\n  {\n    \"stat_name\": \"mdisk_w_mb\",\n    \"stat_current\": \"102\",\n    \"stat_peak\": \"616\",\n    \"stat_peak_time\": \"260902225039\"\n  },\n  {\n    \"stat_name\": \"mdisk_w_io\",\n    \"stat_current\": \"2649\",\n    \"stat_peak\": \"7986\",\n    \"stat_peak_time\": \"260902225254\"\n  },\n  {\n    \"stat_name\": \"mdisk_w_ms\",\n    \"stat_current\": \"0.347\",\n    \"stat_peak\": \"0.438\",\n    \"stat_peak_time\": \"260902225039\"\n  },\n  {\n    \"stat_name\": \"drive_r_mb\",\n    \"stat_current\": \"720\",\n    \"stat_peak\": \"1900\",\n    \"stat_peak_time\": \"260902225149\"\n  },\n  {\n    \"stat_name\": \"drive_r_io\",\n    \"stat_current\": \"11531\",\n    \"stat_peak\": \"25655\",\n    \"stat_peak_time\": \"260902224834\"\n  },\n  {\n    \"stat_name\": \"drive_r_ms\",\n    \"stat_current\": \"0.259\",\n    \"stat_peak\": \"0.292\",\n    \"stat_peak_time\": \"260902225149\"\n  },\n  {\n    \"stat_name\": \"drive_w_mb\",\n    \"stat_current\": \"255\",\n    \"stat_peak\": \"1370\",\n    \"stat_peak_time\": \"260902225039\"\n  },\n  {\n    \"stat_name\": \"drive_w_io\",\n    \"stat_current\": \"7995\",\n    \"stat_peak\": \"24191\",\n    \"stat_peak_time\": \"260902225254\"\n  },\n  {\n    \"stat_name\": \"drive_w_ms\",\n    \"stat_current\": \"0.101\",\n    \"stat_peak\": \"0.147\",\n    \"stat_peak_time\": \"260902225104\"\n  },\n  {\n    \"stat_name\": \"power_w\",\n    \"stat_current\": \"543\",\n    \"stat_peak\": \"543\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"temp_c\",\n    \"stat_current\": \"26\",\n    \"stat_peak\": \"26\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"temp_f\",\n    \"stat_current\": \"78\",\n    \"stat_peak\": \"78\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"iplink_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"iplink_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"iplink_comp_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"cloud_up_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"cloud_up_ms\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"cloud_down_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"cloud_down_ms\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"iser_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"iser_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"nvme_rdma_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"nvme_rdma_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"nvme_tcp_mb\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  },\n  {\n    \"stat_name\": \"nvme_tcp_io\",\n    \"stat_current\": \"0\",\n    \"stat_peak\": \"0\",\n    \"stat_peak_time\": \"260902225329\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "d9d5d8b5-19a8-54b5-ac6b-5d51ec47d12d",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lstargetportfc",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "32110905-9cf8-53f6-ad74-0d0e47e9f204",
+          "body": "[\n  {\n    \"id\": \"1\",\n    \"WWPN\": \"50050768108B45C0\",\n    \"WWNN\": \"5005076810F8CAD2\",\n    \"port_id\": \"1\",\n    \"owning_node_id\": \"1\",\n    \"current_node_id\": \"1\",\n    \"nportid\": \"140060\",\n    \"host_io_permitted\": \"no\",\n    \"virtualized\": \"no\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"1\",\n    \"portset_count\": \"0\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"3\"\n  },\n  {\n    \"id\": \"2\",\n    \"WWPN\": \"50050768102B49C0\",\n    \"WWNN\": \"5005076810F8CAD2\",\n    \"port_id\": \"1\",\n    \"owning_node_id\": \"1\",\n    \"current_node_id\": \"1\",\n    \"nportid\": \"140061\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"1\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"54\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"3\",\n    \"WWPN\": \"50050768102D8376\",\n    \"WWNN\": \"5005076810F8CAD2\",\n    \"port_id\": \"1\",\n    \"owning_node_id\": \"1\",\n    \"current_node_id\": \"1\",\n    \"nportid\": \"140062\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"nvme\",\n    \"fc_io_port_id\": \"1\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"4\",\n    \"WWPN\": \"5005076810079942\",\n    \"WWNN\": \"5005076810F8CAD2\",\n    \"port_id\": \"2\",\n    \"owning_node_id\": \"1\",\n    \"current_node_id\": \"1\",\n    \"nportid\": \"280020\",\n    \"host_io_permitted\": \"no\",\n    \"virtualized\": \"no\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"2\",\n    \"portset_count\": \"0\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"3\"\n  },\n  {\n    \"id\": \"5\",\n    \"WWPN\": \"5005076810514069\",\n    \"WWNN\": \"5005076810F8CAD2\",\n    \"port_id\": \"2\",\n    \"owning_node_id\": \"1\",\n    \"current_node_id\": \"1\",\n    \"nportid\": \"280021\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"2\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"54\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"6\",\n    \"WWPN\": \"50050768106B8623\",\n    \"WWNN\": \"5005076810F8CAD2\",\n    \"port_id\": \"2\",\n    \"owning_node_id\": \"1\",\n    \"current_node_id\": \"1\",\n    \"nportid\": \"280022\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"nvme\",\n    \"fc_io_port_id\": \"2\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"7\",\n    \"WWPN\": \"5005076810A01169\",\n    \"WWNN\": \"5005076810F8CAD2\",\n    \"port_id\": \"3\",\n    \"owning_node_id\": \"1\",\n    \"current_node_id\": \"1\",\n    \"nportid\": \"0A0040\",\n    \"host_io_permitted\": \"no\",\n    \"virtualized\": \"no\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"3\",\n    \"portset_count\": \"0\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"8\",\n    \"WWPN\": \"5005076810C2465C\",\n    \"WWNN\": \"5005076810F8CAD2\",\n    \"port_id\": \"3\",\n    \"owning_node_id\": \"1\",\n    \"current_node_id\": \"1\",\n    \"nportid\": \"0A0041\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"3\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"54\",\n    \"active_login_count\": \"78\"\n  },\n  {\n    \"id\": \"9\",\n    \"WWPN\": \"50050768101CD493\",\n    \"WWNN\": \"5005076810F8CAD2\",\n    \"port_id\": \"3\",\n    \"owning_node_id\": \"1\",\n    \"current_node_id\": \"1\",\n    \"nportid\": \"0A0042\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"nvme\",\n    \"fc_io_port_id\": \"3\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"10\",\n    \"WWPN\": \"5005076810E03A8A\",\n    \"WWNN\": \"5005076810F8CAD2\",\n    \"port_id\": \"4\",\n    \"owning_node_id\": \"1\",\n    \"current_node_id\": \"1\",\n    \"nportid\": \"1E0040\",\n    \"host_io_permitted\": \"no\",\n    \"virtualized\": \"no\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"4\",\n    \"portset_count\": \"0\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"11\",\n    \"WWPN\": \"500507681048C1E0\",\n    \"WWNN\": \"5005076810F8CAD2\",\n    \"port_id\": \"4\",\n    \"owning_node_id\": \"1\",\n    \"current_node_id\": \"1\",\n    \"nportid\": \"1E0041\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"4\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"54\",\n    \"active_login_count\": \"78\"\n  },\n  {\n    \"id\": \"12\",\n    \"WWPN\": \"50050768105E25D1\",\n    \"WWNN\": \"5005076810F8CAD2\",\n    \"port_id\": \"4\",\n    \"owning_node_id\": \"1\",\n    \"current_node_id\": \"1\",\n    \"nportid\": \"1E0042\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"nvme\",\n    \"fc_io_port_id\": \"4\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"73\",\n    \"WWPN\": \"5005076810079D5D\",\n    \"WWNN\": \"5005076810D81735\",\n    \"port_id\": \"1\",\n    \"owning_node_id\": \"2\",\n    \"current_node_id\": \"2\",\n    \"nportid\": \"140040\",\n    \"host_io_permitted\": \"no\",\n    \"virtualized\": \"no\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"1\",\n    \"portset_count\": \"0\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"3\"\n  },\n  {\n    \"id\": \"74\",\n    \"WWPN\": \"5005076810A28B59\",\n    \"WWNN\": \"5005076810D81735\",\n    \"port_id\": \"1\",\n    \"owning_node_id\": \"2\",\n    \"current_node_id\": \"2\",\n    \"nportid\": \"140041\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"1\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"54\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"75\",\n    \"WWPN\": \"5005076810F19A54\",\n    \"WWNN\": \"5005076810D81735\",\n    \"port_id\": \"1\",\n    \"owning_node_id\": \"2\",\n    \"current_node_id\": \"2\",\n    \"nportid\": \"140042\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"nvme\",\n    \"fc_io_port_id\": \"1\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"76\",\n    \"WWPN\": \"50050768103ECA97\",\n    \"WWNN\": \"5005076810D81735\",\n    \"port_id\": \"2\",\n    \"owning_node_id\": \"2\",\n    \"current_node_id\": \"2\",\n    \"nportid\": \"280000\",\n    \"host_io_permitted\": \"no\",\n    \"virtualized\": \"no\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"2\",\n    \"portset_count\": \"0\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"3\"\n  },\n  {\n    \"id\": \"77\",\n    \"WWPN\": \"50050768101D47EB\",\n    \"WWNN\": \"5005076810D81735\",\n    \"port_id\": \"2\",\n    \"owning_node_id\": \"2\",\n    \"current_node_id\": \"2\",\n    \"nportid\": \"280001\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"2\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"54\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"78\",\n    \"WWPN\": \"5005076810D2C660\",\n    \"WWNN\": \"5005076810D81735\",\n    \"port_id\": \"2\",\n    \"owning_node_id\": \"2\",\n    \"current_node_id\": \"2\",\n    \"nportid\": \"280002\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"nvme\",\n    \"fc_io_port_id\": \"2\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"79\",\n    \"WWPN\": \"5005076810A1D2AC\",\n    \"WWNN\": \"5005076810D81735\",\n    \"port_id\": \"3\",\n    \"owning_node_id\": \"2\",\n    \"current_node_id\": \"2\",\n    \"nportid\": \"0A0060\",\n    \"host_io_permitted\": \"no\",\n    \"virtualized\": \"no\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"3\",\n    \"portset_count\": \"0\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"80\",\n    \"WWPN\": \"500507681099DDDB\",\n    \"WWNN\": \"5005076810D81735\",\n    \"port_id\": \"3\",\n    \"owning_node_id\": \"2\",\n    \"current_node_id\": \"2\",\n    \"nportid\": \"0A0061\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"3\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"54\",\n    \"active_login_count\": \"78\"\n  },\n  {\n    \"id\": \"81\",\n    \"WWPN\": \"5005076810941DFD\",\n    \"WWNN\": \"5005076810D81735\",\n    \"port_id\": \"3\",\n    \"owning_node_id\": \"2\",\n    \"current_node_id\": \"2\",\n    \"nportid\": \"0A0062\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"nvme\",\n    \"fc_io_port_id\": \"3\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"82\",\n    \"WWPN\": \"50050768106DF95B\",\n    \"WWNN\": \"5005076810D81735\",\n    \"port_id\": \"4\",\n    \"owning_node_id\": \"2\",\n    \"current_node_id\": \"2\",\n    \"nportid\": \"1E0060\",\n    \"host_io_permitted\": \"no\",\n    \"virtualized\": \"no\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"4\",\n    \"portset_count\": \"0\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"0\"\n  },\n  {\n    \"id\": \"83\",\n    \"WWPN\": \"500507681012C763\",\n    \"WWNN\": \"5005076810D81735\",\n    \"port_id\": \"4\",\n    \"owning_node_id\": \"2\",\n    \"current_node_id\": \"2\",\n    \"nportid\": \"1E0061\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"scsi\",\n    \"fc_io_port_id\": \"4\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"54\",\n    \"active_login_count\": \"78\"\n  },\n  {\n    \"id\": \"84\",\n    \"WWPN\": \"50050768104FA030\",\n    \"WWNN\": \"5005076810D81735\",\n    \"port_id\": \"4\",\n    \"owning_node_id\": \"2\",\n    \"current_node_id\": \"2\",\n    \"nportid\": \"1E0062\",\n    \"host_io_permitted\": \"yes\",\n    \"virtualized\": \"yes\",\n    \"protocol\": \"nvme\",\n    \"fc_io_port_id\": \"4\",\n    \"portset_count\": \"1\",\n    \"host_count\": \"0\",\n    \"active_login_count\": \"0\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "5c0b1304-0720-54e0-aefe-c4e7ac18610d",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsvdisk",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "8a060dbb-f5be-576e-8fb0-eb51d87925af",
+          "body": "[\n  {\n    \"id\": \"0\",\n    \"name\": \"vol-001\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"19d7d74b76c03538ab9e61f0930e6c5e\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"0\",\n    \"volume_name\": \"vol-001\",\n    \"function\": \"\",\n    \"volume_group_id\": \"0\",\n    \"volume_group_name\": \"vg-01\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"1\",\n    \"name\": \"vol-002\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"5a564aedd2b440c838c3a84ce9c5f2b1\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"1\",\n    \"volume_name\": \"vol-002\",\n    \"function\": \"\",\n    \"volume_group_id\": \"0\",\n    \"volume_group_name\": \"vg-01\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"2\",\n    \"name\": \"vol-003\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"fcef6799a99724c113c9ba1bc6b55ed6\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"2\",\n    \"volume_name\": \"vol-003\",\n    \"function\": \"\",\n    \"volume_group_id\": \"0\",\n    \"volume_group_name\": \"vg-01\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"3\",\n    \"name\": \"vol-004\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"e95b2a7932d61ac43e553be21441e66d\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"3\",\n    \"volume_name\": \"vol-004\",\n    \"function\": \"\",\n    \"volume_group_id\": \"0\",\n    \"volume_group_name\": \"vg-01\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"4\",\n    \"name\": \"vol-005\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"d8fbb27e87ee0d8892c71abffc73125b\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"4\",\n    \"volume_name\": \"vol-005\",\n    \"function\": \"\",\n    \"volume_group_id\": \"0\",\n    \"volume_group_name\": \"vg-01\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"5\",\n    \"name\": \"vol-006\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"f5da46a4f51b8f9a770931398f7dd151\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"5\",\n    \"volume_name\": \"vol-006\",\n    \"function\": \"\",\n    \"volume_group_id\": \"0\",\n    \"volume_group_name\": \"vg-01\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"6\",\n    \"name\": \"vol-007\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"6822f502125642ea4f4c8c2d5ab903cd\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"6\",\n    \"volume_name\": \"vol-007\",\n    \"function\": \"\",\n    \"volume_group_id\": \"0\",\n    \"volume_group_name\": \"vg-01\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"7\",\n    \"name\": \"vol-008\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"f20fb281bfbd567c88841e1851af73e6\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"7\",\n    \"volume_name\": \"vol-008\",\n    \"function\": \"\",\n    \"volume_group_id\": \"0\",\n    \"volume_group_name\": \"vg-01\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"8\",\n    \"name\": \"vol-009\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"e28fa6aae8a75603d885a158c80cda39\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"8\",\n    \"volume_name\": \"vol-009\",\n    \"function\": \"\",\n    \"volume_group_id\": \"0\",\n    \"volume_group_name\": \"vg-01\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"9\",\n    \"name\": \"vol-010\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"2ea1557f59e0492c93c062928ff4ff7b\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"9\",\n    \"volume_name\": \"vol-010\",\n    \"function\": \"\",\n    \"volume_group_id\": \"0\",\n    \"volume_group_name\": \"vg-01\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"10\",\n    \"name\": \"vol-011\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"35.00GB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"e94f5a36e5c77b4a6d4b09f42caa2d54\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"10\",\n    \"volume_name\": \"vol-011\",\n    \"function\": \"\",\n    \"volume_group_id\": \"4\",\n    \"volume_group_name\": \"vg-05\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"11\",\n    \"name\": \"vol-012\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"3679dccf8af03629a9cc1b572e7a2b23\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"11\",\n    \"volume_name\": \"vol-012\",\n    \"function\": \"\",\n    \"volume_group_id\": \"0\",\n    \"volume_group_name\": \"vg-01\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"12\",\n    \"name\": \"vol-013\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"50.00GB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"39433ee86107b7dad653b8ffaec4a12c\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"12\",\n    \"volume_name\": \"vol-013\",\n    \"function\": \"\",\n    \"volume_group_id\": \"4\",\n    \"volume_group_name\": \"vg-05\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"13\",\n    \"name\": \"vol-014\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"150.00GB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"3144f2a9612fd19433c2b611c13df4d2\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"13\",\n    \"volume_name\": \"vol-014\",\n    \"function\": \"\",\n    \"volume_group_id\": \"4\",\n    \"volume_group_name\": \"vg-05\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"14\",\n    \"name\": \"vol-015\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"55.00GB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"f9169699912c997095d3d713572f46ed\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"14\",\n    \"volume_name\": \"vol-015\",\n    \"function\": \"\",\n    \"volume_group_id\": \"4\",\n    \"volume_group_name\": \"vg-05\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"15\",\n    \"name\": \"vol-016\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"256.00GB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"130a9f05914befdd181eda467dc295c1\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"15\",\n    \"volume_name\": \"vol-016\",\n    \"function\": \"\",\n    \"volume_group_id\": \"4\",\n    \"volume_group_name\": \"vg-05\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"16\",\n    \"name\": \"vol-017\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"256.00GB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"0423c5be9f8cce17f7364d3d7292c530\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"16\",\n    \"volume_name\": \"vol-017\",\n    \"function\": \"\",\n    \"volume_group_id\": \"4\",\n    \"volume_group_name\": \"vg-05\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"17\",\n    \"name\": \"vol-018\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"256.00GB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"cce0d89c94b47ae76770981b2c7598d4\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"17\",\n    \"volume_name\": \"vol-018\",\n    \"function\": \"\",\n    \"volume_group_id\": \"4\",\n    \"volume_group_name\": \"vg-05\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"18\",\n    \"name\": \"vol-019\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"256.00GB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"2c606602cbfdb609e70c03eb7ed92793\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"18\",\n    \"volume_name\": \"vol-019\",\n    \"function\": \"\",\n    \"volume_group_id\": \"4\",\n    \"volume_group_name\": \"vg-05\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  },\n  {\n    \"id\": \"19\",\n    \"name\": \"vol-020\",\n    \"IO_group_id\": \"0\",\n    \"IO_group_name\": \"io_grp0\",\n    \"status\": \"online\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"256.00GB\",\n    \"type\": \"striped\",\n    \"FC_id\": \"many\",\n    \"FC_name\": \"many\",\n    \"RC_id\": \"\",\n    \"RC_name\": \"\",\n    \"vdisk_UID\": \"e54acb58da9fe25112be81aa8de39a4a\",\n    \"fc_map_count\": \"2\",\n    \"copy_count\": \"1\",\n    \"fast_write_state\": \"not_empty\",\n    \"se_copy_count\": \"1\",\n    \"RC_change\": \"no\",\n    \"compressed_copy_count\": \"0\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"formatting\": \"no\",\n    \"encrypt\": \"no\",\n    \"volume_id\": \"19\",\n    \"volume_name\": \"vol-020\",\n    \"function\": \"\",\n    \"volume_group_id\": \"4\",\n    \"volume_group_name\": \"vg-05\",\n    \"protocol\": \"scsi\",\n    \"is_snapshot\": \"no\",\n    \"snapshot_count\": \"0\",\n    \"volume_type\": \"\",\n    \"replication_mode\": \"\",\n    \"is_safeguarded_snapshot\": \"no\",\n    \"safeguarded_snapshot_count\": \"0\",\n    \"restore_in_progress\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "30be061d-7704-5a83-87de-4f95e3fc8f74",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsvdiskcopy",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "31ea1cce-a0f5-5e51-8015-d542e699faf1",
+          "body": "[\n  {\n    \"vdisk_id\": \"0\",\n    \"vdisk_name\": \"vol-001\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"1\",\n    \"vdisk_name\": \"vol-002\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"2\",\n    \"vdisk_name\": \"vol-003\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"3\",\n    \"vdisk_name\": \"vol-004\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"4\",\n    \"vdisk_name\": \"vol-005\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"5\",\n    \"vdisk_name\": \"vol-006\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"6\",\n    \"vdisk_name\": \"vol-007\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"7\",\n    \"vdisk_name\": \"vol-008\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"8\",\n    \"vdisk_name\": \"vol-009\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"9\",\n    \"vdisk_name\": \"vol-010\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"10\",\n    \"vdisk_name\": \"vol-011\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"35.00GB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"11\",\n    \"vdisk_name\": \"vol-012\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"20.00TB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"12\",\n    \"vdisk_name\": \"vol-013\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"50.00GB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"13\",\n    \"vdisk_name\": \"vol-014\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"150.00GB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"14\",\n    \"vdisk_name\": \"vol-015\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"55.00GB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"15\",\n    \"vdisk_name\": \"vol-016\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"256.00GB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"16\",\n    \"vdisk_name\": \"vol-017\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"256.00GB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"17\",\n    \"vdisk_name\": \"vol-018\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"256.00GB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"18\",\n    \"vdisk_name\": \"vol-019\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"256.00GB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  },\n  {\n    \"vdisk_id\": \"19\",\n    \"vdisk_name\": \"vol-020\",\n    \"copy_id\": \"0\",\n    \"status\": \"online\",\n    \"sync\": \"yes\",\n    \"primary\": \"yes\",\n    \"mdisk_grp_id\": \"0\",\n    \"mdisk_grp_name\": \"pool-a\",\n    \"capacity\": \"256.00GB\",\n    \"type\": \"striped\",\n    \"se_copy\": \"yes\",\n    \"easy_tier\": \"on\",\n    \"easy_tier_status\": \"balanced\",\n    \"compressed_copy\": \"no\",\n    \"parent_mdisk_grp_id\": \"0\",\n    \"parent_mdisk_grp_name\": \"pool-a\",\n    \"encrypt\": \"no\",\n    \"deduplicated_copy\": \"no\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "e8e10c15-d711-5bc5-937d-c42f005df49b",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsvolumegroup",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "408014d3-dfb0-5b79-9e60-ae080a2815b2",
+          "body": "[\n  {\n    \"id\": \"0\",\n    \"name\": \"vg-01\",\n    \"volume_count\": \"28\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"5\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"1\",\n    \"name\": \"vg-02\",\n    \"volume_count\": \"0\",\n    \"backup_status\": \"empty\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"3\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"2\",\n    \"name\": \"vg-03\",\n    \"volume_count\": \"3\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"b\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"3\",\n    \"name\": \"vg-04\",\n    \"volume_count\": \"4\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"ff\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"4\",\n    \"name\": \"vg-05\",\n    \"volume_count\": \"30\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"1\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"5\",\n    \"name\": \"vg-06\",\n    \"volume_count\": \"6\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"6\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"6\",\n    \"name\": \"vg-07\",\n    \"volume_count\": \"7\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"74\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"7\",\n    \"name\": \"vg-08\",\n    \"volume_count\": \"10\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"e8\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"8\",\n    \"name\": \"vg-09\",\n    \"volume_count\": \"4\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"51\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"9\",\n    \"name\": \"vg-10\",\n    \"volume_count\": \"16\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"2a\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"10\",\n    \"name\": \"vg-11\",\n    \"volume_count\": \"6\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"2b\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"11\",\n    \"name\": \"vg-12\",\n    \"volume_count\": \"2\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"bb\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"12\",\n    \"name\": \"vg-13\",\n    \"volume_count\": \"37\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"1a\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"13\",\n    \"name\": \"vg-14\",\n    \"volume_count\": \"5\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"09\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"14\",\n    \"name\": \"vg-15\",\n    \"volume_count\": \"4\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"9c\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"15\",\n    \"name\": \"vg-16\",\n    \"volume_count\": \"16\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"f2\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"16\",\n    \"name\": \"vg-17\",\n    \"volume_count\": \"3\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"11\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"17\",\n    \"name\": \"vg-18\",\n    \"volume_count\": \"2\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"5c\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"18\",\n    \"name\": \"vg-19\",\n    \"volume_count\": \"20\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"04\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"19\",\n    \"name\": \"vg-20\",\n    \"volume_count\": \"5\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"b1\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"20\",\n    \"name\": \"vg-21\",\n    \"volume_count\": \"25\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"22\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"21\",\n    \"name\": \"vg-22\",\n    \"volume_count\": \"7\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"d6\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"22\",\n    \"name\": \"vg-23\",\n    \"volume_count\": \"42\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"a2\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"23\",\n    \"name\": \"vg-24\",\n    \"volume_count\": \"2\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"ce\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"24\",\n    \"name\": \"vg-25\",\n    \"volume_count\": \"4\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"ed\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"25\",\n    \"name\": \"vg-26\",\n    \"volume_count\": \"8\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"24\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"26\",\n    \"name\": \"vg-27\",\n    \"volume_count\": \"1\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"a7\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"27\",\n    \"name\": \"vg-28\",\n    \"volume_count\": \"1\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"8f\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"28\",\n    \"name\": \"vg-29\",\n    \"volume_count\": \"1\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"b3\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"29\",\n    \"name\": \"vg-30\",\n    \"volume_count\": \"13\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"a5\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"30\",\n    \"name\": \"vg-31\",\n    \"volume_count\": \"6\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"82\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"31\",\n    \"name\": \"vg-32\",\n    \"volume_count\": \"25\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"e4\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"32\",\n    \"name\": \"vg-33\",\n    \"volume_count\": \"2\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"29\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  },\n  {\n    \"id\": \"33\",\n    \"name\": \"vg-34\",\n    \"volume_count\": \"3\",\n    \"backup_status\": \"off\",\n    \"last_backup_time\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"safeguarded_policy_id\": \"\",\n    \"safeguarded_policy_name\": \"\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"\",\n    \"ha_replication_policy_name\": \"\",\n    \"volume_group_type\": \"\",\n    \"uid\": \"98\",\n    \"source_volume_group_id\": \"\",\n    \"source_volume_group_name\": \"\",\n    \"parent_uid\": \"\",\n    \"source_snapshot\": \"\",\n    \"snapshot_policy_id\": \"\",\n    \"snapshot_policy_name\": \"\",\n    \"partition_id\": \"\",\n    \"partition_name\": \"\",\n    \"restore_in_progress\": \"no\",\n    \"owner_type\": \"none\",\n    \"draft_partition_id\": \"\",\n    \"draft_partition_name\": \"\",\n    \"last_restore_time\": \"\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "f5608b6d-de8e-5935-9aaa-692ac679f0f1",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsvolumegroupreplication",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "be5ae927-f481-55c8-85bb-9b7a0e96bcc7",
+          "body": "[\n  {\n    \"id\": \"0\",\n    \"name\": \"vg-01\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"1\",\n    \"name\": \"vg-02\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"2\",\n    \"name\": \"vg-03\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"3\",\n    \"name\": \"vg-04\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"0\",\n    \"partition_name\": \"partition-a\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"4\",\n    \"name\": \"vg-05\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"5\",\n    \"name\": \"vg-06\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"6\",\n    \"name\": \"vg-07\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"7\",\n    \"name\": \"vg-08\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"8\",\n    \"name\": \"vg-09\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"9\",\n    \"name\": \"vg-10\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"10\",\n    \"name\": \"vg-11\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"11\",\n    \"name\": \"vg-12\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"12\",\n    \"name\": \"vg-13\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"13\",\n    \"name\": \"vg-14\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"14\",\n    \"name\": \"vg-15\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"15\",\n    \"name\": \"vg-16\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"16\",\n    \"name\": \"vg-17\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"17\",\n    \"name\": \"vg-18\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"18\",\n    \"name\": \"vg-19\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"19\",\n    \"name\": \"vg-20\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"20\",\n    \"name\": \"vg-21\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"21\",\n    \"name\": \"vg-22\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"22\",\n    \"name\": \"vg-23\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"23\",\n    \"name\": \"vg-24\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"24\",\n    \"name\": \"vg-25\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"25\",\n    \"name\": \"vg-26\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"26\",\n    \"name\": \"vg-27\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"27\",\n    \"name\": \"vg-28\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"28\",\n    \"name\": \"vg-29\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"29\",\n    \"name\": \"vg-30\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"30\",\n    \"name\": \"vg-31\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"31\",\n    \"name\": \"vg-32\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  },\n  {\n    \"id\": \"32\",\n    \"name\": \"vg-33\",\n    \"replication_policy_id\": \"\",\n    \"replication_policy_name\": \"\",\n    \"ha_replication_policy_id\": \"0\",\n    \"ha_replication_policy_name\": \"policy-a\",\n    \"location1_system_name\": \"\",\n    \"location1_replication_mode\": \"production\",\n    \"location1_within_rpo\": \"\",\n    \"location2_system_name\": \"\",\n    \"location2_replication_mode\": \"production\",\n    \"location2_within_rpo\": \"\",\n    \"link1_status\": \"synchronized\",\n    \"partition_id\": \"1\",\n    \"partition_name\": \"partition-b\",\n    \"recovery_test_active\": \"\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    },
+    {
+      "uuid": "bc8f13a9-643a-5db1-8e2f-978d0352ee33",
+      "type": "http",
+      "documentation": "",
+      "method": "post",
+      "endpoint": "rest/v1/lsvolumegroupsnapshot",
+      "responseMode": null,
+      "responses": [
+        {
+          "uuid": "bbc401ef-649d-5098-a4f6-86adf45b0957",
+          "body": "[\n  {\n    \"id\": \"0\",\n    \"name\": \"snapshot-a\",\n    \"volume_group_id\": \"29\",\n    \"volume_group_name\": \"vg-30\",\n    \"time\": \"260130184119\",\n    \"state\": \"active\",\n    \"matches_group\": \"no\",\n    \"parent_uid\": \"52\",\n    \"expiration_time\": \"\",\n    \"protection_provisioned_capacity\": \"103.00GB\",\n    \"protection_written_capacity\": \"332.00MB\",\n    \"operation_start_time\": \"\",\n    \"operation_completion_estimate\": \"\",\n    \"owner_id\": \"\",\n    \"owner_name\": \"\",\n    \"auto_snapshot\": \"no\",\n    \"safeguarded\": \"no\",\n    \"last_restored_from\": \"\"\n  }\n]",
+          "latency": 0,
+          "statusCode": 200,
+          "label": "",
+          "headers": [
+            {
+              "key": "Content-Type",
+              "value": "application/json"
+            }
+          ],
+          "bodyType": "INLINE",
+          "filePath": "",
+          "databucketID": "",
+          "sendFileAsBody": false,
+          "rules": [],
+          "rulesOperator": "OR",
+          "disableTemplating": false,
+          "fallbackTo404": false,
+          "default": true,
+          "crudKey": "id",
+          "callbacks": []
+        }
+      ]
+    }
+  ],
+  "rootChildren": [
+    {
+      "type": "route",
+      "uuid": "b4f61efd-1ba0-5771-97f0-059191ecdce1"
+    },
+    {
+      "type": "route",
+      "uuid": "cea66f97-6715-5ae2-b1f7-f22d75abdef4"
+    },
+    {
+      "type": "route",
+      "uuid": "aa50e61c-2aa8-53ec-9997-8ec9ad242c58"
+    },
+    {
+      "type": "route",
+      "uuid": "b503e9e3-021c-516f-90a7-5d61b257e761"
+    },
+    {
+      "type": "route",
+      "uuid": "7613504c-de71-5d6e-ae90-8aa37337aee9"
+    },
+    {
+      "type": "route",
+      "uuid": "e1896e37-70a6-5899-aefd-98001788d585"
+    },
+    {
+      "type": "route",
+      "uuid": "f8a3cbd5-f84b-521d-adab-266b5fb968c2"
+    },
+    {
+      "type": "route",
+      "uuid": "a2c2c4cc-8228-52a7-973a-148e08a62fcb"
+    },
+    {
+      "type": "route",
+      "uuid": "5cb7f41a-75fa-5ee9-9b43-6917b57811e3"
+    },
+    {
+      "type": "route",
+      "uuid": "91eca571-df43-5432-bd5c-e4d73f5b1ba2"
+    },
+    {
+      "type": "route",
+      "uuid": "85e96d1a-65ab-5647-ae3c-31d209bfae00"
+    },
+    {
+      "type": "route",
+      "uuid": "c859791f-2238-56ed-b944-72000a3c0229"
+    },
+    {
+      "type": "route",
+      "uuid": "908433d6-5090-52f3-aaf3-e629c127c259"
+    },
+    {
+      "type": "route",
+      "uuid": "cf562a14-70b1-5c78-9c8e-20a16f8ddaab"
+    },
+    {
+      "type": "route",
+      "uuid": "69b0e2e5-9edd-5d0b-a6ce-8841b579d136"
+    },
+    {
+      "type": "route",
+      "uuid": "1e1f8175-5402-52d1-a628-f1c5b3005066"
+    },
+    {
+      "type": "route",
+      "uuid": "4e7f6364-b9f5-5e91-b2c1-7c5d4d3b89f1"
+    },
+    {
+      "type": "route",
+      "uuid": "aceda8b8-e54f-5018-a2f8-6252d07050f1"
+    },
+    {
+      "type": "route",
+      "uuid": "7e85b908-06ca-5596-8d8b-5601d60f4431"
+    },
+    {
+      "type": "route",
+      "uuid": "28ec9134-23ed-506b-ad92-7c431b09d243"
+    },
+    {
+      "type": "route",
+      "uuid": "3cc1762c-56cc-5e01-962c-cb2843fe0712"
+    },
+    {
+      "type": "route",
+      "uuid": "2fbcb166-2abc-572d-896a-10bcbbf6baa0"
+    },
+    {
+      "type": "route",
+      "uuid": "9b9be1af-6642-5f71-9c84-db0632e8f5b7"
+    },
+    {
+      "type": "route",
+      "uuid": "fe6f586c-73a0-5233-b603-0649aaa13309"
+    },
+    {
+      "type": "route",
+      "uuid": "09df032d-3dc4-57e1-8e65-a8187d61fa28"
+    },
+    {
+      "type": "route",
+      "uuid": "721cf1e2-cdf7-5994-9be4-d2d41fa5a4c6"
+    },
+    {
+      "type": "route",
+      "uuid": "5aa8cfac-9df6-522c-b6b2-8861f6f02a8d"
+    },
+    {
+      "type": "route",
+      "uuid": "37fe1820-d09f-5593-b8a1-62963da81edd"
+    },
+    {
+      "type": "route",
+      "uuid": "1c0dc23b-65ea-5e69-b9fd-bbaaa6bee6ed"
+    },
+    {
+      "type": "route",
+      "uuid": "c5b3890b-a857-5902-901c-075565d35b8b"
+    },
+    {
+      "type": "route",
+      "uuid": "f58f9340-9852-58fb-9141-30f0f0c49f46"
+    },
+    {
+      "type": "route",
+      "uuid": "418259f9-c8d5-516f-b153-6bd4db667f05"
+    },
+    {
+      "type": "route",
+      "uuid": "df42e467-14eb-571f-bf0f-e580c1b9bff2"
+    },
+    {
+      "type": "route",
+      "uuid": "f63ae8a0-70de-59ee-96a9-67cfea6b7c87"
+    },
+    {
+      "type": "route",
+      "uuid": "8c2d1088-254c-5104-bcbc-230b342b82fb"
+    },
+    {
+      "type": "route",
+      "uuid": "23e70d54-df07-5b5b-a2da-5bdb93499f59"
+    },
+    {
+      "type": "route",
+      "uuid": "d7a91b9c-7770-532e-80ac-2753425d3a7f"
+    },
+    {
+      "type": "route",
+      "uuid": "3c68601a-dcac-5dfa-a5ca-db00b5ed6be2"
+    },
+    {
+      "type": "route",
+      "uuid": "834d7d81-6440-54a4-8422-ba9db86b37d0"
+    },
+    {
+      "type": "route",
+      "uuid": "1740866b-e275-57d4-980a-db07701c53af"
+    },
+    {
+      "type": "route",
+      "uuid": "749f43e5-4969-563a-97ae-11f926028b67"
+    },
+    {
+      "type": "route",
+      "uuid": "b6d1c3de-a71c-56f7-abc3-db29af52f214"
+    },
+    {
+      "type": "route",
+      "uuid": "d9d5d8b5-19a8-54b5-ac6b-5d51ec47d12d"
+    },
+    {
+      "type": "route",
+      "uuid": "5c0b1304-0720-54e0-aefe-c4e7ac18610d"
+    },
+    {
+      "type": "route",
+      "uuid": "30be061d-7704-5a83-87de-4f95e3fc8f74"
+    },
+    {
+      "type": "route",
+      "uuid": "e8e10c15-d711-5bc5-937d-c42f005df49b"
+    },
+    {
+      "type": "route",
+      "uuid": "f5608b6d-de8e-5935-9aaa-692ac679f0f1"
+    },
+    {
+      "type": "route",
+      "uuid": "bc8f13a9-643a-5db1-8e2f-978d0352ee33"
+    }
+  ],
+  "proxyMode": false,
+  "proxyHost": "",
+  "proxyRemovePrefix": false,
+  "tlsOptions": {
+    "enabled": false,
+    "type": "CERT",
+    "pfxPath": "",
+    "certPath": "",
+    "keyPath": "",
+    "caPath": "",
+    "passphrase": ""
+  },
+  "cors": true,
+  "headers": [
+    {
+      "key": "Content-Type",
+      "value": "application/json"
+    },
+    {
+      "key": "Access-Control-Allow-Origin",
+      "value": "*"
+    },
+    {
+      "key": "Access-Control-Allow-Methods",
+      "value": "GET,POST,PUT,PATCH,DELETE,HEAD,OPTIONS"
+    },
+    {
+      "key": "Access-Control-Allow-Headers",
+      "value": "Content-Type, Origin, Accept, Authorization, Content-Length, X-Requested-With"
+    }
+  ],
+  "proxyReqHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "proxyResHeaders": [
+    {
+      "key": "",
+      "value": ""
+    }
+  ],
+  "data": [],
+  "callbacks": []
+}

--- a/tests/storage/ibm/flashsystem/restapi/performance.robot
+++ b/tests/storage/ibm/flashsystem/restapi/performance.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}mockoon.json
+
+${CMD}              ${CENTREON_PLUGINS}
+...                 --plugin=storage::ibm::flashsystem::restapi::plugin
+...                 --mode=performance
+...                 --hostname=${HOSTNAME}
+...                 --proto='http'
+...                 --port=${APIPORT}
+...                 --api-path='/rest/v1'
+...                 --api-username='user'
+...                 --api-password='pass'
+...                 --statefile-dir=/tmp
+
+
+*** Test Cases ***
+performance ${tc}
+    [Tags]    storage    ibm    flashsystem    restapi
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:         tc      extra_options                                                 expected_result    --
+            ...       1       ${EMPTY}                                                      OK: Performance: latency 0.398 ms, read 0.341 ms, write 0.472 ms, 7923 IOPS, bandwidth 408.00 MB/s, cpu 15 %, compression cpu 0 %, write cache 34 %, total cache 80 %, backend 0.314 ms, drives 0.194 ms, fc 29503 IOPS, fc 546.00 MB/s - All node CPUs are ok | 'system.io.latency.milliseconds'=0.398ms;;;0; 'system.io.read.latency.milliseconds'=0.341ms;;;0; 'system.io.write.latency.milliseconds'=0.472ms;;;0; 'system.io.usage.iops'=7923iops;;;0; 'system.io.usage.bytespersecond'=427819008B/s;;;0; 'system.cpu.utilization.percentage'=15%;;;0;100 'system.cpu.compression.utilization.percentage'=0%;;;0;100 'system.cache.write.usage.percentage'=34%;;;0;100 'system.cache.total.usage.percentage'=80%;;;0;100 'system.backend.latency.milliseconds'=0.314ms;;;0; 'system.drive.latency.milliseconds'=0.194ms;;;0; 'system.fc.usage.iops'=29503iops;;;0; 'system.fc.usage.bytespersecond'=572522496B/s;;;0; 'node1#node.cpu.utilization.percentage'=15%;;;0;100 'node2#node.cpu.utilization.percentage'=15%;;;0;100
+            ...       2       --filter-counters='latency'                                   OK: Performance: latency 0.398 ms, read 0.341 ms, write 0.472 ms, backend 0.314 ms, drives 0.194 ms | 'system.io.latency.milliseconds'=0.398ms;;;0; 'system.io.read.latency.milliseconds'=0.341ms;;;0; 'system.io.write.latency.milliseconds'=0.472ms;;;0; 'system.backend.latency.milliseconds'=0.314ms;;;0; 'system.drive.latency.milliseconds'=0.194ms;;;0;
+            ...       3       --filter-counters='cpu' --warning-cpu=10 --critical-cpu=90    WARNING: Performance: cpu 15 % | 'system.cpu.utilization.percentage'=15%;0:10;0:90;0;100 'system.cpu.compression.utilization.percentage'=0%;;;0;100 'node1#node.cpu.utilization.percentage'=15%;;;0;100 'node2#node.cpu.utilization.percentage'=15%;;;0;100
+            ...       4       --filter-counters='iops|bandwidth|cache'                      OK: Performance: 7923 IOPS, bandwidth 408.00 MB/s, write cache 34 %, total cache 80 %, fc 29503 IOPS, fc 546.00 MB/s | 'system.io.usage.iops'=7923iops;;;0; 'system.io.usage.bytespersecond'=427819008B/s;;;0; 'system.cache.write.usage.percentage'=34%;;;0;100 'system.cache.total.usage.percentage'=80%;;;0;100 'system.fc.usage.iops'=29503iops;;;0; 'system.fc.usage.bytespersecond'=572522496B/s;;;0;
+            ...       5       --add-peaks                                                   OK: Performance: latency 0.398 ms, read 0.341 ms, write 0.472 ms, 7923 IOPS, bandwidth 408.00 MB/s, cpu 15 %, compression cpu 0 %, write cache 34 %, total cache 80 %, backend 0.314 ms, drives 0.194 ms, fc 29503 IOPS, fc 546.00 MB/s - All node CPUs are ok | 'system.io.latency.milliseconds'=0.398ms;;;0; 'system.io.read.latency.milliseconds'=0.341ms;;;0; 'system.io.write.latency.milliseconds'=0.472ms;;;0; 'system.io.usage.iops'=7923iops;;;0; 'system.io.usage.bytespersecond'=427819008B/s;;;0; 'system.cpu.utilization.percentage'=15%;;;0;100 'system.cpu.compression.utilization.percentage'=0%;;;0;100 'system.cache.write.usage.percentage'=34%;;;0;100 'system.cache.total.usage.percentage'=80%;;;0;100 'system.backend.latency.milliseconds'=0.314ms;;;0; 'system.drive.latency.milliseconds'=0.194ms;;;0; 'system.fc.usage.iops'=29503iops;;;0; 'system.fc.usage.bytespersecond'=572522496B/s;;;0; 'node1#node.cpu.utilization.percentage'=15%;;;0;100 'node2#node.cpu.utilization.percentage'=15%;;;0;100

--- a/tests/storage/ibm/flashsystem/restapi/replication.robot
+++ b/tests/storage/ibm/flashsystem/restapi/replication.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}mockoon.json
+
+${CMD}              ${CENTREON_PLUGINS}
+...                 --plugin=storage::ibm::flashsystem::restapi::plugin
+...                 --mode=replication
+...                 --hostname=${HOSTNAME}
+...                 --proto='http'
+...                 --port=${APIPORT}
+...                 --api-path='/rest/v1'
+...                 --api-username='user'
+...                 --api-password='pass'
+...                 --statefile-dir=/tmp
+
+
+*** Test Cases ***
+replication ${tc}
+    [Tags]    storage    ibm    flashsystem    restapi
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:         tc      extra_options                                            expected_result    --
+            ...       1       ${EMPTY}                                                 CRITICAL: Storage partition 'partition-b' high availability status: problem, link: synchronized, system-a: healthy, system-b: healthy | 'replication.partitions.detected.count'=2;;;0; 'replication.volumegroups.detected.count'=33;;;0; 'replication.relationships.detected.count'=0;;;0;
+            ...       2       --filter-partition='partition-a'                         OK: Replication: 1 partition(s), 4 replicated volume group(s), 0 remote copy relationship(s) - Storage partition 'partition-a' high availability status: established, link: synchronized, system-a: healthy, system-b: healthy - All replicated volume groups are healthy - Partnership 'system-b' partnership: fully_configured, type: fc | 'replication.partitions.detected.count'=1;;;0; 'replication.volumegroups.detected.count'=4;;;0; 'replication.relationships.detected.count'=0;;;0;
+            ...       3       --critical-partition-status='\\\%{ha_status} =~ /never/'    OK: Replication: 2 partition(s), 33 replicated volume group(s), 0 remote copy relationship(s) - All storage partitions are healthy - All replicated volume groups are healthy - Partnership 'system-b' partnership: fully_configured, type: fc | 'replication.partitions.detected.count'=2;;;0; 'replication.volumegroups.detected.count'=33;;;0; 'replication.relationships.detected.count'=0;;;0;
+            ...       4       --filter-partnership='nomatch'                           CRITICAL: Storage partition 'partition-b' high availability status: problem, link: synchronized, system-a: healthy, system-b: healthy | 'replication.partitions.detected.count'=2;;;0; 'replication.volumegroups.detected.count'=33;;;0; 'replication.relationships.detected.count'=0;;;0;

--- a/tests/storage/ibm/flashsystem/restapi/system-status.robot
+++ b/tests/storage/ibm/flashsystem/restapi/system-status.robot
@@ -1,0 +1,35 @@
+*** Settings ***
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}mockoon.json
+
+${CMD}              ${CENTREON_PLUGINS}
+...                 --plugin=storage::ibm::flashsystem::restapi::plugin
+...                 --mode=system-status
+...                 --hostname=${HOSTNAME}
+...                 --proto='http'
+...                 --port=${APIPORT}
+...                 --api-path='/rest/v1'
+...                 --api-username='user'
+...                 --api-password='pass'
+...                 --statefile-dir=/tmp
+
+
+*** Test Cases ***
+system-status ${tc}
+    [Tags]    storage    ibm    flashsystem    restapi
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:         tc      extra_options       expected_result    --
+            ...       1       ${EMPTY}            OK: Array is serving: canisters 2/2 online, pools 1/1 online 
+            ...       2       --skip-canisters    OK: Array is serving: pools 1/1 online 
+            ...       3       --skip-pools        OK: Array is serving: canisters 2/2 online 

--- a/tests/storage/ibm/flashsystem/restapi/volume-groups.robot
+++ b/tests/storage/ibm/flashsystem/restapi/volume-groups.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}mockoon.json
+
+${CMD}              ${CENTREON_PLUGINS}
+...                 --plugin=storage::ibm::flashsystem::restapi::plugin
+...                 --mode=volume-groups
+...                 --hostname=${HOSTNAME}
+...                 --proto='http'
+...                 --port=${APIPORT}
+...                 --api-path='/rest/v1'
+...                 --api-username='user'
+...                 --api-password='pass'
+...                 --statefile-dir=/tmp
+
+
+*** Test Cases ***
+volume-groups ${tc}
+    [Tags]    storage    ibm    flashsystem    restapi
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:         tc      extra_options                                                                expected_result    --
+            ...       1       ${EMPTY}                                                                     OK: Volume groups: 34 detected, 33 replicated, 34 without a snapshot policy, 0 restoring - All volume groups are healthy | 'volumegroups.detected.count'=34;;;0; 'volumegroups.replicated.count'=33;;;0; 'volumegroups.without.snapshot.policy.count'=34;;;0; 'volumegroups.restoring.count'=0;;;0;
+            ...       2       --filter-partition='partition-a'                                             OK: Volume groups: 4 detected, 4 replicated, 4 without a snapshot policy, 0 restoring - All volume groups are healthy | 'volumegroups.detected.count'=4;;;0; 'volumegroups.replicated.count'=4;;;0; 'volumegroups.without.snapshot.policy.count'=4;;;0; 'volumegroups.restoring.count'=0;;;0;
+            ...       3       --warning-without-snapshot-policy=0                                          WARNING: Volume groups: 34 without a snapshot policy | 'volumegroups.detected.count'=34;;;0; 'volumegroups.replicated.count'=33;;;0; 'volumegroups.without.snapshot.policy.count'=34;0:0;;0; 'volumegroups.restoring.count'=0;;;0;
+            ...       4       --critical-status='\\\%{backup_status} =~ /off/' --filter-name='^vg-0[1-2]$'    CRITICAL: Volume group 'vg-01' 28 volume(s), backup: off, partition: partition-a, replication: policy-a | 'volumegroups.detected.count'=2;;;0; 'volumegroups.replicated.count'=2;;;0; 'volumegroups.without.snapshot.policy.count'=2;;;0; 'volumegroups.restoring.count'=0;;;0;

--- a/tests/storage/ibm/flashsystem/restapi/volumes.robot
+++ b/tests/storage/ibm/flashsystem/restapi/volumes.robot
@@ -1,0 +1,36 @@
+*** Settings ***
+Resource            ${CURDIR}${/}..${/}..${/}..${/}..${/}resources/import.resource
+
+Suite Setup         Start Mockoon    ${MOCKOON_JSON}
+Suite Teardown      Stop Mockoon
+Test Timeout        120s
+
+
+*** Variables ***
+${MOCKOON_JSON}     ${CURDIR}${/}mockoon.json
+
+${CMD}              ${CENTREON_PLUGINS}
+...                 --plugin=storage::ibm::flashsystem::restapi::plugin
+...                 --mode=volumes
+...                 --hostname=${HOSTNAME}
+...                 --proto='http'
+...                 --port=${APIPORT}
+...                 --api-path='/rest/v1'
+...                 --api-username='user'
+...                 --api-password='pass'
+...                 --statefile-dir=/tmp
+
+
+*** Test Cases ***
+volumes ${tc}
+    [Tags]    storage    ibm    flashsystem    restapi
+    ${command}    Catenate
+    ...    ${CMD}
+    ...    ${extra_options}
+    Ctn Run Command And Check Result As Strings    ${command}    ${expected_result}
+
+    Examples:         tc      extra_options                                                             expected_result    --
+            ...       1       ${EMPTY}                                                                  OK: Volumes: 20 detected, 20 online, 0 degraded, 0 offline, 0 with copies out of sync | 'volumes.detected.count'=20;;;0; 'volumes.online.count'=20;;;0; 'volumes.degraded.count'=0;;;0; 'volumes.offline.count'=0;;;0; 'volumes.unsynchronised.count'=0;;;0;
+            ...       2       --filter-name='^vol-00[1-3]$'                                             OK: Volumes: 3 detected, 3 online, 0 degraded, 0 offline, 0 with copies out of sync | 'volumes.detected.count'=3;;;0; 'volumes.online.count'=3;;;0; 'volumes.degraded.count'=0;;;0; 'volumes.offline.count'=0;;;0; 'volumes.unsynchronised.count'=0;;;0;
+            ...       3       --add-all-volumes                                                         OK: Volumes: 20 detected, 20 online, 0 degraded, 0 offline, 0 with copies out of sync - All volumes are online and synchronised | 'volumes.detected.count'=20;;;0; 'volumes.online.count'=20;;;0; 'volumes.degraded.count'=0;;;0; 'volumes.offline.count'=0;;;0; 'volumes.unsynchronised.count'=0;;;0;
+            ...       4       --warning-status='\\\%{status} =~ /online/' --filter-name='^vol-00[1-2]$'    OK: Volumes: 2 detected, 2 online, 0 degraded, 0 offline, 0 with copies out of sync | 'volumes.detected.count'=2;;;0; 'volumes.online.count'=2;;;0; 'volumes.degraded.count'=0;;;0; 'volumes.offline.count'=0;;;0; 'volumes.unsynchronised.count'=0;;;0;


### PR DESCRIPTION
# Community contributors

## Description

New plugin `storage::ibm::flashsystem::restapi` for IBM Storage Virtualize systems — FlashSystem, Storwize and SAN Volume Controller — through the REST API served on port 7443 (Storage Virtualize 8.1.3 and later).

The repository currently covers this product line through `storage::ibm::storwize::ssh` (four modes over SSH). The REST API exposes much more, and this plugin runs in production on two FlashSystem 5300 (Storage Virtualize 8.7.0.8) with twelve modes:

| Mode | What it checks |
|---|---|
| `system-status` | meant as the **host check**: DOWN only when the array stopped serving (no answer, no canister online, no pool online) — a dead power supply or a degraded partition never take the host down, because that would make every service UNREACHABLE |
| `hardware` | enclosures, node and expansion canisters, power supplies, batteries, fan modules, drives, arrays, mdisks, quorum devices, plus the enclosure `online_*/total_*` counters and the temperature / power draw metrics |
| `drives` | per-drive FlashCore Module wear, NVMe path redundancy and physical fill (detailed `lsdrive/<id>` views) |
| `capacity` | physical usage (the figure that matters on over-allocated FlashCore Module pools), logical usage, pool status, data reduction ratio read from the layer that actually reduces (data reduction pools, or the FCM hardware compression from the detailed mdisk view) |
| `volumes` | aggregated volume states, abnormal volumes named in the output, `--add-all-volumes` for the full list |
| `volume-groups` | backup state, restore in progress, attached policies |
| `hosts` | declared hosts, offline / degraded |
| `eventlog` | unfixed `alert` entries — the GUI "Recommended Actions" — with `message` entries counted but not alerting |
| `fc-ports` | Fibre Channel ports, negotiated speed, host logins aggregated from the NPIV target ports |
| `eth-ports` | Ethernet ports and their IP configuration |
| `performance` | latency (volume, read, write, backend, drive), IOPS, bandwidth, cache occupancy, CPU overall and per canister |
| `replication` | storage partitions (8.7 high availability), policy-based volume group replication (8.5.2+), partnerships, and legacy Metro/Global Mirror relationships |

Design points worth knowing for the review:

- Nothing array-specific is hard-coded: everything is discovered from the API, and every `--filter-*` is empty by default. Default severities follow one rule — CRITICAL means service lost, WARNING means redundancy lost — since every part of this hardware is redundant.
- The array rate-limits authentications (HTTP 429) and a session lasts two hours: the token is cached in a statefile and re-obtained on 401/403. An optional response cache (`--command-cache-ttl`, **0 by default**) lets a site that splits the monitoring into many services share the `ls*` answers between checks.
- Every API command is a POST, including the `ls*` reads; the prefix (`/rest/v1` since 8.1.3, `/rest` before) is auto-detected or pinned with `--api-path`.
- `hosts` inverts the usual order on purpose: `offline` is WARNING (the array cannot tell a deliberately powered-off server from a failed one), `degraded` is CRITICAL (a running host on eaten-into redundancy). The reasoning is in the help; I am happy to align on whatever default you prefer.

**Two naming questions** — this is why the pull request is opened as a draft:

1. **Path.** The code sits under `src/storage/ibm/flashsystem/restapi/`. The product line is "Storage Virtualize" and covers Storwize and SVC as well, and the existing SSH plugin lives under `storwize/`. Would you rather have `storage/ibm/storwize/restapi` for symmetry, or a new `storage/ibm/storagevirtualize/restapi`? I will move it wherever you say.
2. **Hardware mode name.** The SSH plugin calls it `components`; this one calls it `hardware`. Same answer: I will align.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested ?

**Automated tests** — twelve Robot suites, fifty cases, against a Mockoon environment built from a real FlashSystem 5300 collection and anonymised (WWPNs, serials, ids, host / volume / partition / system names, addresses):

```
robot tests/storage/ibm/flashsystem/restapi/
```

Each mode is exercised through its plain run, filters, a forced status expression and numeric thresholds, so OK, WARNING and CRITICAL paths are all covered. Result on RHEL 9 with the framework dependencies: `50 tests, 50 passed, 0 failed`.

**Against a real system** — an account with the *Monitor* role is enough:

```
perl centreon_plugins.pl --plugin=storage::ibm::flashsystem::restapi::plugin --mode=hardware \
    --hostname=<array> --api-username=<user> --api-password=<password> --insecure
```

**API facts, for the reviewers** (the arrays present a self-signed certificate, hence `-k`):

```
# authentication: credentials in headers, a token in the answer
curl -k -X POST https://<array>:7443/rest/v1/auth \
     -H 'X-Auth-Username: <user>' -H 'X-Auth-Password: <password>'
# {"token": "..."}

# every command is a POST, parameters in a JSON body
curl -k -X POST https://<array>:7443/rest/v1/lssystem \
     -H 'X-Auth-Token: <token>' -H 'Content-Type: application/json' -d '{}'
curl -k -X POST https://<array>:7443/rest/v1/lseventlog \
     -H 'X-Auth-Token: <token>' -H 'Content-Type: application/json' -d '{"filtervalue":"fixed=no"}'
# detailed view of one object: the id goes in the path
curl -k -X POST https://<array>:7443/rest/v1/lsdrive/0 \
     -H 'X-Auth-Token: <token>' -H 'Content-Type: application/json' -d '{}'
```

**Sample outputs** — the plugin's real output against the anonymised environment (these are the expectations of the Robot suites):

```
OK: Array is serving: canisters 2/2 online, pools 1/1 online
OK: Hardware: 35 component(s), 0 not online - All hardware components are online - Enclosure: temperature 26 C, power draw 540 W - All enclosure subsystems are fully populated | 'hardware.components.detected.count'=35;;;0; ...
OK: Drives: 12 detected - All drives have both paths online | 'drives.detected.count'=12;;;0; '0#drive.endurance.used.percentage'=0%;;;0;100 ...
OK: Physical capacity: used 47.10 %, 146.48 TB, free 164.51 TB, overallocation 137 % - Logical: used 292.98 TB, free 629.24 TB - Data reduction: 1.81:1, saved 118.97 TB - Pool 'pool-a' status: online, overallocation: 137%, data reduction: no, used 32.74 %, free 629.06 TB | ...
WARNING: Host 'host-29' status: offline, ports: 4, partition: partition-b - Host 'host-43' status: offline, ports: 4, partition: partition-b ...
CRITICAL: Storage partition 'partition-b' high availability status: problem, link: synchronized, system-a: healthy, system-b: healthy | 'replication.partitions.detected.count'=2;;;0; ...
OK: Performance: latency 0.398 ms, read 0.341 ms, write 0.472 ms, 7923 IOPS, bandwidth 408.00 MB/s, cpu 15 %, compression cpu 0 %, write cache 34 %, total cache 80 %, backend 0.314 ms, drives 0.194 ms, fc 29503 IOPS, fc 546.00 MB/s - All node CPUs are ok | ...
```

Also included: the packaging directory (`centreon-plugin-Hardware-Storage-Ibm-Flashsystem-Restapi`), one help entry per option with the default expression under the matching severity, and the Storage Virtualize vocabulary the help uses added to the spell checker dictionary.

## Checklist

- [x] I have followed the **[coding style guidelines](https://github.com/centreon/centreon-plugins/blob/develop/doc/en/developer/plugins_global.md#5-code-style-guidelines)** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (develop).
- [x] I have provide data or shown output displaying the result of this code in the plugin area concerned.
