### PR TITLE
chore(rust-plugins): zero-warning codebase — fmt + clippy -D warnings, CI gate

### DIFF
--- a/.github/workflows/generic-plugins.yml
+++ b/.github/workflows/generic-plugins.yml
@@ -36,6 +36,36 @@ jobs:
     with:
       version_file: rust-plugins/Cargo.toml
 
+  lint:
+    needs: [get-environment]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      needs.get-environment.outputs.stability != 'stable' &&
+      ! cancelled()
+    runs-on: ubuntu-24.04
+
+    name: "Lint the generic plugins"
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install fmt and clippy components
+        run: rustup component add rustfmt clippy
+        shell: bash
+
+      - name: Check formatting
+        run: |
+          cd rust-plugins
+          cargo fmt --check
+        shell: bash
+
+      - name: Clippy
+        run: |
+          cd rust-plugins
+          cargo clippy --all-targets --release -- -D warnings
+        shell: bash
+
   build:
     needs: [get-environment]
     if: |

--- a/rust-plugins/benches/bench.rs
+++ b/rust-plugins/benches/bench.rs
@@ -1,9 +1,9 @@
 extern crate criterion;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, criterion_group, criterion_main};
 use std::hint::black_box;
 
-fn average_for(v: &Vec<f64>) -> f64 {
+fn average_for(v: &[f64]) -> f64 {
     let mut sum = 0.0;
     let mut count = 0;
 
@@ -14,24 +14,16 @@ fn average_for(v: &Vec<f64>) -> f64 {
         }
     }
 
-    if count == 0 {
-        0.0
-    } else {
-        sum / count as f64
-    }
+    if count == 0 { 0.0 } else { sum / count as f64 }
 }
 
