### PR TITLE
fix(rust-plugins): remove reachable panics from expression evaluation and metric assembly

### DIFF
--- a/rust-plugins/src/compute/ast.rs
+++ b/rust-plugins/src/compute/ast.rs
@@ -50,11 +50,11 @@ pub enum ExprResult {
 }
 
 impl std::ops::Add for ExprResult {
-    type Output = ExprResult;
+    type Output = Result<ExprResult, String>;
 
     fn add(self, other: Self) -> Self::Output {
         match (self, other) {
-            (ExprResult::Number(a), ExprResult::Number(b)) => ExprResult::Number(a + b),
+            (ExprResult::Number(a), ExprResult::Number(b)) => Ok(ExprResult::Number(a + b)),
             (ExprResult::Vector(a), ExprResult::Vector(b)) => {
                 let len_a = a.len();
                 let len_b = b.len();
@@ -63,7 +63,7 @@ impl std::ops::Add for ExprResult {
                     for i in 0..len_a {
                         result.push(a[i] + b[i]);
                     }
-                    ExprResult::Vector(result)
+                    Ok(ExprResult::Vector(result))
                 } else {
                     warn!(
                         "Trying to add to arrays of different lengths: {} and {}",
@@ -74,13 +74,13 @@ impl std::ops::Add for ExprResult {
                         for (idx, value) in b.iter().enumerate() {
                             result[idx] += value;
                         }
-                        ExprResult::Vector(result)
+                        Ok(ExprResult::Vector(result))
                     } else {
                         let mut result = b;
                         for (idx, value) in a.iter().enumerate() {
                             result[idx] += value;
                         }
-                        ExprResult::Vector(result)
+                        Ok(ExprResult::Vector(result))
                     }
                 }
             }
@@ -89,26 +89,26 @@ impl std::ops::Add for ExprResult {
                 for value in result.iter_mut() {
                     *value += a;
                 }
-                ExprResult::Vector(result)
+                Ok(ExprResult::Vector(result))
             }
             (ExprResult::Vector(a), ExprResult::Number(b)) => {
                 let mut result = a;
                 for value in result.iter_mut() {
                     *value += b;
                 }
-                ExprResult::Vector(result)
+                Ok(ExprResult::Vector(result))
             }
-            _ => panic!("Invalid operation"),
+            _ => Err("Cannot add these expression results: expected numbers or vectors".to_string()),
         }
     }
 }
 
 impl std::ops::Sub for ExprResult {
-    type Output = ExprResult;
+    type Output = Result<ExprResult, String>;
 
     fn sub(self, other: Self) -> Self::Output {
         match (self, other) {
-            (ExprResult::Number(a), ExprResult::Number(b)) => ExprResult::Number(a - b),
+            (ExprResult::Number(a), ExprResult::Number(b)) => Ok(ExprResult::Number(a - b)),
             (ExprResult::Vector(a), ExprResult::Vector(b)) => {
                 let len_a = a.len();
                 let len_b = b.len();
@@ -117,7 +117,7 @@ impl std::ops::Sub for ExprResult {
                     for i in 0..len_a {
                         result.push(a[i] - b[i]);
                     }
-                    ExprResult::Vector(result)
+                    Ok(ExprResult::Vector(result))
                 } else {
                     warn!(
                         "Trying to subtract arrays of different lengths: {} and {}",
@@ -128,7 +128,7 @@ impl std::ops::Sub for ExprResult {
                         for (idx, value) in b.iter().enumerate() {
                             result[idx] -= value;
                         }
-                        ExprResult::Vector(result)
+                        Ok(ExprResult::Vector(result))
                     } else {
                         let mut result = b;
                         for (idx, value) in result.iter_mut().enumerate() {
@@ -138,7 +138,7 @@ impl std::ops::Sub for ExprResult {
                                 *value = -*value;
                             }
                         }
-                        ExprResult::Vector(result)
+                        Ok(ExprResult::Vector(result))
                     }
                 }
             }
@@ -147,26 +147,26 @@ impl std::ops::Sub for ExprResult {
                 for (idx, value) in result.iter_mut().enumerate() {
                     *value = a - b[idx];
                 }
-                ExprResult::Vector(result)
+                Ok(ExprResult::Vector(result))
             }
             (ExprResult::Vector(a), ExprResult::Number(b)) => {
                 let mut result = a;
                 for value in result.iter_mut() {
                     *value -= b;
                 }
-                ExprResult::Vector(result)
+                Ok(ExprResult::Vector(result))
             }
-            _ => panic!("Invalid operation"),
+            _ => Err("Cannot subtract these expression results: expected numbers or vectors".to_string()),
         }
     }
 }
 
 impl std::ops::Mul for ExprResult {
-    type Output = ExprResult;
+    type Output = Result<ExprResult, String>;
 
     fn mul(self, other: Self) -> Self::Output {
         match (self, other) {
-            (ExprResult::Number(a), ExprResult::Number(b)) => ExprResult::Number(a * b),
+            (ExprResult::Number(a), ExprResult::Number(b)) => Ok(ExprResult::Number(a * b)),
             (ExprResult::Vector(a), ExprResult::Vector(b)) => {
                 let len_a = a.len();
                 let len_b = b.len();
@@ -175,7 +175,7 @@ impl std::ops::Mul for ExprResult {
                     for i in 0..len_a {
                         result.push(a[i] * b[i]);
                     }
-                    ExprResult::Vector(result)
+                    Ok(ExprResult::Vector(result))
                 } else {
                     warn!(
                         "Trying to multiply arrays of different lengths: {} and {}",
@@ -186,13 +186,13 @@ impl std::ops::Mul for ExprResult {
                         for (idx, value) in b.iter().enumerate() {
                             result[idx] *= value;
                         }
-                        ExprResult::Vector(result)
+                        Ok(ExprResult::Vector(result))
                     } else {
                         let mut result = b;
                         for (idx, value) in a.iter().enumerate() {
                             result[idx] *= value;
                         }
-                        ExprResult::Vector(result)
+                        Ok(ExprResult::Vector(result))
                     }
                 }
             }
@@ -201,26 +201,26 @@ impl std::ops::Mul for ExprResult {
                 for value in result.iter_mut() {
                     *value *= a;
                 }
-                ExprResult::Vector(result)
+                Ok(ExprResult::Vector(result))
             }
             (ExprResult::Vector(a), ExprResult::Number(b)) => {
                 let mut result = a.clone();
                 for value in result.iter_mut() {
                     *value *= b;
                 }
-                ExprResult::Vector(result)
+                Ok(ExprResult::Vector(result))
             }
-            _ => panic!("Invalid operation"),
+            _ => Err("Cannot multiply these expression results: expected numbers or vectors".to_string()),
         }
     }
 }
 
 impl std::ops::Div for ExprResult {
-    type Output = ExprResult;
+    type Output = Result<ExprResult, String>;
 
     fn div(self, other: Self) -> Self::Output {
         match (self, other) {
-            (ExprResult::Number(a), ExprResult::Number(b)) => ExprResult::Number(a / b),
+            (ExprResult::Number(a), ExprResult::Number(b)) => Ok(ExprResult::Number(a / b)),
             (ExprResult::Vector(a), ExprResult::Vector(b)) => {
                 let len_a = a.len();
                 let len_b = b.len();
@@ -229,7 +229,7 @@ impl std::ops::Div for ExprResult {
                     for i in 0..len_a {
                         result.push(a[i] / b[i]);
                     }
-                    ExprResult::Vector(result)
+                    Ok(ExprResult::Vector(result))
                 } else {
                     warn!(
                         "Trying to divide arrays of different lengths: {} and {}",
@@ -240,7 +240,7 @@ impl std::ops::Div for ExprResult {
                         for (idx, value) in b.iter().enumerate() {
                             result[idx] /= value;
                         }
-                        ExprResult::Vector(result)
+                        Ok(ExprResult::Vector(result))
                     } else {
                         let mut result = b;
                         for (idx, value) in result.iter_mut().enumerate() {
@@ -250,7 +250,7 @@ impl std::ops::Div for ExprResult {
                                 *value = 1_f64 / *value;
                             }
                         }
-                        ExprResult::Vector(result)
+                        Ok(ExprResult::Vector(result))
                     }
                 }
             }
@@ -259,16 +259,16 @@ impl std::ops::Div for ExprResult {
                 for (idx, value) in result.iter_mut().enumerate() {
                     *value = a / b[idx];
                 }
-                ExprResult::Vector(result)
+                Ok(ExprResult::Vector(result))
             }
             (ExprResult::Vector(a), ExprResult::Number(b)) => {
                 let mut result = a;
                 for value in result.iter_mut() {
                     *value /= b;
                 }
-                ExprResult::Vector(result)
+                Ok(ExprResult::Vector(result))
             }
-            _ => panic!("Invalid operation"),
+            _ => Err("Cannot divide these expression results: expected numbers or vectors".to_string()),
         }
     }
 }
@@ -279,7 +279,7 @@ impl ExprResult {
     /// When `self` is a string vector and `other` is a numeric vector, converts
     /// the numbers to strings before concatenation, padding to match lengths
     /// where necessary.
-    pub fn join(&mut self, other: &ExprResult) {
+    pub fn join(&mut self, other: &ExprResult) -> Result<(), String> {
         trace!("[join] self: {:?} - other: {:?}", &self, &other);
         match self {
             ExprResult::Empty => match other {
@@ -294,7 +294,7 @@ impl ExprResult {
                         vv.iter().map(|n| crate::output::float_string(n)).collect(),
                     );
                 }
-                _ => panic!("Unable to join objects others than strings"),
+                _ => return Err("Unable to join objects others than strings".to_string()),
             },
             ExprResult::StrVector(v) => match other {
                 ExprResult::StrVector(vv) => {
@@ -332,7 +332,7 @@ impl ExprResult {
                 ExprResult::Str(s) => {
                     *v = v.iter().map(|a| format!("{}{}", a, s)).collect();
                 }
-                _ => panic!("Unable to join objects others than strings"),
+                _ => return Err("Unable to join objects others than strings".to_string()),
             },
             ExprResult::Str(s) => match other {
                 ExprResult::StrVector(vv) => {
@@ -350,12 +350,13 @@ impl ExprResult {
                     trace!("[join] n: {:?}", &n);
                     *s = format!("{}{}", s, crate::output::float_string(n));
                 }
-                _ => panic!("Unable to join objects others than strings"),
+                _ => return Err("Unable to join objects others than strings".to_string()),
             },
             _ => {
-                panic!("Unable to join objects that are not strings");
+                return Err("Unable to join objects that are not strings".to_string());
             }
         }
+        Ok(())
     }
 
     pub fn values(&self) -> Vec<String> {
@@ -418,17 +419,22 @@ impl<'input> Expr<'input> {
                                     return Ok(ExprResult::Vector(n.clone()));
                                 }
                             }
-                            _ => panic!("Should be a number"),
+                            _ => {
+                                return Err(format!(
+                                    "Macro '{{{}}}' does not hold a numeric value",
+                                    k
+                                ));
+                            }
                         },
                         None => continue,
                     }
                 }
                 Ok(ExprResult::Number(0.0))
             }
-            Expr::OpPlus(left, right) => Ok(left.eval(collect)? + right.eval(collect)?),
-            Expr::OpMinus(left, right) => Ok(left.eval(collect)? - right.eval(collect)?),
-            Expr::OpStar(left, right) => Ok(left.eval(collect)? * right.eval(collect)?),
-            Expr::OpSlash(left, right) => Ok(left.eval(collect)? / right.eval(collect)?),
+            Expr::OpPlus(left, right) => left.eval(collect)? + right.eval(collect)?,
+            Expr::OpMinus(left, right) => left.eval(collect)? - right.eval(collect)?,
+            Expr::OpStar(left, right) => left.eval(collect)? * right.eval(collect)?,
+            Expr::OpSlash(left, right) => left.eval(collect)? / right.eval(collect)?,
             Expr::Fn(func, expr) => {
                 let v = expr.eval(collect)?;
                 match func {
@@ -449,7 +455,7 @@ impl<'input> Expr<'input> {
                                 Ok(ExprResult::Number(f64::NAN))
                             }
                         }
-                        _ => panic!("Invalid operation"),
+                        _ => Err("Average() requires a number or a vector".to_string()),
                     },
                     Func::Min => match v {
                         ExprResult::Number(n) => Ok(ExprResult::Number(n)),
@@ -457,7 +463,7 @@ impl<'input> Expr<'input> {
                             let min = v.iter().cloned().fold(f64::INFINITY, f64::min);
                             Ok(ExprResult::Number(min))
                         }
-                        _ => panic!("Invalid operation"),
+                        _ => Err("Min() requires a number or a vector".to_string()),
                     },
                     Func::Max => match v {
                         ExprResult::Number(n) => Ok(ExprResult::Number(n)),
@@ -465,7 +471,7 @@ impl<'input> Expr<'input> {
                             let max = v.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
                             Ok(ExprResult::Number(max))
                         }
-                        _ => panic!("Invalid operation"),
+                        _ => Err("Max() requires a number or a vector".to_string()),
                     },
                 }
             }

--- a/rust-plugins/src/compute/mod.rs
+++ b/rust-plugins/src/compute/mod.rs
@@ -118,13 +118,13 @@ impl<'a> Parser<'a> {
                 let start = m.start();
                 let end = m.end();
                 if start > 0 {
-                    result.join(&ExprResult::Str(suffix[0..start].to_string()));
+                    result.join(&ExprResult::Str(suffix[0..start].to_string()))?;
                 }
                 let macro_name = &suffix[start + 1..end - 1];
                 let mut found = false;
                 for snmp_result in self.collect {
                     if let Some(v) = snmp_result.items.get(macro_name) {
-                        result.join(v);
+                        result.join(v)?;
                         found = true;
                         break;
                     }
@@ -133,7 +133,7 @@ impl<'a> Parser<'a> {
                     if self.check_format {
                         return Err(format!("Undefined macro in expression: {{{}}}", macro_name));
                     } else {
-                        result.join(&ExprResult::Str("".to_string()));
+                        result.join(&ExprResult::Str("".to_string()))?;
                     }
                 }
                 debug!(
@@ -142,7 +142,7 @@ impl<'a> Parser<'a> {
                 );
                 suffix = &suffix[end..];
             } else {
-                result.join(&ExprResult::Str(suffix.to_string()));
+                result.join(&ExprResult::Str(suffix.to_string()))?;
                 break;
             }
         }
@@ -798,7 +798,7 @@ mod test {
     fn join_str_str_str() {
         let mut a = ExprResult::Str("test".to_string());
         let b = ExprResult::Str("foobar".to_string());
-        a.join(&b);
+        a.join(&b).unwrap();
         match a {
             ExprResult::Str(s) => assert_eq!(s, "testfoobar".to_string()),
             _ => panic!("Expected a string"),

--- a/rust-plugins/src/generic/mod.rs
+++ b/rust-plugins/src/generic/mod.rs
@@ -413,7 +413,7 @@ impl Command {
 
             let compute_threshold = |idx: usize, expr: &ExprResult| match &expr {
                 ExprResult::Number(value) => Some(*value),
-                ExprResult::Vector(v) => Some(v[idx]),
+                ExprResult::Vector(v) => v.get(idx).copied(),
                 _ => None,
             };
             match &value {
@@ -434,7 +434,7 @@ impl Command {
                     for (i, item) in v.iter().enumerate() {
                         // first, compose the instance name
                         let instance_name = match &prefix_str {
-                            ExprResult::StrVector(v) => v[i].to_string(),
+                            ExprResult::StrVector(v) => v.get(i).cloned().unwrap_or_default(),
                             ExprResult::Str(s) => s.to_string(),
                             ExprResult::Empty => {
                                 let res = idx.to_string();
@@ -442,7 +442,12 @@ impl Command {
                                 res
                             }
                             _ => {
-                                panic!("A label must be a string");
+                                return Err(error::Error::InvalidJSON {
+                                    message: format!(
+                                        "Metric \"{}\": field \"prefix\" must evaluate to a string",
+                                        metric.name
+                                    ),
+                                });
                             }
                         };
                         // then apply filters exclusion and inclusion filters
@@ -527,7 +532,14 @@ impl Command {
                     trace!("New metric '{}' with value {:?}", m.name, m.value);
                     metrics.push(m);
                 }
-                _ => panic!("Aggregation must be applied to a vector"),
+                _ => {
+                    return Err(error::Error::InvalidJSON {
+                        message: format!(
+                            "Metric \"{}\": field \"value\" must evaluate to a number or a vector",
+                            metric.name
+                        ),
+                    });
+                }
             }
             let key = format!("metrics.{}", metric.name);
             debug!("New ID '{}' with content: {:?}", key, value);
@@ -567,10 +579,25 @@ impl Command {
                     Some(match res {
                         ExprResult::Number(v) => v,
                         ExprResult::Vector(v) => {
-                            assert!(v.len() == 1);
+                            if v.len() != 1 {
+                                return Err(error::Error::InvalidJSON {
+                                    message: format!(
+                                        "Aggregation \"{}\": field \"max_expr\" must evaluate to a single value, got {}",
+                                        metric.name,
+                                        v.len()
+                                    ),
+                                });
+                            }
                             v[0]
                         }
-                        _ => panic!("Aggregation must be applied to a vector"),
+                        _ => {
+                            return Err(error::Error::InvalidJSON {
+                                message: format!(
+                                    "Aggregation \"{}\": field \"max_expr\" must evaluate to a number or a vector",
+                                    metric.name
+                                ),
+                            });
+                        }
                     })
                 } else if let Some(max_value) = metric.max {
                     Some(max_value)
@@ -589,10 +616,25 @@ impl Command {
                     Some(match res {
                         ExprResult::Number(v) => v,
                         ExprResult::Vector(v) => {
-                            assert!(v.len() == 1);
+                            if v.len() != 1 {
+                                return Err(error::Error::InvalidJSON {
+                                    message: format!(
+                                        "Aggregation \"{}\": field \"min_expr\" must evaluate to a single value, got {}",
+                                        metric.name,
+                                        v.len()
+                                    ),
+                                });
+                            }
                             v[0]
                         }
-                        _ => panic!("Aggregation must be applied to a vector"),
+                        _ => {
+                            return Err(error::Error::InvalidJSON {
+                                message: format!(
+                                    "Aggregation \"{}\": field \"min_expr\" must evaluate to a number or a vector",
+                                    metric.name
+                                ),
+                            });
+                        }
                     })
                 } else if let Some(min_value) = metric.min {
                     Some(min_value)
@@ -665,7 +707,14 @@ impl Command {
                         trace!("New metric '{}' with value {:?}", m.name, m.value);
                         metrics.push(m);
                     }
-                    _ => panic!("Aggregation must be applied to a vector"),
+                    _ => {
+                        return Err(error::Error::InvalidJSON {
+                            message: format!(
+                                "Aggregation \"{}\": field \"value\" must evaluate to a number or a vector",
+                                metric.name
+                            ),
+                        });
+                    }
                 }
                 let key = format!("aggregations.{}", metric.name);
                 debug!("New ID '{}' with content: {:?}", key, value);

--- a/rust-plugins/src/main.rs
+++ b/rust-plugins/src/main.rs
@@ -188,14 +188,22 @@ fn snmp_plugin() -> Result<(), Error> {
                                 }
                             }
                             Arg::Long(name) => {
-                                return Err(Error::UnknownArgument {
-                                    arg: format!("--{}", name),
-                                });
+                                println!(
+                                    "UNKNOWN: {}",
+                                    Error::UnknownArgument {
+                                        arg: format!("--{}", name),
+                                    }
+                                );
+                                std::process::exit(3);
                             }
                             Arg::Short(c) => {
-                                return Err(Error::UnknownArgument {
-                                    arg: format!("-{}", c),
-                                });
+                                println!(
+                                    "UNKNOWN: {}",
+                                    Error::UnknownArgument {
+                                        arg: format!("-{}", c),
+                                    }
+                                );
+                                std::process::exit(3);
                             }
                             _ => {}
                         }
@@ -206,8 +214,8 @@ fn snmp_plugin() -> Result<(), Error> {
                 }
             },
             Err(err) => {
-                println!("Error: {}", err);
-                std::process::exit(1);
+                println!("UNKNOWN: {}", err);
+                std::process::exit(3);
             }
         }
     }

--- a/rust-plugins/src/snmp/mod.rs
+++ b/rust-plugins/src/snmp/mod.rs
@@ -54,14 +54,13 @@ pub enum ValueType {
 impl ValueType {
     /// Converts this value to a float for storage in a numeric [`ExprResult`].
     ///
-    /// # Panics
-    /// Panics if called on a [`ValueType::String`]; callers must only reach
-    /// this path for OIDs whose previously stored values were numeric.
-    fn as_f64(&self) -> f64 {
+    /// Returns `None` for [`ValueType::String`]; callers must only reach this
+    /// path for OIDs whose previously stored values were numeric.
+    fn as_f64(&self) -> Option<f64> {
         match self {
-            ValueType::Integer(i) => *i as f64,
-            ValueType::Counter64(i) => *i as f64,
-            ValueType::String(_) => panic!("Expected a numeric SNMP value, got a string"),
+            ValueType::Integer(i) => Some(*i as f64),
+            ValueType::Counter64(i) => Some(*i as f64),
+            ValueType::String(_) => None,
         }
     }
 }
@@ -362,7 +361,9 @@ impl SnmpResult {
                 }
             },
             _ => {
-                let value = typ.as_f64();
+                let value = typ.as_f64().ok_or_else(|| InvalidSnmpValue {
+                    detail: "Expected a numeric SNMP value, got a string".to_string(),
+                })?;
                 match self.items.entry(key) {
                     std::collections::hash_map::Entry::Occupied(mut e) => match e.get_mut() {
                         ExprResult::Vector(v) => v.push(value),


### PR DESCRIPTION
## Summary
- Several `panic!()`/`assert!()` calls were reachable from a malformed JSON command definition rather than only from internal invariant violations, and would crash the plugin instead of reporting `UNKNOWN` with a message:
  - `compute::ast::ExprResult`'s `Add`/`Sub`/`Mul`/`Div` operators and `join()` now return `Result<_, String>` instead of panicking on incompatible operand types; `Expr::eval` propagates these as errors.
  - `generic::Command::execute`'s metric/aggregation assembly now returns `Error::InvalidJSON` instead of panicking when a `prefix`/`value`/`max_expr`/`min_expr` expression evaluates to an unexpected type or a vector of unexpected length, and no longer indexes into vectors without bounds-checking.
- Closes two CLI-parsing gaps in `main.rs` (unrecognized `--flag`/`-x`, lexopt parse errors) that bypassed the `UNKNOWN: ...` + `exit(3)` contract used everywhere else in the file, instead exiting 1 with a raw `Error: ...` message.
- Defensively hardens `snmp::ValueType::as_f64` (currently unreachable given its single call site, but fragile to a future refactor of that call site) to return `None` instead of panicking on a string value.

## Test plan
- [x] `cargo build --release` succeeds
- [x] `cargo test` : 67 passed, 0 failed