### PR TITLE
feat(rust-plugins): value-map DSL primitive — map numeric values to human-readable labels

### DIFF
--- a/rust-plugins/examples/new-interfaces-status.json
+++ b/rust-plugins/examples/new-interfaces-status.json
@@ -1,0 +1,40 @@
+{
+  "collect": {
+    "snmp": [
+      {
+        "name": "if",
+        "oid": "1.3.6.1.2.1.2.2.1",
+        "query": "Walk",
+        "labels": {
+          "1.2": "descr",
+          "1.8": "operstatus"
+        }
+      }
+    ]
+  },
+  "compute": {
+    "metrics": [
+      {
+        "name": "interface.status",
+        "value": "{if.operstatus}",
+        "prefix": "{if.descr}",
+        "value-map": {
+          "1": "up",
+          "2": "down",
+          "3": "testing",
+          "4": "unknown",
+          "5": "dormant",
+          "6": "notPresent",
+          "7": "lowerLayerDown"
+        },
+        "value-map-default": "unmapped",
+        "perfdata": false,
+        "threshold-suffix": "status",
+        "critical": "1:1"
+      }
+    ]
+  },
+  "output": {
+    "ok": "OK: All interfaces are up"
+  }
+}

--- a/rust-plugins/src/compute/mod.rs
+++ b/rust-plugins/src/compute/mod.rs
@@ -49,6 +49,27 @@ pub struct Metric {
     pub warning: Option<String>,
     /// Critical threshold in Nagios format.
     pub critical: Option<String>,
+    /// Optional mapping from raw numeric values to human-readable labels
+    /// (e.g. `{"1": "up", "2": "down"}` for `ifOperStatus`). Keys are the
+    /// decimal string form of the value. When set, detail messages show the
+    /// label instead of the number, and the mapped labels are exposed to
+    /// output/prefix templates as `{metrics.<name>.label}`.
+    /// Thresholds keep operating on the raw numeric value (e.g. `"1:1"`
+    /// alerts whenever the status is not `up`).
+    #[serde(rename = "value-map")]
+    pub value_map: Option<std::collections::HashMap<String, String>>,
+    /// Label used when a value is absent from `value_map`
+    /// (default: the raw number is displayed).
+    #[serde(rename = "value-map-default")]
+    pub value_map_default: Option<String>,
+    /// Whether this metric appears in perfdata (default: `true`).
+    /// Status-like metrics mapped to labels usually don't belong in perfdata.
+    #[serde(default = "default_true")]
+    pub perfdata: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn empty_string() -> String {

--- a/rust-plugins/src/generic/mod.rs
+++ b/rust-plugins/src/generic/mod.rs
@@ -12,8 +12,8 @@ extern crate serde_json;
 pub mod error;
 
 use self::error::Result;
-use crate::compute::{Compute, Parser, ast::ExprResult, threshold::Threshold};
-use crate::output::{Output, OutputFormatter};
+use crate::compute::{Compute, Metric, Parser, ast::ExprResult, threshold::Threshold};
+use crate::output::{Output, OutputFormatter, float_string};
 use crate::snmp::SnmpResult;
 use crate::snmp::{snmp_bulk_get, snmp_bulk_walk, snmp_bulk_walk_with_labels};
 use log::{debug, trace};
@@ -36,6 +36,49 @@ pub struct Perfdata<'p> {
     pub warning: Option<&'p str>,
     pub critical: Option<&'p str>,
     pub status: Option<Status>,
+    /// Human-readable label mapped from the raw value (`value-map` in the
+    /// JSON definition). Detail messages show it instead of the number.
+    pub label: Option<String>,
+    /// Whether this entry is emitted in the perfdata section
+    /// (`perfdata` field in the JSON definition, default `true`).
+    /// Detail messages are unaffected.
+    pub perfdata: bool,
+}
+
+/// Maps a raw numeric value to its human-readable label using the metric's
+/// `value-map`, falling back to `value-map-default` for unmapped values.
+///
+/// Matching uses **exact integer semantics**: only a whole value matches its
+/// decimal key (`2.0` matches `"2"`, `1.996` does not) — SNMP enumerations
+/// are always integers, and a non-integer value silently rounding onto a
+/// status label would hide a data problem. Non-integer or unmapped values
+/// fall back to `value-map-default`.
+///
+/// Returns `None` when the metric has no `value-map`, or when the value is
+/// unmapped and no default is configured (the caller then displays the raw
+/// number).
+///
+/// Labels are sanitized for output safety (see [`sanitize_label`]).
+fn map_value(value: f64, metric: &Metric) -> Option<String> {
+    let map = metric.value_map.as_ref()?;
+    let mapped = if value.is_finite() && value.fract() == 0.0 {
+        map.get(&format!("{}", value as i64))
+    } else {
+        None
+    };
+    mapped
+        .or(metric.value_map_default.as_ref())
+        .map(|label| sanitize_label(label))
+}
+
+/// Replaces characters that would corrupt the Nagios output format with
+/// spaces: `|` starts the perfdata section, control characters (newlines,
+/// tabs, ...) break line-based parsing on the poller side.
+fn sanitize_label(label: &str) -> String {
+    label
+        .chars()
+        .map(|c| if c == '|' || c.is_control() { ' ' } else { c })
+        .collect()
 }
 
 /// Nagios-compatible plugin exit status.
@@ -477,6 +520,8 @@ impl Command {
                             warning: w,
                             critical: c,
                             status: Some(current_status),
+                            label: map_value(*item, metric),
+                            perfdata: metric.perfdata,
                         };
                         trace!("New metric '{}' with value {:?}", m.name, m.value);
                         metrics.push(m);
@@ -523,11 +568,31 @@ impl Command {
                         warning: w,
                         critical: c,
                         status: Some(current_status),
+                        label: map_value(*s, metric),
+                        perfdata: metric.perfdata,
                     };
                     trace!("New metric '{}' with value {:?}", m.name, m.value);
                     metrics.push(m);
                 }
                 _ => panic!("Aggregation must be applied to a vector"),