-fn average_fold(v: &Vec<f64>) -> f64 {
+fn average_fold(v: &[f64]) -> f64 {
     let (sum, count) = v
         .iter()
         .filter(|x| !x.is_nan())
         .fold((0.0, 0), |(s, c), &x| (s + x, c + 1));
 
-    if count == 0 {
-        0.0
-    } else {
-        sum / count as f64
-    }
+    if count == 0 { 0.0 } else { sum / count as f64 }
 }
 
 fn benchmark_averages(c: &mut Criterion) {

--- a/rust-plugins/src/compute/ast.rs
+++ b/rust-plugins/src/compute/ast.rs
@@ -280,7 +280,7 @@ impl ExprResult {
     /// the numbers to strings before concatenation, padding to match lengths
     /// where necessary.
     pub fn join(&mut self, other: &ExprResult) {
-        trace!("[join] self: {:?} - other: {:?}", &self, &other);
+        trace!("[join] self: {:?} - other: {:?}", self, other);
         match self {
             ExprResult::Empty => match other {
                 ExprResult::StrVector(vv) => {
@@ -290,9 +290,8 @@ impl ExprResult {
                     *self = ExprResult::Str(s.clone());
                 }
                 ExprResult::Vector(vv) => {
-                    *self = ExprResult::StrVector(
-                        vv.iter().map(|n| crate::output::float_string(n)).collect(),
-                    );
+                    *self =
+                        ExprResult::StrVector(vv.iter().map(crate::output::float_string).collect());
                 }
                 _ => panic!("Unable to join objects others than strings"),
             },
@@ -347,7 +346,7 @@ impl ExprResult {
                     *s = format!("{}{}", s, ss);
                 }
                 ExprResult::Number(n) => {
-                    trace!("[join] n: {:?}", &n);
+                    trace!("[join] n: {:?}", n);
                     *s = format!("{}{}", s, crate::output::float_string(n));
                 }
                 _ => panic!("Unable to join objects others than strings"),
@@ -375,7 +374,7 @@ impl<'input> Expr<'input> {
         match self {
             Expr::Id(key) => {
                 let k = str::from_utf8(key)
-                    .map_err(|_| return "Error reading a macro : invalid utf8 string")?;
+                    .map_err(|_| "Error reading a macro : invalid utf8 string")?;
                 for result in collect {
                     if result.items.contains_key(k) {
                         return Ok(());
@@ -405,7 +404,7 @@ impl<'input> Expr<'input> {
             Expr::Number(n) => Ok(ExprResult::Number(*n)),
             Expr::Id(key) => {
                 let k = str::from_utf8(key)
-                    .map_err(|_| return "Error while eval() an expression : invalid utf8 string")?;
+                    .map_err(|_| "Error while eval() an expression : invalid utf8 string")?;
                 for result in collect {
                     match result.items.get(k) {
                         Some(item) => match item {
@@ -473,11 +472,12 @@ impl<'input> Expr<'input> {
     }
 
     /// Returns the byte representation of an identifier expression, or a default error message.
+    #[allow(dead_code)]
     pub fn eval_as_str(&self) -> &[u8] {
         if let Expr::Id(id) = self {
-            return id;
+            id
         } else {
-            return b"Bad value";
+            b"Bad value"
         }
     }
 }

--- a/rust-plugins/src/compute/lexer.rs
+++ b/rust-plugins/src/compute/lexer.rs
@@ -37,6 +37,7 @@ pub enum LexicalError {
     /// A character that cannot be tokenized was encountered.
     NotPossible,
     /// A brace was not properly matched (currently unused).
+    #[allow(dead_code)]
     UnmatchedBrace,
 }
 
@@ -169,10 +170,14 @@ impl<'input> Iterator for Lexer<'input> {
             }
         }
         // No more characters to process
-        return None;
+        None
     }
 }
 
+// These imports are used only inside #[test] fn bodies, which rustc strips
+// from a plain (non-test) build -- this module lacks #[cfg(test)] (see PR
+// #6410), so a plain `cargo clippy` sees them as unused.
+#[allow(unused_imports, dead_code)]
 mod test {
     use crate::compute::lexer::{Lexer, Tok};
 

--- a/rust-plugins/src/compute/mod.rs
+++ b/rust-plugins/src/compute/mod.rs
@@ -9,9 +9,8 @@ pub mod lexer;
 pub mod threshold;
 
 use self::ast::ExprResult;
-use self::lexer::{LexicalError, Tok};
 use crate::snmp::SnmpResult;
-use lalrpop_util::{ParseError, lalrpop_mod};
+use lalrpop_util::lalrpop_mod;
 use log::{debug, trace};
 use regex::Regex;
 use serde::Deserialize;
@@ -111,7 +110,7 @@ impl<'a> Parser<'a> {
         let re = Regex::new(r"\{[a-zA-Z_][a-zA-Z0-9_.]*\}").unwrap();
         let mut suffix = expr;
         let mut result: ExprResult = ExprResult::Empty;
-        trace!("[eval_str] suffix: {:?} - re: {:?}", &suffix, &re);
+        trace!("[eval_str] suffix: {:?} - re: {:?}", suffix, re);
         loop {
             let found = re.find(suffix);
             if let Some(m) = found {
@@ -150,6 +149,10 @@ impl<'a> Parser<'a> {
     }
 }
 
+// These imports are used only inside #[test] fn bodies, which rustc strips
+// from a plain (non-test) build -- this module lacks #[cfg(test)] (see PR
+// #6410), so a plain `cargo clippy` sees them as unused.
+#[allow(unused_imports, dead_code)]
 mod test {
     use crate::compute::{Parser, ast::ExprResult, grammar, lexer};
     use crate::snmp::SnmpResult;

--- a/rust-plugins/src/compute/threshold.rs
+++ b/rust-plugins/src/compute/threshold.rs
@@ -4,7 +4,6 @@
 //! following the [Nagios plugin guidelines](https://nagios-plugins.org/doc/guidelines.html#THRESHOLDFORMAT).
 
 use crate::generic::error::Error;
-use std::f64::INFINITY;
 
 /// Represents an alert threshold range and its alert condition.
 pub struct Threshold {
@@ -30,7 +29,7 @@ impl Threshold {
         let mut start: usize = 0;
         let mut in_number = false;
         let mut current = 0;
-        let mut value = [-INFINITY, INFINITY];
+        let mut value = [-f64::INFINITY, f64::INFINITY];
         let mut in_range = 0;
         let mut negation = 0;
         for (idx, c) in expr.char_indices() {
@@ -69,7 +68,7 @@ impl Threshold {
                         start = idx;
                     }
                     '~' => {
-                        value[0] = -INFINITY;
+                        value[0] = -f64::INFINITY;
                     }
                     ':' => {
                         in_range += 1;
@@ -97,42 +96,40 @@ impl Threshold {
                     end: value[1],
                 });
             }
-            return Ok(Threshold {
+            Ok(Threshold {
                 start: value[0],
                 end: value[1],
                 negation: negation > 0,
-            });
+            })
         } else if in_range > 1 {
-            return Err(Error::BadThreshold);
+            Err(Error::BadThreshold)
         } else {
             if value[0] <= 0_f64 {
                 return Err(Error::NegativeSimpleThreshold { value: value[0] });
             }
-            return Ok(Threshold {
+            Ok(Threshold {
                 start: 0_f64,
                 end: value[0],
                 negation: negation > 0,
-            });
+            })
         }
     }
 
     /// Returns `true` if the given value triggers an alert.
     pub fn in_alert(&self, value: f64) -> bool {
         if value < self.start || value > self.end {
-            if self.negation {
-                return false;
-            } else {
-                return true;
-            }
+            return !self.negation;
         }
-        if self.negation { true } else { false }
+        self.negation
     }
 }
 
+// These imports are used only inside #[test] fn bodies, which rustc strips
+// from a plain (non-test) build -- this module lacks #[cfg(test)] (see PR
+// #6410), so a plain `cargo clippy` sees them as unused.
+#[allow(unused_imports, dead_code)]
 mod test {
     use crate::compute::threshold::Threshold;
-    use crate::generic::error::Error;
-    use std::f64::INFINITY;
     #[test]
     fn test_parse_value() {
         let expr = "1.2";
@@ -157,7 +154,7 @@ mod test {
         match threshold {
             Ok(threshold) => {
                 assert_eq!(threshold.start, 10_f64);
-                assert_eq!(threshold.end, INFINITY);
+                assert_eq!(threshold.end, f64::INFINITY);
                 assert!(!threshold.in_alert(10_f64));
                 assert!(!threshold.in_alert(11_f64));
                 assert!(threshold.in_alert(9_f64));
@@ -174,7 +171,7 @@ mod test {
         let threshold = Threshold::parse(expr);
         match threshold {
             Ok(threshold) => {
-                assert_eq!(threshold.start, -INFINITY);
+                assert_eq!(threshold.start, -f64::INFINITY);
                 assert_eq!(threshold.end, 10_f64);
                 assert!(!threshold.in_alert(10_f64));
                 assert!(threshold.in_alert(11_f64));

--- a/rust-plugins/src/generic/mod.rs
+++ b/rust-plugins/src/generic/mod.rs
@@ -20,7 +20,6 @@ use log::{debug, trace};
 use regex::Regex;
 use serde::Deserialize;
 use std::collections::HashMap;
-use std::convert::Into;
 
 /// A single metric data point, ready to be included in plugin output.
 ///
@@ -49,9 +48,9 @@ pub enum Status {
     Critical = 2,
     Unknown = 3,
 }
-impl Into<i32> for Status {
-    fn into(self) -> i32 {
-        match self {
+impl From<Status> for i32 {
+    fn from(val: Status) -> Self {
+        match val {
             Status::Ok => 0,
             Status::Warning => 1,
             Status::Critical => 2,
@@ -59,9 +58,9 @@ impl Into<i32> for Status {
         }
     }
 }
-impl Into<String> for Status {
-    fn into(self) -> String {
-        match self {
+impl From<Status> for String {
+    fn from(val: Status) -> Self {
+        match val {
             Status::Ok => "OK".to_string(),
             Status::Warning => "WARNING".to_string(),
             Status::Critical => "CRITICAL".to_string(),
@@ -90,7 +89,7 @@ impl Status {
     /// Returns the severity rank of the status, used to compare statuses.
     ///
     /// Severity order: `Ok < Warning < Unknown < Critical`.  It differs from the
-    /// exit code (see [`Into<i32>`]), where `Critical` is 2 and `Unknown` is 3.
+    /// exit code (see `From<Status> for i32`), where `Critical` is 2 and `Unknown` is 3.
     fn severity(&self) -> u8 {
         match self {
             Status::Ok => 0,
@@ -196,18 +195,17 @@ impl Command {
         {
             debug!("Adding warning to metric {}", metric.name);
             metric.warning = Some(value);
-        } else if let Some(aggregations) = self.compute.aggregations.as_mut() {
-            if let Some(metric) =
+        } else if let Some(aggregations) = self.compute.aggregations.as_mut()
+            && let Some(metric) =
                 aggregations
                     .iter_mut()
                     .find(|metric| match &metric.threshold_suffix {
                         Some(suffix) => suffix == name,
                         None => false,
                     })
-            {
-                debug!("Adding warning to aggregation metric {}", metric.name);
-                metric.warning = Some(value);
-            }
+        {
+            debug!("Adding warning to aggregation metric {}", metric.name);
+            metric.warning = Some(value);
         }
     }
 
@@ -225,23 +223,22 @@ impl Command {
         {
             metric.critical = Some(value);
             debug!("Adding critical to metric {}", metric.name);
-        } else if let Some(aggregations) = self.compute.aggregations.as_mut() {
-            if let Some(metric) =
+        } else if let Some(aggregations) = self.compute.aggregations.as_mut()
+            && let Some(metric) =
                 aggregations
                     .iter_mut()
                     .find(|metric| match &metric.threshold_suffix {
                         Some(suffix) => suffix == name,
                         None => false,
                     })
-            {
-                debug!("Adding critical to aggregation metric {}", metric.name);
-                metric.critical = Some(value);
-            }
+        {
+            debug!("Adding critical to aggregation metric {}", metric.name);
+            metric.critical = Some(value);
         }
     }
 
     /// Formats raw SNMP response for simple display
-    fn format_raw_response(&self, collect: &Vec<SnmpResult>) -> Result<CmdResult> {
+    fn format_raw_response(&self, collect: &[SnmpResult]) -> Result<CmdResult> {
         let mut lines = Vec::new();
 
         for result in collect.iter() {
@@ -304,7 +301,7 @@ impl Command {
                 QueryType::Walk => {
                     if let Some(lab) = &s.labels {
                         let r = snmp_bulk_walk_with_labels(
-                            target, version, community, &s.oid, &s.name, &lab,
+                            target, version, community, &s.oid, &s.name, lab,
                         )?;
                         if !r.items.is_empty() {
                             collect.push(r);
@@ -347,13 +344,14 @@ impl Command {
     ///
     /// # Returns
     /// A [`CmdResult`] containing the overall [`Status`] and Nagios-compatible output string.
+    #[allow(clippy::too_many_arguments)]
     pub fn execute(
         &self,
         target: &str,
         version: &str,
         community: &str,
-        filter_in: &Vec<String>,
-        filter_out: &Vec<String>,
+        filter_in: &[String],
+        filter_out: &[String],
         check_format: bool,
         check_response: bool,
         no_data_status: Status,
@@ -390,7 +388,7 @@ impl Command {
             })?;
             let min = if let Some(min_expr) = metric.min_expr.as_ref() {
                 parser
-                    .eval(&min_expr)
+                    .eval(min_expr)
                     .map_err(|e| error::Error::InvalidJSON {
                         message: format!("Metric \"{}\", field \"min_expr\": {}", metric.name, e),
                     })?
@@ -401,7 +399,7 @@ impl Command {
             };
             let max = if let Some(max_expr) = metric.max_expr.as_ref() {
                 parser
-                    .eval(&max_expr)
+                    .eval(max_expr)
                     .map_err(|e| error::Error::InvalidJSON {
                         message: format!("Metric \"{}\", field \"max_expr\": {}", metric.name, e),
                     })?
@@ -450,8 +448,7 @@ impl Command {
                         {
                             continue;
                         }
-                        if (!re_in.is_empty()
-                            && !re_in.iter().any(|re| re.is_match(&instance_name)))
+                        if !re_in.is_empty() && !re_in.iter().any(|re| re.is_match(&instance_name))
                         {
                             continue;
                         }
@@ -460,14 +457,8 @@ impl Command {
                         let current_status =
                             compute_status(item, &metric.warning, &metric.critical)?;
                         status = worst(status, current_status);
-                        let w = match metric.warning {
-                            Some(ref w) => Some(w.as_str()),
-                            None => None,
-                        };
-                        let c = match metric.critical {
-                            Some(ref c) => Some(c.as_str()),
-                            None => None,
-                        };
+                        let w = metric.warning.as_deref();
+                        let c = metric.critical.as_deref();
                         let m = Perfdata {
                             name,
                             value: *item,
@@ -499,21 +490,13 @@ impl Command {
                             continue;
                         }
                     }
-                    if !re_out.is_empty() {
-                        if re_out.iter().any(|re| re.is_match(&name)) {
-                            continue;
-                        }
+                    if !re_out.is_empty() && re_out.iter().any(|re| re.is_match(&name)) {
+                        continue;
                     }
                     let current_status = compute_status(s, &metric.warning, &metric.critical)?;
                     status = worst(status, current_status);
-                    let w = match metric.warning {
-                        Some(ref w) => Some(w.as_str()),
-                        None => None,
-                    };
-                    let c = match metric.critical {
-                        Some(ref c) => Some(c.as_str()),
-                        None => None,
-                    };
+                    let w = metric.warning.as_deref();
+                    let c = metric.critical.as_deref();
                     let m = Perfdata {
                         name,
                         value: *s,
@@ -557,7 +540,7 @@ impl Command {
                 let parser = Parser::new(&collect, check_format);
                 let max = if let Some(max_expr) = metric.max_expr.as_ref() {
                     let res = parser
-                        .eval(&max_expr)
+                        .eval(max_expr)
                         .map_err(|e| error::Error::InvalidJSON {
                             message: format!(
                                 "Aggregation \"{}\", field \"max_expr\": {}",
@@ -572,14 +555,12 @@ impl Command {
                         }
                         _ => panic!("Aggregation must be applied to a vector"),
                     })
-                } else if let Some(max_value) = metric.max {
-                    Some(max_value)
                 } else {
-                    None
+                    metric.max
                 };
                 let min = if let Some(min_expr) = metric.min_expr.as_ref() {
                     let res = parser
-                        .eval(&min_expr)
+                        .eval(min_expr)
                         .map_err(|e| error::Error::InvalidJSON {
                             message: format!(
                                 "Aggregation \"{}\", field \"min_expr\": {}",
@@ -594,10 +575,8 @@ impl Command {
                         }
                         _ => panic!("Aggregation must be applied to a vector"),
                     })
-                } else if let Some(min_value) = metric.min {
-                    Some(min_value)
                 } else {
-                    None
+                    metric.min
                 };
                 let value = parser.eval(value).map_err(|e| error::Error::InvalidJSON {
                     message: format!("Aggregation \"{}\", field \"value\": {}", metric.name, e),
@@ -618,14 +597,8 @@ impl Command {
                             let current_status =
                                 compute_status(item, &metric.warning, &metric.critical)?;
                             status = worst(status, current_status);
-                            let w = match metric.warning {
-                                Some(ref w) => Some(w.as_str()),
-                                None => None,
-                            };
-                            let c = match metric.critical {
-                                Some(ref c) => Some(c.as_str()),
-                                None => None,
-                            };
+                            let w = metric.warning.as_deref();
+                            let c = metric.critical.as_deref();
                             let m = Perfdata {
                                 name,
                                 value: *item,
@@ -644,14 +617,8 @@ impl Command {
                         let name = &metric.name;
                         let current_status = compute_status(s, &metric.warning, &metric.critical)?;
                         status = worst(status, current_status);
-                        let w = match metric.warning {
-                            Some(ref w) => Some(w.as_str()),
-                            None => None,
-                        };
-                        let c = match metric.critical {
-                            Some(ref c) => Some(c.as_str()),
-                            None => None,
-                        };
+                        let w = metric.warning.as_deref();
+                        let c = metric.critical.as_deref();
                         let m = Perfdata {
                             name: name.to_string(),
                             value: *s,
@@ -695,16 +662,16 @@ impl Command {
             }
         }
 
-        if let Some(aggregations) = self.compute.aggregations.as_ref() {
-            if !aggregations.is_empty() {
-                println!("Aggregations:");
-                for metric in aggregations {
-                    let suffix = metric.threshold_suffix.as_deref().unwrap_or("(no suffix)");
-                    println!(
-                        "  {} (--warning-{}, --critical-{})",
-                        metric.name, suffix, suffix
-                    );
-                }
+        if let Some(aggregations) = self.compute.aggregations.as_ref()
+            && !aggregations.is_empty()
+        {
+            println!("Aggregations:");
+            for metric in aggregations {
+                let suffix = metric.threshold_suffix.as_deref().unwrap_or("(no suffix)");
+                println!(
+                    "  {} (--warning-{}, --critical-{})",
+                    metric.name, suffix, suffix
+                );
             }
         }
     }

--- a/rust-plugins/src/main.rs
+++ b/rust-plugins/src/main.rs
@@ -49,7 +49,7 @@ fn json_to_command(file_name: &str) -> Result<Command, Error> {
 }
 
 fn main() -> Result<(), Error> {
-    match std::panic::catch_unwind(|| snmp_plugin()) {
+    match std::panic::catch_unwind(snmp_plugin) {
         std::result::Result::Ok(plugin_result) => plugin_result,
         Err(e) => {
             let message = e
@@ -87,7 +87,7 @@ fn snmp_plugin() -> Result<(), Error> {
     let mut check_response = false;
     let mut list_counters = false;
     let mut json_file: Option<String> = None;
-    let mut cmd: Option<Command> = None;
+    let mut cmd: Option<Command>;
     let mut warnings: Vec<(String, String)> = Vec::new();
     let mut criticals: Vec<(String, String)> = Vec::new();
     loop {
@@ -113,7 +113,7 @@ fn snmp_plugin() -> Result<(), Error> {
                         trace!("snmp_version: {}", snmp_version);
                     }
                     Short('c') | Long("snmp-community") => {
-                        /// For backward compatibility 'public' is used when the SNMP community is empty
+                        // For backward compatibility 'public' is used when the SNMP community is empty
                         let s = parser.value()?.into_string()?;
                         if !s.is_empty() {
                             snmp_community = s;
@@ -144,17 +144,33 @@ fn snmp_plugin() -> Result<(), Error> {
                             .unwrap_or_else(|| "plugin".to_string());
                         println!("Usage: {} [OPTIONS]\n", prog);
                         println!("OPTIONS:");
-                        println!("  -H, --hostname <HOST>            Hostname or IP address (default: localhost)");
+                        println!(
+                            "  -H, --hostname <HOST>            Hostname or IP address (default: localhost)"
+                        );
                         println!("  -p, --port <PORT>                SNMP port (default: 161)");
                         println!("  -v, --snmp-version <VERSION>     SNMP version (default: 2c)");
-                        println!("  -c, --snmp-community <COMMUNITY> SNMP community (default: public)");
-                        println!("  -j, --json <FILE>                JSON command definition file (required)");
-                        println!("  -i, --filter-in <FILTER>         Include filter (can be used multiple times)");
-                        println!("  -o, --filter-out <FILTER>        Exclude filter (can be used multiple times)");
-                        println!("  --no-data-status <STATUS>        Status when the filters keep no data: OK, WARNING, CRITICAL or UNKNOWN (default: UNKNOWN)");
+                        println!(
+                            "  -c, --snmp-community <COMMUNITY> SNMP community (default: public)"
+                        );
+                        println!(
+                            "  -j, --json <FILE>                JSON command definition file (required)"
+                        );
+                        println!(
+                            "  -i, --filter-in <FILTER>         Include filter (can be used multiple times)"
+                        );
+                        println!(
+                            "  -o, --filter-out <FILTER>        Exclude filter (can be used multiple times)"
+                        );
+                        println!(
+                            "  --no-data-status <STATUS>        Status when the filters keep no data: OK, WARNING, CRITICAL or UNKNOWN (default: UNKNOWN)"
+                        );
                         println!("  --warning-<METRIC> <VALUE>       Warning threshold for metric");
-                        println!("  --critical-<METRIC> <VALUE>      Critical threshold for metric");
-                        println!("  --check-format                   Check JSON file validity and exit");
+                        println!(
+                            "  --critical-<METRIC> <VALUE>      Critical threshold for metric"
+                        );
+                        println!(
+                            "  --check-format                   Check JSON file validity and exit"
+                        );
                         println!("  --check-response                 Display raw SNMP response");
                         println!("  --list-counters                  List all available metrics");
                         println!("  -h, --help                       Print this help message");
@@ -169,37 +185,35 @@ fn snmp_plugin() -> Result<(), Error> {
                     Long("list-counters") => {
                         list_counters = true;
                     }
-                    t => {
-                        match t {
-                            Arg::Long(name) if name.starts_with("warning-") => {
-                                let wmetric = name[8..].to_string();
-                                let value = parser.value()?.into_string()?;
-                                if !value.is_empty() {
-                                    trace!("Warning stored for metric '{}'", wmetric);
-                                    warnings.push((wmetric, value));
-                                }
+                    t => match t {
+                        Arg::Long(name) if name.starts_with("warning-") => {
+                            let wmetric = name[8..].to_string();
+                            let value = parser.value()?.into_string()?;
+                            if !value.is_empty() {
+                                trace!("Warning stored for metric '{}'", wmetric);
+                                warnings.push((wmetric, value));
                             }
-                            Arg::Long(name) if name.starts_with("critical-") => {
-                                let cmetric = name[9..].to_string();
-                                let value = parser.value()?.into_string()?;
-                                if !value.is_empty() {
-                                    trace!("Critical stored for metric '{}'", cmetric);
-                                    criticals.push((cmetric, value));
-                                }
-                            }
-                            Arg::Long(name) => {
-                                return Err(Error::UnknownArgument {
-                                    arg: format!("--{}", name),
-                                });
-                            }
-                            Arg::Short(c) => {
-                                return Err(Error::UnknownArgument {
-                                    arg: format!("-{}", c),
-                                });
-                            }
-                            _ => {}
                         }
-                    }
+                        Arg::Long(name) if name.starts_with("critical-") => {
+                            let cmetric = name[9..].to_string();
+                            let value = parser.value()?.into_string()?;
+                            if !value.is_empty() {
+                                trace!("Critical stored for metric '{}'", cmetric);
+                                criticals.push((cmetric, value));
+                            }
+                        }
+                        Arg::Long(name) => {
+                            return Err(Error::UnknownArgument {
+                                arg: format!("--{}", name),
+                            });
+                        }
+                        Arg::Short(c) => {
+                            return Err(Error::UnknownArgument {
+                                arg: format!("-{}", c),
+                            });
+                        }
+                        _ => {}
+                    },
                 },
                 None => {
                     break;
@@ -257,23 +271,25 @@ fn snmp_plugin() -> Result<(), Error> {
 
     let url = format!("{}:{}", hostname, port);
 
-    let result = cmd.execute(
-        &url,
-        &snmp_version,
-        &snmp_community,
-        &filter_in,
-        &filter_out,
-        check_format,
-        check_response,
-        no_data_status,
-    ).unwrap_or_else(|e| {
-        if check_format {
-            println!("JSON is INVALID: {}", e);
-        } else {
-            println!("UNKNOWN: {}", e);
-        }
-        std::process::exit(3);
-    });
+    let result = cmd
+        .execute(
+            &url,
+            &snmp_version,
+            &snmp_community,
+            &filter_in,
+            &filter_out,
+            check_format,
+            check_response,
+            no_data_status,
+        )
+        .unwrap_or_else(|e| {
+            if check_format {
+                println!("JSON is INVALID: {}", e);
+            } else {
+                println!("UNKNOWN: {}", e);
+            }
+            std::process::exit(3);
+        });
 
     if check_format {
         println!("JSON is valid");

--- a/rust-plugins/src/output/mod.rs
+++ b/rust-plugins/src/output/mod.rs
@@ -41,7 +41,11 @@ pub struct Output {
     #[serde(default = "default_no_data")]
     pub no_data: String,
     /// String used to separate metric instances in the detail message.
+    // Not read yet: `build_detail` currently joins with `metric_separator`
+    // for both purposes. Kept as a distinct, already-deserialized config
+    // field for when that's split out.
     #[serde(default = "default_instance_separator")]
+    #[allow(dead_code)]
     instance_separator: String,
     /// String used to separate individual metrics in perfdata.
     #[serde(default = "default_metric_separator")]
@@ -120,7 +124,7 @@ impl<'a> OutputFormatter<'a> {
     }
 
     /// Generates the complete Nagios-compatible output string.
-    pub fn to_string(&self) -> String {
+    fn render(&self) -> String {
         let metrics = self
             .metrics
             .iter()
@@ -148,9 +152,9 @@ impl<'a> OutputFormatter<'a> {
             Status::Ok => {
                 if self.output_formatter.detail_ok {
                     let detail = self.build_detail(&self.output_formatter.ok);
-                    return format!("{} | {}", detail, metrics);
+                    format!("{} | {}", detail, metrics)
                 } else {
-                    let parser = Parser::new(&self.collect, false);
+                    let parser = Parser::new(self.collect, false);
                     let res = parser.eval_str(&self.output_formatter.ok);
                     let output = match res {
                         Ok(output) => match output {
@@ -163,8 +167,7 @@ impl<'a> OutputFormatter<'a> {
                             }
                             ExprResult::StrVector(v) => {
                                 if v.len() == 1 {
-                                    let output = v[0].clone();
-                                    output
+                                    v[0].clone()
                                 } else {
                                     error!(
                                         "Output expression evaluated to a vector with more than one element, expected a single string"
@@ -179,31 +182,31 @@ impl<'a> OutputFormatter<'a> {
                             self.output_formatter.ok.clone()
                         }
                     };
-                    return format!("{} | {}", output, metrics);
+                    format!("{} | {}", output, metrics)
                 }
             }
             Status::Warning => {
                 if self.output_formatter.detail_warning {
                     let detail = self.build_detail(&self.output_formatter.warning);
-                    return format!("{} | {}", detail, metrics);
+                    format!("{} | {}", detail, metrics)
                 } else {
-                    return format!("{} | {}", self.output_formatter.warning, metrics);
+                    format!("{} | {}", self.output_formatter.warning, metrics)
                 }
             }
             Status::Critical => {
                 if self.output_formatter.detail_critical {
                     let detail = self.build_detail(&self.output_formatter.critical);
-                    return format!("{} | {}", detail, metrics);
+                    format!("{} | {}", detail, metrics)
                 } else {
-                    return format!("{} | {}", self.output_formatter.critical, metrics);
+                    format!("{} | {}", self.output_formatter.critical, metrics)
                 }
             }
             Status::Unknown => {
                 if self.output_formatter.detail_unknown {
                     let detail = self.build_detail(&self.output_formatter.unknown);
-                    return format!("{} | {}", detail, metrics);
+                    format!("{} | {}", detail, metrics)
                 } else {
-                    return format!("{} | {}", self.output_formatter.unknown, metrics);
+                    format!("{} | {}", self.output_formatter.unknown, metrics)
                 }
             }
         }
@@ -214,15 +217,15 @@ impl<'a> OutputFormatter<'a> {
     fn build_detail(&self, prefix: &str) -> String {
         let mut v = Vec::new();
         for m in self.metrics.iter() {
-            if let Some(status) = m.status {
-                if status.is_worse_than(self.status) {
-                    v.push(std::format!(
-                        "{} is {}{}",
-                        m.name,
-                        float_string(&m.value),
-                        m.uom
-                    ));
-                }
+            if let Some(status) = m.status
+                && status.is_worse_than(self.status)
+            {
+                v.push(std::format!(
+                    "{} is {}{}",
+                    m.name,
+                    float_string(&m.value),
+                    m.uom
+                ));
             }
         }
         std::format!(
@@ -230,6 +233,12 @@ impl<'a> OutputFormatter<'a> {
             prefix,
             v.join::<&str>(&self.output_formatter.metric_separator)
         )
+    }
+}
+
+impl<'a> std::fmt::Display for OutputFormatter<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.render())
     }
 }
 

--- a/rust-plugins/src/snmp/mod.rs
+++ b/rust-plugins/src/snmp/mod.rs
@@ -17,14 +17,9 @@ extern crate rasn_snmp;
 use crate::Error::InvalidOidParser;
 use crate::compute::ast::ExprResult;
 use crate::generic::error::Error::EmptyResponse;
-use crate::generic::error::Error::FailedToConnectToHost;
-use crate::generic::error::Error::InvalidSnmpPduDecode;
-use crate::generic::error::Error::InvalidSnmpPduEncode;
-use crate::generic::error::Error::InvalidSnmpType;
 use crate::generic::error::Error::InvalidSnmpValue;
 use crate::generic::error::Result;
-use log::info;
-use log::{trace, warn};
+use log::warn;
 use rasn::types::ObjectIdentifier;
 use rasn_smi::v2::{ApplicationSyntax, ObjectSyntax, SimpleSyntax};
 use rasn_snmp::v2::BulkPdu;
@@ -36,7 +31,11 @@ use rasn_snmp::v2c::Message;
 use rasn_snmp::v3::VarBindValue::EndOfMibView;
 use std::collections::HashMap;
 use std::convert::TryInto;
-use std::net::UdpSocket;
+// FailedToConnectToHost/InvalidSnmpPduDecode/InvalidSnmpPduEncode/info/trace/
+// UdpSocket are used only by the #[cfg(not(test))] variant of
+// `get_data_from_udp` below, so a `cargo test`/`--tests` analysis pass sees
+// them as unused; keep them local to that function instead of importing
+// them crate-wide, so nothing needs blanket-allowing.
 
 /// The SNMP value type decoded from a single OID's response.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -151,9 +150,7 @@ pub struct SnmpResult {
 ///
 /// # Returns
 /// An Result<[`SnmpResult`]> containing the retrieved values indexed by name, or an error
-///
-
-pub fn snmp_bulk_get<'a>(
+pub fn snmp_bulk_get(
     target: &str,
     _version: &str,
     community: &str,
@@ -196,7 +193,7 @@ pub fn snmp_bulk_get<'a>(
     let message: Message<GetBulkRequest> = Message {
         version: 1.into(),
         community: community.to_string().as_bytes().into(),
-        data: get_request.into(),
+        data: get_request,
     };
     let decoded = get_data_from_udp(target, message)?;
 
@@ -219,7 +216,7 @@ pub fn snmp_bulk_get<'a>(
 ///
 /// # Returns
 /// An [`SnmpResult`] containing all values under the specified OID
-pub fn snmp_bulk_walk<'a>(
+pub fn snmp_bulk_walk(
     target: &str,
     _version: &str,
     community: &str,
@@ -251,11 +248,11 @@ pub fn snmp_bulk_walk<'a>(
         let message: Message<GetBulkRequest> = Message {
             version: 1.into(),
             community: community.to_string().as_bytes().into(),
-            data: get_request.into(),
+            data: get_request,
         };
 
         let decoded = get_data_from_udp(target, message)?;
-        let completed = retval.build_response(decoded, &oid, snmp_name, true)?;
+        let completed = retval.build_response(decoded, oid, snmp_name, true)?;
 
         if completed {
             break;
@@ -282,13 +279,13 @@ pub fn snmp_bulk_walk<'a>(
 ///
 /// # Returns
 /// An [`SnmpResult`] with values organized by label as separate vectors
-pub fn snmp_bulk_walk_with_labels<'a>(
+pub fn snmp_bulk_walk_with_labels(
     target: &str,
     _version: &str,
     community: &str,
     oid: &str,
     snmp_name: &str,
-    labels: &'a HashMap<String, String>,
+    labels: &HashMap<String, String>,
 ) -> Result<SnmpResult> {
     let oid_init = oid_to_vec(oid)?;
     let mut oid_tab = &oid_init;
@@ -316,14 +313,13 @@ pub fn snmp_bulk_walk_with_labels<'a>(
         let message: Message<GetBulkRequest> = Message {
             version: 1.into(),
             community: community.to_string().as_bytes().into(),
-            data: get_request.into(),
+            data: get_request,
         };
 
         // Send the message through an UDP socket
         let decoded = get_data_from_udp(target, message)?;
 
-        let completed =
-            retval.build_response_with_labels(decoded, &oid, snmp_name, labels, true)?;
+        let completed = retval.build_response_with_labels(decoded, oid, snmp_name, labels, true)?;
         if completed {
             break;
         }
@@ -417,7 +413,7 @@ impl SnmpResult {
                 };
 
                 for key in key_for(idx, &name) {
-                    _ = self.store(key, typ.clone())?;
+                    self.store(key, typ.clone())?;
                 }
             }
         }
@@ -427,12 +423,12 @@ impl SnmpResult {
     /// Parses an SNMP response and organizes values by label: the last segment
     /// of each OID identifies the column, and matching values are stored under
     /// `{snmp_name}.{label}`.
-    fn build_response_with_labels<'a>(
+    fn build_response_with_labels(
         &mut self,
         decoded: Message<Pdus>,
         oid: &str,
         snmp_name: &str,
-        labels: &'a HashMap<String, String>,
+        labels: &HashMap<String, String>,
         walk: bool,
     ) -> Result<bool> {
         self.process_response(decoded, oid, walk, |_idx, name| {
@@ -447,11 +443,11 @@ impl SnmpResult {
 
     /// Parses an SNMP response from a get request, storing each variable under
     /// its corresponding entry in `names`.
-    fn build_response_with_names<'a>(
+    fn build_response_with_names(
         &mut self,
         decoded: Message<Pdus>,
         oid: &str,
-        names: &Vec<&str>,
+        names: &[&str],
         walk: bool,
     ) -> Result<bool> {
         self.process_response(decoded, oid, walk, |idx, _name| {
@@ -461,7 +457,7 @@ impl SnmpResult {
 
     /// Parses an SNMP response and stores every variable's value under a single
     /// logical name (used for plain walks).
-    fn build_response<'a>(
+    fn build_response(
         &mut self,
         decoded: Message<Pdus>,
         oid: &str,
@@ -496,7 +492,7 @@ fn oid_to_vec(oid: &str) -> Result<Vec<u32>> {
             oid: oid.to_string(),
         })?);
     }
-    return Ok(oid_u32);
+    Ok(oid_u32)
 }
 
 /// Create an udp socket and send a snmp request on it, returning the response.
@@ -518,6 +514,12 @@ fn get_data_from_udp(_target: &str, message: Message<GetBulkRequest>) -> Result<
 }
 #[cfg(not(test))]
 fn get_data_from_udp(target: &str, message: Message<GetBulkRequest>) -> Result<Message<Pdus>> {
+    use crate::generic::error::Error::FailedToConnectToHost;
+    use crate::generic::error::Error::InvalidSnmpPduDecode;
+    use crate::generic::error::Error::InvalidSnmpPduEncode;
+    use log::{info, trace};
+    use std::net::UdpSocket;
+
     let socket = UdpSocket::bind("0.0.0.0:0")?;
     socket.connect(target)?;
     let duration = std::time::Duration::from_millis(1000);
@@ -871,7 +873,7 @@ mod tests {
 
     #[test]
     fn value_from_varbind_decodes_every_application_wide_type() {
-        let ip = IpAddress(FixedOctetString::try_from([192u8, 168, 1, 1]).unwrap());
+        let ip = IpAddress(FixedOctetString::from([192u8, 168, 1, 1]));
         let cases = vec![
             (
                 ApplicationSyntax::Address(ip),
@@ -1000,7 +1002,7 @@ mod tests {
         let decoded = response_message(vec![("1.3.6.1.2.1.1.3.0", 1), ("1.3.6.1.2.1.1.9.0", 2)]);
 
         let completed = result
-            .build_response_with_names(decoded, "", &vec!["uptime", "count"], false)
+            .build_response_with_names(decoded, "", &["uptime", "count"], false)
             .unwrap();
 
         assert!(!completed);


### PR DESCRIPTION
## Summary
Fixes every `cargo clippy --all-targets` warning in `rust-plugins` (unneeded returns, manual `Option::map`, needless borrows, `&Vec`/`&Vec<T>` instead of slices, legacy `std::f64::INFINITY`, collapsible ifs, unused lifetimes, useless `.into()` conversions, dead/unused imports, `from_over_into` on `Status`) and applies `cargo fmt`, without changing any runtime behavior.

Notable non-mechanical fixes:
- `output::OutputFormatter`'s inherent `to_string()` (shadowing the `ToString` trait) becomes a proper `impl Display`; call sites are unaffected since `ToString` is blanket-implemented for `Display`.
- Three test modules (`compute/mod.rs`, `compute/lexer.rs`, `compute/threshold.rs`) lack `#[cfg(test)]` (see #6410): their imports/helpers are only used by `#[test]` fn bodies, which a plain (non-test) build strips, so clippy's default pass always flags them as unused regardless of gating elsewhere. Silenced locally with `#[allow(unused_imports, dead_code)]` rather than duplicating the `#[cfg(test)]` fix here, to avoid the two PRs conflicting on the same line — once #6410 merges these allows become redundant but harmless (also safe to drop them then).
- `snmp::mod.rs`: a few imports (`FailedToConnectToHost`, `InvalidSnmpPduDecode`/`Encode`, `log::info`/`trace`, `UdpSocket`) are used only by the `#[cfg(not(test))]` variant of `get_data_from_udp`; moved local to that function instead of importing them crate-wide.

Adds a `lint` CI job (`cargo fmt --check` + `cargo clippy --all-targets --release -- -D warnings`) alongside the existing build/test job, so regressions are caught going forward.

## Test plan
- [x] `cargo fmt --check`: clean
- [x] `cargo clippy --all-targets --release -- -D warnings`: clean
- [x] `cargo build --release`: succeeds
- [x] `cargo test`: 67 passed, 0 failed