### PR TITLE
chore(rust-plugins): add a local quality gate script, pin the toolchain, dedupe the generated parser

### DIFF
--- a/.githooks/pre-commit.d/25_rust_plugins.sh
+++ b/.githooks/pre-commit.d/25_rust_plugins.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Get list of committed files touching rust-plugins/
+mapfile -t rust_files < <(git diff --cached --name-only --diff-filter=ACMR -- rust-plugins/)
+
+if [ "${#rust_files[@]}" -eq 0 ]; then
+    exit 0
+fi
+
+echo "INFO: rust-plugins/ files staged, running the quality gate"
+rust-plugins/scripts/check.sh

--- a/rust-plugins/README.md
+++ b/rust-plugins/README.md
@@ -71,3 +71,25 @@ In this example, the output is built using several internal variables that are:
 So you could also define others variables for the output.
 
 In the query entry, there is also an `idx` variable that is an integer enumerating the entries og the query. It is used to build the name of the variable in the output. It starts from 0.
+
+# Development — quality gate
+
+Before opening a pull request touching `rust-plugins/`, run:
+
+```bash
+./scripts/check.sh
+```
+
+It matches what the `lint` and `build` jobs of `.github/workflows/generic-plugins.yml`
+enforce in CI (`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`,
+`cargo test`), plus a stricter local-only check: a scan proving that no
+`panic!`/`unwrap()` is reachable outside `#[cfg(test)]` modules — a panic
+reachable from untrusted input (a malformed JSON definition, a malicious SNMP
+response) turns a reportable `UNKNOWN` into a plugin crash.
+
+The toolchain is pinned by `rust-toolchain.toml` so everyone lints with the
+same rustc/clippy/rustfmt versions.
+
+If you use the repository's git hooks (`git config core.hooksPath .githooks`),
+the gate also runs automatically on commit whenever a staged file is under
+`rust-plugins/` (see `.githooks/pre-commit.d/25_rust_plugins.sh`).

--- a/rust-plugins/rust-toolchain.toml
+++ b/rust-plugins/rust-toolchain.toml
@@ -1,0 +1,6 @@
+# Pinned so every checkout runs the same rustc/clippy/rustfmt: the quality
+# gate (scripts/check.sh) enforces zero clippy warnings, which is only
+# meaningful with a fixed lint set. Bump deliberately, re-running the gate.
+[toolchain]
+channel = "1.97.1"
+components = ["rustfmt", "clippy"]

--- a/rust-plugins/scripts/check.sh
+++ b/rust-plugins/scripts/check.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Quality gate for rust-plugins — matches what the "lint" and "build" jobs of
+# .github/workflows/generic-plugins.yml enforce in CI. Run it locally before
+# pushing to catch issues without waiting on a CI round trip.
+#
+# The reachable-panic scan below is not currently part of the CI gate: it is
+# a stricter, complementary local check — a panic!/unwrap() reachable from
+# untrusted input (a malformed JSON definition, a malicious SNMP response)
+# turns a reportable UNKNOWN into a plugin crash.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+echo "==> cargo fmt --check"
+cargo fmt --check
+
+echo "==> cargo clippy --all-targets -- -D warnings"
+cargo clippy --all-targets --quiet -- -D warnings
+
+echo "==> cargo test"
+cargo test --quiet
+
+echo "==> reachable panic scan (production code, outside #[cfg(test)])"
+# panic!/unwrap()/todo!/unreachable! are only tolerated inside test modules:
+# for each source file, scan the content BEFORE its first #[cfg(test)] marker.
+fail=0
+while IFS= read -r -d '' file; do
+    hits=$(awk '/#\[cfg\(test\)\]/{exit} {print NR": "$0}' "$file" \
+        | grep -E 'panic!|\.unwrap\(\)|todo!\(|unreachable!' || true)
+    if [ -n "$hits" ]; then
+        echo "reachable panic/unwrap in $file:"
+        echo "$hits"
+        fail=1
+    fi
+done < <(find src -name '*.rs' -print0)
+if [ "$fail" -ne 0 ]; then
+    echo "FAILED: reachable panics found outside test modules"
+    exit 1
+fi
+
+echo "ALL CHECKS PASSED"

--- a/rust-plugins/src/grammar.lalrpop
+++ b/rust-plugins/src/grammar.lalrpop
@@ -18,11 +18,11 @@ pub Product: Box<ast::Expr<'input>> = {
 pub Function: Box<ast::Expr<'input>> = {
     <f:"id"> "(" <a:Var> ")" => {
       match f {
-	b"Average" => return Box::new(ast::Expr::Fn(ast::Func::Average, a)),
-	b"Max" => return Box::new(ast::Expr::Fn(ast::Func::Max, a)),
-	b"Min" => return Box::new(ast::Expr::Fn(ast::Func::Min, a)),
+	b"Average" => Box::new(ast::Expr::Fn(ast::Func::Average, a)),
+	b"Max" => Box::new(ast::Expr::Fn(ast::Func::Max, a)),
+	b"Min" => Box::new(ast::Expr::Fn(ast::Func::Min, a)),
 	// FIXME DBO: This case is an error case...
-	_ => return a,
+	_ => a,
       }
     }
 };

--- a/rust-plugins/src/main.rs
+++ b/rust-plugins/src/main.rs
@@ -30,12 +30,9 @@ use env_logger::Env;
 use generic::Command;
 use generic::Status;
 use generic::error::*;
-use lalrpop_util::lalrpop_mod;
 use lexopt::Arg;
 use log::trace;
 use std::fs;
-
-lalrpop_mod!(grammar);
 
 /// Reads a JSON file and deserializes it into a [`Command`].
 ///


### PR DESCRIPTION
## Summary
Adds `rust-plugins/scripts/check.sh`: a single local command (fmt check, `clippy --all-targets -D warnings`, test, and a reachable-panic scan) matching what the `lint`/`build` CI jobs enforce, plus a stricter local-only check not in CI: no `panic!()`/`.unwrap()` may be reachable from production code (outside `#[cfg(test)]`) — a panic reachable from untrusted input (a malformed JSON definition, a malicious SNMP response) turns a reportable `UNKNOWN` into a crash. Wired into `.githooks/pre-commit.d/` so it runs automatically for contributors using the repository's git hooks (`git config core.hooksPath .githooks`).

Pins the toolchain via `rust-toolchain.toml` (1.97.1 + rustfmt/clippy): zero-warning is only meaningful with a fixed lint set.

Removes a duplicate `lalrpop_mod!(grammar)` in `main.rs` — the ~4500-line generated parser was being compiled twice (once per declaration site); `main.rs` never referenced the `grammar` module directly, only `compute::mod.rs` does. Also drops the needless `return`s clippy flags in `grammar.lalrpop`'s own action code.

## Test plan
- [x] `cargo build --release` / `cargo test`: 67 passed, 0 failed
- [x] Confirmed only one `lalrpop_mod!(grammar)` remains in the crate
- [x] `./scripts/check.sh`'s fmt/clippy steps currently flag the pre-existing findings #6415 fixes, and its panic scan currently reports the 103 pre-existing hits #6410 (70+15, false positives from two ungated test modules) and #6411 (12+5+1, genuinely reachable panics) fix — verified by hand that the counts match exactly. Once those merge, this script reads `ALL CHECKS PASSED`.