### PR TITLE
feat(vmware-vsphere8): add the VCF Operations Real-Time Metrics source (--metrics-source=rtm)

### DIFF
--- a/src/apps/vmware/vsphere8/custom/api.pm
+++ b/src/apps/vmware/vsphere8/custom/api.pm
@@ -58,7 +58,18 @@ sub new {
                 'vstats-interval:s' => { name => 'vstats_interval',     default => 60 },
                 'vstats-duration:s' => { name => 'vstats_duration',     default => 2764800 }, # 2764800 seconds in 32 days
                 'metrics-source:s'  => { name => 'metrics_source',       default => 'auto' },
-                'timeout:s'         => { name => 'timeout',             default => 10 }
+                'timeout:s'         => { name => 'timeout',             default => 10 },
+                # Real-Time Metrics source: it queries VCF Operations, not the vCenter,
+                # hence its own address, credentials and mapping overrides.
+                'rtm-hostname:s'    => { name => 'rtm_hostname' },
+                'rtm-port:s'        => { name => 'rtm_port',            default => '443' },
+                'rtm-proto:s'       => { name => 'rtm_proto',           default => 'https' },
+                'rtm-username:s'    => { name => 'rtm_username' },
+                'rtm-password:s'    => { name => 'rtm_password' },
+                'rtm-auth-source:s' => { name => 'rtm_auth_source' },
+                'rtm-base-path:s'   => { name => 'rtm_base_path',       default => '/data-query-service' },
+                'rtm-moid-label:s'  => { name => 'rtm_moid_label' },
+                'rtm-metric-map:s@' => { name => 'rtm_metric_map' }
             }
         );
     }
