### PR TITLE
ci(plugins): scope the "common" change-detection filter to the core e…

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -86,7 +86,9 @@ jobs:
           list-files: shell
           filters: |
             common:
-              - added|deleted|modified: src/centreon/**
+              # Only the cross-plugin engine forces a full rebuild/test; src/centreon/common/**
+              # is already covered by the "plugins" filter below and resolved per package.
+              - added|deleted|modified: src/centreon/plugins/**
               - modified: .github/packaging/centreon-plugin.yaml.template
             packages:
               - added|modified: packaging/**


### PR DESCRIPTION
## Description

The `common` path filter in `.github/workflows/plugins.yml` (used to decide whether to build/test every plugin package) matched `src/centreon/**`. Since `src/centreon/` contains both the generic engine (`src/centreon/plugins/`) and per-vendor/tech shared libraries (`src/centreon/common/<vendor>/`, e.g. `kubernetes`, `cisco`, `huawei`), any change to a single vendor's shared code triggered a full-repo build and test run instead of just the packages that actually use it.

The `plugins` filter (`src/**`) below already covers `src/centreon/common/**` and already resolves changes there to the specific packages that declare the path in their `pkg.json` `files` (via `get_pack_from_path` in `list-plugins-to-build-and-test.py`) — this fine-grained resolution simply never ran for `common/` changes because the `common` filter matched first and took the "build everything" path.

This PR narrows `common` to `src/centreon/plugins/**`, so only changes to the truly cross-plugin engine still trigger a full rebuild/test; vendor-scoped shared code now falls through to the existing fine-grained resolution.

**Refs:** CTOR-2524

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Functionality enhancement or optimization (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## How this pull request can be tested?

`dorny/paths-filter` itself can't be run outside GitHub Actions, so the `changes` and `get-plugins` jobs' logic (the filter definitions, the bash folder-normalization step, and `list-plugins-to-build-and-test.py`) was replayed locally, unmodified, against the real repository tree (681 `pkg.json` packages) for several file-change scenarios:

| Scenario | Changed file(s) | `changes_common` | Packages targeted |
|---|---|---|---|
| Core engine change | `src/centreon/plugins/misc.pm` | `true` | 681 (all — unchanged behavior) |
| Single-vendor common change | `src/centreon/common/kubernetes/misc.pm` | `false` | 2 (`Cloud-Kubernetes-Api`, `Cloud-OpenShift-Api`) |
| Multi-vendor common change (1 PR) | `.../kubernetes/` + `.../huawei/...` | `false` | 4 (correct union of both vendors) |
| Packaging-only change | `packaging/.../Biztalk/pkg.json` | `false` | 1 (`Biztalk`) |
| Ordinary plugin change (non-common) | `src/apps/github/mode/commits.pm` | `false` | 1 (`Github-Restapi`) |
| Tests-only change | `tests/database/mssql/databasessize.robot` | `false` | 5 (test-only, `build=False`) |
| Mixed: core engine + packaging | engine file + `Biztalk/pkg.json` | `true` | 681 (OR logic preserved) |

Confirms: a vendor-scoped `common/` change is now correctly scoped (never 0, never all), a core engine change still triggers the full repo as before, and targeting for `packaging/**`, ordinary `src/**` and `tests/**` changes is unaffected by this change.

## Checklist

- [x] I have **rebased** my development branch on the base branch (develop).
- [x] After having created the PR, I will make sure that all the tests provided in this PR have run and passed.
