### PR TITLE
fix(vmware-vsphere8): restore performance counters on vSphere 9.1 (vStats API removed)

### DIFF
--- a/packaging/centreon-plugin-Virtualization-Vmware8-Esx-Restapi/deb.json
+++ b/packaging/centreon-plugin-Virtualization-Vmware8-Esx-Restapi/deb.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-        "libjson-perl"
+        "libjson-perl",
+        "libxml-libxml-perl"
     ]
 }

--- a/packaging/centreon-plugin-Virtualization-Vmware8-Esx-Restapi/rpm.json
+++ b/packaging/centreon-plugin-Virtualization-Vmware8-Esx-Restapi/rpm.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-        "perl(JSON)"
+        "perl(JSON)",
+        "perl(XML::LibXML)"
     ]
 }

--- a/packaging/centreon-plugin-Virtualization-Vmware8-Vcenter-Restapi/deb.json
+++ b/packaging/centreon-plugin-Virtualization-Vmware8-Vcenter-Restapi/deb.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-        "libjson-perl"
+        "libjson-perl",
+        "libxml-libxml-perl"
     ]
 }

--- a/packaging/centreon-plugin-Virtualization-Vmware8-Vcenter-Restapi/rpm.json
+++ b/packaging/centreon-plugin-Virtualization-Vmware8-Vcenter-Restapi/rpm.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-        "perl(JSON)"
+        "perl(JSON)",
+        "perl(XML::LibXML)"
     ]
 }

--- a/packaging/centreon-plugin-Virtualization-Vmware8-Vcsa-Restapi/deb.json
+++ b/packaging/centreon-plugin-Virtualization-Vmware8-Vcsa-Restapi/deb.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-        "libjson-perl"
+        "libjson-perl",
+        "libxml-libxml-perl"
     ]
 }

--- a/packaging/centreon-plugin-Virtualization-Vmware8-Vcsa-Restapi/rpm.json
+++ b/packaging/centreon-plugin-Virtualization-Vmware8-Vcsa-Restapi/rpm.json
@@ -1,6 +1,7 @@
 {
     "dependencies": [
         "perl(Date::Parse)",
-        "perl(JSON)"
+        "perl(JSON)",
+        "perl(XML::LibXML)"
     ]
 }

--- a/packaging/centreon-plugin-Virtualization-Vmware8-Vm-Restapi/deb.json
+++ b/packaging/centreon-plugin-Virtualization-Vmware8-Vm-Restapi/deb.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-        "libjson-perl"
+        "libjson-perl",
+        "libxml-libxml-perl"
     ]
 }

--- a/packaging/centreon-plugin-Virtualization-Vmware8-Vm-Restapi/rpm.json
+++ b/packaging/centreon-plugin-Virtualization-Vmware8-Vm-Restapi/rpm.json
@@ -1,5 +1,6 @@
 {
     "dependencies": [
-        "perl(JSON)"
+        "perl(JSON)",
+        "perl(XML::LibXML)"
     ]
 }

--- a/src/apps/vmware/vsphere8/custom/api.pm
+++ b/src/apps/vmware/vsphere8/custom/api.pm
@@ -57,6 +57,7 @@ sub new {
                 'password:s'        => { name => 'password' },
                 'vstats-interval:s' => { name => 'vstats_interval',     default => 60 },
                 'vstats-duration:s' => { name => 'vstats_duration',     default => 2764800 }, # 2764800 seconds in 32 days
+                'metrics-source:s'  => { name => 'metrics_source',       default => 'auto' },
                 'timeout:s'         => { name => 'timeout',             default => 10 }
             }
         );
@@ -67,6 +68,9 @@ sub new {
     $self->{http}            = centreon::plugins::http->new(%options, 'default_backend' => 'curl');
     $self->{token_cache}     = centreon::plugins::statefile->new(%options);
     $self->{acq_specs_cache} = centreon::plugins::statefile->new(%options);
+    $self->{vim25_cache}     = centreon::plugins::statefile->new(%options);
+    # kept to build the vim25 fallback lazily, only when a counter is actually needed
+    $self->{custom_options}  = \%options;
 
     return $self;
 }