+            }
+            // Expose the mapped labels to output/prefix templates as
+            // `{metrics.<name>.label}` (aligned with the metric values).
+            if metric.value_map.is_some() {
+                let labels = match &value {
+                    ExprResult::Vector(v) => ExprResult::StrVector(
+                        v.iter()
+                            .map(|x| map_value(*x, metric).unwrap_or_else(|| float_string(x)))
+                            .collect(),
+                    ),
+                    ExprResult::Number(n) => {
+                        ExprResult::Str(map_value(*n, metric).unwrap_or_else(|| float_string(n)))
+                    }
+                    _ => ExprResult::Empty,
+                };
+                let label_key = format!("metrics.{}.label", metric.name);
+                debug!("New ID '{}' with content: {:?}", label_key, labels);
+                my_res.items.insert(label_key, labels);
             }
             let key = format!("metrics.{}", metric.name);
             debug!("New ID '{}' with content: {:?}", key, value);
@@ -635,6 +700,8 @@ impl Command {
                                 warning: w,
                                 critical: c,
                                 status: Some(current_status),
+                                label: map_value(*item, metric),
+                                perfdata: metric.perfdata,
                             };
                             trace!("New metric '{}' with value {:?}", m.name, m.value);
                             metrics.push(m);
@@ -661,6 +728,8 @@ impl Command {
                             warning: w,
                             critical: c,
                             status: Some(current_status),
+                            label: map_value(*s, metric),
+                            perfdata: metric.perfdata,
                         };
                         trace!("New metric '{}' with value {:?}", m.name, m.value);
                         metrics.push(m);
@@ -748,5 +817,55 @@ mod tests {
             err,
             error::Error::InvalidStatus { ref value } if value == "pending"
         ));