@@ -69,6 +80,7 @@ sub new {
     $self->{token_cache}     = centreon::plugins::statefile->new(%options);
     $self->{acq_specs_cache} = centreon::plugins::statefile->new(%options);
     $self->{vim25_cache}     = centreon::plugins::statefile->new(%options);
+    $self->{rtm_cache}       = centreon::plugins::statefile->new(%options);
     # kept to build the vim25 fallback lazily, only when a counter is actually needed
     $self->{custom_options}  = \%options;
 
@@ -96,9 +108,9 @@ sub check_options {
     $self->{vstats_duration} = $self->{option_results}->{vstats_duration};
     $self->{metrics_source}  = $self->{option_results}->{metrics_source} // 'auto';
 
-    if ($self->{metrics_source} !~ /^(auto|vstats|vim25)$/) {
+    if ($self->{metrics_source} !~ /^(auto|vstats|vim25|rtm)$/) {
         $self->{output}->option_exit(short_msg => "Unsupported --metrics-source '" . $self->{metrics_source}
-            . "'. Expected one of: auto, vstats, vim25.");
+            . "'. Expected one of: auto, vstats, vim25, rtm.");
     }
 
     if ($self->{hostname} eq '') {
@@ -114,6 +126,7 @@ sub check_options {
     $self->{token_cache}->check_options(option_results => $self->{option_results});
     $self->{acq_specs_cache}->check_options(option_results => $self->{option_results});
     $self->{vim25_cache}->check_options(option_results => $self->{option_results});
+    $self->{rtm_cache}->check_options(option_results => $self->{option_results});
 
     return 0;
 }
@@ -336,8 +349,9 @@ sub vstats_unavailable_message {
         . $self->{http}->get_code() . "']. The vStats API is Tech Preview in vSphere 8.0 to 9.0 "
         . "and has been removed in vSphere 9.1, therefore performance counters cannot be "
         . "collected through it. Use --metrics-source=vim25 to read them from the "
-        . "PerformanceManager SOAP API instead. Modes that do not rely on performance "
-        . "counters (status, health, count, list...) are not affected.";
+        . "PerformanceManager SOAP API of the same vCenter, or --metrics-source=rtm to read "
+        . "them from the Real-Time Metrics API of VCF Operations. Modes that do not rely on "
+        . "performance counters (status, health, count, list...) are not affected.";
 }
 
 # vim25 PerformanceManager fallback, built only when a counter is actually requested
@@ -380,6 +394,30 @@ sub invalidate_acq_specs {
     $self->{acq_specs_stale} = 1;
 
     return 1;
+}
+
+# VCF Operations Real-Time Metrics source, built only when explicitly requested
+sub rtm {
+    my ($self, %options) = @_;
+
+    return $self->{rtm} if (defined($self->{rtm}));
+
+    centreon::plugins::misc::mymodule_load(
+        output    => $self->{output},
+        module    => 'apps::vmware::vsphere8::custom::rtm',
+        error_msg => "Cannot load module 'apps::vmware::vsphere8::custom::rtm'."
+    );
+
+    $self->{rtm} = apps::vmware::vsphere8::custom::rtm->new(
+        %{$self->{custom_options}},
+        noptions => 1,
+        output   => $self->{output},
+        cache    => $self->{rtm_cache}
+    );
+    $self->{rtm}->set_options(option_results => $self->{option_results});
+    $self->{rtm}->check_options();
+
+    return $self->{rtm};
 }
 
 sub get_all_acq_specs {
@@ -585,8 +623,10 @@ sub get_stats {
         $self->{output}->option_exit(short_msg => "get_stats method called without cid, will get all available stats for resource");
     }
 
-    # vim25 is either forced, or used as a fallback when vStats is gone (vSphere 9.1)
+    # vim25 is either forced, or used as a fallback when vStats is gone (vSphere 9.1).
+    # rtm is never automatic: it targets another appliance with its own credentials.
     return $self->vim25()->get_perf_value(%options) if ($self->{metrics_source} eq 'vim25');
+    return $self->rtm()->get_perf_value(%options)   if ($self->{metrics_source} eq 'rtm');
 
     if ( !$self->check_acq_spec(%options) ) {
         if ($self->{vstats_unavailable}) {
@@ -1093,12 +1133,63 @@ The C<vim25> source reads the same counters from the C<PerformanceManager> of th
 vim25 SOAP API, which vSphere 9.1 still serves. It requires neither the VMware Perl
 SDK nor the C<centreon_vmware> daemon.
 
+The C<rtm> source reads them from the Real-Time Metrics API of VCF Operations, the
+replacement Broadcom offers for vStats. It is not served by the vCenter, so it needs
+the C<--rtm-*> options below, and it is never selected by C<auto>.
+
 With C<auto>, C<vstats> is used and C<vim25> takes over when the vCenter no longer
-serves vStats, so the same command works from 8.0 to 9.1. Force C<vstats> or C<vim25>
-to pin one source, for instance to make an unsupported version fail loudly.
+serves vStats, so the same command works from 8.0 to 9.1. Force C<vstats>, C<vim25>
+or C<rtm> to pin one source, for instance to make an unsupported version fail loudly.
 
 Modes that do not read performance counters (status, health, count, list...) never
 use this option.
+
+=item B<--rtm-hostname>
+
+Define the address of the VCF Operations appliance serving the Real-Time Metrics API.
+Required by C<--metrics-source=rtm>.
+
+=item B<--rtm-port>
+
+Define the port of the VCF Operations appliance (default: 443).
+
+=item B<--rtm-proto>
+
+Define the protocol used to reach VCF Operations (default: C<https>).
+
+=item B<--rtm-username>
+
+Define the username used to authenticate against VCF Operations. Required by
+C<--metrics-source=rtm>.
+
+=item B<--rtm-password>
+
+Define the password used to authenticate against VCF Operations. Required by
+C<--metrics-source=rtm>.
+
+=item B<--rtm-auth-source>
+
+Define the VCF Operations authentication source of the account, when it is not the
+local one.
+
+=item B<--rtm-base-path>
+
+Define the base path of the Real-Time Metrics API (default: C</data-query-service>).
+The Prometheus endpoints are queried under that path, as C<< <base path>/v1/query >>.
+
+=item B<--rtm-moid-label>
+
+Define the metric label carrying the managed object id of the monitored resource, for
+instance C<moid>. When omitted, it is discovered on the first query and the value to
+use is reported in the long output.
+
+=item B<--rtm-metric-map>
+
+Map a counter id to the metric name it must be read from, as
+C<counter.id=metric_name>. Can be used several times. Use it when the appliance
+publishes a metric under a name the plugin does not know, as reported by the error
+message. Example:
+C<--rtm-metric-map='cpu.capacity.usage.HOST=vcenter_host_cpu_usage_mhz'>.
 
 =item B<--vstats-interval>
 

--- a/src/apps/vmware/vsphere8/custom/rtm.pm
+++ b/src/apps/vmware/vsphere8/custom/rtm.pm
@@ -1,0 +1,557 @@
+#
+# Copyright 2026-Present Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package apps::vmware::vsphere8::custom::rtm;
+
+# Performance counters source based on the VCF Operations Real-Time Metrics API,
+# the official replacement Broadcom offers for the vStats API removed in vSphere 9.1.
+#
+# Unlike vStats and vim25, this API is NOT served by vCenter: it belongs to VCF
+# Operations, needs its Real-Time Metrics component to be deployed, and authenticates
+# with a JWT bearer token rather than a vCenter session. It therefore takes its own
+# hostname and credentials, and is never selected automatically.
+#
+# Authentication is a three-step sequence documented by Broadcom:
+#   POST /suite-api/api/auth/token/acquire      -> OpsToken
+#   GET  /suite-api/api/integrations/services   -> service key of the VCF_VODAP entry
+#   POST /suite-api/api/auth/token/exchange     -> JWT bearer token
+#
+# Metrics are then read with the Prometheus-compatible endpoints:
+#   GET <base path>/v1/query        (instant PromQL query)
+#   GET <base path>/v1/metadata     (metric catalogue)
+
+use strict;
+use warnings;
+use centreon::plugins::http;
+use centreon::plugins::statefile;
+use Digest::SHA qw(sha256_hex);
+use centreon::plugins::misc qw/json_encode json_decode is_empty/;
+
+# Object type each resource id prefix maps to, as named in the metric labels.
+my %entity_types = (
+    'HOST' => 'HostSystem',
+    'VM'   => 'VirtualMachine'
+);
+
+# Labels that may carry the managed object id of the resource, by order of preference.
+# The label actually in use is discovered at runtime and can be pinned with
+# --rtm-moid-label; this list only bootstraps the discovery.
+my @moid_label_candidates = qw(moid entity_id resource_id object_id vm host id);
+
+# Unit conversion, identical in spirit to the vim25 source: every unit is a factor
+# towards the base unit of its dimension, so a conversion is only allowed inside one
+# dimension and can never silently turn bytes into hertz.
+my %units = (
+    'hertz'              => [ 'frequency', 1 ],
+    'kilohertz'          => [ 'frequency', 1e3 ],
+    'megahertz'          => [ 'frequency', 1e6 ],
+    'bytes'              => [ 'bytes',     1 ],
+    'kilobytes'          => [ 'bytes',     1024 ],
+    'megabytes'          => [ 'bytes',     1024 ** 2 ],
+    'gigabytes'          => [ 'bytes',     1024 ** 3 ],
+    'bytespersecond'     => [ 'rate',      1 ],
+    'kilobytespersecond' => [ 'rate',      1024 ],
+    'percent'            => [ 'percent',   1 ],
+    'ratio'              => [ 'percent',   100 ],
+    'number'             => [ 'number',    1 ],
+    'watts'              => [ 'power',     1 ],
+    'joules'             => [ 'energy',    1 ],
+    'seconds'            => [ 'time',      1 ],
+    'milliseconds'       => [ 'time',      1e-3 ],
+    'microseconds'       => [ 'time',      1e-6 ],
+    # canonical target units, expressing what the modes expect
+    'Hz'   => [ 'frequency', 1 ],
+    'kHz'  => [ 'frequency', 1e3 ],
+    'MHz'  => [ 'frequency', 1e6 ],
+    'B'    => [ 'bytes',     1 ],
+    'KB'   => [ 'bytes',     1024 ],
+    'MB'   => [ 'bytes',     1024 ** 2 ],
+    'Bps'  => [ 'rate',      1 ],
+    'KBps' => [ 'rate',      1024 ],
+    'pct'  => [ 'percent',   1 ],
+    'count'=> [ 'number',    1 ],
+    'W'    => [ 'power',     1 ],
+    'ms'   => [ 'time',      1e-3 ]
+);
+
+# Each vStats counter id is mapped to the PromQL metric it is read from, the unit that
+# metric is published in, and the unit the modes expect. The target units are derived
+# from the arithmetic the modes apply to the value, exactly as in the vim25 source.
+#
+# The metric names below follow the VCF Operations naming of the vCenter adapter. They
+# are ALWAYS validated against the /v1/metadata catalogue of the appliance before use,
+# and an unknown name raises an explicit error instead of returning nothing. Any name
+# can be overridden without touching this table, with --rtm-metric-map.
+my %counter_map = (
+    'cpu.capacity.provisioned.HOST'   => { metric => 'vcenter_host_cpu_capacity_provisioned_megahertz', unit => 'megahertz', target => 'kHz' },
+    'cpu.capacity.usage.HOST'         => { metric => 'vcenter_host_cpu_capacity_usage_megahertz',       unit => 'megahertz', target => 'kHz' },
+    'cpu.capacity.demand.HOST'        => { metric => 'vcenter_host_cpu_capacity_demand_megahertz',      unit => 'megahertz', target => 'kHz' },
+    'cpu.capacity.contention.HOST'    => { metric => 'vcenter_host_cpu_capacity_contention_percent',    unit => 'percent',   target => 'pct' },
+    'cpu.corecount.provisioned.HOST'  => { metric => 'vcenter_host_cpu_corecount_provisioned',          unit => 'number',    target => 'count' },
+    'cpu.corecount.usage.HOST'        => { metric => 'vcenter_host_cpu_corecount_usage',                unit => 'number',    target => 'count' },
+    'cpu.corecount.contention.HOST'   => { metric => 'vcenter_host_cpu_corecount_contention_percent',   unit => 'percent',   target => 'pct' },
+    'mem.capacity.provisioned.HOST'   => { metric => 'vcenter_host_mem_capacity_provisioned_kilobytes', unit => 'kilobytes', target => 'MB' },
+    'mem.capacity.usable.HOST'        => { metric => 'vcenter_host_mem_capacity_usable_kilobytes',      unit => 'kilobytes', target => 'MB' },
+    'mem.capacity.usage.HOST'         => { metric => 'vcenter_host_mem_capacity_usage_kilobytes',       unit => 'kilobytes', target => 'MB' },
+    'mem.capacity.contention.HOST'    => { metric => 'vcenter_host_mem_capacity_contention_percent',    unit => 'percent',   target => 'pct' },
+    'mem.consumed.vms.HOST'           => { metric => 'vcenter_host_mem_consumed_vms_kilobytes',         unit => 'kilobytes', target => 'MB' },
+    'mem.consumed.userworlds.HOST'    => { metric => 'vcenter_host_mem_consumed_userworlds_kilobytes',  unit => 'kilobytes', target => 'MB' },
+    'mem.reservedCapacityPct.HOST'    => { metric => 'vcenter_host_mem_reserved_capacity_percent',      unit => 'percent',   target => 'pct' },
+    'mem.swap.current.HOST'           => { metric => 'vcenter_host_mem_swap_current_kilobytes',         unit => 'kilobytes', target => 'KB' },
+    'mem.swap.target.HOST'            => { metric => 'vcenter_host_mem_swap_target_kilobytes',          unit => 'kilobytes', target => 'KB' },
+    'mem.swap.readrate.HOST'          => { metric => 'vcenter_host_mem_swap_readrate_kilobytespersecond',  unit => 'kilobytespersecond', target => 'KBps' },
+    'mem.swap.writerate.HOST'         => { metric => 'vcenter_host_mem_swap_writerate_kilobytespersecond', unit => 'kilobytespersecond', target => 'KBps' },
+    'disk.throughput.usage.HOST'      => { metric => 'vcenter_host_disk_throughput_usage_kilobytespersecond', unit => 'kilobytespersecond', target => 'KBps' },
+    'disk.throughput.contention.HOST' => { metric => 'vcenter_host_disk_throughput_contention_milliseconds',  unit => 'milliseconds',       target => 'ms' },
+    'net.throughput.usage.HOST'       => { metric => 'vcenter_host_net_throughput_usage_kilobytespersecond',       unit => 'kilobytespersecond', target => 'KBps' },
+    'net.throughput.usable.HOST'      => { metric => 'vcenter_host_net_throughput_usable_kilobytespersecond',      unit => 'kilobytespersecond', target => 'KBps' },
+    'net.throughput.provisioned.HOST' => { metric => 'vcenter_host_net_throughput_provisioned_kilobytespersecond', unit => 'kilobytespersecond', target => 'KBps' },
+    'net.throughput.contention.HOST'  => { metric => 'vcenter_host_net_throughput_contention',          unit => 'number',    target => 'count' },
+    'power.capacity.usage.HOST'       => { metric => 'vcenter_host_power_capacity_usage_watts',         unit => 'watts',     target => 'W' },
+    'cpu.capacity.provisioned.VM'     => { metric => 'vcenter_vm_cpu_capacity_provisioned_megahertz',   unit => 'megahertz', target => 'MHz' },
+    'cpu.capacity.entitlement.VM'     => { metric => 'vcenter_vm_cpu_capacity_entitlement_megahertz',   unit => 'megahertz', target => 'MHz' },
+    'cpu.capacity.usage.VM'           => { metric => 'vcenter_vm_cpu_capacity_usage_megahertz',         unit => 'megahertz', target => 'MHz' },
+    'mem.capacity.entitlement.VM'     => { metric => 'vcenter_vm_mem_capacity_entitlement_kilobytes',   unit => 'kilobytes', target => 'MB' },
+    'mem.capacity.usage.VM'           => { metric => 'vcenter_vm_mem_capacity_usage_kilobytes',         unit => 'kilobytes', target => 'MB' },
+    'disk.throughput.usage.VM'        => { metric => 'vcenter_vm_disk_throughput_usage_kilobytespersecond',       unit => 'kilobytespersecond', target => 'KBps' },
+    'disk.throughput.contention.VM'   => { metric => 'vcenter_vm_disk_throughput_contention_milliseconds',        unit => 'milliseconds',       target => 'ms' },
+    'net.throughput.usage.VM'         => { metric => 'vcenter_vm_net_throughput_usage_kilobytespersecond',        unit => 'kilobytespersecond', target => 'KBps' },
+    'net.throughput.contention.VM'    => { metric => 'vcenter_vm_net_throughput_contention',            unit => 'number',    target => 'count' },
+    'power.capacity.usage.VM'         => { metric => 'vcenter_vm_power_capacity_usage_watts',           unit => 'watts',     target => 'W' }
+);
+
+sub new {
+    my ($class, %options) = @_;
+    my $self = bless {}, $class;
+
+    $self->{output} = $options{output};
+    $self->{http}   = centreon::plugins::http->new(%options);
+    $self->{cache}  = $options{cache};
+
+    return $self;
+}
+
+sub set_options {
+    my ($self, %options) = @_;
+
+    $self->{option_results} = $options{option_results};
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+
+    my $results = $self->{option_results};
+
+    $self->{hostname}   = $results->{rtm_hostname};
+    $self->{port}       = $results->{rtm_port}      // 443;
+    $self->{proto}      = $results->{rtm_proto}     // 'https';
+    $self->{base_path}  = $results->{rtm_base_path} // '/data-query-service';
+    $self->{username}   = $results->{rtm_username};
+    $self->{password}   = $results->{rtm_password};
+    $self->{auth_source}= $results->{rtm_auth_source};
+    $self->{moid_label} = $results->{rtm_moid_label};
+    $self->{timeout}    = $results->{timeout} // 10;
+
+    for my $option (qw/rtm-hostname rtm-username rtm-password/) {
+        (my $key = $option) =~ tr/-/_/;
+        next if (!is_empty($results->{$key}));
+        $self->{output}->option_exit(short_msg => "The Real-Time Metrics source needs the --"
+            . $option . " option. It queries VCF Operations, not the vCenter, so it takes "
+            . "its own address and credentials.");
+    }
+
+    # --rtm-metric-map cid=metric_name overrides an entry of the built-in mapping
+    $self->{metric_overrides} = {};
+    for my $override (@{ $results->{rtm_metric_map} // [] }) {
+        if ($override !~ /^([^=]+)=(.+)$/) {
+            $self->{output}->option_exit(short_msg => "Malformed --rtm-metric-map value '" . $override
+                . "'. Expected the 'counter.id=metric_name' format.");
+        }
+        $self->{metric_overrides}->{$1} = $2;
+    }
+
+    $self->{base_path} =~ s/\/$//;
+
+    return 0;
+}
+
+sub settings {
+    my ($self, %options) = @_;
+
+    return 1 if (defined($self->{settings_done}));
+
+    $self->{option_results}->{hostname} = $self->{hostname};
+    $self->{option_results}->{port}     = $self->{port};
+    $self->{option_results}->{proto}    = $self->{proto};
+    $self->{option_results}->{timeout}  = $self->{timeout};
+    # error payloads carry the reason and must be read rather than turned into UNKNOWN
+    $self->{option_results}->{unknown_status}  = '';
+    $self->{option_results}->{warning_status}  = '';
+    $self->{option_results}->{critical_status} = '';
+
+    $self->{http}->set_options(%{$self->{option_results}});
+    $self->{settings_done} = 1;
+
+    return 1;
+}
+
+sub request {
+    my ($self, %options) = @_;
+
+    $self->settings();
+
+    my $headers = [ 'Accept: application/json' ];
+    push @$headers, 'Content-Type: application/json' if (defined($options{post_body}));
+    push @$headers, @{ $options{header} // [] };
+
+    my $content = $self->{http}->request(
+        method          => $options{method} // 'GET',
+        url_path        => $options{url_path},
+        get_param       => $options{get_param},
+        query_form_post => $options{post_body},
+        header          => $headers,
+        insecure        => (defined($self->{option_results}->{insecure}) ? 1 : 0)
+    );
+
+    my $code = $self->{http}->get_code();
+    if (!defined($content) || $content eq '') {
+        $self->{output}->option_exit(short_msg => "Real-Time Metrics API returned an empty body for '"
+            . $options{url_path} . "' [http code: '" . $code . "'].");
+    }
+
+    my $decoded = json_decode($content);
+    if (!defined($decoded)) {
+        $self->{output}->option_exit(short_msg => "Real-Time Metrics API returned a non-JSON body for '"
+            . $options{url_path} . "' [http code: '" . $code . "'].");
+    }
+
+    return ($decoded, $code);
+}
+
+# Three-step JWT acquisition. The resulting token is cached: replaying the whole
+# sequence on every check would triple the calls against VCF Operations.
+sub get_token {
+    my ($self, %options) = @_;
+
+    return $self->{token} if (defined($self->{token}));
+
+    my $statefile = 'vsphere8_rtm_token_' . sha256_hex($self->{hostname} . ':' . $self->{port} . '_' . $self->{username});
+    if (!$options{force_authentication} && defined($self->{cache}) && $self->{cache}->read(statefile => $statefile)) {
+        my $token   = $self->{cache}->get(name => 'token');
+        my $expires = $self->{cache}->get(name => 'expires');
+        if (!is_empty($token) && defined($expires) && $expires > time()) {
+            $self->{token} = $token;
+            return $self->{token};
+        }
+    }
+
+    # 1. acquire an OpsToken from the VCF Operations credentials
+    my $credentials = { username => $self->{username}, password => $self->{password} };
+    $credentials->{authSource} = $self->{auth_source} if (!is_empty($self->{auth_source}));
+
+    my ($acquired) = $self->request(
+        method    => 'POST',
+        url_path  => '/suite-api/api/auth/token/acquire',
+        post_body => json_encode($credentials)
+    );
+    if (is_empty($acquired->{token})) {
+        $self->{output}->option_exit(short_msg => "Could not acquire a VCF Operations token on '"
+            . $self->{hostname} . "'. Check --rtm-username, --rtm-password and --rtm-auth-source.");
+    }
+
+    # 2. find the service key of the Real-Time Metrics service (VCF_VODAP)
+    my ($services) = $self->request(
+        url_path => '/suite-api/api/integrations/services',
+        header   => [ 'Authorization: OpsToken ' . $acquired->{token} ]
+    );
+
+    my @service_list = @{ $services->{services} // $services->{service} // [] };
+    my ($rtm_service) = grep { ($_->{type} // '') eq 'VCF_VODAP' } @service_list;
+    if (!defined($rtm_service) || is_empty($rtm_service->{serviceKey})) {
+        $self->{output}->option_exit(short_msg => "No 'VCF_VODAP' service is registered on '"
+            . $self->{hostname} . "' (found: " . (join(', ', map { $_->{type} // '?' } @service_list) || 'none')
+            . "). The Real-Time Metrics component is most likely not deployed: install it from "
+            . "Build > Lifecycle > VCF Management > Add Component.");
+    }
+
+    # 3. exchange the service key for the JWT bearer token
+    my ($exchanged) = $self->request(
+        method    => 'POST',
+        url_path  => '/suite-api/api/auth/token/exchange',
+        post_body => json_encode([ $rtm_service->{serviceKey} ]),
+        header    => [ 'Authorization: OpsToken ' . $acquired->{token} ]
+    );
+
+    my $jwt = $exchanged->{token} // $exchanged->{accessToken};
+    if (is_empty($jwt)) {
+        $self->{output}->option_exit(short_msg => "Could not exchange the 'VCF_VODAP' service key for a "
+            . "JWT token on '" . $self->{hostname} . "'.");
+    }
+
+    $self->{token} = $jwt;
+    # the announced validity is honoured when present, with a safety margin
+    my $validity = $exchanged->{expiresIn} // $exchanged->{validity} // 3600;
+    $self->{cache}->write(data => { updated => time(), token => $jwt, expires => time() + $validity - 60 })
+        if (defined($self->{cache}));
+
+    return $self->{token};
+}
+
+sub query_api {
+    my ($self, %options) = @_;
+
+    my ($response, $code) = $self->request(
+        %options,
+        url_path => $self->{base_path} . $options{endpoint},
+        header   => [ 'Authorization: Bearer ' . $self->get_token() ]
+    );
+
+    # the token may have expired between two checks: authenticate again once
+    if ($code == 401 || $code == 403) {
+        delete $self->{token};
+        ($response, $code) = $self->request(
+            %options,
+            url_path => $self->{base_path} . $options{endpoint},
+            header   => [ 'Authorization: Bearer ' . $self->get_token(force_authentication => 1) ]
+        );
+    }
+
+    if (($response->{status} // '') eq 'error') {
+        $self->{output}->option_exit(short_msg => "Real-Time Metrics API error on '" . $options{endpoint}
+            . "': " . ($response->{errorType} // 'unknown') . " - " . ($response->{error} // 'no detail'));
+    }
+
+    return $response;
+}
+
+# Metric catalogue advertised by the appliance, cached for the lifetime of the run.
+sub metric_catalogue {
+    my ($self, %options) = @_;
+
+    return $self->{catalogue} if (defined($self->{catalogue}));
+
+    my $response = $self->query_api(endpoint => '/v1/metadata');
+    my $data     = $response->{data} // {};
+
+    # the Prometheus metadata payload is keyed by metric name
+    $self->{catalogue} = { map { $_ => 1 } keys %$data };
+
+    if (!keys %{$self->{catalogue}}) {
+        $self->{output}->option_exit(short_msg => "The Real-Time Metrics API of '" . $self->{hostname}
+            . "' advertises no metric. The collection profile is most likely not enabled: activate "
+            . "'Standard' and/or 'ESXi Top' for the vCenter object types in "
+            . "Operate > Administration > Configurations > Policy Definition.");
+    }
+
+    return $self->{catalogue};
+}
+
+sub resolve_metric {
+    my ($self, %options) = @_;
+
+    my $mapping = $counter_map{ $options{cid} };
+    if (!defined($mapping)) {
+        $self->{output}->option_exit(short_msg => "Counter '" . $options{cid} . "' has no Real-Time Metrics "
+            . "equivalent declared. Use --rtm-metric-map '" . $options{cid} . "=<metric_name>' to map it.");
+    }
+
+    # a copy, so an override never mutates the package-level table
+    my %resolved = %$mapping;
+    $resolved{metric} = $self->{metric_overrides}->{ $options{cid} }
+        if (defined($self->{metric_overrides}->{ $options{cid} }));
+
+    my $catalogue = $self->metric_catalogue();
+    if (!defined($catalogue->{ $resolved{metric} })) {
+        $self->{output}->option_exit(short_msg => "Metric '" . $resolved{metric} . "' (counter '" . $options{cid}
+            . "') is not advertised by the Real-Time Metrics API of '" . $self->{hostname} . "'. "
+            . "Check the enabled collection profile, or map the counter explicitly with "
+            . "--rtm-metric-map '" . $options{cid} . "=<metric_name>'.");
+    }
+
+    return \%resolved;
+}
+
+# Discovers which label carries the managed object id, by looking at the labels of the
+# series the appliance actually returns. Pinned with --rtm-moid-label when needed.
+sub resolve_moid_label {
+    my ($self, %options) = @_;
+
+    return $self->{moid_label} if (!is_empty($self->{moid_label}));
+
+    my $response = $self->query_api(
+        endpoint  => '/v1/query',
+        get_param => [ 'query=' . $options{metric} ]
+    );
+
+    my @series = @{ $response->{data}->{result} // [] };
+    for my $candidate (@moid_label_candidates) {
+        for my $serie (@series) {
+            next if (!defined($serie->{metric}->{$candidate}));
+            if ($serie->{metric}->{$candidate} eq $options{rsrc_id}) {
+                $self->{moid_label} = $candidate;
+                $self->{output}->add_option_msg(long_msg => "Real-Time Metrics: resource ids are carried by the '"
+                    . $candidate . "' label. Pass --rtm-moid-label=" . $candidate . " to skip this discovery query.");
+                return $self->{moid_label};
+            }
+        }
+    }
+
+    my %seen;
+    my @labels = grep { !$seen{$_}++ } map { keys %{ $_->{metric} // {} } } @series;
+    $self->{output}->option_exit(short_msg => "Could not find which label of metric '" . $options{metric}
+        . "' carries the resource id '" . $options{rsrc_id} . "' (labels seen: "
+        . (join(', ', sort @labels) || 'none') . "). Pin it with --rtm-moid-label.");
+}
+
+sub convert_unit {
+    my ($self, %options) = @_;
+
+    my $from = $units{ lc($options{from}) } // $units{ $options{from} };
+    my $to   = $units{ $options{to} };
+
+    if (!defined($from) || !defined($to)) {
+        $self->{output}->option_exit(short_msg => "Unknown unit in the conversion of counter '" . $options{cid}
+            . "' ('" . $options{from} . "' to '" . $options{to} . "').");
+    }
+    if ($from->[0] ne $to->[0]) {
+        $self->{output}->option_exit(short_msg => "Counter '" . $options{cid} . "' is published in '"
+            . $options{from} . "' but is expected in '" . $options{to} . "', which measures something else ('"
+            . $from->[0] . "' against '" . $to->[0] . "'). Refusing to report a wrong value.");
+    }
+
+    return $options{value} * $from->[1] / $to->[1];
+}
+
+# Reads one counter for one resource and returns it in the unit the modes expect.
+sub get_perf_value {
+    my ($self, %options) = @_;
+
+    if (is_empty($options{cid}) || is_empty($options{rsrc_id})) {
+        $self->{output}->option_exit(short_msg => "Real-Time Metrics: get_perf_value needs both a cid and a rsrc_id.");
+    }
+
+    my $mapping = $self->resolve_metric(cid => $options{cid});
+    my $label   = $self->resolve_moid_label(metric => $mapping->{metric}, rsrc_id => $options{rsrc_id});
+
+    my $query = $mapping->{metric} . '{' . $label . '="' . escape_label_value($options{rsrc_id}) . '"}';
+    my $response = $self->query_api(endpoint => '/v1/query', get_param => [ 'query=' . $query ]);
+
+    my @series = @{ $response->{data}->{result} // [] };
+    if (!@series) {
+        # An empty result is ambiguous: the resource may genuinely have no sample right
+        # now, or the selector may simply match nothing because the label or the resource
+        # id is wrong. One selector-less query tells both apart, so that a mistake is
+        # reported instead of silently looking like an idle resource.
+        my $unfiltered = $self->query_api(endpoint => '/v1/query', get_param => [ 'query=' . $mapping->{metric} ]);
+        my @all = @{ $unfiltered->{data}->{result} // [] };
+
+        if (@all) {
+            my %seen;
+            my @values = grep { !$seen{$_}++ } map { $_->{metric}->{$label} // '' } @all;
+            $self->{output}->option_exit(short_msg => "Metric '" . $mapping->{metric} . "' has "
+                . scalar(@all) . " series but none with " . $label . '="' . $options{rsrc_id} . '". '
+                . "Check the resource id, or the label carrying it (--rtm-moid-label). "
+                . "Values seen for '" . $label . "': " . (join(', ', grep { $_ ne '' } @values) || 'none') . ".");
+        }
+
+        $self->{output}->add_option_msg(short_msg => "no data for resource " . $options{rsrc_id}
+            . " counter " . $options{cid} . " at the moment.");
+        return undef;
+    }
+    if (@series > 1) {
+        $self->{output}->option_exit(short_msg => "The query '" . $query . "' returned " . scalar(@series)
+            . " series instead of one. Refusing to pick one arbitrarily.");
+    }
+
+    # instant vector: value is the [ timestamp, "value" ] pair
+    my $raw = $series[0]->{value}->[1];
+    return undef if (!defined($raw) || $raw !~ /^-?\d+(\.\d+)?([eE][-+]?\d+)?$/);
+
+    return $self->convert_unit(
+        value => $raw,
+        from  => $mapping->{unit},
+        to    => $mapping->{target},
+        cid   => $options{cid}
+    );
+}
+
+# Only used to build the label selector, so the value is quoted, not interpolated.
+sub escape_label_value {
+    my ($value) = @_;
+
+    return '' if (!defined($value));
+    $value =~ s/\\/\\\\/g;
+    $value =~ s/"/\\"/g;
+
+    return $value;
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+apps::vmware::vsphere8::custom::rtm - Performance counters read from the VCF Operations Real-Time Metrics API
+
+=head1 DESCRIPTION
+
+Collects performance counters through the Real-Time Metrics API of VCF Operations, the
+replacement Broadcom offers for the vStats API removed in vSphere 9.1.
+
+This API is not served by vCenter. It belongs to VCF Operations, requires its
+Real-Time Metrics component to be deployed and a collection profile to be enabled, and
+authenticates with a JWT bearer token obtained in three steps. It therefore takes its
+own address and credentials through the C<--rtm-*> options and is never selected
+automatically by C<--metrics-source=auto>.
+
+Counter ids keep the vStats naming (C<cpu.capacity.usage.HOST>), so the modes are
+unchanged. Every metric name is validated against the C</v1/metadata> catalogue of the
+appliance before being queried, the label carrying the managed object id is discovered
+at runtime, and values are converted to the unit each mode expects. Anything that
+cannot be resolved raises an explicit error rather than a wrong or empty value.
+
+=head1 METHODS
+
+=head2 get_perf_value
+
+    my $value = $rtm->get_perf_value(cid => 'cpu.capacity.usage.HOST', rsrc_id => 'host-35');
+
+Returns the current value of the given counter for the given resource, converted to the
+unit expected by the modes, or C<undef> when the appliance currently has no sample.
+
+=head2 get_token
+
+Runs the three-step authentication sequence (C<token/acquire>, C<integrations/services>
+filtered on the C<VCF_VODAP> entry, C<token/exchange>) and caches the resulting JWT for
+its announced validity.
+
+=head2 metric_catalogue
+
+Returns the set of metric names advertised by C</v1/metadata>. An empty catalogue means
+no collection profile is enabled on the appliance.
+
+=head2 resolve_moid_label
+
+Discovers which metric label carries the managed object id of the monitored resource,
+by inspecting the labels of the series the appliance returns. Bypassed by
+C<--rtm-moid-label>.
+
+=cut

--- a/tests/apps/vmware/vsphere8/api.t
+++ b/tests/apps/vmware/vsphere8/api.t
@@ -5,6 +5,7 @@ use FindBin;
 use lib "$FindBin::RealBin/../../../../src";
 use apps::vmware::vsphere8::custom::api;
 use apps::vmware::vsphere8::custom::vim25;
+use apps::vmware::vsphere8::custom::rtm;
 
 
 # Mock options class
@@ -306,6 +307,120 @@ sub test_acq_specs_invalidation {
     is($api->{acq_specs_stale}, 1,      'the list is flagged as stale on invalidation');
 }
 
+# The Real-Time Metrics source targets VCF Operations, not the vCenter, and must never
+# report a value it could not resolve or convert safely.
+sub build_rtm {
+    my (%options) = @_;
+
+    my $rtm = apps::vmware::vsphere8::custom::rtm->new(
+        noptions => 1,
+        options  => MockOptions->new(),
+        output   => ExitingOutput->new()
+    );
+    $rtm->set_options(option_results => {
+        rtm_hostname => 'vcfops.example.tld',
+        rtm_username => 'svc-centreon',
+        rtm_password => 's3cret',
+        %options
+    });
+
+    return $rtm;
+}
+
+sub test_rtm_options {
+    my $rtm = build_rtm();
+    $rtm->check_options();
+    is($rtm->{hostname},  'vcfops.example.tld',   'the VCF Operations address is taken from --rtm-hostname');
+    is($rtm->{base_path}, '/data-query-service',  'the base path defaults to the data-query-service');
+    is($rtm->{port},      443,                    'the port defaults to 443');
+
+    # a trailing slash would produce a double slash in every query
+    my $trailing = build_rtm(rtm_base_path => '/data-query-service/');
+    $trailing->check_options();
+    is($trailing->{base_path}, '/data-query-service', 'a trailing slash is stripped from the base path');
+
+    # the source cannot silently fall back on the vCenter credentials
+    for my $missing (qw/rtm_hostname rtm_username rtm_password/) {
+        my $incomplete = build_rtm($missing => undef);
+        (my $option = $missing) =~ tr/_/-/;
+        like(dies { $incomplete->check_options() }, qr/needs the --\Q$option\E option/,
+            "--$option is required by the Real-Time Metrics source");
+    }
+
+    my $mapped = build_rtm(rtm_metric_map => [ 'cpu.capacity.usage.HOST=custom_metric' ]);
+    $mapped->check_options();
+    is($mapped->{metric_overrides}->{'cpu.capacity.usage.HOST'}, 'custom_metric',
+        'a --rtm-metric-map entry is parsed');
+
+    my $malformed = build_rtm(rtm_metric_map => [ 'no_equal_sign' ]);
+    like(dies { $malformed->check_options() }, qr/Malformed --rtm-metric-map/,
+        'a malformed --rtm-metric-map entry is refused');
+}
+
+sub test_rtm_metric_resolution {
+    my $rtm = build_rtm();
+    $rtm->check_options();
+    $rtm->{catalogue} = { 'vcenter_host_cpu_capacity_usage_megahertz' => 1, 'custom_metric' => 1 };
+
+    my $resolved = $rtm->resolve_metric(cid => 'cpu.capacity.usage.HOST');
+    is($resolved->{metric}, 'vcenter_host_cpu_capacity_usage_megahertz', 'a known counter resolves to its metric');
+    is($resolved->{target}, 'kHz',                                      'the target unit of the host CPU counter is kHz');
+
+    # a metric absent from the appliance catalogue must not be queried blindly
+    $rtm->{catalogue} = { 'something_else' => 1 };
+    like(dies { $rtm->resolve_metric(cid => 'cpu.capacity.usage.HOST') },
+        qr/is not advertised by the Real-Time Metrics API/, 'a metric missing from the catalogue is refused');
+
+    # an unknown counter tells the user how to map it
+    like(dies { $rtm->resolve_metric(cid => 'made.up.counter.HOST') },
+        qr/--rtm-metric-map/, 'an unmapped counter points at --rtm-metric-map');
+
+    # an override wins, and must not corrupt the shared mapping table
+    my $overridden = build_rtm(rtm_metric_map => [ 'cpu.capacity.usage.HOST=custom_metric' ]);
+    $overridden->check_options();
+    $overridden->{catalogue} = { 'custom_metric' => 1 };
+    is($overridden->resolve_metric(cid => 'cpu.capacity.usage.HOST')->{metric}, 'custom_metric',
+        'an override replaces the metric name');
+
+    my $untouched = build_rtm();
+    $untouched->check_options();
+    $untouched->{catalogue} = { 'vcenter_host_cpu_capacity_usage_megahertz' => 1 };
+    is($untouched->resolve_metric(cid => 'cpu.capacity.usage.HOST')->{metric},
+        'vcenter_host_cpu_capacity_usage_megahertz', 'the override did not leak into the package mapping');
+}
+
+sub test_rtm_unit_conversion {
+    my $rtm = build_rtm();
+    $rtm->check_options();
+
+    is($rtm->convert_unit(value => 3200, from => 'megahertz', to => 'kHz', cid => 'cpu.capacity.usage.HOST'),
+        3200000, 'megahertz are converted to kHz');
+    is($rtm->convert_unit(value => 1048576, from => 'kilobytes', to => 'MB', cid => 'mem.capacity.usable.HOST'),
+        1024, 'kilobytes are converted to MB');
+    # a ratio published as 0..1 has to become a percentage
+    is($rtm->convert_unit(value => 0.45, from => 'ratio', to => 'pct', cid => 'cpu.capacity.contention.HOST'),
+        45, 'a ratio is converted to a percentage');
+    is($rtm->convert_unit(value => 210, from => 'watts', to => 'W', cid => 'power.capacity.usage.HOST'),
+        210, 'identical units leave the value untouched');
+
+    like(dies { $rtm->convert_unit(value => 1, from => 'kilobytes', to => 'kHz', cid => 'bogus.HOST') },
+        qr/Refusing to report a wrong value/, 'a cross-dimension conversion is refused');
+    like(dies { $rtm->convert_unit(value => 1, from => 'furlongs', to => 'kHz', cid => 'bogus.HOST') },
+        qr/Unknown unit/, 'an unknown unit is refused');
+}
+
+sub test_rtm_label_escaping {
+    # a resource id is injected into a PromQL selector and must stay quoted
+    is(apps::vmware::vsphere8::custom::rtm::escape_label_value('host-35'), 'host-35',
+        'a plain resource id is left untouched');
+    is(apps::vmware::vsphere8::custom::rtm::escape_label_value('a"b'), 'a\\"b',
+        'a double quote is escaped in a label value');
+    is(apps::vmware::vsphere8::custom::rtm::escape_label_value('a\\b'), 'a\\\\b',
+        'a backslash is escaped in a label value');
+    is(apps::vmware::vsphere8::custom::rtm::escape_label_value(undef), '',
+        'an undefined value becomes an empty string');
+}
+
 sub main {
     #process_test('localhost', 443, 'https', '/v2', 10, 'user', 'pass');
     process_test('localhost', 3000, 'http', undef, 10, 'login', 'password');
@@ -315,6 +430,10 @@ sub main {
     test_vim25_xml_hardening();
     test_poisoned_cache_is_ignored();
     test_acq_specs_invalidation();
+    test_rtm_options();
+    test_rtm_metric_resolution();
+    test_rtm_unit_conversion();
+    test_rtm_label_escaping();
 }
 
 main();


### PR DESCRIPTION
# Centreon team (internal PR)

> **Stacked on [#6425](https://github.com/centreon/centreon-plugins/pull/6425).** The base branch of this PR is `fix/vmware-vsphere8-vstats-removed-in-9.1`, so the diff below shows **only** the Real-Time Metrics work. GitHub retargets it to `develop` automatically once #6425 is merged. Please review #6425 first.
>
> **No JIRA ID yet** — tell me the ticket and I rename both branches.

## Description

[#6425](https://github.com/centreon/centreon-plugins/pull/6425) restores metric collection on vSphere 9.1 through the vim25 `PerformanceManager`, which is the pragmatic answer: it works today, on any vCenter, with no extra infrastructure.

This PR adds the **other** answer — the one Broadcom officially designates as the replacement for the removed vStats API: the **VCF Operations Real-Time Metrics API**. It is exposed as `--metrics-source=rtm`.

It is deliberately shipped as a *second* source rather than as *the* answer, because it carries constraints the vim25 source does not.

### Why it is not, and cannot be, the default

| | vim25 (#6425) | **rtm (this PR)** |
|---|---|---|
| Served by | the vCenter itself | **VCF Operations**, another appliance |
| Prerequisite | none | **Real-Time Metrics component deployed** + a collection profile enabled |
| Environment | any vCenter | **VCF or VVF only** |
| Authentication | vCenter session | **JWT bearer**, three-step sequence |
| Credentials | the vCenter ones | **its own**, on its own host |
| Granularity | 20 s | down to **2 s** (ESXi Top profile) |

Two consequences drive the design:

1. **`--metrics-source=auto` never selects `rtm`.** Silently redirecting collection to a different appliance, with different credentials, would be surprising and would fail for everyone who does not run VCF. It must be asked for explicitly.
2. **Standalone vCenter customers cannot use it at all.** This is a real product limitation on Broadcom's side, not something we can engineer around — hence #6425 remaining the general-purpose answer.

Worth remembering, and it is why this PR exists now rather than later: the ESXi Top profile delivers 2-second granularity that neither vStats nor vim25 can reach. When the fleet moves to VCF 9.1+, this becomes the interesting source rather than the constrained one.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## What this PR adds

### The documented API surface, implemented in full

Authentication is the three-step sequence from the [Real-Time Metrics API reference](https://developer.broadcom.com/xapis/realtime-metrics-api/latest/):

```
POST /suite-api/api/auth/token/acquire      -> OpsToken
GET  /suite-api/api/integrations/services   -> service key of the entry where type = VCF_VODAP
POST /suite-api/api/auth/token/exchange     -> JWT bearer token
```

The JWT is **cached for its announced validity** (with a 60 s safety margin), so the three calls are not replayed on every check — verified below. A `401`/`403` on a query re-authenticates once, then gives up.

Counters are read with the Prometheus-compatible endpoints, under a configurable base path defaulting to `/data-query-service`:

| Endpoint | Use |
|---|---|
| `GET <base>/v1/query` | the PromQL instant query returning the counter value |
| `GET <base>/v1/metadata` | the metric catalogue, used to validate every name before querying it |

`PUT /v1/vcenters/{vcId}/metrics_config` exists and toggles the STANDARD / VERBOSE profiles, but **is deliberately not implemented**: a monitoring plugin has no business mutating the collection configuration of the system it observes. Enabling the profile stays an explicit operator action, documented below.

### The same safety rules as #6425

**No mode is modified.** Counter ids keep their vStats naming (`cpu.capacity.usage.HOST`); the mapping to PromQL metric names lives entirely in the new package, so the three sources are interchangeable behind one option.

**Every metric name is validated against `/v1/metadata` before being queried.** An unknown name produces an error naming the metric, the counter and the fix, instead of an empty result.

**The identifying label is discovered, not guessed.** The plugin inspects the labels of the series the appliance actually returns to find which one carries the managed object id, then prints the value to pin:

```
Real-Time Metrics: resource ids are carried by the 'moid' label.
Pass --rtm-moid-label=moid to skip this discovery query.
```

**Units are never converted across dimensions.** Same rule as vim25: a conversion that would turn kilobytes into hertz is refused rather than reporting a wrong number.

**Empty results are disambiguated.** An empty PromQL result is ambiguous — an idle resource, or a selector matching nothing. One selector-less query tells them apart, so a wrong resource id or a wrong label is reported explicitly:

```
Metric 'vcenter_host_cpu_capacity_provisioned_megahertz' has 1 series but none with moid="host-999".
Check the resource id, or the label carrying it (--rtm-moid-label). Values seen for 'moid': host-35.
```

This matters: without it, the two most likely misconfigurations would look exactly like the silent failure #6425 was written to eliminate.

**The two prerequisite failures get their own message.** A missing component and a disabled profile are the two things a first-time user will hit:

```
No 'VCF_VODAP' service is registered on '<host>' (found: VCF_AUTOMATION). The Real-Time Metrics
component is most likely not deployed: install it from Build > Lifecycle > VCF Management > Add Component.

The Real-Time Metrics API of '<host>' advertises no metric. The collection profile is most likely
not enabled: activate 'Standard' and/or 'ESXi Top' for the vCenter object types in
Operate > Administration > Configurations > Policy Definition.
```

### New options

```
--metrics-source=rtm
--rtm-hostname     VCF Operations appliance (required)
--rtm-username     (required)
--rtm-password     (required)
--rtm-port         default 443
--rtm-proto        default https
--rtm-auth-source  when the account is not local
--rtm-base-path    default /data-query-service
--rtm-moid-label   pin the label carrying the managed object id
--rtm-metric-map   'counter.id=metric_name', repeatable, overrides a mapping
```

`--rtm-metric-map` is the escape hatch: if the appliance publishes a metric under a name we do not know, the operator fixes it from the command line without waiting for a release. It is the direct answer to the main limitation below.

## How this pull request can be tested ?

### Automated tests

```bash
perl -Isrc tests/apps/vmware/vsphere8/api.t
```

**63 assertions** (38 in #6425, 25 added here):

| Area | What is asserted |
|---|---|
| Options | base path default and trailing-slash stripping, port default, each of `--rtm-hostname/username/password` required, `--rtm-metric-map` parsed, malformed entry refused |
| Metric resolution | known counter resolves with its target unit; a metric absent from the catalogue is refused; an unmapped counter points at `--rtm-metric-map`; an override wins **and does not leak into the package-level table** |
| Unit conversion | megahertz→kHz, kilobytes→MB, ratio→percent, identity; cross-dimension and unknown units refused |
| Label escaping | quotes and backslashes escaped in the PromQL selector, undef handled |

### Manual end-to-end verification

No VCF Operations appliance was available, so verification used a mock implementing the documented contract (source at the end). It honours PromQL label selectors, so a wrong selector genuinely returns an empty result as a real endpoint would.

| Scenario | Result |
|---|---|
| Nominal, label discovered | `OK: CPU average usage is 40.00 %, used frequency is 3200000 kHz` |
| Nominal, `--rtm-moid-label=moid` | identical, one query fewer |
| `VCF_VODAP` service absent | `UNKNOWN: No 'VCF_VODAP' service is registered ... (found: VCF_AUTOMATION)` + install path |
| Collection profile disabled | `UNKNOWN: ... advertises no metric` + policy path |
| Wrong password | `UNKNOWN: Could not acquire a VCF Operations token ...` |
| `--rtm-metric-map` to an unknown metric | `UNKNOWN: Metric 'does_not_exist' ... is not advertised` |
| Malformed `--rtm-metric-map` | `UNKNOWN: Malformed --rtm-metric-map value 'pasdegal'` |
| Wrong `--rtm-moid-label` | `UNKNOWN: ... has 1 series but none with vcenter="host-35"` + labels seen |
| Unknown resource id | `UNKNOWN: ... none with moid="host-999"` + values seen |
| **Missing `--rtm-hostname`** | refuses, rather than silently reusing the vCenter credentials |

**The value is identical across all three sources** — `3200 MHz` from RTM, `3200000 kHz` from vim25, `3200000` from vStats all render as `40.00 %` and `3200000 kHz`. That cross-source agreement is the point of keeping the conversion layer.

### JWT caching, verified

Three consecutive runs sharing a statefile directory, counting calls on `token/acquire`:

```
run 1 -> token/acquire called 1 time in total
run 2 -> token/acquire called 1 time in total
run 3 -> token/acquire called 1 time in total
```

One authentication for three checks: the cache works and VCF Operations is not hammered.

### Non-regression on #6425

Re-run after this PR's changes to `api.pm`:

| Scenario | Result |
|---|---|
| 9.1, `auto` | falls back to vim25, `OK ... 3200000 kHz` |
| **9.0 healthy, `auto`** | **vStats used, `/sdk` never called** |
| `--metrics-source=bogus` | `UNKNOWN: Unsupported --metrics-source 'bogus'. Expected one of: auto, vstats, vim25, rtm.` |

### Command line

```bash
./centreon_plugins.pl --plugin=apps::vmware::vsphere8::esx::plugin --mode=cpu \
  --hostname=<vcenter> --username=<user> --password=<password> --esx-id=host-35 \
  --metrics-source=rtm \
  --rtm-hostname=<vcf-operations-fqdn> \
  --rtm-username=<ops-user> --rtm-password=<ops-password> \
  --verbose
```

The vCenter options are still required: inventory (resolving `--esx-name` to an id, listing objects) keeps going to the vCenter REST API. Only the counters come from VCF Operations.

### Prerequisites on the appliance, for whoever tests this

1. **Install the component** — *Build → Lifecycle → VCF Management → Add Component → Real-time metrics*.
2. **Enable a collection profile** — *Operate → Administration → Configurations → Policy Definition*, activate `vCenter / Standard` and/or `Host System / ESX Top`. Essentials is always on and cannot be disabled; Standard and ESXi Top require the Real-Time Metrics component to be **scaled from Small to Large**.
3. The Swagger of the appliance is at `https://<vcf-instance-services-fqdn>/data-query-service/swagger-ui/index.html`, also reachable from *Build → Developer Center → APIs & SDKs*.

### curl examples

Full authentication sequence and a first query:

```bash
OPS=$(curl -sk -X POST https://<vcf-ops>/suite-api/api/auth/token/acquire \
  -H 'Content-Type: application/json' -H 'Accept: application/json' \
  -d '{"username":"<user>","password":"<password>"}' | jq -r .token)

KEY=$(curl -sk https://<vcf-ops>/suite-api/api/integrations/services \
  -H "Authorization: OpsToken $OPS" -H 'Accept: application/json' \
  | jq -r '.services[] | select(.type=="VCF_VODAP") | .serviceKey')

JWT=$(curl -sk -X POST https://<vcf-ops>/suite-api/api/auth/token/exchange \
  -H "Authorization: OpsToken $OPS" -H 'Content-Type: application/json' \
  -d "[\"$KEY\"]" | jq -r .token)

# metric catalogue — empty means no collection profile is enabled
curl -sk https://<vcf-ops>/data-query-service/v1/metadata \
  -H "Authorization: Bearer $JWT" | jq '.data | keys | length'

# instant PromQL query
curl -sk -G https://<vcf-ops>/data-query-service/v1/query \
  -H "Authorization: Bearer $JWT" \
  --data-urlencode 'query=vcenter_host_cpu_capacity_usage_megahertz{moid="host-35"}' | jq .
```

The second command is the one to run first on a real appliance: **it prints the real metric names**, which is exactly what this PR needs validated.

## Known limitations — please challenge these

1. **The PromQL metric names are the weak point, and I want to be blunt about it.** The endpoints, the authentication sequence and the response shapes are documented and implemented faithfully; the *metric names* are not published anywhere I could find, and the Swagger lives on the appliance rather than on the developer portal. The names in `%counter_map` follow the VCF Operations vCenter-adapter convention but **are not verified against a real appliance**. The design contains that risk deliberately — every name is validated against `/v1/metadata` before use, a mismatch is a loud error naming the fix, and `--rtm-metric-map` corrects any of them without a release. But expect the first run against a real VCF Operations to need a handful of `--rtm-metric-map` entries, and please send them back so the table can be corrected.
2. **Units per metric are declared in the mapping table, not read from the appliance.** Prometheus metadata carries a `unit` field that is empty in practice, so the unit is inferred from the metric name suffix as the convention dictates. If a name is corrected via `--rtm-metric-map` and its unit differs, the value would be wrong — the dimension check only catches *incompatible* dimensions, not a kilobytes/megabytes mix-up. Documented in the module header; a `--rtm-unit-map` companion option is the obvious follow-up if the field reports it is needed.
3. Only instant queries (`/v1/query`) are used. `/v1/query_range` would be needed for rate or average-over-window counters, which no current mode requires.
4. `PUT /v1/vcenters/{vcId}/metrics_config` is not implemented, on purpose (see above).
5. Only `HostSystem` and `VirtualMachine` resources, as in the other two sources.
6. **No robot/mockoon integration test**, same as #6425. Wiring both new sources into the mockoon fixtures is the natural follow-up and I am happy to do it in either PR.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially **hard-to-understand areas** of the PR
- [x] I have **rebased** my development branch on the base branch
- [ ] In case of a new plugin, I have created the new packaging directory accordingly — *n/a; no new dependency either, the source only needs JSON which is already declared*
- [x] I have implemented automated tests related to my commits
  - [x] Data used for automated tests are anonymized
- [x] I have reviewed all the help messages in all the .pm files I have modified
  - [x] All sentences begin with a capital letter
  - [x] All sentences end with a period
  - [x] I am able to understand all the help messages
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed

---

<details>
<summary><b>Mock VCF Operations appliance used for the end-to-end verification</b> (standalone, click to expand)</summary>

Implements the documented contract: three-step authentication, `/v1/metadata`, `/v1/query` with real PromQL label-selector filtering. `MODE` is `ok`, `nordm` (VCF_VODAP not registered) or `noprofile` (empty catalogue).

```python
import json, re, sys, time, urllib.parse
from http.server import BaseHTTPRequestHandler, HTTPServer

MODE = sys.argv[1] if len(sys.argv) > 1 else "ok"

METRICS = {
    "vcenter_host_cpu_capacity_usage_megahertz":       ("host-35", 3200),
    "vcenter_host_cpu_capacity_provisioned_megahertz": ("host-35", 8000),
    "vcenter_host_mem_capacity_usable_kilobytes":      ("host-35", 134217728),
    "vcenter_host_mem_consumed_vms_kilobytes":         ("host-35", 67108864),
    "vcenter_host_power_capacity_usage_watts":         ("host-35", 210),
}

class H(BaseHTTPRequestHandler):
    def log_message(self, *a): pass

    def _json(self, code, payload):
        b = json.dumps(payload).encode()
        self.send_response(code); self.send_header("Content-Type", "application/json")
        self.send_header("Content-Length", str(len(b))); self.end_headers(); self.wfile.write(b)

    def do_POST(self):
        n = int(self.headers.get("Content-Length", 0))
        body = self.rfile.read(n).decode() if n else ""
        if self.path == "/suite-api/api/auth/token/acquire":
            creds = json.loads(body)
            if creds.get("username") != "svc-centreon" or creds.get("password") != "s3cret":
                return self._json(401, {"message": "invalid credentials"})
            return self._json(200, {"token": "OPS-TOKEN-abc", "validity": 3600})
        if self.path == "/suite-api/api/auth/token/exchange":
            if self.headers.get("Authorization") != "OpsToken OPS-TOKEN-abc":
                return self._json(401, {"message": "bad ops token"})
            return self._json(200, {"token": "JWT-xyz", "expiresIn": 1800})
        self._json(404, {"message": "not found"})

    def do_GET(self):
        if self.path == "/suite-api/api/integrations/services":
            if self.headers.get("Authorization") != "OpsToken OPS-TOKEN-abc":
                return self._json(401, {"message": "bad ops token"})
            services = [{"type": "VCF_AUTOMATION", "serviceKey": "k1"}]
            if MODE != "nordm":
                services.append({"type": "VCF_VODAP", "serviceKey": "rtm-service-key"})
            return self._json(200, {"services": services})

        if not self.path.startswith("/data-query-service/"):
            return self._json(404, {"message": "not found"})
        if self.headers.get("Authorization") != "Bearer JWT-xyz":
            return self._json(401, {"status": "error", "errorType": "unauthorized", "error": "bad jwt"})

        parsed = urllib.parse.urlparse(self.path)
        if parsed.path == "/data-query-service/v1/metadata":
            if MODE == "noprofile":
                return self._json(200, {"status": "success", "data": {}})
            return self._json(200, {"status": "success",
                                    "data": {m: [{"type": "gauge", "help": m, "unit": ""}] for m in METRICS}})

        if parsed.path == "/data-query-service/v1/query":
            q = urllib.parse.parse_qs(parsed.query).get("query", [""])[0]
            name = q.split("{")[0]
            if name not in METRICS:
                return self._json(200, {"status": "success", "data": {"resultType": "vector", "result": []}})
            moid, value = METRICS[name]
            labels = {"__name__": name, "moid": moid, "vcenter": "vc01", "name": "esx01.example.tld"}
            sel = re.search(r"\{(.+)\}", q)
            if sel:
                for pair in sel.group(1).split(","):
                    m = re.match(r'\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"(.*)"\s*$', pair)
                    if not m or labels.get(m.group(1)) != m.group(2):
                        return self._json(200, {"status": "success",
                                                "data": {"resultType": "vector", "result": []}})
            return self._json(200, {"status": "success", "data": {"resultType": "vector", "result": [
                {"metric": labels, "value": [int(time.time()), str(value)]}]}})

        self._json(404, {"message": "not found"})

HTTPServer(("127.0.0.1", 8932), H).serve_forever()
```

Run it next to the vCenter 9.1 mock from #6425, then:

```bash
python3 fake_vcfops.py ok &
python3 fake_vc91.py capacity &
perl -Isrc src/centreon_plugins.pl --plugin=apps::vmware::vsphere8::esx::plugin --mode=cpu \
  --hostname=127.0.0.1 --port=8931 --proto=http --username=u --password=p --http-backend=lwp \
  --esx-id=host-35 --statefile-dir=/tmp/vsphere8-test --metrics-source=rtm \
  --rtm-hostname=127.0.0.1 --rtm-port=8932 --rtm-proto=http \
  --rtm-username=svc-centreon --rtm-password=s3cret --verbose
```

</details>

## References

- [VCF 9.1 Product Support Notes](https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-1/release-notes/vmware-cloud-foundation-9-1-0-0-release-notes/vcf-91-product-support-notes.html) — the vStats removal this PR ultimately answers
- [Real-Time Metrics API reference](https://developer.broadcom.com/xapis/realtime-metrics-api/latest/) — authentication sequence and operation index
- [Unlocking Programmable Infrastructure with VCF 9.1](https://blogs.vmware.com/cloud-foundation/2026/05/25/unlocking-the-full-potential-of-programmable-infrastructure-with-vmware-cloud-foundation-9-1-new-features-and-capabilities/) — Prometheus-compatible edge APIs, collection profiles
- [Real-Time Metrics policy workspace](https://techdocs.broadcom.com/us/en/vmware-cis/vcf/vcf-9-0-and-later/9-1/infrastructure-operations/configuring-policies/using-the-monitoring-policy-workspace/policy-workspace/real-time-metrics-policy-workspace.html) — enabling the Standard and ESXi Top profiles