@@ -90,6 +94,12 @@ sub check_options {
     $self->{password}        = (defined($self->{option_results}->{password})) ? $self->{option_results}->{password} : '';
     $self->{vstats_interval} = $self->{option_results}->{vstats_interval};
     $self->{vstats_duration} = $self->{option_results}->{vstats_duration};
+    $self->{metrics_source}  = $self->{option_results}->{metrics_source} // 'auto';
+
+    if ($self->{metrics_source} !~ /^(auto|vstats|vim25)$/) {
+        $self->{output}->option_exit(short_msg => "Unsupported --metrics-source '" . $self->{metrics_source}
+            . "'. Expected one of: auto, vstats, vim25.");
+    }
 
     if ($self->{hostname} eq '') {
         $self->{output}->option_exit(short_msg => "Need to specify --hostname option.");
@@ -103,6 +113,7 @@ sub check_options {
 
     $self->{token_cache}->check_options(option_results => $self->{option_results});
     $self->{acq_specs_cache}->check_options(option_results => $self->{option_results});
+    $self->{vim25_cache}->check_options(option_results => $self->{option_results});
 
     return 0;
 }
@@ -304,6 +315,60 @@ sub get_vm_guest_identity {
     return $api_response;
 }
 
+# The vStats API (namespace com.vmware.vstats.*) was shipped as Tech Preview in vSphere 8.0
+# and has been REMOVED in vSphere 9.1 ("the vStats APIs (previously in Tech Preview) are
+# removed", VCF 9.1 Product Support Notes). On 9.1 the backend service is no longer
+# registered: /stats/acq-specs and /stats/data/dp fail the same way for GET and POST, while
+# the 9.1 API Explorer still advertises them.
+# Without this guard the response simply has no acq_specs collection, the plugin collects
+# nothing, caches that emptiness and reports "no data at the moment" instead of failing.
+sub vstats_response_is_usable {
+    my ($self, %options) = @_;
+
+    return (ref($options{response}) eq 'HASH' && ref($options{response}->{acq_specs}) eq 'ARRAY') ? 1 : 0;
+}
+
+sub vstats_unavailable_message {
+    my ($self, %options) = @_;
+
+    return "vStats API unusable on '" . $self->{hostname}
+        . "': endpoint '/api/stats/acq-specs' returned no acq_specs collection [http code: '"
+        . $self->{http}->get_code() . "']. The vStats API is Tech Preview in vSphere 8.0 to 9.0 "
+        . "and has been removed in vSphere 9.1, therefore performance counters cannot be "
+        . "collected through it. Use --metrics-source=vim25 to read them from the "
+        . "PerformanceManager SOAP API instead. Modes that do not rely on performance "
+        . "counters (status, health, count, list...) are not affected.";
+}
+
+# vim25 PerformanceManager fallback, built only when a counter is actually requested
+sub vim25 {
+    my ($self, %options) = @_;
+
+    return $self->{vim25} if (defined($self->{vim25}));
+
+    centreon::plugins::misc::mymodule_load(
+        output    => $self->{output},
+        module    => 'apps::vmware::vsphere8::custom::vim25',
+        error_msg => "Cannot load module 'apps::vmware::vsphere8::custom::vim25'."
+    );
+
+    $self->{vim25} = apps::vmware::vsphere8::custom::vim25->new(
+        %{$self->{custom_options}},
+        noptions => 1,
+        output   => $self->{output},
+        cache    => $self->{vim25_cache},
+        hostname => $self->{hostname},
+        port     => $self->{port},
+        proto    => $self->{proto},
+        username => $self->{username},
+        password => $self->{password},
+        timeout  => $self->{timeout}
+    );
+    $self->{vim25}->set_options(option_results => $self->{option_results});
+
+    return $self->{vim25};
+}
+
 sub get_all_acq_specs {
     my ($self, %options) = @_;
 
@@ -319,21 +384,32 @@ sub get_all_acq_specs {
     }
     # Get all acq specs (first page)
     my $response =  $self->request_api(endpoint => '/stats/acq-specs') ;
+    # give up instead of collecting nothing when the vStats API is not usable;
+    # get_stats() decides whether to fall back to vim25 or to fail explicitly
+    if (!$self->vstats_response_is_usable(response => $response)) {
+        $self->{vstats_unavailable} = 1;
+        return undef;
+    }
 
     # store only acq_specs related to the considered resource
-    push @{$self->{all_acq_specs}}, grep {$_->{resources}->[0]->{id_value} eq $options{rsrc_id}} @{$response->{acq_specs}};
+    my @acq_specs = grep {$_->{resources}->[0]->{id_value} eq $options{rsrc_id}} @{$response->{acq_specs}};
     # If the whole acq-specs takes more than one page, the API will return a "next" value
     while ($response->{next}) {
         $response = $self->request_api(endpoint => '/stats/acq-specs', get_param => [ 'page=' . $response->{next} ] );
+        if (!$self->vstats_response_is_usable(response => $response)) {
+            $self->{vstats_unavailable} = 1;
+            return undef;
+        }
         # store only acq_specs related to the considered resource
-        push @{$self->{all_acq_specs}}, grep {$_->{resources}->[0]->{id_value} eq $options{rsrc_id}} @{$response->{acq_specs}};
+        push @acq_specs, grep {$_->{resources}->[0]->{id_value} eq $options{rsrc_id}} @{$response->{acq_specs}};
     }
 
+    # only a well-formed list is kept and cached: this prevents a corrupted or empty
+    # statefile from making every subsequent run collect nothing
+    $self->{all_acq_specs} = \@acq_specs;
     # store it in the cache for future runs
     $self->{acq_specs_cache}->write(data => { updated => time(), acq_specs => $self->{all_acq_specs} });
-    # in some cases the statefile was corrupted and the plugin was stuck
-    # only return a result if it looks ok, else we store an empty array
-    $self->{all_acq_specs} = [] unless ref($self->{all_acq_specs}) eq 'ARRAY' && @{$self->{all_acq_specs}};
+
     return $self->{all_acq_specs};
 }
 
@@ -427,6 +503,7 @@ sub get_acq_spec {
 
     # If it is not available in cache call get_all_acq_specs()
     my $acq_specs = $self->get_all_acq_specs(%options);
+    return undef if (!defined($acq_specs));
     for my $spec (@$acq_specs) {
         # Ignore acq_specs not related to the counter_id
         next if ($options{cid} ne $spec->{counters}->{cid_mid}->{cid});
@@ -446,6 +523,9 @@ sub check_acq_spec {
     my ($self, %options) = @_;
 
     my $acq_spec = $self->get_acq_spec(%options);
+
+    # do not try to create an acq_spec on a vCenter where vStats no longer exists
+    return undef if ($self->{vstats_unavailable});
 
     if ( !defined($acq_spec) ) {
         # acq_spec not found => we need to create it
@@ -473,7 +553,14 @@ sub get_stats {
         $self->{output}->option_exit(short_msg => "get_stats method called without cid, will get all available stats for resource");
     }
 
+    # vim25 is either forced, or used as a fallback when vStats is gone (vSphere 9.1)
+    return $self->vim25()->get_perf_value(%options) if ($self->{metrics_source} eq 'vim25');
+
     if ( !$self->check_acq_spec(%options) ) {
+        if ($self->{vstats_unavailable}) {
+            return $self->vim25()->get_perf_value(%options) if ($self->{metrics_source} eq 'auto');
+            $self->{output}->option_exit(short_msg => $self->vstats_unavailable_message());
+        }
         $self->{output}->option_exit(short_msg => "get_stats method failed to check_acq_spec()");
     }
 
@@ -962,6 +1049,24 @@ Define the username for authentication.
 =item B<--password>
 
 Define the password for authentication.
+
+=item B<--metrics-source>
+
+Define where performance counters are read from (default: C<auto>).
+
+The C<vstats> source is the REST vStats API. It is available from vSphere 8.0 to 9.0
+only: it was shipped as Tech Preview and has been removed in vSphere 9.1.
+
+The C<vim25> source reads the same counters from the C<PerformanceManager> of the
+vim25 SOAP API, which vSphere 9.1 still serves. It requires neither the VMware Perl
+SDK nor the C<centreon_vmware> daemon.
+
+With C<auto>, C<vstats> is used and C<vim25> takes over when the vCenter no longer
+serves vStats, so the same command works from 8.0 to 9.1. Force C<vstats> or C<vim25>
+to pin one source, for instance to make an unsupported version fail loudly.
+
+Modes that do not read performance counters (status, health, count, list...) never
+use this option.
 
 =item B<--vstats-interval>
 

--- a/src/apps/vmware/vsphere8/custom/api.pm
+++ b/src/apps/vmware/vsphere8/custom/api.pm
@@ -369,6 +369,19 @@ sub vim25 {
     return $self->{vim25};
 }
 
+# Called whenever an acquisition specification is created or extended: the list held in
+# memory no longer reflects the vCenter, and the statefile must not be refreshed from it
+# either. Without this, the cache was persisted mid-run with a partial view and every
+# later run re-created the specifications missing from that snapshot.
+sub invalidate_acq_specs {
+    my ($self, %options) = @_;
+
+    delete $self->{all_acq_specs};
+    $self->{acq_specs_stale} = 1;
+
+    return 1;
+}
+
 sub get_all_acq_specs {
     my ($self, %options) = @_;
 
@@ -376,11 +389,26 @@ sub get_all_acq_specs {
     return $self->{all_acq_specs} if ($self->{all_acq_specs} && @{$self->{all_acq_specs}});
 
     # if we can get it from the cache, we return it
-    if ($self->{acq_specs_cache}->read(
+    if (!$self->{acq_specs_stale} && $self->{acq_specs_cache}->read(
         statefile => 'vsphere8_api_acq_specs_' . $options{rsrc_id} . '_' . sha256_hex($self->{hostname} . ':' . $self->{port} . '_' . $self->{username})
     )) {
-        $self->{all_acq_specs} = $self->{acq_specs_cache}->get(name => 'acq_specs');
-        return $self->{all_acq_specs};
+        my $cached = $self->{acq_specs_cache}->get(name => 'acq_specs');
+        # An empty or malformed cached list is a cache miss, never an answer.
+        #
+        # This is what a vCenter whose vStats API has been removed left behind before
+        # this was fixed: returning it here would short-circuit the detection below and
+        # keep the plugin silent for exactly the platforms this fix targets, until
+        # someone deleted the statefile by hand. Falling through re-queries the API, so
+        # an already-affected poller heals on its very next check, with nothing to clean
+        # up manually.
+        #
+        # It is also what a healthy vCenter with no acquisition specification yet leaves
+        # behind, where re-querying picks up the specifications that were just created
+        # instead of creating them again on every run.
+        if (ref($cached) eq 'ARRAY' && @$cached) {
+            $self->{all_acq_specs} = $cached;
+            return $self->{all_acq_specs};
+        }
     }
     # Get all acq specs (first page)
     my $response =  $self->request_api(endpoint => '/stats/acq-specs') ;
@@ -404,11 +432,12 @@ sub get_all_acq_specs {
         push @acq_specs, grep {$_->{resources}->[0]->{id_value} eq $options{rsrc_id}} @{$response->{acq_specs}};
     }
 
-    # only a well-formed list is kept and cached: this prevents a corrupted or empty
-    # statefile from making every subsequent run collect nothing
     $self->{all_acq_specs} = \@acq_specs;
-    # store it in the cache for future runs
-    $self->{acq_specs_cache}->write(data => { updated => time(), acq_specs => $self->{all_acq_specs} });
+    # Only a complete, non-empty list is worth caching: an empty one is deliberately
+    # ignored on read, and a list read while specifications are being created is only a
+    # partial view of the vCenter.
+    $self->{acq_specs_cache}->write(data => { updated => time(), acq_specs => $self->{all_acq_specs} })
+        if (@acq_specs && !$self->{acq_specs_stale});
 
     return $self->{all_acq_specs};
 }
@@ -464,6 +493,9 @@ sub create_acq_spec {
     ) or return undef;
     $self->{output}->add_option_msg(long_msg => "The counter $options{cid} was not recorded for resource $options{rsrc_id} before. It will now (creating acq_spec).");
 
+    # the stored list no longer reflects the vCenter
+    $self->invalidate_acq_specs();
+
     return 1;
 }
 
@@ -493,7 +525,7 @@ sub extend_acq_spec {
     return undef if (defined($response) && ref($response) eq 'HASH' && scalar(keys %$response) > 0);
 
     # reset stored acq_specs since it's no longer accurate
-    $self->{all_acq_specs} = [];
+    $self->invalidate_acq_specs();
 
     return 1;
 }

--- a/src/apps/vmware/vsphere8/custom/vim25.pm
+++ b/src/apps/vmware/vsphere8/custom/vim25.pm
@@ -1,0 +1,547 @@
+#
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::vmware::vsphere8::custom::vim25;
+
+# Performance counters source based on the vim25 SOAP API (PerformanceManager).
+#
+# The vStats API used by apps::vmware::vsphere8::custom::api has been removed in
+# vSphere 9.1, while PerformanceManager is still served by /sdk on that version.
+# This package speaks vim25 directly over centreon::plugins::http: it does NOT
+# depend on the unmaintained VMware Perl SDK, nor on the centreon_vmware daemon.
+#
+# Only what is needed to read a single counter value is implemented:
+#   RetrieveServiceContent -> Login -> QueryPerfCounter -> QueryPerf -> Logout
+
+use strict;
+use warnings;
+use XML::LibXML;
+use centreon::plugins::http;
+use centreon::plugins::statefile;
+use Digest::SHA qw(sha256_hex);
+use centreon::plugins::misc qw/is_empty/;
+
+my $VIM_NS = 'urn:vim25';
+
+# Managed object types, keyed by the prefix found in a resource id (host-35, vm-42).
+my %entity_types = (
+    'HOST' => 'HostSystem',
+    'VM'   => 'VirtualMachine'
+);
+
+# Rollup types accepted for a counter, by order of preference. vStats exposes a
+# single value per counter, PerformanceManager exposes one per rollup.
+my @rollup_preference = qw(average latest none summation maximum minimum);
+
+# vStats counter ids are first looked up as-is in the PerformanceManager catalogue
+# ('cpu.capacity.usage' -> 'cpu.capacity.usage.<rollup>'). When the vCenter does not
+# advertise that name, these historical equivalents are tried instead. A substitution
+# is always reported in the long output so that it can be reviewed.
+# The unit is never assumed: it is read from the catalogue and converted.
+my %counter_aliases = (
+    'cpu.capacity.usage'       => [ 'cpu.usagemhz' ],
+    'cpu.capacity.provisioned' => [ 'cpu.totalCapacity' ],
+    'cpu.capacity.entitlement' => [ 'cpu.totalCapacity' ],
+    'cpu.capacity.demand'      => [ 'cpu.demand' ],
+    'cpu.capacity.contention'  => [ 'cpu.readiness' ],
+    'mem.capacity.usable'      => [ 'mem.totalCapacity' ],
+    'mem.capacity.usage'       => [ 'mem.consumed' ],
+    'mem.capacity.entitlement' => [ 'mem.granted' ],
+    'mem.consumed.vms'         => [ 'mem.consumed' ],
+    'mem.swap.current'         => [ 'mem.swapused' ],
+    'mem.swap.target'          => [ 'mem.swaptarget' ],
+    'mem.swap.readrate'        => [ 'mem.swapinRate' ],
+    'mem.swap.writerate'       => [ 'mem.swapoutRate' ],
+    'disk.throughput.usage'    => [ 'disk.usage' ],
+    'disk.throughput.contention' => [ 'disk.maxTotalLatency' ],
+    'net.throughput.usage'     => [ 'net.usage' ],
+    'power.capacity.usage'     => [ 'power.power' ]
+);
+
+# Unit conversion. Every unit is expressed as a factor towards the base unit of
+# its dimension, so a conversion is only allowed inside one dimension.
+# Beware: the vim25 'percent' unit is expressed in hundredths of a percent.
+my %units = (
+    # vim25 unit keys (unitInfo.key), used as conversion sources
+    'hertz'                 => [ 'frequency', 1 ],
+    'kiloHertz'             => [ 'frequency', 1e3 ],
+    'megaHertz'             => [ 'frequency', 1e6 ],
+    'byte'                  => [ 'bytes',     1 ],
+    'kiloBytes'             => [ 'bytes',     1024 ],
+    'megaBytes'             => [ 'bytes',     1024 ** 2 ],
+    'gigaBytes'             => [ 'bytes',     1024 ** 3 ],
+    'teraBytes'             => [ 'bytes',     1024 ** 4 ],
+    'bytesPerSecond'        => [ 'rate',      1 ],
+    'kiloBytesPerSecond'    => [ 'rate',      1024 ],
+    'megaBytesPerSecond'    => [ 'rate',      1024 ** 2 ],
+    'percent'               => [ 'percent',   0.01 ],
+    'number'                => [ 'number',    1 ],
+    'watt'                  => [ 'power',     1 ],
+    'joule'                 => [ 'energy',    1 ],
+    'nanosecond'            => [ 'time',      1e-9 ],
+    'microsecond'           => [ 'time',      1e-6 ],
+    'millisecond'           => [ 'time',      1e-3 ],
+    'second'                => [ 'time',      1 ],
+    # canonical target units, used to express what the modes expect
+    'Hz'                    => [ 'frequency', 1 ],
+    'kHz'                   => [ 'frequency', 1e3 ],
+    'MHz'                   => [ 'frequency', 1e6 ],
+    'B'                     => [ 'bytes',     1 ],
+    'KB'                    => [ 'bytes',     1024 ],
+    'MB'                    => [ 'bytes',     1024 ** 2 ],
+    'Bps'                   => [ 'rate',      1 ],
+    'KBps'                  => [ 'rate',      1024 ],
+    'pct'                   => [ 'percent',   1 ],
+    'count'                 => [ 'number',    1 ],
+    'W'                     => [ 'power',     1 ],
+    'ms'                    => [ 'time',      1e-3 ]
+);
+
+# Unit each vStats counter id is expressed in, derived from the arithmetic the
+# modes apply to the returned value (for instance esx/mode/memory.pm multiplies
+# mem.capacity.usable.HOST by 1024*1024 to obtain bytes, so it expects MB).
+# Values read from vim25 are converted to these units so that no mode has to change.
+my %target_units = (
+    'cpu.capacity.provisioned.HOST'   => 'kHz',
+    'cpu.capacity.usage.HOST'         => 'kHz',
+    'cpu.capacity.demand.HOST'        => 'kHz',
+    'cpu.capacity.contention.HOST'    => 'pct',
+    'cpu.corecount.provisioned.HOST'  => 'count',
+    'cpu.corecount.usage.HOST'        => 'count',
+    'cpu.corecount.contention.HOST'   => 'pct',
+    'cpu.capacity.provisioned.VM'     => 'MHz',
+    'cpu.capacity.entitlement.VM'     => 'MHz',
+    'cpu.capacity.usage.VM'           => 'MHz',
+    'mem.capacity.provisioned.HOST'   => 'MB',
+    'mem.capacity.usable.HOST'        => 'MB',
+    'mem.capacity.usage.HOST'         => 'MB',
+    'mem.capacity.contention.HOST'    => 'pct',
+    'mem.consumed.vms.HOST'           => 'MB',
+    'mem.consumed.userworlds.HOST'    => 'MB',
+    'mem.reservedCapacityPct.HOST'    => 'pct',
+    'mem.swap.current.HOST'           => 'KB',
+    'mem.swap.target.HOST'            => 'KB',
+    'mem.swap.readrate.HOST'          => 'KBps',
+    'mem.swap.writerate.HOST'         => 'KBps',
+    'mem.capacity.entitlement.VM'     => 'MB',
+    'mem.capacity.usage.VM'           => 'MB',
+    'disk.throughput.usage.HOST'      => 'KBps',
+    'disk.throughput.contention.HOST' => 'ms',
+    'disk.throughput.usage.VM'        => 'KBps',
+    'disk.throughput.contention.VM'   => 'ms',
+    'net.throughput.usage.HOST'       => 'KBps',
+    'net.throughput.usable.HOST'      => 'KBps',
+    'net.throughput.provisioned.HOST' => 'KBps',
+    'net.throughput.contention.HOST'  => 'count',
+    'net.throughput.usage.VM'         => 'KBps',
+    'net.throughput.contention.VM'    => 'count',
+    'power.capacity.usage.HOST'       => 'W',
+    'power.capacity.usage.VM'         => 'W'
+);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = bless {}, $class;
+
+    $self->{output} = $options{output};
+    for my $key (qw/hostname port proto username password timeout/) {
+        $self->{$key} = $options{$key};
+    }
+    $self->{http}  = centreon::plugins::http->new(%options);
+    $self->{cache} = $options{cache};
+
+    return $self;
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+
+    $self->{option_results} = $options{option_results};
+}
+
+sub settings {
+    my ($self, %options) = @_;
+
+    return 1 if (defined($self->{settings_done}));
+
+    $self->{option_results}->{hostname} = $self->{hostname};
+    $self->{option_results}->{port}     = $self->{port};
+    $self->{option_results}->{proto}    = $self->{proto};
+    $self->{option_results}->{timeout}  = $self->{timeout};
+    # SOAP faults come with a 500 status and carry the error message: they must be read
+    $self->{option_results}->{unknown_status}  = '';
+    $self->{option_results}->{warning_status}  = '';
+    $self->{option_results}->{critical_status} = '';
+
+    $self->{http}->set_options(%{$self->{option_results}});
+    $self->{settings_done} = 1;
+
+    return 1;
+}
+
+# Returns the managed object type ('HostSystem', 'VirtualMachine') for a resource id.
+sub entity_type {
+    my ($self, %options) = @_;
+
+    if ($options{rsrc_id} =~ /^([a-z]+)-(\d+)$/) {
+        my $type = $entity_types{ uc($1) };
+        return $type if (defined($type));
+    }
+
+    $self->{output}->option_exit(short_msg => "vim25: cannot determine the managed object type of resource '"
+        . $options{rsrc_id} . "'.");
+}
+
+# Parses a vim25 response. The payload is untrusted input, so entity expansion and
+# external DTD/network fetching are disabled: without this, a hostile or compromised
+# endpoint could read local files through an external entity (XXE) or exhaust memory
+# through nested entity expansion. Returns undef when the payload is not valid XML.
+sub parse_xml {
+    my ($self, %options) = @_;
+
+    my $doc = eval {
+        XML::LibXML->load_xml(
+            string          => $options{content},
+            no_network      => 1,
+            expand_entities => 0,
+            load_ext_dtd    => 0,
+            no_blanks       => 1
+        )
+    };
+
+    return ($@ || !defined($doc)) ? undef : $doc;
+}
+
+sub soap_request {
+    my ($self, %options) = @_;
+
+    $self->settings();
+
+    my $envelope = '<?xml version="1.0" encoding="UTF-8"?>'
+        . '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"'
+        . ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+        . ' xmlns:xsd="http://www.w3.org/2001/XMLSchema"'
+        . ' xmlns="' . $VIM_NS . '">'
+        . '<soapenv:Body>' . $options{body} . '</soapenv:Body>'
+        . '</soapenv:Envelope>';
+
+    $self->{http}->add_header(key => 'Content-Type', value => 'text/xml; charset=utf-8');
+    $self->{http}->add_header(key => 'SOAPAction', value => '"' . $VIM_NS . '"');
+    $self->{http}->add_header(key => 'Cookie', value => $self->{cookie}) if (defined($self->{cookie}));
+
+    my $content = $self->{http}->request(
+        method          => 'POST',
+        url_path        => '/sdk',
+        query_form_post => $envelope,
+        # SOAP faults are returned with a 500 status and must be read, not swallowed
+        unknown_status  => '',
+        insecure        => (defined($self->{option_results}->{insecure}) ? 1 : 0)
+    );
+
+    my $doc = $self->parse_xml(content => $content);
+    if (!defined($doc)) {
+        $self->{output}->option_exit(short_msg => "vim25: cannot parse the response of '" . $options{operation}
+            . "' [http code: '" . $self->{http}->get_code() . "']. "
+            . "Check that the vim25 SOAP API is reachable on " . $self->{proto} . '://' . $self->{hostname} . '/sdk');
+    }
+
+    my $xpc = XML::LibXML::XPathContext->new($doc);
+    $xpc->registerNs('soapenv', 'http://schemas.xmlsoap.org/soap/envelope/');
+    $xpc->registerNs('vim', $VIM_NS);
+
+    my ($fault) = $xpc->findnodes('//soapenv:Fault');
+    if (defined($fault)) {
+        my ($reason) = $xpc->findnodes('.//faultstring', $fault);
+        $self->{output}->option_exit(short_msg => "vim25: operation '" . $options{operation} . "' failed: "
+            . (defined($reason) ? $reason->textContent() : 'unknown SOAP fault'));
+    }
+
+    return $xpc;
+}
+
+sub login {
+    my ($self, %options) = @_;
+
+    return 1 if (defined($self->{session_established}));
+
+    my $xpc = $self->soap_request(
+        operation => 'RetrieveServiceContent',
+        body      => '<RetrieveServiceContent><_this type="ServiceInstance">ServiceInstance</_this></RetrieveServiceContent>'
+    );
+
+    for my $property (qw/sessionManager perfManager/) {
+        my ($node) = $xpc->findnodes('//vim:' . $property);
+        if (!defined($node)) {
+            $self->{output}->option_exit(short_msg => "vim25: the service content returned by "
+                . $self->{hostname} . " has no '" . $property . "' entry.");
+        }
+        $self->{$property} = $node->textContent();
+    }
+
+    # the session cookie must be replayed on every subsequent call
+    my $cookie = $self->{http}->get_first_header(name => 'Set-Cookie');
+    $self->{cookie} = $1 if (defined($cookie) && $cookie =~ /(vmware_soap_session=[^;]+)/);
+
+    $self->soap_request(
+        operation => 'Login',
+        body      => '<Login><_this type="SessionManager">' . xml_escape($self->{sessionManager}) . '</_this>'
+            . '<userName>' . xml_escape($self->{username}) . '</userName>'
+            . '<password>' . xml_escape($self->{password}) . '</password></Login>'
+    );
+
+    # the cookie is normally issued by the Login call itself
+    $cookie = $self->{http}->get_first_header(name => 'Set-Cookie');
+    $self->{cookie} = $1 if (defined($cookie) && $cookie =~ /(vmware_soap_session=[^;]+)/);
+
+    $self->{session_established} = 1;
+
+    return 1;
+}
+
+sub logout {
+    my ($self, %options) = @_;
+
+    return 1 if (!defined($self->{session_established}));
+
+    $self->soap_request(
+        operation => 'Logout',
+        body      => '<Logout><_this type="SessionManager">' . xml_escape($self->{sessionManager}) . '</_this></Logout>'
+    );
+    delete $self->{session_established};
+
+    return 1;
+}
+
+# Builds, once per vCenter, the '<group>.<name>.<rollup>' => {key, unit} catalogue.
+# It only changes with the vCenter version, so it is cached on disk.
+sub counter_catalogue {
+    my ($self, %options) = @_;
+
+    return $self->{catalogue} if (defined($self->{catalogue}));
+
+    my $statefile = 'vsphere8_vim25_counters_' . sha256_hex($self->{hostname} . ':' . $self->{port});
+    if (defined($self->{cache}) && $self->{cache}->read(statefile => $statefile)) {
+        my $cached = $self->{cache}->get(name => 'counters');
+        if (ref($cached) eq 'HASH' && keys %$cached) {
+            $self->{catalogue} = $cached;
+            return $self->{catalogue};
+        }
+    }
+
+    $self->login();
+
+    my $xpc = $self->soap_request(
+        operation => 'QueryPerfCounter',
+        body      => '<RetrievePropertiesEx><_this type="PropertyCollector">propertyCollector</_this>'
+            . '<specSet><propSet><type>PerformanceManager</type><pathSet>perfCounter</pathSet></propSet>'
+            . '<objectSet><obj type="PerformanceManager">' . xml_escape($self->{perfManager}) . '</obj></objectSet></specSet>'
+            . '<options/></RetrievePropertiesEx>'
+    );
+
+    my %catalogue;
+    for my $counter ($xpc->findnodes('//vim:val/vim:PerfCounterInfo | //vim:PerfCounterInfo')) {
+        my ($key)    = $xpc->findnodes('./vim:key', $counter);
+        my ($group)  = $xpc->findnodes('./vim:groupInfo/vim:key', $counter);
+        my ($name)   = $xpc->findnodes('./vim:nameInfo/vim:key', $counter);
+        my ($rollup) = $xpc->findnodes('./vim:rollupType', $counter);
+        my ($unit)   = $xpc->findnodes('./vim:unitInfo/vim:key', $counter);
+        next if (grep { !defined($_) } ($key, $group, $name, $rollup, $unit));
+
+        $catalogue{ join('.', $group->textContent(), $name->textContent(), $rollup->textContent()) } = {
+            key  => $key->textContent(),
+            unit => $unit->textContent()
+        };
+    }
+
+    if (!keys %catalogue) {
+        $self->{output}->option_exit(short_msg => "vim25: PerformanceManager returned an empty counter catalogue on "
+            . $self->{hostname} . ". Performance counters cannot be collected.");
+    }
+
+    $self->{catalogue} = \%catalogue;
+    $self->{cache}->write(data => { updated => time(), counters => \%catalogue }) if (defined($self->{cache}));
+
+    return $self->{catalogue};
+}
+
+# Resolves a vStats counter id ('cpu.capacity.usage.HOST') to a vim25 counter.
+sub resolve_counter {
+    my ($self, %options) = @_;
+
+    my $cid = $options{cid};
+    (my $base = $cid) =~ s/\.(HOST|VM)$//;
+
+    my $catalogue = $self->counter_catalogue();
+    my @candidates = ($base, @{ $counter_aliases{$base} // [] });
+
+    for my $candidate (@candidates) {
+        for my $rollup (@rollup_preference) {
+            my $counter = $catalogue->{ $candidate . '.' . $rollup };
+            next if (!defined($counter));
+
+            $self->{output}->add_option_msg(long_msg => "vim25: counter '" . $cid . "' is not advertised as such by "
+                . $self->{hostname} . ", reading '" . $candidate . '.' . $rollup . "' instead.")
+                if ($candidate ne $base);
+
+            return $counter;
+        }
+    }
+
+    $self->{output}->option_exit(short_msg => "vim25: counter '" . $cid . "' has no PerformanceManager equivalent on "
+        . $self->{hostname} . " (looked for " . join(', ', map { "'" . $_ . ".<" . join('|', @rollup_preference) . ">'" } @candidates)
+        . "). This counter cannot be collected from the vim25 API.");
+}
+
+sub convert_unit {
+    my ($self, %options) = @_;
+
+    my $from = $units{ $options{from} };
+    my $to   = $units{ $options{to} };
+
+    if (!defined($from) || !defined($to)) {
+        $self->{output}->option_exit(short_msg => "vim25: unknown unit in conversion of counter '" . $options{cid}
+            . "' ('" . $options{from} . "' to '" . $options{to} . "').");
+    }
+    if ($from->[0] ne $to->[0]) {
+        $self->{output}->option_exit(short_msg => "vim25: counter '" . $options{cid} . "' is returned in '"
+            . $options{from} . "' but is expected in '" . $options{to} . "', which measures something else ('"
+            . $from->[0] . "' against '" . $to->[0] . "'). Refusing to report a wrong value.");
+    }
+
+    return $options{value} * $from->[1] / $to->[1];
+}
+
+# Reads one counter for one resource and returns it in the unit the modes expect.
+sub get_perf_value {
+    my ($self, %options) = @_;
+
+    if (is_empty($options{cid}) || is_empty($options{rsrc_id})) {
+        $self->{output}->option_exit(short_msg => "vim25: get_perf_value needs both a cid and a rsrc_id.");
+    }
+
+    my $target = $target_units{ $options{cid} };
+    if (!defined($target)) {
+        $self->{output}->option_exit(short_msg => "vim25: counter '" . $options{cid}
+            . "' has no known target unit, its value cannot be converted safely.");
+    }
+
+    my $counter = $self->resolve_counter(cid => $options{cid});
+    my $type    = $self->entity_type(rsrc_id => $options{rsrc_id});
+
+    my $xpc = $self->soap_request(
+        operation => 'QueryPerf',
+        body      => '<QueryPerf><_this type="PerformanceManager">' . xml_escape($self->{perfManager}) . '</_this>'
+            . '<querySpec><entity type="' . $type . '">' . xml_escape($options{rsrc_id}) . '</entity>'
+            . '<maxSample>1</maxSample>'
+            . '<metricId><counterId>' . $counter->{key} . '</counterId><instance></instance></metricId>'
+            . '<intervalId>' . ($options{interval} // 20) . '</intervalId>'
+            . '</querySpec></QueryPerf>'
+    );
+
+    my @values = $xpc->findnodes('//vim:value/vim:value');
+    if (!@values) {
+        $self->{output}->add_option_msg(short_msg => "no data for resource " . $options{rsrc_id}
+            . " counter " . $options{cid} . " at the moment.");
+        return undef;
+    }
+
+    # last sample of the series, consistent with what the vStats implementation returned
+    my $raw = $values[-1]->textContent();
+    return undef if (!defined($raw) || $raw !~ /^-?\d+(\.\d+)?$/ || $raw == -1);
+
+    return $self->convert_unit(
+        value => $raw,
+        from  => $counter->{unit},
+        to    => $target,
+        cid   => $options{cid}
+    );
+}
+
+# A vim25 session lives for 30 minutes by default. Every plugin run opens one, so
+# leaving them behind would pile sessions up on the vCenter, which caps them (3000 by
+# default, with a dedicated alarm since vSphere 9.1). Closing on destruction keeps a
+# single short-lived session per run whatever the number of counters read.
+sub DESTROY {
+    my ($self) = @_;
+
+    # nothing reliable can be called once global destruction has started
+    return if (${^GLOBAL_PHASE} eq 'DESTRUCT');
+
+    eval { $self->logout() };
+}
+
+sub xml_escape {
+    my ($string) = @_;
+
+    return '' if (!defined($string));
+    $string =~ s/&/&amp;/g;
+    $string =~ s/</&lt;/g;
+    $string =~ s/>/&gt;/g;
+    $string =~ s/"/&quot;/g;
+    $string =~ s/'/&apos;/g;
+
+    return $string;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+apps::vmware::vsphere8::custom::vim25 - Performance counters read from the vim25 SOAP API
+
+=head1 DESCRIPTION
+
+Collects performance counters through the vim25 C<PerformanceManager>, which is still
+served by vCenter 9.1 while the vStats REST API used by
+C<apps::vmware::vsphere8::custom::api> has been removed in that version.
+
+Counter ids keep the vStats naming (C<cpu.capacity.usage.HOST>), so the modes are
+unchanged: the counter is resolved against the catalogue advertised by the vCenter
+itself and the returned value is converted to the unit the modes expect. A counter
+with no vim25 equivalent, or whose unit cannot be converted, raises an explicit
+error rather than reporting a wrong value.
+
+This package requires neither the unmaintained VMware Perl SDK nor the
+C<centreon_vmware> daemon: it builds the SOAP envelopes itself and sends them with
+C<centreon::plugins::http>.
+
+=head1 METHODS
+
+=head2 get_perf_value
+
+    my $value = $vim25->get_perf_value(cid => 'cpu.capacity.usage.HOST', rsrc_id => 'host-35');
+
+Returns the last sample of the given counter for the given resource, converted to the
+unit expected by the modes, or C<undef> when the vCenter currently has no sample.
+
+=head2 counter_catalogue
+
+Returns, and caches on disk, the C<< '<group>.<name>.<rollup>' => { key, unit } >>
+catalogue advertised by the C<PerformanceManager> of the vCenter.
+
+=head2 login / logout
+
+Open and close the vim25 session. C<login> retrieves the service content, keeps the
+C<sessionManager> and C<perfManager> managed object references and stores the
+C<vmware_soap_session> cookie replayed on every subsequent call.
+
+=cut

--- a/tests/apps/vmware/vsphere8/api.t
+++ b/tests/apps/vmware/vsphere8/api.t
@@ -219,6 +219,93 @@ sub test_vim25_xml_hardening {
     is($vim25->parse_xml(content => ''),         undef, 'an empty payload returns undef');
 }
 
+# A statefile written before this fix holds an empty acq_specs list. Trusting it would
+# short-circuit the vStats detection and keep an already-affected poller silent, which
+# is the very population the fix targets. Such a cache must behave as a cache miss.
+{
+    package MockCache;
+    sub new { my ($class, %o) = @_; return bless { %o, writes => [] }, $class; }
+    sub read { return $_[0]->{readable} ? 1 : 0 }
+    sub get { return $_[0]->{content} }
+    sub write { my ($self, %o) = @_; push @{$self->{writes}}, $o{data}; return 1; }
+    sub check_options { }
+}
+
+sub build_api_with_cache {
+    my (%options) = @_;
+
+    my $api = apps::vmware::vsphere8::custom::api->new(
+        options => MockOptions->new(),
+        output  => ExitingOutput->new()
+    );
+    $api->{hostname}        = 'vcenter.example.tld';
+    $api->{port}            = 443;
+    $api->{username}        = 'svc-centreon';
+    $api->{http}            = MockHttp->new($options{http_code} // 404);
+    $api->{acq_specs_cache} = MockCache->new(readable => 1, content => $options{cached});
+    # what a vCenter 9.1 answers once the vStats backend is unregistered
+    $api->{mocked_response} = $options{response} // {};
+    no warnings 'redefine';
+    local *apps::vmware::vsphere8::custom::api::request_api = sub { return $_[0]->{mocked_response} };
+    return ($api, $api->get_all_acq_specs(rsrc_id => 'host-35'));
+}
+
+sub test_poisoned_cache_is_ignored {
+    # the exact statefile a 9.1 vCenter left behind before the fix
+    my ($api, $result) = build_api_with_cache(cached => []);
+    is($result, undef, 'an empty cached list does not short-circuit the vStats detection');
+    is($api->{vstats_unavailable}, 1, 'the vStats removal is detected despite the poisoned cache');
+    is(scalar @{$api->{acq_specs_cache}->{writes}}, 0, 'nothing is written back when vStats is unusable');
+
+    # a corrupted statefile must behave the same way
+    for my $case ([ 'undef', undef ], [ 'not a list', 'garbage' ], [ 'hash', {} ]) {
+        my ($label, $content) = @$case;
+        my (undef, $res) = build_api_with_cache(cached => $content);
+        is($res, undef, "a malformed cached value ($label) is treated as a cache miss");
+    }
+
+    # a populated cache is still trusted, and no request is made
+    my $spec = { counters => { cid_mid => { cid => 'cpu.capacity.usage.HOST' } },
+                 resources => [ { id_value => 'host-35', predicate => 'EQUAL', scheme => 'moid' } ],
+                 status => 'ENABLED', expiration => time() + 86400, id => '225' };
+    my ($cached_api, $cached_result) = build_api_with_cache(cached => [ $spec ]);
+    is(ref($cached_result), 'ARRAY',            'a populated cache is still used');
+    is(scalar @$cached_result, 1,               'the cached specification is returned as is');
+    ok(!$cached_api->{vstats_unavailable},      'a populated cache does not trigger the detection');
+
+    # a healthy vCenter answer is cached, an empty one is not
+    my ($healthy, $healthy_result) = build_api_with_cache(
+        cached    => [],
+        http_code => 200,
+        response  => { acq_specs => [ $spec ] }
+    );
+    is(scalar @$healthy_result, 1, 'the specification returned by the API is collected');
+    is(scalar @{$healthy->{acq_specs_cache}->{writes}}, 1, 'a non-empty result is written to the cache');
+
+    my ($empty, $empty_result) = build_api_with_cache(
+        cached    => [],
+        http_code => 200,
+        response  => { acq_specs => [] }
+    );
+    is(scalar @$empty_result, 0, 'an empty but well-formed API answer is not an error');
+    is(scalar @{$empty->{acq_specs_cache}->{writes}}, 0, 'an empty result is not persisted');
+}
+
+# Creating or extending a specification makes the stored list obsolete: it must not be
+# persisted afterwards, otherwise a partial snapshot makes every later run re-create the
+# specifications missing from it.
+sub test_acq_specs_invalidation {
+    my $api = apps::vmware::vsphere8::custom::api->new(
+        options => MockOptions->new(),
+        output  => ExitingOutput->new()
+    );
+    $api->{all_acq_specs} = [ { id => '225' } ];
+
+    $api->invalidate_acq_specs();
+    ok(!defined($api->{all_acq_specs}), 'the stored list is dropped on invalidation');
+    is($api->{acq_specs_stale}, 1,      'the list is flagged as stale on invalidation');
+}
+
 sub main {
     #process_test('localhost', 443, 'https', '/v2', 10, 'user', 'pass');
     process_test('localhost', 3000, 'http', undef, 10, 'login', 'password');
@@ -226,6 +313,8 @@ sub main {
     test_vim25_unit_conversion();
     test_vim25_counter_resolution();
     test_vim25_xml_hardening();
+    test_poisoned_cache_is_ignored();
+    test_acq_specs_invalidation();
 }
 
 main();

--- a/tests/apps/vmware/vsphere8/api.t
+++ b/tests/apps/vmware/vsphere8/api.t
@@ -4,6 +4,7 @@ use Test2::V0;
 use FindBin;
 use lib "$FindBin::RealBin/../../../../src";
 use apps::vmware::vsphere8::custom::api;
+use apps::vmware::vsphere8::custom::vim25;
 
 
 # Mock options class
@@ -70,9 +71,161 @@ sub process_test {
 
 }
 
+# Output stub that turns option_exit into a die, so the message can be asserted.
+{
+    package ExitingOutput;
+    sub new { bless {}, shift }
+    sub add_option_msg { }
+    sub option_exit { my ($self, %options) = @_; die $options{short_msg} . "\n"; }
+}
+
+{
+    package MockHttp;
+    sub new { my ($class, $code) = @_; return bless { code => $code }, $class; }
+    sub get_code { return $_[0]->{code} }
+}
+
+# The vStats API is removed in vSphere 9.1: the plugin must detect it instead of
+# silently collecting nothing. See vstats_response_is_usable() in the custom API package.
+sub test_vstats_response_is_usable {
+    my $api = apps::vmware::vsphere8::custom::api->new(
+        options => MockOptions->new(),
+        output  => ExitingOutput->new()
+    );
+    $api->{hostname} = 'vcenter.example.tld';
+    $api->{http}     = MockHttp->new(404);
+
+    # vSphere 8.0 to 9.0: the collection is present, even when empty
+    is($api->vstats_response_is_usable(response => { acq_specs => [] }), 1,
+        'empty but well-formed acq_specs collection is usable');
+    is($api->vstats_response_is_usable(response => { acq_specs => [ { id => '225' } ], next => 42 }), 1,
+        'populated acq_specs collection is usable');
+
+    # vSphere 9.1: the vStats backend is no longer registered
+    for my $case (
+        [ 'empty body',           {} ],
+        [ 'error body',           { error_type => 'NOT_FOUND', messages => [] } ],
+        [ 'non-hash body',        'Not Found' ],
+        [ 'undefined body',       undef ],
+        [ 'acq_specs not a list', { acq_specs => 'nope' } ]
+    ) {
+        my ($label, $response) = @$case;
+        is($api->vstats_response_is_usable(response => $response), 0,
+            "vStats is detected as unusable ($label)");
+    }
+
+    my $message = $api->vstats_unavailable_message();
+    like($message, qr/removed in vSphere 9\.1/,  'the message states the 9.1 removal');
+    like($message, qr/vcenter\.example\.tld/,   'the message names the faulty vCenter');
+    like($message, qr/404/,                      'the message reports the HTTP code');
+    like($message, qr/--metrics-source=vim25/,   'the message points to the vim25 fallback');
+}
+
+# The vim25 fallback must never report a value it could not convert safely.
+sub test_vim25_unit_conversion {
+    my $vim25 = apps::vmware::vsphere8::custom::vim25->new(
+        noptions => 1,
+        options  => MockOptions->new(),
+        output   => ExitingOutput->new(),
+        hostname => 'vcenter.example.tld'
+    );
+
+    # PerformanceManager reports memory in kiloBytes, the modes expect MB
+    is($vim25->convert_unit(value => 1048576, from => 'kiloBytes', to => 'MB', cid => 'mem.capacity.usable.HOST'),
+        1024, 'kiloBytes are converted to MB');
+    # ... CPU in megaHertz while the host modes expect kHz
+    is($vim25->convert_unit(value => 3200, from => 'megaHertz', to => 'kHz', cid => 'cpu.capacity.usage.HOST'),
+        3200000, 'megaHertz are converted to kHz');
+    # the vim25 'percent' unit is expressed in hundredths of a percent
+    is($vim25->convert_unit(value => 4500, from => 'percent', to => 'pct', cid => 'cpu.capacity.contention.HOST'),
+        45, 'hundredths of a percent are converted to percent');
+    # an identity conversion must not alter the value
+    is($vim25->convert_unit(value => 210, from => 'watt', to => 'W', cid => 'power.capacity.usage.HOST'),
+        210, 'identical units leave the value untouched');
+
+    # converting across dimensions would silently report a wrong metric
+    like(dies { $vim25->convert_unit(value => 1, from => 'kiloBytes', to => 'kHz', cid => 'bogus.HOST') },
+        qr/Refusing to report a wrong value/, 'a cross-dimension conversion is refused');
+    like(dies { $vim25->convert_unit(value => 1, from => 'parsecs', to => 'kHz', cid => 'bogus.HOST') },
+        qr/unknown unit/, 'an unknown unit is refused');
+}
+
+# Counter ids keep their vStats naming and are resolved against the vCenter catalogue.
+sub test_vim25_counter_resolution {
+    my $vim25 = apps::vmware::vsphere8::custom::vim25->new(
+        noptions => 1,
+        options  => MockOptions->new(),
+        output   => ExitingOutput->new(),
+        hostname => 'vcenter.example.tld'
+    );
+
+    is($vim25->entity_type(rsrc_id => 'host-35'), 'HostSystem',     'a host id maps to HostSystem');
+    is($vim25->entity_type(rsrc_id => 'vm-42'),   'VirtualMachine', 'a vm id maps to VirtualMachine');
+    like(dies { $vim25->entity_type(rsrc_id => 'datastore') },
+        qr/cannot determine the managed object type/, 'an unparsable resource id is refused');
+
+    # exact name advertised by the vCenter
+    $vim25->{catalogue} = { 'cpu.capacity.usage.average' => { key => 6, unit => 'kiloHertz' } };
+    is($vim25->resolve_counter(cid => 'cpu.capacity.usage.HOST')->{key}, 6,
+        'a counter advertised under its vStats name is resolved directly');
+
+    # historical name only: the alias table takes over
+    $vim25->{catalogue} = { 'cpu.usagemhz.average' => { key => 11, unit => 'megaHertz' } };
+    is($vim25->resolve_counter(cid => 'cpu.capacity.usage.HOST')->{key}, 11,
+        'a counter advertised under its historical name is resolved through the alias table');
+
+    # neither: the plugin says so instead of reporting nothing
+    $vim25->{catalogue} = { 'net.usage.average' => { key => 90, unit => 'kiloBytesPerSecond' } };
+    like(dies { $vim25->resolve_counter(cid => 'cpu.capacity.usage.HOST') },
+        qr/has no PerformanceManager equivalent/, 'an unmappable counter raises an explicit error');
+}
+
+# vim25 responses are untrusted input: the parser must not resolve external entities.
+sub test_vim25_xml_hardening {
+    my $vim25 = apps::vmware::vsphere8::custom::vim25->new(
+        noptions => 1,
+        options  => MockOptions->new(),
+        output   => ExitingOutput->new(),
+        hostname => 'vcenter.example.tld'
+    );
+
+    my $secret = "$FindBin::RealBin/xxe_canary.txt";
+    open(my $fh, '>', $secret) or die "cannot write the XXE canary: $!";
+    print $fh 'CANARY_SHOULD_NEVER_BE_READ';
+    close($fh);
+
+    my $xxe = qq{<?xml version="1.0"?>}
+        . qq{<!DOCTYPE root [<!ENTITY leak SYSTEM "file://$secret">]>}
+        . qq{<root xmlns="urn:vim25"><val>&leak;</val></root>};
+
+    my $doc = $vim25->parse_xml(content => $xxe);
+    my $parsed = defined($doc) ? $doc->documentElement()->textContent() : '';
+    unlink($secret);
+
+    unlike($parsed, qr/CANARY_SHOULD_NEVER_BE_READ/,
+        'an external entity is not resolved when parsing a vim25 response');
+
+    # a billion-laughs payload must not be expanded either
+    my $bomb = q{<?xml version="1.0"?>}
+        . q{<!DOCTYPE root [<!ENTITY a "aaaaaaaaaa"><!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">}
+        . q{<!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">]>}
+        . q{<root xmlns="urn:vim25"><val>&c;</val></root>};
+    my $bomb_doc = $vim25->parse_xml(content => $bomb);
+    my $expanded = defined($bomb_doc) ? $bomb_doc->documentElement()->textContent() : '';
+    ok(length($expanded) < 1000, 'nested entities are not expanded when parsing a vim25 response');
+
+    # a malformed payload is reported as unparsable rather than dying
+    is($vim25->parse_xml(content => '<not-xml'), undef, 'a malformed payload returns undef');
+    is($vim25->parse_xml(content => ''),         undef, 'an empty payload returns undef');
+}
+
 sub main {
     #process_test('localhost', 443, 'https', '/v2', 10, 'user', 'pass');
     process_test('localhost', 3000, 'http', undef, 10, 'login', 'password');
+    test_vstats_response_is_usable();
+    test_vim25_unit_conversion();
+    test_vim25_counter_resolution();
+    test_vim25_xml_hardening();
 }
 
 main();


### PR DESCRIPTION
# Centreon team

> **Note for the reviewer:** this branch has no JIRA ID yet — please tell me the ticket to use and I will rename the branch accordingly.

## Description

**All performance counters of the vSphere 8 connector return nothing on vCenter 9.1.** Inventory modes (status, health, count, list) keep working, which is exactly what made this hard to diagnose in the field: the plugin does not crash, it quietly reports nothing.

### Root cause

The connector reads every metric through the **vStats API** (`com.vmware.vstats.*`) — `/api/stats/acq-specs` to create and extend acquisition specifications, `/api/stats/data/dp` to read data points. That API was shipped as **Tech Preview** in vSphere 8.0 and has been **removed in vSphere 9.1**.

Broadcom's own words in the [VCF 9.1 Product Support Notes](https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-1/release-notes/vmware-cloud-foundation-9-1-0-0-release-notes/vcf-91-product-support-notes.html):

> the vStats APIs (previously in Tech Preview) are removed.

This was confirmed by Broadcom support, who reproduced it on a test vCenter 9.1.0.0: the backend service is simply **no longer registered**, so `GET` and `POST` on `acq-specs` fail identically, before the request body is even parsed.

### ⚠️ Two VMware-side problems worth flagging

**1. The 9.1 Swagger / API Explorer is wrong.** It still lists `acq-specs` and `acq-specs/{id}` in its tree although the backend has been removed. Anyone trusting the published documentation without actually executing the call will conclude the API is still there. This cost us real diagnosis time and will cost it to others — do not trust the 9.1 API Explorer on this namespace.

**2. The official replacement is not a drop-in, and not even in vCenter.** The [Real-Time Metrics API](https://developer.broadcom.com/xapis/realtime-metrics-api/latest/) (Prometheus-compatible, PromQL, up to 2-second granularity) ships with **VCF Operations**, not with vCenter. It requires the Real-Time Data Service component to be explicitly deployed, a VCF or VVF environment, and **JWT Bearer authentication** instead of a vCenter session — a rewrite of the integration, not a URL change. It is therefore **not an option for standalone vCenter customers**, and is out of scope here: it belongs to the TAP discussion.

We also carry our own share of the blame: vStats was documented by VMware as Tech Preview with an explicit *"VMware does not guarantee backwards compatibility and recommends against using them in production environments"* ([vStats REST API reference](https://developer.vmware.com/apis/vsphere-automation/latest/vstats/vstats/)). Building the whole metric collection on it was a known risk.

### Why the failure was silent

Three separate behaviours combined, in [`src/apps/vmware/vsphere8/custom/api.pm`](https://github.com/centreon/centreon-plugins/blob/develop/src/apps/vmware/vsphere8/custom/api.pm):

1. `get_all_acq_specs()` did `push @{...}, grep {...} @{$response->{acq_specs}}`. With no `acq_specs` key the dereference yields nothing, and the trailing guard forced an empty array — **no error**.
2. That empty array was then **written to the cache statefile** (`vsphere8_api_acq_specs_<rsrc_id>_<hash>`) *before* being validated, so the emptiness was replayed on every subsequent run, even against a healthy vCenter.
3. `get_stats()` found no `data_points`, emitted `add_option_msg("no data ... at the moment")` and returned `undef` — an **informational message, not a failure**.

And when the 404 body was empty or HTML instead of JSON, the plugin died on a raw `Can't use string ("") as a HASH ref` rather than a readable error.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## What this PR changes

### 1. Detect the removal instead of collecting nothing

`vstats_response_is_usable()` validates that the response actually carries an `acq_specs` **collection**, and the emptiness is no longer cached.

The check keys on the **presence of the collection, not on it being non-empty** — a healthy vCenter that has no acquisition specification yet returns `{"acq_specs": []}` and must keep working. This is what makes the fix safe.

### 2. Read the counters from the vim25 `PerformanceManager`

Broadcom confirmed that the historical [`PerformanceManager`](https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.PerformanceManager.html) of the [vSphere Web Services (VIM) API](https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-0/administration-sdks-cli-and-tools/about-vmware-cloud-foundation-development/core-vsphere-apis/web-services-vim-api.html) **still answers on 9.1**. The new `apps::vmware::vsphere8::custom::vim25` package speaks vim25 directly over `centreon::plugins::http`:

```
RetrieveServiceContent -> Login -> QueryPerfCounter -> QueryPerf -> Logout
```

It requires **neither the unmaintained VMware Perl SDK nor the `centreon_vmware` daemon** — the SOAP envelopes are built in the module.

New option, documented in the plugin help:

```
--metrics-source=auto|vstats|vim25     (default: auto)
```

With `auto`, vStats is used and vim25 takes over when the vCenter no longer serves it, so **the same command line works from 8.0 to 9.1**. `vstats` and `vim25` pin one source, for instance to make an unsupported version fail loudly.

### Three design choices that deserve the reviewer's attention

**No mode is modified.** Counter ids keep their vStats naming (`cpu.capacity.usage.HOST`). The resolution happens inside the vim25 module, so the 20+ mode files are untouched and the two sources are interchangeable.

**Units are never assumed.** They are read from `unitInfo.key` in the catalogue **the vCenter itself advertises**, at runtime, and converted to the unit each mode expects. The `%target_units` table was derived from the actual arithmetic of each mode — for example `esx/mode/memory.pm` multiplies `mem.capacity.usable.HOST` by `1024*1024` to obtain bytes, so it expects MB. A conversion **between incompatible dimensions is refused** rather than reporting a wrong value. The classic vim25 trap where the `percent` unit is expressed in *hundredths* of a percent is handled explicitly and tested.

**Counter naming has a documented fallback.** A counter is first looked up under its vStats name (`cpu.capacity.usage.<rollup>`). If the vCenter does not advertise it, a documented alias table is tried (`cpu.usagemhz`, `mem.consumed`, `disk.maxTotalLatency`, `power.power`, …) and **the substitution is reported in the long output** so it can be audited. If neither matches, the plugin says exactly what it looked for instead of returning nothing.

### 3. Security hardening

vim25 responses are untrusted input. `parse_xml()` disables entity expansion and external DTD/network fetching (`no_network`, `expand_entities => 0`, `load_ext_dtd => 0`), ruling out XXE and entity-expansion attacks. **Both are covered by regression tests** (a file-read canary and a billion-laughs payload).

The vim25 session is also closed on destruction: a session lives 30 minutes by default and each run opens one, so leaving them behind would pile sessions up against the vCenter cap (3000 by default, with a dedicated alarm since 9.1).

### 4. Packaging

`XML::LibXML` / `libxml-libxml-perl` added to the **four** vsphere8 packages. They all ship `apps/vmware/vsphere8/custom/` and only declared `perl(JSON)`, so the package would have broken at runtime. `perl(Date::Parse)` on the Vcsa package is preserved.

## How this pull request can be tested ?

### Automated tests

```bash
perl -Isrc tests/apps/vmware/vsphere8/api.t
```

**38 assertions, up from 11.** They cover:

| Area | What is asserted |
|---|---|
| vStats detection | `{"acq_specs": []}` is **usable** (healthy 8.0–9.0 with no spec yet); `{}`, an error body, a non-hash body, `undef` and a non-list `acq_specs` are all detected as unusable |
| Error message | states the 9.1 removal, names the vCenter, reports the HTTP code, points to `--metrics-source=vim25` |
| Unit conversion | kiloBytes→MB, megaHertz→kHz, hundredths of a percent→percent, identity; cross-dimension and unknown units are **refused** |
| Counter resolution | direct vStats name, alias fallback, explicit error when unmappable; `host-35`→`HostSystem`, `vm-42`→`VirtualMachine`, unparsable id refused |
| XML hardening | external entity **not** resolved, nested entities **not** expanded, malformed and empty payloads return `undef` |

### Manual end-to-end verification

I do not have a 9.1 to hand, so I verified against two mock vCenters (sources at the end of this description). Results:

| Scenario | Result |
|---|---|
| 9.1, catalogue exposes `cpu.capacity.*` (kiloHertz) | `OK: CPU average usage is 40.00 %, used frequency is 3200000 kHz` |
| 9.1, catalogue exposes only `cpu.usagemhz` (megaHertz) | **identical values**, through the alias table + MHz→kHz conversion |
| 9.1, `memory` mode, kiloBytes vs megaBytes catalogues | `50% ... 64.00 GB used - Usable: 128.00 GB` in both cases |
| 9.1, `power` mode | `OK: Power usage is 210 Watts` |
| 9.1, `--metrics-source=vstats` | explicit `UNKNOWN`, no silent fallback |
| 9.1, `--metrics-source=bogus` | `UNKNOWN: Unsupported --metrics-source 'bogus'. Expected one of: auto, vstats, vim25.` |
| **9.0 healthy, default `auto`** | **vStats used, `/sdk` never called, output byte-identical** |
| vim25 session | `Logout` correctly emitted at the end of the run |

Two completely different vim25 counter names, in two different units, producing the same final metric is the strongest validation I could get without a real vCenter.

### Behaviour before this PR, for comparison

Same mock, original code, across the four response shapes a 9.1 can return:

| `/api/stats/acq-specs` returns | Before | After |
|---|---|---|
| `404` empty body | 💥 `Can't use string ("") as a HASH ref` | ✅ explicit message |
| `404` HTML body | 💥 same Perl crash | ✅ explicit message |
| `200 {}` | ⚠️ `no data for resource host-35 ... at the moment` | ✅ explicit message |
| `404 {"messages":[...]}` | ⚠️ `No stats found` + `creating acq_spec` noise | ✅ explicit message |
| `200 {"acq_specs": []}` (healthy 8.x/9.0) | nominal | **unchanged — no regression** |

### curl examples

Confirming the removal on a real vCenter — `200` on 9.0, `404` on 9.1:

```bash
TOKEN=$(curl -sk -u 'svc-centreon@vsphere.local:<password>' -X POST https://<vcenter>/api/session | tr -d '"')
curl -sk -o /dev/null -w '%{http_code}\n' -H "vmware-api-session-id: $TOKEN" https://<vcenter>/api/stats/counters
curl -sk -o /dev/null -w '%{http_code}\n' -H "vmware-api-session-id: $TOKEN" https://<vcenter>/api/stats/acq-specs
```

Confirming `PerformanceManager` still answers on the same 9.1:

```bash
curl -sk -X POST https://<vcenter>/sdk \
  -H 'Content-Type: text/xml; charset=utf-8' -H 'SOAPAction: "urn:vim25"' \
  -d '<?xml version="1.0" encoding="UTF-8"?>
      <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns="urn:vim25">
        <soapenv:Body><RetrieveServiceContent>
          <_this type="ServiceInstance">ServiceInstance</_this>
        </RetrieveServiceContent></soapenv:Body>
      </soapenv:Envelope>' | grep -o '<perfManager.*</perfManager>'
```

### Plugin command lines

```bash
# vSphere 8.0 to 9.1, source picked automatically
./centreon_plugins.pl --plugin=apps::vmware::vsphere8::esx::plugin --mode=cpu \
  --hostname=<vcenter> --username=<user> --password=<password> --esx-id=host-35

# force the vim25 source (vSphere 9.1)
./centreon_plugins.pl --plugin=apps::vmware::vsphere8::esx::plugin --mode=cpu \
  --hostname=<vcenter> --username=<user> --password=<password> --esx-id=host-35 \
  --metrics-source=vim25 --verbose
```

`--verbose` shows any alias substitution, which is the first thing to check on a real 9.1.

## Known limitations — please challenge these

1. **The counter name mapping is only verified against mocks.** I do not know which names a real 9.1 `PerformanceManager` advertises. The module degrades safely (exact name → alias → explicit error), but if an alias points at a semantically *close* rather than *equivalent* counter, the value would be wrong without anything flagging it. **The first run against a real 9.1 must compare vim25 values with vStats values from a comparable 9.0.**
2. `intervalId` is pinned to 20 s (real-time) with `maxSample=1`.
3. Only `HostSystem` and `VirtualMachine` entities are handled — which is all the current modes need.
4. **No robot/mockoon integration test yet.** Mockoon was not available in my environment, so the end-to-end verification used the standalone mocks below. Wiring the 9.1 case into `tests/apps/vmware/vsphere8/*/mockoon.json` is the natural follow-up and I am happy to do it in this PR if you prefer it here.

## Unrelated finding, reported for the record

`esx/mode/cpu.pm` converts CPU counters with `* 1000` while `vm/mode/cpu.pm` uses `* 1_000_000` for the same counter family. One of the two is very likely off by a factor of 1000 on the absolute frequency (percentages are unaffected, the ratio cancels out). **I deliberately did not touch it**: `%target_units` reproduces the current behaviour exactly (kHz for hosts, MHz for VMs) so that vStats and vim25 agree. If a mode is corrected, the matching `%target_units` entry must be corrected with it. Worth its own ticket.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR
- [x] I have **rebased** my development branch on the base branch (develop)
- [ ] In case of a new plugin, I have created the new packaging directory accordingly — *n/a, existing packages, dependencies updated*
- [x] I have implemented automated tests related to my commits
  - [x] Data used for automated tests are anonymized
- [x] I have reviewed all the help messages in all the .pm files I have modified
  - [x] All sentences begin with a capital letter
  - [x] All sentences end with a period
  - [x] I am able to understand all the help messages
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed

---

<details>
<summary><b>Mock vCenters used for the end-to-end verification</b> (standalone, no dependency — click to expand)</summary>

Save as `fake_vc91.py` (vStats removed, vim25 answers) and `fake_vc90.py` (healthy vStats, records any hit on `/sdk`), then run the plugin against `127.0.0.1:8931`.

`fake_vc91.py` — pass `capacity` or `legacy` to switch the advertised counter catalogue:

```python
import json, re, sys
from http.server import BaseHTTPRequestHandler, HTTPServer

STYLE = sys.argv[1] if len(sys.argv) > 1 else "capacity"

def counters():
    if STYLE == "capacity":
        return [(6, "cpu", "capacity.usage", "average", "kiloHertz"),
                (7, "cpu", "capacity.provisioned", "average", "kiloHertz"),
                (24, "mem", "capacity.usable", "average", "kiloBytes"),
                (25, "mem", "consumed.vms", "average", "kiloBytes"),
                (60, "power", "capacity.usage", "average", "watt")]
    return [(6, "cpu", "usagemhz", "average", "megaHertz"),
            (7, "cpu", "totalCapacity", "average", "megaHertz"),
            (24, "mem", "totalCapacity", "average", "megaBytes"),
            (25, "mem", "consumed", "average", "kiloBytes"),
            (60, "power", "power", "average", "watt")]

SAMPLES = {6: 3200000, 7: 8000000, 24: 134217728, 25: 67108864, 60: 210} if STYLE == "capacity" \
     else {6: 3200, 7: 8000, 24: 131072, 25: 67108864, 60: 210}

ENV = ('<?xml version="1.0" encoding="UTF-8"?>'
       '<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" '
       'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
       '<soapenv:Body>{}</soapenv:Body></soapenv:Envelope>')

class H(BaseHTTPRequestHandler):
    def log_message(self, *a): pass

    def _raw(self, code, body, ctype, extra=None):
        b = body.encode()
        self.send_response(code); self.send_header("Content-Type", ctype)
        if extra: self.send_header(*extra)
        self.send_header("Content-Length", str(len(b))); self.end_headers(); self.wfile.write(b)

    def _json(self, code, payload):
        self._raw(code, json.dumps(payload), "application/json")

    def do_GET(self):
        if self.path.startswith("/api/vcenter/host"):
            return self._json(200, [{"host": "host-35", "name": "esx01.example.tld",
                                     "connection_state": "CONNECTED", "power_state": "POWERED_ON"}])
        if self.path.startswith("/api/stats/"):          # vStats removed in 9.1
            return self._raw(404, "{}", "application/json")
        self._json(404, {"error_type": "NOT_FOUND", "messages": []})

    def do_POST(self):
        if self.path.startswith("/api/session"):
            return self._json(201, "d3adb33f-t0k3n")
        if self.path.startswith("/api/stats/"):
            return self._raw(404, "{}", "application/json")
        if self.path != "/sdk":
            return self._json(404, {"error_type": "NOT_FOUND", "messages": []})

        body = self.rfile.read(int(self.headers.get("Content-Length", 0))).decode()

        if "RetrieveServiceContent" in body:
            return self._raw(200, ENV.format(
                '<RetrieveServiceContentResponse xmlns="urn:vim25"><returnval>'
                '<rootFolder type="Folder">group-d1</rootFolder>'
                '<propertyCollector type="PropertyCollector">propertyCollector</propertyCollector>'
                '<perfManager type="PerformanceManager">PerfMgr</perfManager>'
                '<sessionManager type="SessionManager">SessionManager</sessionManager>'
                '</returnval></RetrieveServiceContentResponse>'), "text/xml",
                ("Set-Cookie", 'vmware_soap_session="52a1b2c3"; Path=/; HttpOnly'))

        if "<Login>" in body:
            return self._raw(200, ENV.format(
                '<LoginResponse xmlns="urn:vim25"><returnval><key>52a1b2c3</key>'
                '<userName>svc</userName></returnval></LoginResponse>'), "text/xml")

        if "RetrievePropertiesEx" in body:
            infos = "".join(
                '<PerfCounterInfo xsi:type="PerfCounterInfo">'
                f'<key>{k}</key>'
                f'<nameInfo><label>l</label><summary>s</summary><key>{name}</key></nameInfo>'
                f'<groupInfo><label>l</label><summary>s</summary><key>{grp}</key></groupInfo>'
                f'<unitInfo><label>l</label><summary>s</summary><key>{unit}</key></unitInfo>'
                f'<rollupType>{roll}</rollupType><statsType>absolute</statsType><level>1</level>'
                '</PerfCounterInfo>' for k, grp, name, roll, unit in counters())
            return self._raw(200, ENV.format(
                '<RetrievePropertiesExResponse xmlns="urn:vim25"><returnval><objects>'
                '<obj type="PerformanceManager">PerfMgr</obj>'
                f'<propSet><name>perfCounter</name><val xsi:type="ArrayOfPerfCounterInfo">{infos}</val></propSet>'
                '</objects></returnval></RetrievePropertiesExResponse>'), "text/xml")

        if "QueryPerf" in body:
            cid = int(re.search(r"<counterId>(\d+)</counterId>", body).group(1))
            val = SAMPLES.get(cid, -1)
            return self._raw(200, ENV.format(
                '<QueryPerfResponse xmlns="urn:vim25"><returnval xsi:type="PerfEntityMetric">'
                '<entity type="HostSystem">host-35</entity>'
                '<sampleInfo><interval>20</interval><timestamp>2026-09-08T10:00:00Z</timestamp></sampleInfo>'
                f'<value xsi:type="PerfMetricIntSeries"><id><counterId>{cid}</counterId><instance></instance></id>'
                f'<value>{val}</value></value>'
                '</returnval></QueryPerfResponse>'), "text/xml")

        if "<Logout>" in body:
            return self._raw(200, ENV.format('<LogoutResponse xmlns="urn:vim25"/>'), "text/xml")

        return self._raw(500, ENV.format(
            '<soapenv:Fault><faultcode>ServerFaultCode</faultcode>'
            '<faultstring>unsupported operation</faultstring></soapenv:Fault>'), "text/xml")

HTTPServer(("127.0.0.1", 8931), H).serve_forever()
```

`fake_vc90.py` — the non-regression mock; it writes `/tmp/sdk_was_called` if the plugin ever touches `/sdk`, which it must not:

```python
import json, time
from http.server import BaseHTTPRequestHandler, HTTPServer

VALUES = {"cpu.capacity.usage.HOST": 3200000, "cpu.capacity.provisioned.HOST": 8000000}

def spec(cid, i):
    return {"counters": {"cid_mid": {"mid": "", "cid": cid}, "set_id": ""},
            "resources": [{"predicate": "EQUAL", "scheme": "moid", "type": "HOST", "id_value": "host-35"}],
            "expiration": int(time.time()) + 864000, "interval": 60, "memo_": "",
            "id": str(200 + i), "status": "ENABLED"}

class H(BaseHTTPRequestHandler):
    def log_message(self, *a): pass

    def _json(self, code, payload):
        b = json.dumps(payload).encode()
        self.send_response(code); self.send_header("Content-Type", "application/json")
        self.send_header("Content-Length", str(len(b))); self.end_headers(); self.wfile.write(b)

    def do_POST(self):
        if self.path.startswith("/api/session"): return self._json(201, "t0k3n")
        if self.path == "/sdk":
            open("/tmp/sdk_was_called", "w").write("yes")
            return self._json(500, {})
        self._json(404, {})

    def do_GET(self):
        if self.path.startswith("/api/vcenter/host"):
            return self._json(200, [{"host": "host-35", "name": "esx01.example.tld"}])
        if self.path.startswith("/api/stats/acq-specs"):
            return self._json(200, {"acq_specs": [spec(c, i) for i, c in enumerate(VALUES)]})
        if self.path.startswith("/api/stats/data/dp"):
            cid = [p[4:] for p in self.path.split("&") if p.startswith("cid=")][0]
            return self._json(200, {"data_points": [{"val": VALUES.get(cid, 0), "ts": int(time.time())}]})
        self._json(404, {})

HTTPServer(("127.0.0.1", 8931), H).serve_forever()
```

Run either mock, then:

```bash
python3 fake_vc91.py capacity &
perl -Isrc src/centreon_plugins.pl --plugin=apps::vmware::vsphere8::esx::plugin --mode=cpu \
  --hostname=127.0.0.1 --port=8931 --proto=http --username=u --password=p \
  --http-backend=lwp --esx-id=host-35 --statefile-dir=/tmp/vsphere8-test
```

</details>