+    }
+
+    fn metric_from(json: &str) -> Metric {
+        serde_json::from_str(json).expect("valid metric JSON")
+    }
+
+    #[test]
+    fn value_map_deserializes_maps_and_falls_back_to_default() {
+        let m = metric_from(
+            r#"{"name":"status","value":"{x}","value-map":{"1":"up","2":"down"},"value-map-default":"unmapped","perfdata":false}"#,
+        );
+        assert!(!m.perfdata);
+        assert_eq!(map_value(1.0, &m).as_deref(), Some("up"));
+        assert_eq!(map_value(2.0, &m).as_deref(), Some("down"));
+        assert_eq!(map_value(7.0, &m).as_deref(), Some("unmapped"));
+    }
+
+    #[test]
+    fn no_value_map_yields_none_and_perfdata_defaults_to_true() {
+        let m = metric_from(r#"{"name":"cpu","value":"{x}"}"#);
+        assert!(m.perfdata);
+        assert_eq!(map_value(1.0, &m), None);
+    }
+
+    #[test]
+    fn unmapped_value_without_default_yields_none() {
+        let m = metric_from(r#"{"name":"status","value":"{x}","value-map":{"1":"up"}}"#);
+        assert_eq!(map_value(3.0, &m), None);
+    }
+
+    #[test]
+    fn non_integer_values_never_match_a_key() {
+        // Exact integer semantics: 1.996 must NOT round onto the "2" key.
+        let m = metric_from(r#"{"name":"status","value":"{x}","value-map":{"2":"down"}}"#);
+        assert_eq!(map_value(1.996, &m), None);
+        assert_eq!(map_value(2.0, &m).as_deref(), Some("down"));
+
+        let m = metric_from(
+            r#"{"name":"status","value":"{x}","value-map":{"2":"down"},"value-map-default":"unmapped"}"#,
+        );
+        assert_eq!(map_value(1.996, &m).as_deref(), Some("unmapped"));
+        assert_eq!(map_value(f64::NAN, &m).as_deref(), Some("unmapped"));
+    }
+
+    #[test]
+    fn labels_are_sanitized_for_output_safety() {
+        // `|` starts the perfdata section and control characters break
+        // line-based parsing: both are replaced with spaces at display time.
+        let m = metric_from(r#"{"name":"status","value":"{x}","value-map":{"1":"up|down\nbad"}}"#);
+        assert_eq!(map_value(1.0, &m).as_deref(), Some("up down bad"));
     }
 }

--- a/rust-plugins/src/output/mod.rs
+++ b/rust-plugins/src/output/mod.rs
@@ -95,6 +95,19 @@ impl Output {
     }
 }
 
+/// Joins the human-readable output text with the perfdata section.
+///
+/// The ` | ` separator is only emitted when there is perfdata to show —
+/// a status-only plugin (all metrics flagged `perfdata: false`) must not
+/// end with a dangling pipe.
+fn join_output(text: &str, metrics: &str) -> String {
+    if metrics.is_empty() {
+        text.trim_end().to_string()
+    } else {
+        format!("{} | {}", text, metrics)
+    }
+}
+
 /// Formats plugin results into Nagios-compatible output string.
 pub struct OutputFormatter<'a> {
     status: Status,
@@ -124,6 +137,9 @@ impl<'a> OutputFormatter<'a> {
         let metrics = self
             .metrics
             .iter()
+            // Metrics flagged `perfdata: false` (e.g. mapped status metrics)
+            // are excluded from perfdata but still drive detail messages.
+            .filter(|m| m.perfdata)
             .map(|m| {
                 format!(
                     "{}={}{};{};{};{};{}",
@@ -148,7 +164,7 @@ impl<'a> OutputFormatter<'a> {
             Status::Ok => {
                 if self.output_formatter.detail_ok {
                     let detail = self.build_detail(&self.output_formatter.ok);
-                    return format!("{} | {}", detail, metrics);
+                    return join_output(&detail, &metrics);
                 } else {
                     let parser = Parser::new(&self.collect, false);
                     let res = parser.eval_str(&self.output_formatter.ok);
@@ -179,31 +195,31 @@ impl<'a> OutputFormatter<'a> {
                             self.output_formatter.ok.clone()
                         }
                     };
-                    return format!("{} | {}", output, metrics);
+                    return join_output(&output, &metrics);
                 }
             }
             Status::Warning => {
                 if self.output_formatter.detail_warning {
                     let detail = self.build_detail(&self.output_formatter.warning);
-                    return format!("{} | {}", detail, metrics);
+                    return join_output(&detail, &metrics);
                 } else {
-                    return format!("{} | {}", self.output_formatter.warning, metrics);
+                    return join_output(&self.output_formatter.warning, &metrics);
                 }
             }
             Status::Critical => {
                 if self.output_formatter.detail_critical {
                     let detail = self.build_detail(&self.output_formatter.critical);
-                    return format!("{} | {}", detail, metrics);
+                    return join_output(&detail, &metrics);
                 } else {
-                    return format!("{} | {}", self.output_formatter.critical, metrics);
+                    return join_output(&self.output_formatter.critical, &metrics);
                 }
             }
             Status::Unknown => {
                 if self.output_formatter.detail_unknown {
                     let detail = self.build_detail(&self.output_formatter.unknown);
-                    return format!("{} | {}", detail, metrics);
+                    return join_output(&detail, &metrics);
                 } else {
-                    return format!("{} | {}", self.output_formatter.unknown, metrics);
+                    return join_output(&self.output_formatter.unknown, &metrics);
                 }
             }
         }
@@ -211,17 +227,19 @@ impl<'a> OutputFormatter<'a> {
 
     /// Builds a detailed message string including the prefix and metrics that
     /// triggered the current status.
+    ///
+    /// When a metric carries a mapped label (`value-map`), the label is shown
+    /// instead of the raw number (e.g. `status is down`, not `status is 2`).
     fn build_detail(&self, prefix: &str) -> String {
         let mut v = Vec::new();
         for m in self.metrics.iter() {
             if let Some(status) = m.status {
                 if status.is_worse_than(self.status) {
-                    v.push(std::format!(
-                        "{} is {}{}",
-                        m.name,
-                        float_string(&m.value),
-                        m.uom
-                    ));
+                    let displayed = match &m.label {
+                        Some(label) => label.clone(),
+                        None => format!("{}{}", float_string(&m.value), m.uom),
+                    };
+                    v.push(std::format!("{} is {}", m.name, displayed));
                 }
             }
         }
@@ -274,5 +292,71 @@ mod test {
 
         assert_eq!(float_string(&f), "0");
         assert_eq!(float_string(&9999999.999), "10000000");
+    }
+}
+
+#[cfg(test)]
+mod value_map_tests {
+    use super::*;
+
+    fn perfdata<'p>(
+        name: &str,
+        value: f64,
+        status: Status,
+        label: Option<String>,
+        perfdata: bool,
+    ) -> Perfdata<'p> {
+        Perfdata {
+            name: name.to_string(),
+            value,
+            uom: "",
+            min: None,
+            max: None,
+            warning: None,
+            critical: None,
+            status: Some(status),
+            label,
+            perfdata,
+        }
+    }
+
+    #[test]
+    fn detail_shows_mapped_label_and_perfdata_flag_hides_metric() {
+        let collect: Vec<SnmpResult> = vec![];
+        let output = Output::new();
+        let metrics = vec![
+            perfdata(
+                "'eth0#interface.status'",
+                2.0,
+                Status::Critical,
+                Some("down".to_string()),
+                false,
+            ),
+            perfdata("cpu", 42.0, Status::Ok, None, true),
+        ];
+        let formatter = OutputFormatter::new(Status::Critical, &collect, &metrics, &output);
+        let s = formatter.to_string();
+        // The label replaces the raw number in the detail message...
+        assert!(s.contains("'eth0#interface.status' is down"), "got: {}", s);
+        // ...and the status metric is excluded from the perfdata section,
+        // while the regular metric remains.
+        assert!(!s.contains("interface.status'=2"), "got: {}", s);
+        assert!(s.contains("cpu=42"), "got: {}", s);
+    }
+
+    #[test]
+    fn empty_perfdata_omits_the_pipe_separator() {
+        let collect: Vec<SnmpResult> = vec![];
+        let output = Output::new();
+        let metrics = vec![perfdata(
+            "'eth0#interface.status'",
+            1.0,
+            Status::Ok,
+            Some("up".to_string()),
+            false,
+        )];
+        let formatter = OutputFormatter::new(Status::Ok, &collect, &metrics, &output);
+        let s = formatter.to_string();
+        assert!(!s.contains('|'), "no dangling pipe expected, got: {}", s);
     }
 }


### PR DESCRIPTION
## Summary
Many SNMP tables carry a status-like column (`ifOperStatus`: 1=up, 2=down, ...) that the Perl mode renders as a label rather than a bare number; the JSON DSL had no way to express that translation.

Adds three optional `Metric` fields (all backward-compatible):
- `value-map`: maps the raw numeric value (decimal string key) to a label. Detail messages show the label instead of the number, and the label is exposed to output/prefix templates as `{metrics.<name>.label}`. Thresholds keep operating on the raw numeric value (e.g. `"critical": "1:1"` still alerts whenever the status isn't `1`/up).
- `value-map-default`: label used for values absent from `value-map`.
- `perfdata` (default `true`): excludes the metric from the perfdata section while still driving status evaluation and detail messages — status-like metrics don't belong in perfdata.

See `rust-plugins/examples/new-interfaces-status.json` for a worked example (`ifOperStatus` mapped to up/down/... with perfdata disabled).

## Test plan
- [x] `cargo build --release` succeeds
- [x] `cargo test`: 74 passed, 0 failed (7 new tests: value-map deserialization/fallback, non-integer-value semantics, label sanitization, perfdata exclusion, no dangling pipe when perfdata is empty)
- [x] `--check-format` validates the new example JSON